### PR TITLE
2.4 compatibility

### DIFF
--- a/scalyr_agent/run_monitor.py
+++ b/scalyr_agent/run_monitor.py
@@ -100,7 +100,8 @@ def run_standalone_monitor(monitor_module, monitor_python_path, monitor_config, 
         log.log(scalyr_logging.DEBUG_LEVEL_1, 'Starting monitor')
         monitor.start()
 
-        while monitor.is_alive():
+        #use isAlive rather than is_alive for 2.4 compatibility
+        while monitor.isAlive():
             time.sleep(0.1)
     except BadMonitorConfiguration, e:
         print >>sys.stderr, 'Invalid monitor configuration: %s' % str(e)

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -452,7 +452,8 @@ class StoppableThread(threading.Thread):
         @type timeout: float|None
         """
         threading.Thread.join(self, timeout)
-        if not self.is_alive() and self.__exception_info is not None:
+        #use isAlive rather than is_alive for 2.4 compatibility
+        if not self.isAlive() and self.__exception_info is not None:
             raise self.__exception_info[0], self.__exception_info[1], self.__exception_info[2]
 
 


### PR DESCRIPTION
Thread.is_alive should be Thread.isAlive in order to maintain compatibility with python 2.4