### PR TITLE
do not resolve $$ to current PID eagerly

### DIFF
--- a/scalyr_agent/builtin_monitors/linux_process_metrics.py
+++ b/scalyr_agent/builtin_monitors/linux_process_metrics.py
@@ -846,13 +846,13 @@ class ProcessMonitor(ScalyrMonitor):
         self.__target_pids = []
 
         # convert target pid into a list. Target pids can be a single pid or a CSV of pids
-        if __target_pids:
+        if __target_pids == "$$":
+            # do not resolve $$ to current process id in case the current process forks and changes pid
+            self.__target_pids = "$$"
+        elif __target_pids:
             for _t in __target_pids.split(','):
                 if _t:
-                    if _t != '$$':
-                        self.__target_pids.append(int(_t))
-                    else:
-                        self.__target_pids.append(int(os.getpid()))
+                    self.__target_pids.append(int(os.getpid()))
 
         # Last 2 values of all metrics which has form:
         # {

--- a/scalyr_agent/builtin_monitors/linux_process_metrics.py
+++ b/scalyr_agent/builtin_monitors/linux_process_metrics.py
@@ -1063,7 +1063,7 @@ class ProcessMonitor(ScalyrMonitor):
             if self.__target_pids:
                 for t_pid in self.__target_pids:
                     if t_pid == "$$":
-                        t_pid = os.getpid()
+                        t_pid = int(os.getpid())
                     else:
                         t_pid = int(t_pid)
                     pids.append(t_pid)

--- a/scalyr_agent/builtin_monitors/linux_process_metrics.py
+++ b/scalyr_agent/builtin_monitors/linux_process_metrics.py
@@ -842,17 +842,11 @@ class ProcessMonitor(ScalyrMonitor):
 
         self.__process_discovery_interval = self._config.get('process_discovery_interval', default=120, convert_to=int)
 
-        __target_pids = self._config.get('pid', default=None, convert_to=str)
-        self.__target_pids = []
-
-        # convert target pid into a list. Target pids can be a single pid or a CSV of pids
-        if __target_pids == "$$":
-            # do not resolve $$ to current process id in case the current process forks and changes pid
-            self.__target_pids = "$$"
-        elif __target_pids:
-            for _t in __target_pids.split(','):
-                if _t:
-                    self.__target_pids.append(int(os.getpid()))
+        self.__target_pids = self._config.get('pid', default=None, convert_to=str)
+        if self.__target_pids:
+            self.__target_pids = self.__target_pids.split(",")
+        else:
+            self.__target_pids = []
 
         # Last 2 values of all metrics which has form:
         # {
@@ -1065,10 +1059,15 @@ class ProcessMonitor(ScalyrMonitor):
         else:
             # See if the specified target pid is running.  If so, then return it.
             # Special case '$$' to mean this process.
-            if self.__target_pids == '$$':
-                self.__pids = [os.getpid()]
-            else:
-                self.__pids = self.__target_pids
+            pids = []
+            if self.__target_pids:
+                for t_pid in self.__target_pids:
+                    if t_pid == "$$":
+                        t_pid = os.getpid()
+                    else:
+                        t_pid = int(t_pid)
+                    pids.append(t_pid)
+            self.__pids = pids
         return self.__pids
 
 


### PR DESCRIPTION
When the Linux process metrics monitor is turned on, the agent process is also monitored for process metrics. If this process forks, the current process dies and starts a child process. 

We were eagerly resolving the current process before the process actually forked, so the agent process being monitored was the parent process that died. The solution is to keep the magic value `$$` till we need the metrics so the child process can resolve to its PID. 

The errors were:
```
15:16:26.925 prodeu-log-6a /var/log/scalyr-agent-2/agent.log 2017-12-04 23:16:26.925Z ERROR [monitor:linux_process_metrics(agent)] [scalyr_logging.py:440] Exception while collecting metrics for PID: 11966 of type: <type 'instance'>. Details: TypeError("'NoneType' object is not iterable",) :stack_trace:
  Traceback (most recent call last):
    File "/usr/share/scalyr-agent-2/py/scalyr_agent/builtin_monitors/linux_process_metrics.py", line 699, in collect
      collector.update(gather.run_single_cycle(collector=collector))
  TypeError: 'NoneType' object is not iterable
15:16:26.925 prodeu-log-6a /var/log/scalyr-agent-2/agent.log 2017-12-04 23:16:26.925Z ERROR [monitor:linux_process_metrics(agent)] [scalyr_logging.py:440] Exception while collecting metrics for PID: 11966 of type: <type 'instance'>. Details: OSError(2, 'No such file or directory') :stack_trace:
  Traceback (most recent call last):
    File "/usr/share/scalyr-agent-2/py/scalyr_agent/builtin_monitors/linux_process_metrics.py", line 699, in collect
      collector.update(gather.run_single_cycle(collector=collector))
    File "/usr/share/scalyr-agent-2/py/scalyr_agent/builtin_monitors/linux_process_metrics.py", line 640, in run_single_cycle
      num_fds = len(os.listdir(self.__path))
  OSError: [Errno 2] No such file or directory: '/proc/11966/fd'
```
