### PR TITLE
k8s config file and updates to docker monitor

### DIFF
--- a/docker/Dockerfile.k8s_config
+++ b/docker/Dockerfile.k8s_config
@@ -1,0 +1,5 @@
+# Dockerfile for building an image of scalyr/scalyr-k8s-agent with custom configuration
+# files for the Scalyr Agent.
+FROM scalyr/scalyr-docker-agent:latest
+COPY k8s-config/agent.d/* /etc/scalyr-agent-2/agent.d/
+CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]

--- a/docker/k8s-config/agent.d/api-key.json
+++ b/docker/k8s-config/agent.d/api-key.json
@@ -1,0 +1,5 @@
+{
+  import_vars: [ "SCALYR_API_KEY" ],
+  api_key: "$SCALYR_API_KEY"
+}
+

--- a/docker/k8s-config/agent.d/docker.json
+++ b/docker/k8s-config/agent.d/docker.json
@@ -1,0 +1,9 @@
+{
+  "monitors":[
+    {
+      "module": "scalyr_agent.builtin_monitors.docker_monitor",
+      "docker_raw_logs": true
+    }
+  ]
+}
+

--- a/k8s/scalyr-agent-2.yaml
+++ b/k8s/scalyr-agent-2.yaml
@@ -1,0 +1,36 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: scalyr-agent-2
+spec:
+  template:
+    metadata:
+      labels:
+        app: scalyr-agent-2
+    spec:
+      containers:
+      - name: scalyr-agent
+        image: scalyr/scalyr-k8s-agent:latest
+        imagePullPolicy: Always
+        env:
+          - name: SCALYR_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: scalyr-api-key
+                key: scalyr-api-key
+        resources:
+          limits:
+            memory: 500Mi
+        volumeMounts:
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: dockersock
+          mountPath: /var/scalyr/docker.sock
+      volumes:
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock


### PR DESCRIPTION
This pull request updates the docker_monitor to log the raw docker logs of all containers from the files on disk rather than through the docker API.  The 'logfile' field will be reset to /docker/<container name>.log

It also includes a new Dockerfile to create a Docker image that is suited for running under Kubernetes.  When building this Docker image, the image name should be scalyr/scalyr-k8s-agent.  It differs from the main scalyr-docker-agent in that it uses the docker_monitor instead of the syslog_monitor to log container output, and it also uses the above raw logging features.

Finally, this request includes a k8s .yaml file that can be used to create and schedule the scalyr-agent to run as a Daemonset on a Kubernetes cluster.