### PR TITLE
run_standalone_monitor not working

### DIFF
--- a/scalyr_agent/run_monitor.py
+++ b/scalyr_agent/run_monitor.py
@@ -94,9 +94,8 @@ def run_standalone_monitor(monitor_module, monitor_python_path, monitor_config, 
         signal.signal(sig, handle_shutdown_signal)
 
     try:
-        monitor = MonitorsManager.build_monitor(parsed_config, monitor_python_path)
+        monitor = MonitorsManager.build_monitor(parsed_config, monitor_python_path, float(monitor_sample_interval))
         log.log(scalyr_logging.DEBUG_LEVEL_1, 'Constructed monitor')
-        monitor.set_sample_interval(float(monitor_sample_interval))
         monitor.open_metric_log()
         log.log(scalyr_logging.DEBUG_LEVEL_1, 'Starting monitor')
         monitor.start()

--- a/scalyr_agent/tests/empty_monitor.py
+++ b/scalyr_agent/tests/empty_monitor.py
@@ -1,0 +1,27 @@
+# Copyright 2014 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+#
+# author: Imron Alston <imron@imralsoftware.com>
+#
+# An empty monitor, that will return immediately without doing anything
+
+
+__author__ = 'imron@imralsoftware.com'
+
+from scalyr_agent.scalyr_monitor import ScalyrMonitor
+
+class EmptyMonitor( ScalyrMonitor ):
+    def run( self ):
+        pass

--- a/scalyr_agent/tests/run_monitor_test.py
+++ b/scalyr_agent/tests/run_monitor_test.py
@@ -1,0 +1,34 @@
+# Copyright 2014 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+#
+# author: Imron Alston <imron@imralsoftware.com>
+
+__author__ = 'imron@imralsoftware.com'
+
+import unittest
+import scalyr_agent.scalyr_logging as scalyr_logging
+
+from scalyr_agent.run_monitor import run_standalone_monitor
+
+
+class RunMonitorTest( unittest.TestCase ):
+    def test_run_standalone_monitor( self ):
+        config = """{
+                 }"""
+
+        run_standalone_monitor( "scalyr_agent.tests.empty_monitor", ".", config, float(0.5), scalyr_logging.DEBUG_LEVEL_1 )
+
+
+


### PR DESCRIPTION
The MonitorsManager.build_monitor function changed its interface (3 parameters instead of 2), but run_standalone_monitor was not updated to reflect this, and this was preventing monitors from being run in a standalone fashion using

```
python -m scalyr_agent.run_monitor scalyr_agent.builtin_monitors.<my_monitor>
```

This PR calls ```build_monitor``` correctly, and adds a unit test calling run_standalone_monitor, which fails using the previous code, and passes with this fix.