### PR TITLE
K8s monitor - Add option to filter containers by namespace name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ xunit.xml
 # Sphinx documentation
 docs/_build/
 
+docker/root


### PR DESCRIPTION
Added new option `namespace_globs` to Kubernetes monitor. It will allow users to stream logs only from containers running in matching namespaces. In case where Kubernetes cluster runs multiple workloads and only subset of them should be integrated with Scalyr.

Let me know if there is something to improve in this patch.