### PR TITLE
parsing right lines of /proc/pid/status

### DIFF
--- a/scalyr_agent/builtin_monitors/linux_process_metrics.py
+++ b/scalyr_agent/builtin_monitors/linux_process_metrics.py
@@ -420,14 +420,15 @@ class StatusReader(BaseReader):
             # for now.
             # if field_name == "FDSize":
             #     self.print_sample("app.fd", int_value)
-
-            collector.update({
-                Metric('app.mem.bytes', 'vmsize'): int_value * 1024,
-                Metric('app.mem.bytes', 'peak_vmsize'): int_value * 1024,
-                Metric('app.mem.bytes', 'resident'): int_value * 1024,
-                Metric('app.mem.bytes', 'peak_resident'): int_value * 1024
-            })
-            return collector
+            if field_name == "VmSize":
+                collector.update({Metric('app.mem.bytes', 'vmsize'): int_value * 1024})
+            elif field_name == "VmPeak":
+                collector.update({Metric('app.mem.bytes', 'peak_vmsize'): int_value * 1024})
+            elif field_name == "VmRSS":
+                collector.update({Metric('app.mem.bytes', 'resident'): int_value * 1024})
+            elif field_name == "VmHWM":
+                collector.update({Metric('app.mem.bytes', 'peak_resident'): int_value * 1024})
+        return collector
 
 
 # Reads stats from /proc/$pid/io.


### PR DESCRIPTION
We were not parsing the right lines of the /proc/pid/status output. Tested agent release `2.0.33.pre34.1` with this change and the logs look better with around 20MB of resident memory usage. Thanks for catching the bug.

https://www.scalyr.com/events?filter=%22app.mem.bytes%22%20agent%20resident%20!peak_resident&teamToken=Sibg6CTKzry90OELNQjD3Q--&logSource=*ip-10-0-13-78*&originalStartTime=4%20hours&startTime=Dec%2011%2C%202017%207%3A19%3A18%20AM&source=autoRefresh&liveTail=true&endTime=Dec%2011%2C%202017%2011%3A19%3A18%20AM