### PR TITLE
Imron/garbage monitor

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -34,6 +34,7 @@
 __author__ = 'czerwin@scalyr.com'
 
 import errno
+import gc
 import os
 import sys
 import time
@@ -733,6 +734,9 @@ class ScalyrAgent(object):
 
                 config_change_check_interval = self.__config.config_change_check_interval
 
+                gc_interval = self.__config.garbage_collect_interval
+                next_gc_time = current_time + gc_interval
+
                 while not self.__run_state.sleep_but_awaken_if_stopped( config_change_check_interval ):
 
                     current_time = time.time()
@@ -790,6 +794,12 @@ class ScalyrAgent(object):
                             # Update the debug_level based on the new config.. we always update it.
                             self.__update_debug_log_level(new_config.debug_level)
 
+                        # see if we need to perform a garbage collection
+                        if gc_interval > 0 and current_time > next_gc_time:
+                            log.log(scalyr_logging.DEBUG_LEVEL_1, 'Performing garbage collection')
+                            gc.collect()
+                            next_gc_time = current_time + gc_interval
+
                         if _check_disabled( current_time, disable_config_equivalence_check_until, "config equivalence check" ):
                             continue
 
@@ -840,6 +850,12 @@ class ScalyrAgent(object):
 
                     self.__current_bad_config = None
                     config_change_check_interval = self.__config.config_change_check_interval
+                    old_gc_interval = gc_interval
+                    gc_interval = self.__config.garbage_collect_interval
+                    # if we have a different gc interval, base the next collection time on the
+                    # new interval rather than the old interval
+                    if old_gc_interval != gc_interval:
+                        next_gc_time += gc_interval - old_gc_interval
 
                     disable_all_config_updates_until = _update_disabled_until( self.__config.disable_all_config_updates, current_time )
                     disable_verify_config_until = _update_disabled_until( self.__config.disable_verify_config, current_time )

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -735,7 +735,7 @@ class ScalyrAgent(object):
                 config_change_check_interval = self.__config.config_change_check_interval
 
                 gc_interval = self.__config.garbage_collect_interval
-                next_gc_time = current_time + gc_interval
+                last_gc_time = current_time
 
                 while not self.__run_state.sleep_but_awaken_if_stopped( config_change_check_interval ):
 
@@ -795,10 +795,9 @@ class ScalyrAgent(object):
                             self.__update_debug_log_level(new_config.debug_level)
 
                         # see if we need to perform a garbage collection
-                        if gc_interval > 0 and current_time > next_gc_time:
-                            log.log(scalyr_logging.DEBUG_LEVEL_1, 'Performing garbage collection')
+                        if gc_interval > 0 and current_time > (last_gc_time + gc_interval):
                             gc.collect()
-                            next_gc_time = current_time + gc_interval
+                            last_gc_time = current_time
 
                         if _check_disabled( current_time, disable_config_equivalence_check_until, "config equivalence check" ):
                             continue
@@ -850,12 +849,7 @@ class ScalyrAgent(object):
 
                     self.__current_bad_config = None
                     config_change_check_interval = self.__config.config_change_check_interval
-                    old_gc_interval = gc_interval
                     gc_interval = self.__config.garbage_collect_interval
-                    # if we have a different gc interval, base the next collection time on the
-                    # new interval rather than the old interval
-                    if old_gc_interval != gc_interval:
-                        next_gc_time += gc_interval - old_gc_interval
 
                     disable_all_config_updates_until = _update_disabled_until( self.__config.disable_all_config_updates, current_time )
                     disable_verify_config_until = _update_disabled_until( self.__config.disable_verify_config, current_time )

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -307,6 +307,10 @@ class Configuration(object):
         return self.__get_config().get_float('config_change_check_interval')
 
     @property
+    def garbage_collect_interval(self):
+        return self.__get_config().get_int('garbage_collect_interval')
+
+    @property
     def disable_verify_config_create_monitors_manager(self):
         return self.__get_config().get_int('disable_leak_verify_config_create_monitors_manager', none_if_missing=True)
 
@@ -949,6 +953,7 @@ class Configuration(object):
         self.__verify_or_set_optional_int(config, 'disable_leak_config_reload', None, description, apply_defaults)
 
         self.__verify_or_set_optional_float(config, 'config_change_check_interval', 30, description, apply_defaults)
+        self.__verify_or_set_optional_int(config, 'garbage_collect_interval', 300, description, apply_defaults)
 
         self.__verify_or_set_optional_int(config, 'disable_leak_verify_config_create_monitors_manager', None, description, apply_defaults)
         self.__verify_or_set_optional_int(config, 'disable_leak_verify_config_create_copying_manager', None, description, apply_defaults)


### PR DESCRIPTION
Calling `gc.collect()` in the main agent loop based on a new config option: `garbage_collection_interval`.

This defaults to 300 seconds (5 minutes).  Set it to <= `config_change_check_interval` to collect garbage every iteration of the main loop.  Set it to <= 0 to disable collection.

The collecter will run exactly every `garbage_collect_interval` seconds.  Rather it runs on the next iteration of the main loop after the `garbage_collect_interval` has expired.

For example, if the `config_change_check_interval` is set to 10 and the `garbage_collect_interval` is set to 15, then it will take at least 20 seconds before garbage collection is performed - the first iteration occurs at t+10 and `garbage_collect_interval` hasn't expired, then the garbage collect interval expires at t+15 but the main loop is still blocked.  When the main loop wakes at t+20 it notices that the garbage collect interval has expired and so performs the collection.  The next collection will occur at t+30.

Also, the `garbage_monitor` has a new flag `disable_garbage_collection_before_dump` that disables garbage collection before doing a dump of garbage objects.