### PR TITLE
k8s monitor

### DIFF
--- a/docker/Dockerfile.custom_k8s_config
+++ b/docker/Dockerfile.custom_k8s_config
@@ -1,4 +1,4 @@
-# Dockerfile for building an image of scalyr/scalyr-docker-agent with custom configuration
+# Dockerfile for building an image of scalyr/scalyr-k8s-agent with custom configuration
 # files for the Scalyr Agent.
 #
 # This Dockerfile expects a gzipped tarball called `agent_config.tar.gz` to be in the local
@@ -15,4 +15,4 @@ COPY agent_config.tar.gz /tmp/
 RUN tar --no-same-owner -C /etc/scalyr-agent-2 -zxf /tmp/agent_config.tar.gz && \
   rm /tmp/agent_config.tar.gz
 
-CMD ["/usr/sbin/scalyr-agent-å2", "--no-fork", "--no-change-user", "start"]
+CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]

--- a/docker/k8s-config/agent.d/docker.json
+++ b/docker/k8s-config/agent.d/docker.json
@@ -1,8 +1,7 @@
 {
   "monitors":[
     {
-      "module": "scalyr_agent.builtin_monitors.docker_monitor",
-      "docker_raw_logs": true
+      "module": "scalyr_agent.builtin_monitors.kubernetes_monitor"
     }
   ]
 }

--- a/scalyr_agent/builtin_monitors/docker_monitor.py
+++ b/scalyr_agent/builtin_monitors/docker_monitor.py
@@ -493,7 +493,7 @@ class ContainerChecker( StoppableThread ):
 
         # checkpoints are only used for querying from the API, so ignore
         # them if we are using raw logs
-        if !self._use_raw_logs:
+        if not self._use_raw_logs:
             for logger in self.docker_loggers:
                 last_request = logger.last_request()
                 self.__checkpoints[logger.stream_name] = last_request

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -19,6 +19,7 @@ __author__ = 'imron@imralsoftware.com'
 import datetime
 import docker
 import fnmatch
+import hashlib
 import traceback
 import logging
 import os
@@ -40,6 +41,7 @@ from scalyr_agent.log_watcher import LogWatcher
 from scalyr_agent.monitor_utils.server_processors import LineRequestParser
 from scalyr_agent.monitor_utils.server_processors import RequestSizeExceeded
 from scalyr_agent.monitor_utils.server_processors import RequestStream
+from scalyr_agent.monitor_utils.k8s import Kubernetes
 
 from scalyr_agent.util import StoppableThread
 
@@ -102,13 +104,6 @@ define_config_option( __monitor__, 'log_mode',
                      'preferred method due to bugs/issues found with the docker API.  It is not the default to protect '
                      'legacy behavior.\n',
                      convert_to=str, default="docker_api")
-
-define_config_option( __monitor__, 'docker_raw_logs',
-                     'Optional (defaults to False). If True, the docker monitor will use the raw log files on disk to read logs.'
-                     'The location of the raw log file is obtained by querying the path from the Docker API. '
-                     'If false, the logs will be streamed over the Docker API.'
-                     convert_to=bool,
-                     default=False)
 
 define_config_option( __monitor__, 'metrics_only',
                      'Optional (defaults to False). If true, the docker monitor will only log docker metrics and not any other information '
@@ -310,6 +305,37 @@ def _get_containers(client, ignore_container=None, restrict_to_container=None, l
 
     return result
 
+class PodInfo( object ):
+    """
+        A collection class that stores label and other information about a kubernetes pod
+    """
+    def __init__( self, name='', namespace='', uid='', nodeName='', labels={}, containers=[] ):
+
+        self.name = name
+        self.namespace = namespace
+        self.uid = uid
+        self.nodeName = nodeName
+        self.labels = labels
+        self.containers = containers
+
+        # generate a hash we can use to compare whether or not
+        # any of the pod info has changed
+        md5 = hashlib.md5()
+        md5.update( name )
+        md5.update( namespace )
+        md5.update( uid )
+        md5.update( nodeName )
+
+        # flatten the labels dict in to a single string
+        flattened = []
+        for k,v in labels.iteritems():
+            flattened.append( k )
+            flattened.append( v )
+        md5.update( ''.join( flattened ) )
+
+        self.digest = md5.digest()
+
+
 class ContainerChecker( StoppableThread ):
     """
         Monitors containers to check when they start and stop running.
@@ -319,8 +345,6 @@ class ContainerChecker( StoppableThread ):
 
         self._config = config
         self._logger = logger
-
-        self._use_raw_logs = config.get('docker_raw_logs')
 
         self.__delay = self._config.get( 'container_check_interval' )
         self.__log_prefix = self._config.get( 'docker_log_prefix' )
@@ -342,7 +366,8 @@ class ContainerChecker( StoppableThread ):
         self.__glob_list = config.get( 'container_globs' )
 
         self.containers = {}
-        self.__checkpoints = {}
+
+        self.__k8s = Kubernetes()
 
         self.__log_watcher = None
         self.__module = None
@@ -350,16 +375,15 @@ class ContainerChecker( StoppableThread ):
         self.__thread = StoppableThread( target=self.check_containers, name="Container Checker" )
 
     def start( self ):
-        self.__load_checkpoints()
-        self.containers = _get_containers(self.__client, ignore_container=self.container_id, glob_list=self.__glob_list, include_log_path=self._use_raw_logs)
+
+        self.containers = _get_containers(self.__client, ignore_container=self.container_id, glob_list=self.__glob_list, include_log_path=True)
 
         # if querying the docker api fails, set the container list to empty
         if self.containers == None:
             self.containers = {}
 
-
-        self.docker_logs = self.__get_docker_logs( self.containers )
-        self.docker_loggers = []
+        k8s_data = self._get_k8s_data()
+        self.docker_logs = self.__get_docker_logs( self.containers, k8s_data )
         self.raw_logs = []
 
         #create and start the DockerLoggers
@@ -371,32 +395,135 @@ class ContainerChecker( StoppableThread ):
         self.__thread.stop( wait_on_join=wait_on_join, join_timeout=join_timeout )
 
         #stop the DockerLoggers
-        if self._use_raw_logs:
-            for logger in self.raw_logs:
-                path = logger['log_config']['path']
-                if self.__log_watcher:
-                    self.__log_watcher.remove_log_path( self.__module, path )
-                self._logger.log(scalyr_logging.DEBUG_LEVEL_1, "Stopping %s" % (path) )
-        else:
-            for logger in self.docker_loggers:
-                if self.__log_watcher:
-                    self.__log_watcher.remove_log_path( self.__module, logger.log_path )
-                logger.stop( wait_on_join, join_timeout )
-                self._logger.log(scalyr_logging.DEBUG_LEVEL_1, "Stopping %s - %s" % (logger.name, logger.stream) )
 
-        self.__update_checkpoints()
+        for logger in self.raw_logs:
+            path = logger['log_config']['path']
+            if self.__log_watcher:
+                self.__log_watcher.remove_log_path( self.__module, path )
+            self._logger.log(scalyr_logging.DEBUG_LEVEL_1, "Stopping %s" % (path) )
 
-        self.docker_loggers = []
         self.raw_logs = []
 
+    def _process_namespaces( self, namespaces ):
+        """ Iterates over all namespaces on this node and then queries
+        every pod in every namespace.
+
+        @param namespaces: The JSON object returned as a response from querying
+            all namespaces from the k8s API
+
+        @return A dict of PodInfo objects, keyed on docker container ID
+        """
+        # get the list of namespaces
+        items = namespaces.get( 'items', [] )
+        containers = {}
+
+        # iterate over all namespaces, querying and processing all pods
+        # in the namespace
+        for namespace in items:
+            metadata = namespace.get( 'metadata', {} )
+            if 'name' in metadata:
+                pods = self.__k8s.query_pods( metadata['name'] )
+                self._process_pods( pods, containers )
+
+        return containers
+
+    def _process_pods( self, pods, containers ):
+        """ Iterates over every pod, storing PodInfo in the containers dict, hashed by
+            docker container id.
+
+            @param pods: The JSON object returned as a response from quering all pods
+                in a specific namespace
+
+            @param containers: A list of containers to add PodInfo to
+        """
+
+        # get all pods
+        items = pods.get( 'items', [] )
+
+        # iterate over all pods, getting PodInfo and storing it in the container
+        # dict, hashed by container ID
+        for pod in items:
+            info = self._process_pod( pod )
+
+            # The JSON object indicates that a Pod can have multiple
+            # containers, so make sure to key each container with this
+            # PodInfo
+            for container in info.containers:
+                containers[container] = info
+
+    def _process_pod( self, pod ):
+        """ Generate a PodInfo object from a JSON object
+        @param pod: The JSON object returned as a response to querying
+            a specific pod from the k8s API
+
+        @return A PodInfo object
+        """
+
+        result = {}
+
+        metadata = pod.get( 'metadata', {} )
+        spec = pod.get( 'spec', {} )
+        labels = metadata.get( 'labels', {} )
+
+        status = pod.get( 'status', {} )
+        containerStatuses = status.get( 'containerStatuses', [] )
+
+        containers = []
+
+        # build list of container ids used by this pod, making sure to
+        # strip docker:// from the front of each one
+        prefix = 'docker://'
+        for container in containerStatuses:
+            if 'containerID' not in container:
+                continue
+
+            containerID = container['containerID']
+
+            if containerID.startswith( prefix ):
+                containerID = containerID[len(prefix):]
+            containers.append( containerID)
+
+        # create the PodInfo
+        result = PodInfo( name=metadata.get( "name", '' ),
+                          namespace=metadata.get( "namespace", '' ),
+                          uid=metadata.get( "uid", '' ),
+                          nodeName=spec.get( "nodeName", '' ),
+                          labels=labels,
+                          containers=containers )
+        return result
+
+    def _get_k8s_data( self ):
+        """ Convenience wrapper to query and process all namespaces
+            and pods retreived by the k8s API for the current node
+            and return them in a dict of PodInfo objects keyed by
+            the container id that runs the pod.
+        """
+        result = {}
+        try:
+            namespaces = self.__k8s.query_namespaces()
+            result = self._process_namespaces( namespaces )
+        except Exception, e:
+            global_log.warn( "Failed to get k8s data: %s\n%s" % (str(e), traceback.format_exc() ),
+                         limit_once_per_x_secs=600, limit_key='get_k8s_data' )
+        return result
+
     def check_containers( self, run_state ):
+        """Update thread for monitoring docker containers and the k8s info such as labels
+        """
+
+        # store the digests from the previous iteration of the main loop to see
+        # if any pod information has changed
+        prev_digests = {}
+        base_attributes = self.__get_base_attributes()
 
         while run_state.is_running():
             try:
-                self.__update_checkpoints()
+
+                self._logger.log(scalyr_logging.DEBUG_LEVEL_2, 'Attempting to retrieve k8s data' )
+                k8s_data = self._get_k8s_data()
 
                 self._logger.log(scalyr_logging.DEBUG_LEVEL_2, 'Attempting to retrieve list of containers:' )
-                running_containers = _get_containers(self.__client, ignore_container=self.container_id, glob_list=self.__glob_list, include_log_path=self._use_raw_logs)
+                running_containers = _get_containers(self.__client, ignore_container=self.container_id, glob_list=self.__glob_list, include_log_path=True)
 
                 # if running_containers is None, that means querying the docker api failed.
                 # rather than resetting the list of running containers to empty
@@ -408,11 +535,27 @@ class ContainerChecker( StoppableThread ):
                 self._logger.log(scalyr_logging.DEBUG_LEVEL_2, 'Found %d containers' % len(running_containers))
                 #get the containers that have started since the last sample
                 starting = {}
+                changed = {}
+                digests = {}
 
                 for cid, info in running_containers.iteritems():
+                    pod = None
+                    if cid in k8s_data:
+                        pod = k8s_data[cid]
+
+                    # start the container if have a container that wasn't running
                     if cid not in self.containers:
                         self._logger.log(scalyr_logging.DEBUG_LEVEL_1, "Starting loggers for container '%s'" % info['name'] )
                         starting[cid] = info
+                    elif cid in prev_digests:
+                        # container was running and it exists in the previous digest dict, so see if
+                        # it has changed
+                        if prev_digests[cid] != pod.digest:
+                            changed[cid] = info
+
+                    # store the digest from this iteration of the loop
+                    if pod:
+                        digests[cid] = pod.digest
 
                 #get the containers that have stopped
                 stopping = {}
@@ -430,7 +573,17 @@ class ContainerChecker( StoppableThread ):
                 self.containers = running_containers
 
                 #start the new ones
-                self.__start_loggers( starting )
+                self.__start_loggers( starting, k8s_data )
+
+                prev_digests = digests
+
+                # update the log config for any changed containers
+                if self.__log_watcher:
+                    for logger in self.raw_logs:
+                        if logger['cid'] in changed:
+                            info = changed[logger['cid']]
+                            new_config = self.__get_log_config_for_container( logger['cid'], info, k8s_data, base_attributes )
+                            self.__log_watcher.update_log_config( self.__module, new_config )
 
             except Exception, e:
                 self._logger.warn( "Exception occurred when checking containers %s\n%s" % (str( e ), traceback.format_exc()) )
@@ -486,34 +639,6 @@ class ContainerChecker( StoppableThread ):
 
         return result
 
-    def __update_checkpoints( self ):
-        """Update the checkpoints for when each docker logger logged a request, and save the checkpoints
-        to file.
-        """
-
-        # checkpoints are only used for querying from the API, so ignore
-        # them if we are using raw logs
-        if !self._use_raw_logs:
-            for logger in self.docker_loggers:
-                last_request = logger.last_request()
-                self.__checkpoints[logger.stream_name] = last_request
-
-            # save to disk
-            if self.__checkpoints:
-                tmp_file = self.__checkpoint_file + '~'
-                scalyr_util.atomic_write_dict_as_json_file( self.__checkpoint_file, tmp_file, self.__checkpoints )
-
-    def __load_checkpoints( self ):
-        try:
-            checkpoints = scalyr_util.read_file_as_json( self.__checkpoint_file )
-        except:
-            self._logger.info( "No checkpoint file '%s' exists.\n\tAll logs will be read starting from their current end.", self.__checkpoint_file )
-            checkpoints = {}
-
-        if checkpoints:
-            for name, last_request in checkpoints.iteritems():
-                self.__checkpoints[name] = last_request
-
     def __stop_loggers( self, stopping ):
         """
         Stops any DockerLoggers in the 'stopping' dict
@@ -523,33 +648,24 @@ class ContainerChecker( StoppableThread ):
         if stopping:
             self._logger.log(scalyr_logging.DEBUG_LEVEL_2, 'Stopping all docker loggers')
 
-            if self._use_raw_logs:
-                for logger in self.raw_logs:
-                    if logger['cid'] in stopping:
-                        path = logger['log_config']['path']
-                        if self.__log_watcher:
-                            self.__log_watcher.remove_log_path( self.__module, path )
 
-                self.raw_logs[:] = [l for l in self.raw_logs if l['cid'] not in stopping]
-            else:
-                for logger in self.docker_loggers:
-                    if logger.cid in stopping:
-                        logger.stop( wait_on_join=True, join_timeout=1 )
-                        if self.__log_watcher:
-                            self.__log_watcher.remove_log_path( self.__module, logger.log_path )
+            for logger in self.raw_logs:
+                if logger['cid'] in stopping:
+                    path = logger['log_config']['path']
+                    if self.__log_watcher:
+                        self.__log_watcher.remove_log_path( self.__module, path )
 
-                self.docker_loggers[:] = [l for l in self.docker_loggers if l.cid not in stopping]
-
+            self.raw_logs[:] = [l for l in self.raw_logs if l['cid'] not in stopping]
             self.docker_logs[:] = [l for l in self.docker_logs if l['cid'] not in stopping]
 
-    def __start_loggers( self, starting ):
+    def __start_loggers( self, starting, k8s_data ):
         """
         Starts a list of DockerLoggers
         @param: starting - a list of DockerLoggers to start
         """
         if starting:
             self._logger.log(scalyr_logging.DEBUG_LEVEL_2, 'Starting all docker loggers')
-            docker_logs = self.__get_docker_logs( starting )
+            docker_logs = self.__get_docker_logs( starting, k8s_data )
             self.__start_docker_logs( docker_logs )
             self.docker_logs.extend( docker_logs )
 
@@ -558,11 +674,7 @@ class ContainerChecker( StoppableThread ):
             if self.__log_watcher:
                 log['log_config'] = self.__log_watcher.add_log_config( self.__module, log['log_config'] )
 
-            if self._use_raw_logs:
-                self.raw_logs.append( log )
-            else:
-                last_request = self.__get_last_request_for_log( log['log_config']['path'] )
-                self.docker_loggers.append( self.__create_docker_logger( log, last_request ) )
+            self.raw_logs.append( log )
 
     def __get_last_request_for_log( self, path ):
         result = datetime.datetime.fromtimestamp( self.__start_time )
@@ -605,205 +717,66 @@ class ContainerChecker( StoppableThread ):
                  'attributes': attributes
                }
 
-    def __get_docker_logs( self, containers ):
+    def __get_base_attributes( self ):
+        attributes = None
+        try:
+            attributes = JsonObject( { "monitor": "agentKubernetes" } )
+            if self.__host_hostname:
+                attributes['serverHost'] = self.__host_hostname
+
+        except Exception, e:
+            self._logger.error( "Error setting monitor attribute in KubernetesMonitor" )
+            raise
+
+        return attributes
+
+    def __get_log_config_for_container( self, cid, info, k8s_data, base_attributes ):
+        result = None
+
+        container_attributes = base_attributes.copy()
+        container_attributes['containerName'] = info['name']
+        container_attributes['containerId'] = cid
+
+        parser = 'docker'
+        if cid in k8s_data:
+            pod = k8s_data[cid]
+
+            container_attributes['podName'] = pod.name
+            container_attributes['namespace'] = pod.namespace
+            container_attributes['podUid'] = pod.uid
+            container_attributes['nodeName'] = pod.nodeName
+            for label, value in pod.labels.iteritems():
+                container_attributes[label] = value
+
+            if 'parser' in pod.labels:
+                parser = pod.labels['parser']
+
+        if 'log_path' in info and info['log_path']:
+            result = self.__create_log_config( parser=parser, path=info['log_path'], attributes=container_attributes, parse_as_json=True )
+            result['rename_logfile'] = '/docker/%s.log' % info['name']
+
+        return result
+
+
+    def __get_docker_logs( self, containers, k8s_data ):
         """Returns a list of dicts containing the container id, stream, and a log_config
         for each container in the 'containers' param.
         """
 
         result = []
 
-        attributes = None
-        try:
-            attributes = JsonObject( { "monitor": "agentDocker" } )
-            if self.__host_hostname:
-                attributes['serverHost'] = self.__host_hostname
-
-        except Exception, e:
-            self._logger.error( "Error setting monitor attribute in DockerMonitor" )
-            raise
+        attributes = self.__get_base_attributes()
 
         prefix = self.__log_prefix + '-'
 
         for cid, info in containers.iteritems():
-            container_attributes = attributes.copy()
-            container_attributes['containerName'] = info['name']
-            container_attributes['containerId'] = cid
-
-            if self._use_raw_logs and 'log_path' in info and info['log_path']:
-                log_config = self.__create_log_config( parser='docker', path=info['log_path'], attributes=container_attributes, parse_as_json=True )
-                log_config['rename_logfile'] = '/docker/%s.log' % info['name']
+            log_config = self.__get_log_config_for_container( cid, info, k8s_data, attributes )
+            if log_config:
                 result.append( { 'cid': cid, 'stream': 'raw', 'log_config': log_config } )
-            else:
-                path =  prefix + info['name'] + '-stdout.log'
-                log_config = self.__create_log_config( parser='dockerStdout', path=path, attributes=container_attributes )
-                result.append( { 'cid': cid, 'stream': 'stdout', 'log_config': log_config } )
-
-                path = prefix + info['name'] + '-stderr.log'
-                log_config = self.__create_log_config( parser='dockerStderr', path=path, attributes=container_attributes.copy() )
-                result.append( { 'cid': cid, 'stream': 'stderr', 'log_config': log_config } )
 
         return result
 
-    def __create_docker_logger( self, log, last_request ):
-        """Creates a new DockerLogger object, based on the parameters passed in in the 'log' param.
 
-        @param: log - a dict consisting of:
-                        cid - the container id
-                        stream - whether this is the stdout or stderr stream
-                        log_config - the log config used by the scalyr-agent for this log file
-        """
-        cid = log['cid']
-        name = self.containers[cid]['name']
-        stream = log['stream']
-        stream_name = name + '-' + stream
-        if stream_name in self.__checkpoints:
-            checkpoint = self.__checkpoints[stream_name]
-            if last_request < checkpoint:
-                last_request = checkpoint
-
-        logger = DockerLogger( self.__socket_file, cid, name, stream, log['log_config']['path'], self._config, last_request )
-        logger.start()
-        return logger
-
-
-
-class DockerLogger( object ):
-    """Abstraction for logging either stdout or stderr from a given container
-
-    Logging is performed on a separate thread because each log is read from a continuous stream
-    over the docker socket.
-    """
-    def __init__( self, socket_file, cid, name, stream, log_path, config, last_request=None, max_log_size=20*1024*1024, max_log_rotations=2 ):
-        self.__socket_file = socket_file
-        self.cid = cid
-        self.name = name
-
-        #stderr or stdout
-        self.stream = stream
-        self.log_path = log_path
-        self.stream_name = name + "-" + stream
-
-        self.__max_previous_lines = config.get( 'max_previous_lines' )
-        self.__log_timestamps = True # Note: always log timestamps for now.  config.get( 'log_timestamps' )
-        self.__docker_api_version = config.get( 'docker_api_version' )
-
-        self.__last_request_lock = threading.Lock()
-
-        self.__last_request = time.time()
-        if last_request:
-            self.__last_request = last_request
-
-        self.__logger = logging.Logger( cid + '.' + stream )
-
-        self.__log_handler = logging.handlers.RotatingFileHandler( filename = log_path, maxBytes = max_log_size, backupCount = max_log_rotations )
-        formatter = logging.Formatter()
-        self.__log_handler.setFormatter( formatter )
-        self.__logger.addHandler( self.__log_handler )
-        self.__logger.setLevel( logging.INFO )
-
-        self.__client = None
-        self.__logs = None
-
-        self.__thread = StoppableThread( target=self.process_request, name="Docker monitor logging thread for %s" % (name + '.' + stream) )
-
-    def start( self ):
-        self.__thread.start()
-
-    def stop( self, wait_on_join=True, join_timeout=5 ):
-        if self.__client and self.__logs and self.__logs.response:
-            sock = self.__client._get_raw_response_socket( self.__logs.response )
-            if sock:
-                sock.shutdown( socket.SHUT_RDWR )
-        self.__thread.stop( wait_on_join=wait_on_join, join_timeout=join_timeout )
-
-    def last_request( self ):
-        self.__last_request_lock.acquire()
-        result = self.__last_request
-        self.__last_request_lock.release()
-        return result
-
-    def process_request( self, run_state ):
-        """This function makes a log request on the docker socket for a given container and continues
-        to read from the socket until the connection is closed
-        """
-        try:
-            # random delay to prevent all requests from starting at the same time
-            delay = random.randint( 500, 5000 ) / 1000
-            run_state.sleep_but_awaken_if_stopped( delay )
-
-            self.__logger.log(scalyr_logging.DEBUG_LEVEL_3, 'Starting to retrieve logs for cid=%s' % str(self.cid))
-            self.__client = DockerClient( base_url=('unix:/%s' % self.__socket_file ), version=self.__docker_api_version )
-
-            epoch = datetime.datetime.utcfromtimestamp( 0 )
-            while run_state.is_running():
-                self.__logger.log(scalyr_logging.DEBUG_LEVEL_3, 'Attempting to retrieve logs for cid=%s' % str(self.cid))
-                sout=False
-                serr=False
-                if self.stream == 'stdout':
-                    sout = True
-                else:
-                    serr = True
-
-                self.__logs = self.__client.logs(
-                    container=self.cid,
-                    stdout=sout,
-                    stderr=serr,
-                    stream=True,
-                    timestamps=True,
-                    tail=self.__max_previous_lines,
-                    follow=True
-                )
-
-                # self.__logs is a generator so don't call len( self.__logs )
-                self.__logger.log(scalyr_logging.DEBUG_LEVEL_3, 'Found log lines for cid=%s' % (str(self.cid)))
-                try:
-                    for line in self.__logs:
-                        #split the docker timestamp from the frest of the line
-                        dt, log_line = _split_datetime_from_line( line )
-                        if not dt:
-                            global_log.error( 'No timestamp found on line: \'%s\'', line )
-                        else:
-                            timestamp = scalyr_util.seconds_since_epoch( dt, epoch )
-
-                            #see if we log the entire line including timestamps
-                            if self.__log_timestamps:
-                                log_line = line
-
-                            #check to make sure timestamp is >= to the last request
-                            #Note: we can safely read last_request here because we are the only writer
-                            if timestamp >= self.__last_request:
-                                self.__logger.info( log_line.strip() )
-
-                                #but we need to lock for writing
-                                self.__last_request_lock.acquire()
-                                self.__last_request = timestamp
-                                self.__last_request_lock.release()
-
-                        if not run_state.is_running():
-                            self.__logger.log(scalyr_logging.DEBUG_LEVEL_3, 'Exiting out of container log for cid=%s' % str(self.cid))
-                            break
-                except ProtocolError, e:
-                    if run_state.is_running():
-                        global_log.warning( "Stream closed due to protocol error: %s" % str( e ) )
-
-                if run_state.is_running():
-                    global_log.warning( "Log stream has been closed for '%s'.  Check docker.log on the host for possible errors.  Attempting to reconnect, some logs may be lost" % (self.name), limit_once_per_x_secs=300, limit_key='stream-closed-%s'%self.name )
-                    delay = random.randint( 500, 3000 ) / 1000
-                    run_state.sleep_but_awaken_if_stopped( delay )
-
-
-            # we are shutting down, so update our last request to be slightly later than it's current
-            # value to prevent duplicate logs when starting up again.
-            self.__last_request_lock.acquire()
-
-            #can't be any smaller than 0.01 because the time value is only saved to 2 decimal places
-            #on disk
-            self.__last_request += 0.01
-
-            self.__last_request_lock.release()
-
-        except Exception, e:
-            global_log.warn('Unhandled exception in DockerLogger.process_request for %s:\n\t%s' % (self.name, str( e )))
 
 
 class ContainerIdResolver():
@@ -1020,15 +993,12 @@ class ContainerIdResolver():
             self.__last_access_time = access_time
 
 
-class DockerMonitor( ScalyrMonitor ):
-    """Monitor plugin for docker containers
+class KubernetesMonitor( ScalyrMonitor ):
+    """Monitor plugin for kubernetes
 
-    This plugin uses the Docker API to detect all containers running on the local host, retrieves metrics for each of
-    them, and logs them to the Scalyr servers.
-
-    It can also collect all log messages written to stdout and stderr by those containers, in conjunction with syslog.
-    See the online documentation for more details.
-
+    This plugin is based of the docker_monitor plugin, and uses the raw logs mode of the docker
+    plugin to send kubernetes logs to Scalyr.  It also reads labels from the Kubernetes api and
+    associates them with the appropriate logs.
     TODO:  Back fill the instructions here.
     """
 

--- a/scalyr_agent/copying_manager.py
+++ b/scalyr_agent/copying_manager.py
@@ -277,17 +277,17 @@ class CopyingManager(StoppableThread, LogWatcher):
 
         return log_config
 
-    def update_log_config( self, monitor, log_config ):
+    def update_log_config( self, monitor_name, log_config ):
         """ Updates the log config of the log matcher that has the same
         path as the one specified in the log_config param
         """
-        log_config = self.__config.parse_log_config( log_config, default_parser='agent-metrics', context_description='Updating log entry requested by module "%s"' % monitor.module_name).copy()
+        log_config = self.__config.parse_log_config( log_config, default_parser='agent-metrics', context_description='Updating log entry requested by module "%s"' % monitor_name).copy()
         try:
             self.__lock.acquire()
 
             log_path = log_config['path']
             if log_path in self.__all_paths:
-                log.log(scalyr_logging.DEBUG_LEVEL_0, 'Updating config for log file \'%s\' for monitor \'%s\'' % (log_path, monitor.module_name ) )
+                log.log(scalyr_logging.DEBUG_LEVEL_0, 'Updating config for log file \'%s\' for monitor \'%s\'' % (log_path, monitor_name ) )
                 # update by removing the old entry and adding a new one
                 self.__log_matchers[:] = [m for m in self.__log_matchers if m.log_path != log_path]
                 matcher = LogMatcher( self.__config, log_config )

--- a/scalyr_agent/copying_manager.py
+++ b/scalyr_agent/copying_manager.py
@@ -277,6 +277,27 @@ class CopyingManager(StoppableThread, LogWatcher):
 
         return log_config
 
+    def update_log_config( self, monitor, log_config ):
+        """ Updates the log config of the log matcher that has the same
+        path as the one specified in the log_config param
+        """
+        log_config = self.__config.parse_log_config( log_config, default_parser='agent-metrics', context_description='Updating log entry requested by module "%s"' % monitor.module_name).copy()
+        try:
+            self.__lock.acquire()
+
+            log_path = log_config['path']
+            if log_path in self.__all_paths:
+                log.log(scalyr_logging.DEBUG_LEVEL_0, 'Updating config for log file \'%s\' for monitor \'%s\'' % (log_path, monitor.module_name ) )
+                # update by removing the old entry and adding a new one
+                self.__log_matchers[:] = [m for m in self.__log_matchers if m.log_path != log_path]
+                matcher = LogMatcher( self.__config, log_config )
+                self.__log_matchers.append(matcher)
+            else:
+                log.warn( "Trying to update log config for nonexistent log: %s" % log_path, 
+                           limit_once_per_x_secs=600, limit_key='update-log-config-%s' % log_path )
+        finally:
+            self.__lock.release()
+
     def remove_log_path( self, monitor, log_path ):
         """Remove the log_path from the list of paths being watched
         params: log_path - a string containing the path to the file no longer being watched

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -521,7 +521,7 @@ class LogFileIterator(object):
 
             except Exception, e:
                 # something went wrong. Return the full line and log a message
-                log.warn("Error parsing line as json.  Logging full line: %s\n%s" % (str(e), result.line),
+                log.warn("Error parsing line as json for %s.  Logging full line: %s\n%s" % (self.__path, str(e), result.line),
                          limit_once_per_x_secs=300, limit_key=('bad-json-%s' % self.__path))
         return result
 

--- a/scalyr_agent/monitor_utils/__init__.py
+++ b/scalyr_agent/monitor_utils/__init__.py
@@ -34,6 +34,6 @@ from scalyr_agent.monitor_utils.server_processors import ServerProcessor
 from scalyr_agent.monitor_utils.server_processors import LineRequestParser
 from scalyr_agent.monitor_utils.server_processors import Int32RequestParser
 from scalyr_agent.monitor_utils.auto_flushing_rotating_file import AutoFlushingRotatingFile
-from scalyr_agent.monitor_utils.k8s import Kubernetes
+from scalyr_agent.monitor_utils.k8s import KubernetesApi
 
-__all__ = ['ServerProcessor', 'LineRequestParser', 'Int32RequestParser', 'AutoFlushingRotatingFile', 'Kubernetes' ]
+__all__ = ['ServerProcessor', 'LineRequestParser', 'Int32RequestParser', 'AutoFlushingRotatingFile', 'KubernetesApi' ]

--- a/scalyr_agent/monitor_utils/__init__.py
+++ b/scalyr_agent/monitor_utils/__init__.py
@@ -34,5 +34,6 @@ from scalyr_agent.monitor_utils.server_processors import ServerProcessor
 from scalyr_agent.monitor_utils.server_processors import LineRequestParser
 from scalyr_agent.monitor_utils.server_processors import Int32RequestParser
 from scalyr_agent.monitor_utils.auto_flushing_rotating_file import AutoFlushingRotatingFile
+from scalyr_agent.monitor_utils.k8s import Kubernetes
 
-__all__ = ['ServerProcessor', 'LineRequestParser', 'Int32RequestParser', 'AutoFlushingRotatingFile' ]
+__all__ = ['ServerProcessor', 'LineRequestParser', 'Int32RequestParser', 'AutoFlushingRotatingFile', 'Kubernetes' ]

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -1,0 +1,77 @@
+
+import scalyr_agent.third_party.requests as requests
+import scalyr_agent.json_lib as json_lib
+from scalyr_agent.json_lib import JsonObject
+from scalyr_agent.json_lib import JsonConversionException, JsonMissingFieldException
+
+class Kubernetes( object ):
+    """Simple wrapper class for querying the k8s api
+    """
+
+    def __init__( self, ca_file='/run/secrets/kubernetes.io/serviceaccount/ca.crt' ):
+        """Init the kubernetes object
+        """
+
+        # fixed well known location for authentication token required to
+        # query the API
+        token_file="/var/run/secrets/kubernetes.io/serviceaccount/token"
+        self._http_host="https://kubernetes.default"
+        self._timeout = 10.0
+
+        self._session = None
+
+        self._ca_file = ca_file
+
+        # We create a few headers ahead of time so that we don't have to recreate them each time we need them.
+        self._standard_headers = {
+            'Connection': 'Keep-Alive',
+            'Accept': 'application/json',
+        }
+
+        token = ''
+
+        try:
+            # using with is ok here, because we need to be running
+            # a recent version of python for various 3rd party libs
+            with open( token_file, 'r' ) as f:
+                token = f.read()
+        except IOError, e:
+            pass
+
+        self._standard_headers["Authorization"] = "Bearer %s" % (token)
+
+    def _verify_connection( self ):
+        """ Return whether or not to use SSL verification
+        """
+        if self._ca_file:
+            return self._ca_file
+        return False
+
+    def _ensure_session( self ):
+        """Create the session if it doesn't exist, otherwise do nothing
+        """
+        if not self._session:
+            self._session = requests.Session()
+            self._session.headers.update( self._standard_headers )
+
+    def query_api( self, path, pretty=0 ):
+        """ Queries the k8s API at 'path', and converts OK responses to JSON objects
+        """
+        self._ensure_session()
+        url = self._http_host + path + '?pretty=%d' % (pretty)
+        response = self._session.get( url, verify=self._verify_connection(), timeout=self._timeout )
+        if response.status_code != 200:
+            raise Exception( "Invalid response from Kubernetes API when querying '%s': %s" %( path, str( response ) ) )
+        return json_lib.parse( response.text )
+
+    def query_pod( self, namespace, pod ):
+        """Wrapper to query a pod in a namespace"""
+        return self.query_api( '/api/v1/namespaces/%s/pods/%s' % (namespace, pod) )
+
+    def query_pods( self, namespace ):
+        """Wrapper to query all pods in a namespace"""
+        return self.query_api( '/api/v1/namespaces/%s/pods' % (namespace) )
+
+    def query_namespaces( self ):
+        """Wrapper to query all namespaces"""
+        return self.query_api( '/api/v1/namespaces' )


### PR DESCRIPTION
The kubernetes monitor is currently based entirely off the
docker monitor, with support added for querying the k8s API
to retrieve information about the pods currently running.

Eventually common functionality between the docker and k8s
monitors needs to be factored out.