### PR TITLE
[Ready For Review] Add Hashing option for the redacted data

### DIFF
--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -39,6 +39,16 @@ try:
 except ImportError:
     from sha import sha as sha1
 
+
+try:
+    # For Python >= 2.5
+    from hashlib import md5
+    new_md5 = True
+except ImportError:
+    import md5
+    new_md5 = False
+
+
 try:
     import scalyr_agent.third_party.uuid_tp.uuid as uuid
 except ImportError:
@@ -124,6 +134,25 @@ def create_unique_id():
         base_value = str(time.time()) + base_value
     result = base64.urlsafe_b64encode(sha1(base_value).digest()) + method
     return result
+
+
+def md5_digest(data):
+    """
+    Returns the md5 digest of the input data
+    @param data: data to be digested(hashed)
+    @type data: str
+    @rtype: str
+    """
+
+    if not (data and isinstance(data, basestring)):
+        raise Exception('invalid data to be hashed: %s', repr(data))
+
+    if not new_md5:
+        m = md5.new()
+    else:
+        m = md5()
+    m.update(data)
+    return m.digest()
 
 
 def remove_newlines_and_truncate(input_string, char_limit):


### PR DESCRIPTION
Still Work in Progress.

Adds the support to hash the redacted data. This introduces 1 more configurations in the `"redaction_rules"` dictionary
e.g.:
```
"redaction_rules": [
  			{
  				"match_expression": "password=[^& ]*",
  				"replacement": "thistextwillbeusedifnothashed",
                                "hash_salt": "fdfhgkhfgjkhfgf"
  			}
```
Currently we support only MD5 hashing algorithm. All the redacted and matched groups will be replaced by (its + salt, if any) MD5 digest. 

Currently, the hashing feature is only available for regular expressions with captured groups.
We now need to know the groups that need to be hashed. Not all groups that are captured in the regular expression may be hashed. For this case, which i presume will be the general case,
we need a little terminology.

eg:

```
redaction_rules: [
       // Delete all instances of password=...
       { match_expression: "password=[^& ]*" },

       // Replace terms like "userInfo=username password" with "userInfo=username"
       {
         match_expression: "userInfo=([^ ]+) [^ ]+",
         replacement: "userInfo=\\H1"
       }
     ]
   }
```

we will need to specify the group that needs to be hashed by using this in the replacement string prefixed by `\\H` followed by the group number. This will help us capture and parse the group before replacement so we can then later hash the actual content of the matched group. One more example is: 
```
redaction_rules: [
       {
         match_expression: "secret(.*?)=([a-z]+\s?)",
         replacement: "secret\\1=\\H2"
       }
     ]
   }
```

This will hash only group number 2 and keep group 1 the same.

I currently ran the following configuration on the local dev and found it working:

```
"logs": [
  	{
  		"path": "/var/log/baz.log",
  		"attributes": {"parser": "appLog"},
  		"redaction_rules": [
  			{
  				"match_expression": "password(.*?)=([a-z]+\\s?)",
  				"replacement": "password\\1=\\H2"
  			}
  		] 	
  	}
  ```

Where the `/var/log/baz.log` looked like: 
```
somegarbage text passwordblahtext=secretstuff some more text and one more passwordfdfdfd=moresecretstuff fdfd
somegarbage text passwordblahtext=secretstuff some more text and one more passwordfdfdfd=moresecretstuff fdfd
somegarbage text passwordblahtext=secretstuff some more text and one more passwordfdfdfd=moresecretstuff fdfd
somegarbage text passwordblahtext=secretstuff some more text and one more passwordfdfdfd=moresecretstuff fdfd
```

and i could see the hashed group of password in the terminal as:
```
somegarbage text passwordblahtext=�,���<�u/�UqL�some more text and one more passwordfdfdfd=�' ԯ6� �h�N  
17:33:03.513 Saurabhs-MBP.lan /var/log/baz.log  somegarbage text passwordblahtext=�,���<�u/�UqL�some more text and one more passwordfdfdfd=�' ԯ6� �h�N  
```


TODO:
- [x] Unit Tests. I'm sure i broke the existing ones. I need to fix those and add a few others.

