### PR TITLE
allow users to easily configure `scalyr_api_key` via env variables

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -293,7 +293,7 @@ class ScalyrAgent(object):
         @type config: scalyr_agent.Configuration
         """
         try:
-            config.parse()
+            config.parse(logger=log)
             monitors_manager = MonitorsManager(config, self.__controller)
             copying_manager = CopyingManager(config, monitors_manager.monitors)
             # To do the full verification, we have to create the managers.  However, this call does not need them,

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -124,9 +124,9 @@ class Configuration(object):
                 self.__add_elements_from_array('monitors', content, self.__config)
                 self.__merge_server_attributes(fp, content, self.__config)
 
-            # Check for api_key in the environment variable `api_key`. Sometimes, injecting a secret key like
+            # Check for api_key in the environment variable `scalyr_api_key`. Sometimes, injecting a secret key like
             # this is preferable via environment variables
-            api_key = os.environ.get('api_key') if os.environ.get('api_key') else api_key
+            api_key = os.environ.get('scalyr_api_key') if os.environ.get('scalyr_api_key') else api_key
 
             self.__set_api_key(self.__config, api_key)
             if scalyr_server is not None:

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -124,6 +124,10 @@ class Configuration(object):
                 self.__add_elements_from_array('monitors', content, self.__config)
                 self.__merge_server_attributes(fp, content, self.__config)
 
+            # Check for api_key in the environment variable `api_key`. Sometimes, injecting a secret key like
+            # this is preferable via environment variables
+            api_key = os.environ.get('api_key') if os.environ.get('api_key') else api_key
+
             self.__set_api_key(self.__config, api_key)
             if scalyr_server is not None:
                 self.__config.put('scalyr_server', scalyr_server)

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -29,14 +29,6 @@ from scalyr_agent.json_lib import JsonObject, JsonArray
 from scalyr_agent.json_lib import JsonConversionException, JsonMissingFieldException
 from scalyr_agent.util import JsonReadFileException
 
-import scalyr_agent.scalyr_logging as scalyr_logging
-
-# Set up the main logger.  We set it up initially to log to standard out,
-# but once we run fork off the daemon, we will use a rotating log file.
-log = scalyr_logging.getLogger('scalyr_agent')
-
-scalyr_logging.set_log_destination(use_stdout=True)
-
 from __scalyr__ import get_install_root
 
 
@@ -83,7 +75,7 @@ class Configuration(object):
         self.max_retry_time = 15 * 60
         self.max_allowed_checkpoint_age = 15 * 60
 
-    def parse(self):
+    def parse(self, logger=None):
         self.__read_time = time.time()
 
         try:
@@ -138,10 +130,12 @@ class Configuration(object):
             env_api_key = os.environ.get('scalyr_api_key')
             if api_key and env_api_key and api_key != env_api_key:
                 # ignore and key in the env variable and warn the user
-                log.warn("You have different api keys in the config file and env variable `scalyr_api_key`."
-                         " Ignoring the env variable.")
+                if logger:
+                    logger.warn("You have different api keys in the config file and env variable `scalyr_api_key`."
+                             " Ignoring the env variable.")
             elif not api_key and env_api_key:
-                log.debug("Using the api key from the env variable `scalyr_api_key`")
+                if logger:
+                    logger.debug("Using the api key from the env variable `scalyr_api_key`")
                 api_key = env_api_key
 
             self.__set_api_key(self.__config, api_key)

--- a/scalyr_agent/run_monitor.py
+++ b/scalyr_agent/run_monitor.py
@@ -104,7 +104,7 @@ def run_standalone_monitor(monitor_module, monitor_python_path, monitor_config, 
             controller = PlatformController.new_platform()
             paths = controller.default_paths
             global_config = Configuration( global_config_path, paths )
-            global_config.parse()
+            global_config.parse(logger=log)
         else:
             global_config = None
         monitor = MonitorsManager.build_monitor(parsed_config, monitor_python_path, float(monitor_sample_interval),

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -694,7 +694,7 @@ class TestConfiguration(ScalyrTestCase):
             api_key: "abcd1234",
           }
         """)
-        os.environ['api_key'] = ''
+        os.environ['scalyr_api_key'] = ''
 
         config = self.__create_test_configuration_instance()
         config.parse()
@@ -707,7 +707,7 @@ class TestConfiguration(ScalyrTestCase):
             api_key: "abcd1234",
           }
         """)
-        os.environ['api_key'] = "xyz"
+        os.environ['scalyr_api_key'] = "xyz"
 
         config = self.__create_test_configuration_instance()
         config.parse()

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -676,6 +676,44 @@ class TestConfiguration(ScalyrTestCase):
 
         self.assertEquals(config.api_key, 'hibye')
 
+    def test_api_key_override_no_override(self):
+        self.__write_file_with_separator_conversion(""" {
+            logs: [ { path:"/var/log/tomcat6/$DIR_VAR.log" }],
+            api_key: "abcd1234",
+          }
+        """)
+
+        config = self.__create_test_configuration_instance()
+        config.parse()
+
+        self.assertEquals(config.api_key, 'abcd1234')
+
+    def test_api_key_override_empty_override(self):
+        self.__write_file_with_separator_conversion(""" {
+            logs: [ { path:"/var/log/tomcat6/$DIR_VAR.log" }],
+            api_key: "abcd1234",
+          }
+        """)
+        os.environ['api_key'] = ''
+
+        config = self.__create_test_configuration_instance()
+        config.parse()
+
+        self.assertEquals(config.api_key, 'abcd1234')
+
+    def test_api_key_override(self):
+        self.__write_file_with_separator_conversion(""" {
+            logs: [ { path:"/var/log/tomcat6/$DIR_VAR.log" }],
+            api_key: "abcd1234",
+          }
+        """)
+        os.environ['api_key'] = "xyz"
+
+        config = self.__create_test_configuration_instance()
+        config.parse()
+
+        self.assertEquals(config.api_key, 'xyz')
+
     def test_json_array_substitution(self):
         self.__write_file_with_separator_conversion(""" {
             import_vars: [ "TEST_VAR", "DIR_VAR" ],

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -35,6 +35,8 @@ class TestConfiguration(ScalyrTestCase):
         self.__config_file = os.path.join(self.__config_dir, 'agent.json')
         self.__config_fragments_dir = os.path.join(self.__config_dir, 'agent.d')
         os.makedirs(self.__config_fragments_dir)
+        if os.environ.get('scalyr_api_key'):
+            del os.environ['scalyr_api_key']
 
     def test_basic_case(self):
         self.__write_file_with_separator_conversion(""" {
@@ -701,10 +703,22 @@ class TestConfiguration(ScalyrTestCase):
 
         self.assertEquals(config.api_key, 'abcd1234')
 
-    def test_api_key_override(self):
+    def test_api_key_override_ignore_env(self):
         self.__write_file_with_separator_conversion(""" {
             logs: [ { path:"/var/log/tomcat6/$DIR_VAR.log" }],
             api_key: "abcd1234",
+          }
+        """)
+        os.environ['scalyr_api_key'] = "xyz"
+
+        config = self.__create_test_configuration_instance()
+        config.parse()
+
+        self.assertEquals(config.api_key, 'abcd1234')
+
+    def test_api_key_override_use_env(self):
+        self.__write_file_with_separator_conversion(""" {
+            logs: [ { path:"/var/log/tomcat6/$DIR_VAR.log" }]
           }
         """)
         os.environ['scalyr_api_key'] = "xyz"


### PR DESCRIPTION
This is especially useful for automated server spinups using a base template like cloudformation, ECS template etc. where the API Key can be baked in those templates as AWS templates have an easy interface to set up environment variables using JSON. The agent.json file doesn't need to be custom built