### PR TITLE
Split status update message into three parts

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -368,6 +368,8 @@ class ScalyrAgent(object):
             finally:
                 client.close()
 
+            print "Server connection verified."
+
     def __start(self, quiet, no_fork, no_check_remote):
         """Executes the start command.
 
@@ -413,7 +415,7 @@ class ScalyrAgent(object):
             self.__fail_if_already_running()
 
             if not quiet:
-                print "Configuration and server connection verified, starting agent in background."
+                print "Starting agent in background."
             self.__controller.start_agent_service(self.__run, quiet, fork=True)
         else:
             self.__controller.start_agent_service(self.__run, quiet, fork=False)
@@ -848,6 +850,8 @@ class ScalyrAgent(object):
 
         if not os.access(config.agent_data_path, os.W_OK):
             raise Exception('User cannot write to agent data directory \'%s\'.' % config.agent_data_path)
+
+        print "Configuration verified."
 
     def __start_or_stop_unsafe_debugging(self):
         """Starts or stops the debugging tool.

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -368,8 +368,6 @@ class ScalyrAgent(object):
             finally:
                 client.close()
 
-            print "Server connection verified."
-
     def __start(self, quiet, no_fork, no_check_remote):
         """Executes the start command.
 
@@ -415,7 +413,10 @@ class ScalyrAgent(object):
             self.__fail_if_already_running()
 
             if not quiet:
-                print "Starting agent in background."
+                if no_check_remote:
+                    print "Configuration verified, starting agent in background."
+                else:
+                    print "Configuration and server connection verified, starting agent in background."
             self.__controller.start_agent_service(self.__run, quiet, fork=True)
         else:
             self.__controller.start_agent_service(self.__run, quiet, fork=False)
@@ -850,8 +851,6 @@ class ScalyrAgent(object):
 
         if not os.access(config.agent_data_path, os.W_OK):
             raise Exception('User cannot write to agent data directory \'%s\'.' % config.agent_data_path)
-
-        print "Configuration verified."
 
     def __start_or_stop_unsafe_debugging(self):
         """Starts or stops the debugging tool.


### PR DESCRIPTION
This way the agent won't claim to have verified the connection when in fact it was started with `--no-check-remote-server`.

(When I run the tests using the command in `.circleci/config.yml`, 20 errors and 47 failures are reported, both before and after this change. If you'd like me to do any of this differently, don't hesitate to ask!)