### PR TITLE
Run platform tests on differnt Python/Linux distributions

### DIFF
--- a/scalyr_agent/platform_tests/README.md
+++ b/scalyr_agent/platform_tests/README.md
@@ -12,7 +12,7 @@ The Platform Tests are run by:
     * run the tests.
 * Once the tests have run, destroy the container and the images created.
 
-# Goal and Further Actions:
+# Goal and Further Actions
 * Completeness: We should be able to run the tests on possibly all OS and their distributions if possible.
 * Sensitivity: The tests should be sensitive to breakage and should alert if something breaks in any environment. 
 This means we need host machines like Jenkins etc. to have these tests run and gather reports and alert on breakage, 

--- a/scalyr_agent/platform_tests/README.md
+++ b/scalyr_agent/platform_tests/README.md
@@ -64,7 +64,7 @@ git clone -b release git://github.com/scalyr/scalyr-agent-2.git
 * Run the tests:
 
 ```
-cd scalyr-agent-2\scalyr_agent
+cd scalyr-agent-2
 
 python run_tests.py
 ```

--- a/scalyr_agent/platform_tests/README.md
+++ b/scalyr_agent/platform_tests/README.md
@@ -17,3 +17,54 @@ The Platform Tests are run by:
 * Sensitivity: The tests should be sensitive to breakage and should alert if something breaks in any environment. 
 This means we need host machines like Jenkins etc. to have these tests run and gather reports and alert on breakage, 
 possibly on each PR requested? TBD
+
+
+
+
+# Windows Tests
+
+The Windows tests cannot be run like the Linux platform tests from OSX machines because
+of the differences in the system architecture. We need a Virtual Machine for that.
+
+We can set up a Windows VM by doing:
+
+* Install vagrant on the host machine. https://www.vagrantup.com/docs/installation/
+* Download and install Virtualbox as the OS image provider. https://www.virtualbox.org/wiki/Downloads
+* Choose a Windows Vagrant image. eg: https://app.vagrantup.com/kensykora/boxes/windows_2012_r2_standard 
+and follow the instruction eg: 
+
+```
+vagrant init kensykora/windows_2012_r2_standard
+
+vagrant up --provider=virtualbox
+```
+* Remote Desktop into the Windows VM. 
+```
+vagrant rdp
+```
+
+* Install Python for windows.
+
+* Install git for Windows.
+
+* Go to the ``cmd`` terminal.
+
+* Download the Scalyr Agent Repo:
+
+```
+git init
+
+git config --local user.name "Scalyr" 
+
+git config --local user.email support@scalyr.com && 
+
+git clone -b release git://github.com/scalyr/scalyr-agent-2.git
+```
+
+* Run the tests:
+
+```
+cd scalyr-agent-2\scalyr_agent
+
+python run_tests.py
+```

--- a/scalyr_agent/platform_tests/README.md
+++ b/scalyr_agent/platform_tests/README.md
@@ -1,0 +1,19 @@
+# Objective
+This module is used to run the tests under scalyr_agent/tests on different OS platforms 
+with different Python versions. The objective is to make sure the Scalyr Agent runs the same way 
+in different distributions of supported OS (Windows/Linux/OSX etc.)
+
+# Steps
+The Platform Tests are run by:
+* iterating over all the Dockerfiles under scalyr_agent/platform_tests
+* for each Dockerfile:
+    * create a Docker Image
+    * run a container
+    * run the tests.
+* Once the tests have run, destroy the container and the images created.
+
+# Goal and Further Actions:
+* Completeness: We should be able to run the tests on possibly all OS and their distributions if possible.
+* Sensitivity: The tests should be sensitive to breakage and should alert if something breaks in any environment. 
+This means we need host machines like Jenkins etc. to have these tests run and gather reports and alert on breakage, 
+possibly on each PR requested? TBD

--- a/scalyr_agent/platform_tests/alpine/Dockerfile
+++ b/scalyr_agent/platform_tests/alpine/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:2-alpine
+
+MAINTAINER Scalyr Inc <support@scalyr.com>
+
+RUN apk update
+RUN apk add "git"
+
+
+WORKDIR /tmp
+
+RUN git init && \
+  git config --local user.name "Scalyr" && git config --local user.email support@scalyr.com && \
+  git clone -b release git://github.com/scalyr/scalyr-agent-2.git
+
+RUN pip install mock==2.0.0
+RUN chmod -R +x scalyr-agent-2
+WORKDIR scalyr-agent-2

--- a/scalyr_agent/platform_tests/jessie/Dockerfile
+++ b/scalyr_agent/platform_tests/jessie/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:2-jessie
+
+MAINTAINER Scalyr Inc <support@scalyr.com>
+
+
+WORKDIR /tmp
+
+RUN git init && \
+  git config --local user.name "Scalyr" && git config --local user.email support@scalyr.com && \
+  git clone -b release git://github.com/scalyr/scalyr-agent-2.git
+
+RUN pip install mock==2.0.0
+RUN chmod -R +x scalyr-agent-2
+WORKDIR scalyr-agent-2

--- a/scalyr_agent/platform_tests/run_platform_test.py
+++ b/scalyr_agent/platform_tests/run_platform_test.py
@@ -1,0 +1,49 @@
+# Copyright 2015 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+#
+# author: Saurabh Jain <saurabh@scalyr.com>
+
+__author__ = 'saurabh@scalyr.com'
+
+import unittest
+from subprocess import call
+import os
+
+
+class cd:
+    """Context manager for changing the current working directory
+    From: https://stackoverflow.com/questions/431684/how-do-i-cd-in-python
+    """
+    def __init__(self, newPath):
+        self.newPath = os.path.expanduser(newPath)
+
+    def __enter__(self):
+        self.savedPath = os.getcwd()
+        os.chdir(self.newPath)
+
+    def __exit__(self, etype, value, traceback):
+        os.chdir(self.savedPath)
+
+
+class RunPlatformTests(unittest.TestCase):
+    """
+    Runs Scalyr Agent Tests on all platforms
+    """
+    @unittest.skipUnless(os.environ.get("SCALYR_NO_SKIP_TESTS"), "Platform Tests")
+    def test_alpine(self):
+        with cd("scalyr_agent/platform_tests/alpine"):
+            call(["pwd"])
+            call(["docker", "build", "-t",  "scalyr:python_2-alpine", "."])
+            call(["docker", "run", "scalyr:python_2-alpine", "python", "run_tests.py", "--verbose"])

--- a/scalyr_agent/platform_tests/run_platform_test.py
+++ b/scalyr_agent/platform_tests/run_platform_test.py
@@ -44,20 +44,32 @@ class RunPlatformTests(unittest.TestCase):
     @unittest.skipUnless(os.environ.get("SCALYR_NO_SKIP_TESTS"), "Platform Tests")
     def test_alpine(self):
         with cd("scalyr_agent/platform_tests/alpine"):
-            call(["pwd"])
             call(["docker", "build", "-t",  "scalyr:python_2-alpine", "."])
-            call(["docker", "run", "scalyr:python_2-alpine", "python", "run_tests.py", "--verbose"])
+            call(
+                ["docker", "run", "--name", "scalyr_container_alpine", "scalyr:python_2-alpine",
+                 "python", "run_tests.py", "--verbose"]
+            )
 
     @unittest.skipUnless(os.environ.get("SCALYR_NO_SKIP_TESTS"), "Platform Tests")
     def test_wheezy(self):
         with cd("scalyr_agent/platform_tests/wheezy"):
-            call(["pwd"])
             call(["docker", "build", "-t",  "scalyr:python_2-wheezy", "."])
-            call(["docker", "run", "scalyr:python_2-wheezy", "python", "run_tests.py", "--verbose"])
+            call(
+                ["docker", "run", "--name", "scalyr_container_wheezy", "scalyr:python_2-wheezy",
+                 "python", "run_tests.py", "--verbose"]
+            )
 
     @unittest.skipUnless(os.environ.get("SCALYR_NO_SKIP_TESTS"), "Platform Tests")
     def test_jessie(self):
         with cd("scalyr_agent/platform_tests/jessie"):
-            call(["pwd"])
             call(["docker", "build", "-t",  "scalyr:python_2-jessie", "."])
-            call(["docker", "run", "scalyr:python_2-jessie", "python", "run_tests.py", "--verbose"])
+            call(
+                ["docker", "run", "--name", "scalyr_container_jessie", "scalyr:python_2-jessie",
+                 "python", "run_tests.py", "--verbose"]
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        call(["docker", "stop", "scalyr_container_alpine", "scalyr_container_wheezy", "scalyr_container_jessie"])
+        call(["docker", "rm", "scalyr_container_alpine", "scalyr_container_wheezy", "scalyr_container_jessie"])
+        call(["docker", "rmi", "scalyr:python_2-alpine", "scalyr:python_2-wheezy", "scalyr:python_2-jessie"])

--- a/scalyr_agent/platform_tests/run_platform_test.py
+++ b/scalyr_agent/platform_tests/run_platform_test.py
@@ -17,12 +17,26 @@
 
 __author__ = 'saurabh@scalyr.com'
 
+"""
+This module is used to run the tests under scalyr_agent/tests on different OS platforms 
+with different Python versions.
+
+We do this by:
+1) iterating over all the Dockerfiles under scalyr_agent/platform_tests
+2) for each Dockerfile:
+    i)   create a Docker Image
+    ii)  run a container
+    iii) run the tests.
+3) Once the tests have run, destroy the container and the images created.
+
+"""
+
 import unittest
 from subprocess import call
 import os
 
 
-class cd:
+class WorkingDirectory:
     """Context manager for changing the current working directory
     From: https://stackoverflow.com/questions/431684/how-do-i-cd-in-python
     """
@@ -43,7 +57,7 @@ class RunPlatformTests(unittest.TestCase):
     """
     @unittest.skipUnless(os.environ.get("SCALYR_NO_SKIP_TESTS"), "Platform Tests")
     def test_alpine(self):
-        with cd("scalyr_agent/platform_tests/alpine"):
+        with WorkingDirectory("scalyr_agent/platform_tests/alpine"):
             call(["docker", "build", "-t",  "scalyr:python_2-alpine", "."])
             call(
                 ["docker", "run", "--name", "scalyr_container_alpine", "scalyr:python_2-alpine",
@@ -52,7 +66,7 @@ class RunPlatformTests(unittest.TestCase):
 
     @unittest.skipUnless(os.environ.get("SCALYR_NO_SKIP_TESTS"), "Platform Tests")
     def test_wheezy(self):
-        with cd("scalyr_agent/platform_tests/wheezy"):
+        with WorkingDirectory("scalyr_agent/platform_tests/wheezy"):
             call(["docker", "build", "-t",  "scalyr:python_2-wheezy", "."])
             call(
                 ["docker", "run", "--name", "scalyr_container_wheezy", "scalyr:python_2-wheezy",
@@ -61,7 +75,7 @@ class RunPlatformTests(unittest.TestCase):
 
     @unittest.skipUnless(os.environ.get("SCALYR_NO_SKIP_TESTS"), "Platform Tests")
     def test_jessie(self):
-        with cd("scalyr_agent/platform_tests/jessie"):
+        with WorkingDirectory("scalyr_agent/platform_tests/jessie"):
             call(["docker", "build", "-t",  "scalyr:python_2-jessie", "."])
             call(
                 ["docker", "run", "--name", "scalyr_container_jessie", "scalyr:python_2-jessie",

--- a/scalyr_agent/platform_tests/run_platform_test.py
+++ b/scalyr_agent/platform_tests/run_platform_test.py
@@ -47,3 +47,17 @@ class RunPlatformTests(unittest.TestCase):
             call(["pwd"])
             call(["docker", "build", "-t",  "scalyr:python_2-alpine", "."])
             call(["docker", "run", "scalyr:python_2-alpine", "python", "run_tests.py", "--verbose"])
+
+    @unittest.skipUnless(os.environ.get("SCALYR_NO_SKIP_TESTS"), "Platform Tests")
+    def test_wheezy(self):
+        with cd("scalyr_agent/platform_tests/wheezy"):
+            call(["pwd"])
+            call(["docker", "build", "-t",  "scalyr:python_2-wheezy", "."])
+            call(["docker", "run", "scalyr:python_2-wheezy", "python", "run_tests.py", "--verbose"])
+
+    @unittest.skipUnless(os.environ.get("SCALYR_NO_SKIP_TESTS"), "Platform Tests")
+    def test_jessie(self):
+        with cd("scalyr_agent/platform_tests/jessie"):
+            call(["pwd"])
+            call(["docker", "build", "-t",  "scalyr:python_2-jessie", "."])
+            call(["docker", "run", "scalyr:python_2-jessie", "python", "run_tests.py", "--verbose"])

--- a/scalyr_agent/platform_tests/wheezy/Dockerfile
+++ b/scalyr_agent/platform_tests/wheezy/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:2-wheezy
+
+MAINTAINER Scalyr Inc <support@scalyr.com>
+
+
+WORKDIR /tmp
+
+RUN git init && \
+  git config --local user.name "Scalyr" && git config --local user.email support@scalyr.com && \
+  git clone -b release git://github.com/scalyr/scalyr-agent-2.git
+
+RUN pip install mock==2.0.0
+RUN chmod -R +x scalyr-agent-2
+WORKDIR scalyr-agent-2


### PR DESCRIPTION
Running the Scalyr Agent tests on different platforms. This structure can be expanded to cover all major Python/OS distributions. 

The base Docker images for Python are listed at https://store.docker.com/images/python

This should cover a lot of ground.

TODO:
- [x] in the `tearDown` method, remove the created image to reduce the memory footprint.