### PR TITLE
Fixed an issue encountered when initializing the journald monitor

### DIFF
--- a/scalyr_agent/builtin_monitors/journald_monitor.py
+++ b/scalyr_agent/builtin_monitors/journald_monitor.py
@@ -199,7 +199,7 @@ class JournaldMonitor(ScalyrMonitor):
     def _initialize(self):
         self._journal_path = self._config.get( 'journal_path' )
         if not os.path.exists( self._journal_path ):
-            raise BadMonitorConfiguration( "journal_path '%s' does not exist or is not a directory" % self._journal_path )
+            raise BadMonitorConfiguration( "journal_path '%s' does not exist or is not a directory" % self._journal_path, 'journal_path' )
 
         self._id = self._config.get( 'id' )
         self._checkpoint_name = self.module_name


### PR DESCRIPTION
When initialising the `journald` monitor with a missing `journal_path`, the exception initialisation is erroneous, thus leading to an unreadable error message.

Given an erroneous configuration, such as:

      {
         "module": "scalyr_agent.builtin_monitors.journald_monitor",
         "id":     "journald",
         "journal_path": "/this_file_does_not_exist"
      }


The follow error will appear:

    Error reading configuration file: __init__() takes exactly 3 arguments (2 given)
    Terminating agent, please fix the configuration file and restart agent.

This is due to a missing argument in `journald_monitor.py` where I suspect `journal_path` argument is missing. With it, you finally get the proper error which is:

    journal_path '/var/log/journal' does not exist or is not a directory
    Error reading configuration file: journal_path '/var/log/journal' does not exist or is not a directory
    Terminating agent, please fix the configuration file and restart agent.
