### PR TITLE
Imron/k8s annotations

### DIFF
--- a/scalyr_agent/all_tests.py
+++ b/scalyr_agent/all_tests.py
@@ -22,6 +22,7 @@ __author__ = 'czerwin@scalyr.com'
 import unittest
 import os
 import sys
+import traceback
 
 
 def find_all_tests(directory=None, base_path=None):
@@ -57,11 +58,19 @@ def run_all_tests():
     """
     test_loader = unittest.defaultTestLoader
     suites = []
+    error = False
     for test_case in find_all_tests():
-        suites.append(test_loader.loadTestsFromName(test_case))
+        try:
+            suites.append(test_loader.loadTestsFromName(test_case))
+        except Exception, e:
+            error = True
+            print( "Error loading test_case '%s'.  %s, %s" % (test_case, str(e), traceback.format_exc()) )
+
     test_suite = unittest.TestSuite(suites)
     text_runner = unittest.TextTestRunner().run(test_suite)
-    sys.exit(not text_runner.wasSuccessful())
+    if not text_runner.wasSuccessful():
+        error = True
+    sys.exit(error)
 
 if __name__ == '__main__':
     run_all_tests()

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -31,7 +31,6 @@ from scalyr_agent.util import JsonReadFileException
 
 from __scalyr__ import get_install_root
 
-
 class Configuration(object):
     """Encapsulates the results of a single read of the configuration file.
 
@@ -1026,6 +1025,14 @@ class Configuration(object):
         self.__verify_or_set_optional_attributes(log_entry, 'attributes', description)
 
         self.__verify_or_set_optional_array( log_entry, 'lineGroupers', description )
+        i = 0
+        for element in log_entry.get_json_array('lineGroupers'):
+            element_description = 'the entry with index=%i in the "lineGroupers" array in ' % i
+            element_description += description
+
+            self.__verify_required_string(element, 'start', element_description)
+            self.__verify_contains_exactly_one_string_out_of( element, [ 'continueThrough', 'continuePast', 'haltBefore', 'haltWith' ], description )
+            i += 1
 
         self.__verify_or_set_optional_bool(log_entry, 'copy_from_start', False, description)
         self.__verify_or_set_optional_bool(log_entry, 'parse_lines_as_json', False, description)
@@ -1124,6 +1131,29 @@ class Configuration(object):
                                    field, 'notString')
         except JsonMissingFieldException:
             raise BadConfiguration('The required field "%s" is missing.  Error is in %s' % (field, config_description),
+                                   field, 'missingRequired')
+
+    def __verify_contains_exactly_one_string_out_of(self, config_object, fields, config_description):
+        """Verifies that config_object has exactly one of the named fields and it can be converted to a string.
+
+        Raises an exception otherwise.
+
+        @param config_object: The JsonObject containing the configuration information.
+        @param fields: A list of field names to check in the config_object.
+        @param config_description: A description of where the configuration object was sourced from to be used in the
+            error reporting to the user.
+        """
+        count = 0
+        for field in fields:
+            try:
+                value = config_object.get_string(field, none_if_missing=True)
+                if value is not None:
+                    count += 1
+            except JsonConversionException:
+                raise BadConfiguration('The field "%s" is not a string.  Error is in %s' % (field, config_description),
+                                       field, 'notString')
+        if count == 0:
+            raise BadConfiguration('A required field is missing.  Object must contain one of "%s".  Error is in %s' % (str(fields), config_description),
                                    field, 'missingRequired')
 
     def __verify_or_set_optional_string(self, config_object, field, default_value, config_description, apply_defaults=True):
@@ -1290,7 +1320,7 @@ class Configuration(object):
             for x in json_array:
                 if not isinstance(x, JsonObject):
                     raise BadConfiguration('The element at index=%i is not a json object as required in the array '
-                                           'field "%s".  Error is in %s' % (index, field, config_description),
+                                           'field "%s (%s, %s)".  Error is in %s' % (index, field, type(x), str(x), config_description),
                                            field, 'notJsonObject')
                 index += 1
         except JsonConversionException:

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1155,6 +1155,9 @@ class Configuration(object):
         if count == 0:
             raise BadConfiguration('A required field is missing.  Object must contain one of "%s".  Error is in %s' % (str(fields), config_description),
                                    field, 'missingRequired')
+        elif count > 1:
+            raise BadConfiguration('A required field has too many options.  Object must contain only one of "%s".  Error is in %s' % (str(fields), config_description),
+                                   field, 'missingRequired')
 
     def __verify_or_set_optional_string(self, config_object, field, default_value, config_description, apply_defaults=True):
         """Verifies that the specified field in config_object is a string if present, otherwise sets default.

--- a/scalyr_agent/copying_manager.py
+++ b/scalyr_agent/copying_manager.py
@@ -208,7 +208,13 @@ class CopyingManager(StoppableThread, LogWatcher):
         # log file has been processed yet
         self.__logs_pending_removal = {}
 
-        # a list of log_matches for logs with configs that need to be reloaded
+        # a list of log_matches for logs with configs that need to be reloaded.
+        # Logs need to be reloaded if their configuration changes at runtime
+        # e.g. with the k8s monitor if an annotation attribute changes such as the
+        # sampling rules or the parser, and this is outside the usual configuration reload mechanism.
+        # By keeping logs that need reloading in a separate 'pending' list
+        # we can avoid locking around log_processors and log_paths_being_processed containers,
+        # and simply process the contents of this list on the main loop
         self.__logs_pending_reload = []
 
         # a list of dynamically added log_matchers that have not been processed yet

--- a/scalyr_agent/json_lib/objects.py
+++ b/scalyr_agent/json_lib/objects.py
@@ -57,11 +57,14 @@ class JsonObject(object):
 
     def to_json(self):
         """Returns a string containing the JSON representation of this object.
-         
+
         Returns the string representation.  If there were comments or other
         non-standard JSON elements in the input that created this object, they
         will not be included."""
         # ???? TODO
+
+    def __repr__(self):
+        return repr( self.__map )
 
     def __len__(self):
         """Returns the number of keys in the JsonObject"""
@@ -99,6 +102,10 @@ class JsonObject(object):
 
     def __iter__(self):
         return self.__map.iterkeys()
+
+    def update( self, other ):
+        """Updates the map with key/value pairs from other.  Overwriting existing keys"""
+        return self.__map.update( other )
 
     def iteritems(self):
         """Returns an iterator over the items (key/value tuple) for this object."""
@@ -216,10 +223,10 @@ class JsonObject(object):
         @raise JsonConversionError: If the value is not either zero or one."""
         if abs(value) < 1E-10:
             return False
-    
+
         if abs(1 - value) < 1E-10:
             return True
-    
+
         return self.__conversion_error(field, value, "boolean")
 
     def get_int(self, field, default_value=None, none_if_missing=False):
@@ -300,7 +307,7 @@ class JsonObject(object):
         if not field in self:
             return self.__compute_missing_value(
                 field, default_value, none_if_missing)
-    
+
         value = self.__map[field]
         value_type = type(value)
 
@@ -345,7 +352,7 @@ class JsonObject(object):
         if not field in self:
             return self.__compute_missing_value(
                 field, default_value, none_if_missing)
-    
+
         value = self.__map[field]
         value_type = type(value)
 
@@ -525,11 +532,17 @@ class JsonArray(object):
 
     def __init__(self, *args):
         """Inits a JsonArray.
-        
+
+        @param content: A dict containing the key/values pairs to use.
         @param *args: The elements to insert into the list."""
+
         self.__items = []
+
         for arg in args:
             self.__items.append(arg)
+
+    def __repr__(self):
+        return repr( self.__items )
 
     def __len__(self):
         """Returns the number of elements in the JsonArray"""
@@ -539,7 +552,7 @@ class JsonArray(object):
         """Returns the value at the specified index as a JsonObject.
 
         @param index: The index to lookup
-        
+
         @return: The JsonObject at the specified index.
 
         @raise JsonConversionException: If the entry is not a JsonObject
@@ -553,7 +566,7 @@ class JsonArray(object):
         """Returns the value at the specified index.
 
         @param index: The index to lookup
-        
+
         @return: The value at the specified index.
 
         @raise IndexError: If there is no entry at that index."""
@@ -586,7 +599,7 @@ class JsonArray(object):
             yield element
 
     def json_objects(self):
-        """Yields all items in the array, 
+        """Yields all items in the array,
         checking to make sure they are JsonObjects.
 
         @raise JsonConversionException: If an item is reached that is not a JsonObject."""

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -521,7 +521,7 @@ class LogFileIterator(object):
 
             except Exception, e:
                 # something went wrong. Return the full line and log a message
-                log.warn("Error parsing line as json for %s.  Logging full line: %s\n%s" % (self.__path, str(e), result.line),
+                log.warn("Error parsing line as json for %s.  Logging full line: %s\n%s" % (self.__path, str(e), result.line.decode( "utf-8", 'replace' )),
                          limit_once_per_x_secs=300, limit_key=('bad-json-%s' % self.__path))
         return result
 

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -2262,7 +2262,7 @@ class LogMatcher(object):
                             str(rule.get('hash_salt', default_value=''))
                         )
                     for rule in self.__log_entry_config['sampling_rules']:
-                        new_processor.add_sampler(rule['match_expression'], rule['sampling_rate'])
+                        new_processor.add_sampler(rule['match_expression'], rule.get_float('sampling_rate', 1.0))
                     result.append(new_processor)
 
             self.__lock.acquire()

--- a/scalyr_agent/monitor_utils/__init__.py
+++ b/scalyr_agent/monitor_utils/__init__.py
@@ -34,6 +34,5 @@ from scalyr_agent.monitor_utils.server_processors import ServerProcessor
 from scalyr_agent.monitor_utils.server_processors import LineRequestParser
 from scalyr_agent.monitor_utils.server_processors import Int32RequestParser
 from scalyr_agent.monitor_utils.auto_flushing_rotating_file import AutoFlushingRotatingFile
-from scalyr_agent.monitor_utils.k8s import KubernetesApi
 
-__all__ = ['ServerProcessor', 'LineRequestParser', 'Int32RequestParser', 'AutoFlushingRotatingFile', 'KubernetesApi' ]
+__all__ = ['ServerProcessor', 'LineRequestParser', 'Int32RequestParser', 'AutoFlushingRotatingFile' ]

--- a/scalyr_agent/monitor_utils/annotation_config.py
+++ b/scalyr_agent/monitor_utils/annotation_config.py
@@ -1,0 +1,249 @@
+# Copyright 2018 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+# author:  Imron Alston <imron@scalyr.com>
+
+__author__ = 'imron@scalyr.com'
+
+import json
+import re
+import scalyr_agent.scalyr_logging as scalyr_logging
+from scalyr_agent.json_lib import JsonObject
+from scalyr_agent.json_lib import JsonArray
+
+global_log = scalyr_logging.getLogger(__name__)
+
+SCALYR_LOG_ANNOTATION_RE = re.compile( '^(config\.agent\.scalyr\.com/)(.+)' )
+SCALYR_ANNOTATION_ELEMENT_RE = re.compile( '([^.]+)\.(.+)' )
+
+class BadAnnotationConfig( Exception ):
+    pass
+
+
+def process_annotations( annotations ):
+    """
+    Process the annotations, extracting config.agent.scalyr.com/* entries
+    and mapping them to a dict corresponding to the same names as the log_config
+    entries.
+    Items separated by a period are mapped to dict keys e.g. if the annotation was
+    specified as:
+
+      config.agent.scalyr.com/attributes.parser: accessLog
+
+    it would be mapped to a dict
+
+    result = {
+        "attributes": {
+            "parser": "accessLog"
+        }
+    }
+
+    Arrays can be specified by using one or more digits as the key, e.g. if the annotation was
+
+      config.agent.scalyr.com/sampling_rules.0.match_expression: INFO
+      config.agent.scalyr.com/sampling_rules.0.sampling_rate: 0.1
+      config.agent.scalyr.com/sampling_rules.1.match_expression: FINE
+      config.agent.scalyr.com/sampling_rules.1.sampling_rate: 0
+
+    This will be mapped to the following structure:
+
+    result = {
+        "sampling_rules": [
+            {
+                "match_expression": "INFO",
+                "sampling_rate": 0.1
+            },
+            {
+                "match_expression": "FINE",
+                "sampling_rate": 0
+            }
+        ]
+    }
+
+    Array keys are sorted by numeric order before processing and unique objects need to have
+    different digits as the array key. If a sub-key has an identical array key as a previously
+    seen sub-key, then the previous value of the sub-key is overwritten, For example the
+    annotations
+
+      config.agent.scalyr.com/sampling_rules.0.match_expression: INFO
+      config.agent.scalyr.com/sampling_rules.0.sampling_rate: 0.1
+      config.agent.scalyr.com/sampling_rules.0.match_expression: FINE
+      config.agent.scalyr.com/sampling_rules.0.sampling_rate: 0
+
+    Would produce the following result
+
+      {
+        "match_expression": "FINE",
+        "sampling_rate": 0
+      }
+
+    because the initial match_expression and sampling_rate are overwritten by the later one.
+
+    There is no guarantee about the order of processing for items with the same numeric array
+    key, so:
+
+      config.agent.scalyr.com/sampling_rules.0.match_expression: INFO
+      config.agent.scalyr.com/sampling_rules.0.sampling_rate: 0.1
+      config.agent.scalyr.com/sampling_rules.0.match_expression: FINE
+      config.agent.scalyr.com/sampling_rules.0.sampling_rate: 0
+
+    might produce:
+
+      {
+        "match_expression": "FINE",
+        "sampling_rate": 0
+      }
+
+    or it might produce:
+
+      {
+        "match_expression": "INFO",
+        "sampling_rate": 0.1
+      }
+
+    or it might produce:
+
+      {
+        "match_expression": "FINE",
+        "sampling_rate": 0.1
+      }
+
+    or it might produce:
+
+      {
+        "match_expression": "INFO",
+        "sampling_rate": 0
+      }
+
+    """
+
+    result = {}
+
+    # first split out any scalyr log-config annotations
+    items = {}
+    for annotation_key, annotation_value in annotations.iteritems():
+        m = SCALYR_LOG_ANNOTATION_RE.match( annotation_key )
+        if m:
+            key = m.group(2)
+            if key in items:
+                global_log.warn( "Duplicate annotation key '%s' found in annotations.  Previous vaue was '%s'" % (key, items[key]),
+                                 limit_once_per_x_secs=300, limit_key='annotation_config_key-%s' % key )
+            else:
+                items[key] = annotation_value
+
+    return _process_annotation_items( items )
+
+def _is_int( string ):
+    """Returns true or false depending on whether or not the passed in string can be converted to an int"""
+    result = False
+    try:
+        value = int( string )
+        result = True
+    except ValueError:
+        result = False
+   
+    return result
+
+def _process_annotation_items( items ):
+    """ Process annotation items after the scalyr config prefix has been stripped
+    """
+    result = {}
+    def sort_annotation( pair ):
+        (key, value) = pair
+        m = SCALYR_ANNOTATION_ELEMENT_RE.match( key )
+        if m:
+            root_key = m.group(1)
+            if _is_int( root_key ):
+                return int( root_key )
+            return root_key
+        
+        return key
+
+    def sort_numeric( pair ):
+        (key, value) = pair
+        if _is_int( key ):
+            return int( key )
+        return key
+            
+    # sort dict by the value of the first sub key (up to the first '.')
+    # this ensures that all items of the same key are processed together
+    sorted_items = sorted( items.iteritems(), key=sort_annotation) 
+    
+    current_object = None
+    previous_key = None
+    is_array = False
+    is_object = False
+    for (key, value) in sorted_items:
+
+        # split out the sub key from the rest of the key
+        m = SCALYR_ANNOTATION_ELEMENT_RE.match( key )
+        if m:
+            root_key = m.group(1)
+            child_key = m.group(2)
+
+            # check for mixed list and dict keys and raise an error if they exist
+            if _is_int( root_key ):
+                is_array = True
+            else:
+                is_object = True
+
+            if is_object == is_array:
+                raise BadAnnotationConfig( "Annotation cannot be both a dict and a list for '%s'.  Current key: %s, previous key: %s" % (key, str(root_key), str(previous_key)) )
+
+            # create an empty object if None exists
+            if current_object is None:
+                current_object = {}
+
+            # else if the keys are different which means we have a new key,
+            # so add the current object to the list of results and create a new object
+            elif previous_key is not None and root_key != previous_key:
+                result[previous_key] = _process_annotation_items( current_object )
+                current_object = {}
+
+            current_object[child_key] = value
+            previous_key = root_key
+
+        else: # no more subkeys so just process as the full key
+
+            # check for mixed list and dict keys and raise an error if they exist
+            if _is_int( key ):
+                is_array = True
+            else:
+                is_object = True
+
+            if is_object == is_array:
+                raise BadAnnotationConfig( "Annotation cannot be both a dict and a list.  Current key: %s, previous key: %s" % (key, str(previous_key)) )
+
+            # if there was a previous key 
+            if previous_key is not None and current_object is not None:
+                # stick it in the result
+                result[previous_key] = _process_annotation_items( current_object )
+
+            # add the current value to the result
+            result[key] = value
+            current_object = None
+            previous_key = None
+
+    # add the final object if there was one
+    if previous_key is not None and current_object is not None:
+        result[previous_key] = _process_annotation_items( current_object )
+
+    # if the result should be an array, return values as a JsonArray, sorted by numeric order of keys
+    if is_array:
+        result = JsonArray( *[r[1] for r in sorted( result.iteritems(), key=sort_numeric )] )
+    else:
+    # return values as a JsonObject
+        result = JsonObject( content=result )
+
+    return result

--- a/scalyr_agent/monitor_utils/annotation_config.py
+++ b/scalyr_agent/monitor_utils/annotation_config.py
@@ -24,7 +24,7 @@ from scalyr_agent.json_lib import JsonArray
 
 global_log = scalyr_logging.getLogger(__name__)
 
-SCALYR_LOG_ANNOTATION_RE = re.compile( '^(config\.agent\.scalyr\.com/)(.+)' )
+SCALYR_LOG_ANNOTATION_RE = re.compile( '^(log\.config\.scalyr\.com/)(.+)' )
 SCALYR_ANNOTATION_ELEMENT_RE = re.compile( '([^.]+)\.(.+)' )
 
 class BadAnnotationConfig( Exception ):
@@ -33,13 +33,13 @@ class BadAnnotationConfig( Exception ):
 
 def process_annotations( annotations ):
     """
-    Process the annotations, extracting config.agent.scalyr.com/* entries
+    Process the annotations, extracting log.config.scalyr.com/* entries
     and mapping them to a dict corresponding to the same names as the log_config
     entries.
     Items separated by a period are mapped to dict keys e.g. if the annotation was
     specified as:
 
-      config.agent.scalyr.com/attributes.parser: accessLog
+      log.config.scalyr.com/attributes.parser: accessLog
 
     it would be mapped to a dict
 
@@ -51,10 +51,10 @@ def process_annotations( annotations ):
 
     Arrays can be specified by using one or more digits as the key, e.g. if the annotation was
 
-      config.agent.scalyr.com/sampling_rules.0.match_expression: INFO
-      config.agent.scalyr.com/sampling_rules.0.sampling_rate: 0.1
-      config.agent.scalyr.com/sampling_rules.1.match_expression: FINE
-      config.agent.scalyr.com/sampling_rules.1.sampling_rate: 0
+      log.config.scalyr.com/sampling_rules.0.match_expression: INFO
+      log.config.scalyr.com/sampling_rules.0.sampling_rate: 0.1
+      log.config.scalyr.com/sampling_rules.1.match_expression: FINE
+      log.config.scalyr.com/sampling_rules.1.sampling_rate: 0
 
     This will be mapped to the following structure:
 
@@ -76,10 +76,10 @@ def process_annotations( annotations ):
     seen sub-key, then the previous value of the sub-key is overwritten, For example the
     annotations
 
-      config.agent.scalyr.com/sampling_rules.0.match_expression: INFO
-      config.agent.scalyr.com/sampling_rules.0.sampling_rate: 0.1
-      config.agent.scalyr.com/sampling_rules.0.match_expression: FINE
-      config.agent.scalyr.com/sampling_rules.0.sampling_rate: 0
+      log.config.scalyr.com/sampling_rules.0.match_expression: INFO
+      log.config.scalyr.com/sampling_rules.0.sampling_rate: 0.1
+      log.config.scalyr.com/sampling_rules.0.match_expression: FINE
+      log.config.scalyr.com/sampling_rules.0.sampling_rate: 0
 
     Would produce the following result
 
@@ -93,10 +93,10 @@ def process_annotations( annotations ):
     There is no guarantee about the order of processing for items with the same numeric array
     key, so:
 
-      config.agent.scalyr.com/sampling_rules.0.match_expression: INFO
-      config.agent.scalyr.com/sampling_rules.0.sampling_rate: 0.1
-      config.agent.scalyr.com/sampling_rules.0.match_expression: FINE
-      config.agent.scalyr.com/sampling_rules.0.sampling_rate: 0
+      log.config.scalyr.com/sampling_rules.0.match_expression: INFO
+      log.config.scalyr.com/sampling_rules.0.sampling_rate: 0.1
+      log.config.scalyr.com/sampling_rules.0.match_expression: FINE
+      log.config.scalyr.com/sampling_rules.0.sampling_rate: 0
 
     might produce:
 

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -45,7 +45,10 @@ class PodInfo( object ):
         md5.update( uid )
         md5.update( node_name )
 
-        # flatten the labels dict in to a single string
+        # flatten the labels dict in to a single string because update
+        # expects a string arg.  To avoid cases where the 'str' of labels is
+        # just the object id, we explicitly create a flattened string of
+        # key/value pairs
         flattened = []
         for k,v in labels.iteritems():
             flattened.append( k )
@@ -53,9 +56,11 @@ class PodInfo( object ):
         md5.update( ''.join( flattened ) )
 
         # flatten the container names
+        # see previous comment for why flattening is necessary
         md5.update( ''.join( container_names ) )
 
         # flatten the annotations dict in to a single string
+        # see previous comment for why flattening is necessary
         flattened = []
         for k,v in annotations.iteritems():
             flattened.append( k )
@@ -784,7 +789,11 @@ class KubernetesApi( object ):
         return self.query_api( query )
 
     def query_pods( self, namespace=None, filter=None ):
-        """Wrapper to query all pods in a namespace, or across the entire cluster"""
+        """Wrapper to query all pods in a namespace, or across the entire cluster
+           A value of None for namespace will search for the pod across the entire cluster.
+           This is handled in the 'query_objects' method.  This method is just a convenience
+           wrapper that passes in the appropriate urls for pod objects
+        """
         return self.query_objects( '/api/v1/pods', '/api/v1/namespaces/%s/pods', namespace, filter )
 
     def query_replicaset( self, namespace, name ):
@@ -796,7 +805,11 @@ class KubernetesApi( object ):
         return self.query_api( query )
 
     def query_replicasets( self, namespace=None, filter=None ):
-        """Wrapper to query all replicasets in a namespace, or across the entire cluster"""
+        """Wrapper to query all replicasets in a namespace, or across the entire cluster
+           A value of None for namespace will search for the replicaset across the entire cluster.
+           This is handled in the 'query_objects' method.  This method is just a convenience
+           wrapper that passes in the appropriate urls for the replicaset objects
+        """
         return self.query_objects( '/apis/apps/v1/replicasets', '/apis/apps/v1/namespaces/%s/replicasets', namespace, filter )
 
     def query_deployment( self, namespace, name ):
@@ -808,7 +821,11 @@ class KubernetesApi( object ):
         return self.query_api( query )
 
     def query_deployments( self, namespace=None, filter=None ):
-        """Wrapper to query all deployments in a namespace, or across the entire cluster"""
+        """Wrapper to query all deployments in a namespace, or across the entire cluster
+           A value of None for namespace will search for the deployment across the entire cluster.
+           This is handled in the 'query_objects' method.  This method is just a convenience
+           wrapper that passes in the appropriate urls for the deployment objects
+        """
         return self.query_objects( '/apis/apps/v1/deployments', '/apis/apps/v1/namespaces/%s/deployments', namespace, filter )
 
     def query_objects( self, url, namespaced_url, namespace=None, filter=None ):

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -26,7 +26,7 @@ class PodInfo( object ):
     """
         A collection class that stores label and other information about a kubernetes pod
     """
-    def __init__( self, name='', namespace='', uid='', node_name='', labels={}, container_names=[], annotations={} ):
+    def __init__( self, name='', namespace='', uid='', node_name='', labels={}, container_names=[], annotations={}, deployment_name=None ):
 
         self.name = name
         self.namespace = namespace
@@ -35,6 +35,7 @@ class PodInfo( object ):
         self.labels = labels
         self.container_names = container_names
         self.annotations = annotations
+        self.deployment_name = deployment_name
 
         # generate a hash we can use to compare whether or not
         # any of the pod info has changed
@@ -96,62 +97,88 @@ class PodInfo( object ):
 
         return result
 
-class KubernetesCache( object ):
+class ReplicaSetInfo( object ):
     """
-        A lazily updated cache for k8s api queries
+        Class for cached ReplicaSet objects
+    """
+    def __init__( self, name='', namespace='', deployment_name=None ):
+        self.name = name
+        self.namespace = namespace
+        self.deployment_name = deployment_name
+
+class DeploymentInfo( object ):
+    """
+        Class for cached Deployment objects
+    """
+    def __init__( self, name='', namespace='', labels={} ):
+
+        self.name = name
+        self.namespace = namespace
+        self.labels = labels
+        flat_labels = []
+        for key, value in labels.iteritems():
+            flat_labels.append( "%s=%s" % (key, value) )
+
+        self.flat_labels = ','.join( flat_labels )
+
+class _K8sCache( object ):
+    """
+        A lazily updated cache of objects from a k8s api query
+
+        This is a private class to this module.  See KubernetesCache which instantiates
+        instances of _K8sCache for querying different k8s API objects.
 
         A full update of cached data occurs whenever the cache is queried and
         `cache_expiry_secs` have passed since the last full update.
 
-        If a cache miss occurs e.g. pods were created since the last cache update but
+        If a cache miss occurs e.g. objects were created since the last cache update but
         that is not yet reflected in the cached data, individual queries to the
         api are made that get the required data only, and no more.
 
         If too many cache misses occur within `cache_miss_interval` (e.g. a large
-        number of pods were created since the last full cache update) this will also
+        number of objects were created since the last full cache update) this will also
         trigger a full update of the cache.
 
         This abstraction is thread-safe-ish, assuming objects returned
         from querying the cache are never written to.
     """
 
-    def __init__( self, k8s, logger, cache_expiry_secs=120, max_cache_misses=20, cache_miss_interval=10, filter=None ):
+    def __init__( self, logger, processor, object_type, cache_expiry_secs=120, max_cache_misses=20, cache_miss_interval=10 ):
         """
             Initialises a Kubernees Cache
-            @param: k8s - a KubernetesApi object
             @param: logger - a Scalyr logger
+            @param: processor - a _K8sProcessor object for querying/processing the k8s api
+            @param: object_type - a string containing a textual name of the objects being cached, for use in log messages
             @param: cache_expiry_secs - the number of seconds to wait before doing a full update of data from the k8s api
             @param: max_cache_misses - the maximum of number of cache misses that can occur in
                                        `cache_miss_interval` before doing a full update of data from the k8s api
             @param: cache_miss_interval - the number of seconds that `max_cache_misses` can occur in before a full
                                           update of the cache occurs
-            @param: filter - a field selector filter when doing bulk query items (e.g. to limit the results to the current node)
         """
-        # protects self.pods
+        # protects self.objects
         self._lock = threading.Lock()
 
-        # dict of pods dicts.  The outer dict is hashed by namespace,
-        # and the inner dict is hashed by pod
-        self._pods = {}
+        # dict of object dicts.  The outer dict is hashed by namespace,
+        # and the inner dict is hashed by object name
+        self._objects = {}
 
-        self._k8s = k8s
         self._logger = logger
-        self._filter = filter
+        self._processor = processor
+        self._object_type = object_type,
 
         self._cache_expiry_secs = cache_expiry_secs
         self._last_full_update = time.time() - cache_expiry_secs - 1
-        self._last_pod_cache_miss_update = self._last_full_update
+        self._last_cache_miss_update = self._last_full_update
         self._max_cache_misses = max_cache_misses
         self._cache_miss_interval = cache_miss_interval
-        self._pod_query_cache_miss = 0
+        self._query_cache_miss = 0
 
-
-    def pods_shallow_copy(self):
-        """Retuns a shallow copy of the pods dict"""
+    def shallow_copy(self):
+        """Returns a shallow copy of all the cached objects dict"""
         result = {}
         self._lock.acquire()
         try:
-            for k, v in self._pods.iteritems():
+            for k, v in self._objects.iteritems():
                 result[k] = v
         finally:
             self._lock.release()
@@ -159,15 +186,15 @@ class KubernetesCache( object ):
         return result
 
     def _update( self, current_time ):
-        """ do a full update of all pod information from the API
+        """ do a full update of all information from the API
         """
 
         try:
             self._logger.log(scalyr_logging.DEBUG_LEVEL_1, 'Attempting to update k8s data from API' )
-            pods_result = self._k8s.query_pods( filter=self._filter )
-            pods = self._process_pods( pods_result )
+            query_result = self._processor.query_all_objects()
+            objects = self._process_objects( query_result )
         except Exception, e:
-            self._logger.warning( "Exception occurred when updating k8s cache.  Cache was not updated %s\n%s" % (str( e ), traceback.format_exc()) )
+            self._logger.warning( "Exception occurred when updating k8s %s cache.  Cache was not updated %s\n%s" % (self._object_type, str( e ), traceback.format_exc()) )
             # early return because we don't want to update our cache with bad data,
             # but wait at least another full cache expiry before trying again
             self._last_full_update = current_time
@@ -175,32 +202,32 @@ class KubernetesCache( object ):
 
         self._lock.acquire()
         try:
-            self._pods = pods
+            self._objects = objects
             self._last_full_update = current_time
         finally:
             self._lock.release()
 
 
-    def _update_pod( self, pod_namespace, pod_name ):
-        """ update a single pod, returns the pod if found, otherwise return None """
+    def _update_object( self, namespace, name ):
+        """ update a single object, returns the object if found, otherwise return None """
         result = None
         try:
-            # query k8s api and process pod
-            pod = self._k8s.query_pod( pod_namespace, pod_name )
-            result = self._process_pod( pod )
+            # query k8s api and process objects
+            obj = self._processor.query_object( namespace, name )
+            result = self._processor.process_object( obj )
         except K8sApiException, e:
-            # Don't do anything here.  This means the pod we are querying doensn't exist
+            # Don't do anything here.  This means the object we are querying doensn't exist
             # and it's up to the caller to handle this by detecting a None result
             pass
 
         # update our cache if we have a result
         if result:
-            self._logger.log( scalyr_logging.DEBUG_LEVEL_2, "Processing single pod: %s/%s" % (result.namespace, result.name) )
+            self._logger.log( scalyr_logging.DEBUG_LEVEL_2, "Processing single %s: %s/%s" % (self._object_type, result.namespace, result.name) )
             self._lock.acquire()
             try:
-                if result.namespace not in self._pods:
-                    self._pods[result.namespace] = {}
-                current = self._pods[result.namespace]
+                if result.namespace not in self._objects:
+                    self._objects[result.namespace] = {}
+                current = self._objects[result.namespace]
                 current[result.name] = result
 
             finally:
@@ -208,39 +235,234 @@ class KubernetesCache( object ):
 
         return result
 
-    def _process_pods( self, pods ):
+    def _process_objects( self, objects ):
         """
-            Processes the JsonObject returned from querying the pods and creates PodInfo object,
+            Processes the JsonObject returned from querying the objects and calls the _K8sProcessor to create relevant objects for caching,
 
-            @param pods: The JSON object returned as a response from quering all pods
+            @param objects: The JSON object returned as a response from quering all objects.  This JSON object should contain an
+                         element called 'items', which is an array of JsonObjects
 
-            @return: a dict keyed by namespace, whose values are a dict of pods inside that namespace, keyed by pod name
+            @return: a dict keyed by namespace, whose values are a dict of objects inside that namespace, keyed by objects name
         """
 
-        # get all pods
-        items = pods.get( 'items', [] )
+        # get all objects
+        items = objects.get( 'items', [] )
 
-        # iterate over all pods, getting PodInfo and storing it in the result
-        # dict, hashed by namespace and pod name
+        # iterate over all objects, getting Info objects and storing them in the result
+        # dict, hashed by namespace and object name
         result = {}
-        for pod in items:
-            info = self._process_pod( pod )
-            self._logger.log( scalyr_logging.DEBUG_LEVEL_1, "Processing pod: %s:%s" % (info.namespace, info.name) )
+        for obj in items:
+            info = self._processor.process_object( obj )
+            self._logger.log( scalyr_logging.DEBUG_LEVEL_1, "Processing %s: %s:%s" % (self._object_type, info.namespace, info.name) )
 
             if info.namespace not in result:
                 result[info.namespace] = {}
 
             current = result[info.namespace]
             if info.name in current:
-                self._logger.warning( "Duplicate pod '%s' found in namespace '%s', overwriting previous values" % (info.name, info.namespace),
-                                      limit_once_per_x_secs=300, limit_key='duplicate-pod-%s' % info.uid )
+                self._logger.warning( "Duplicate %s '%s' found in namespace '%s', overwriting previous values" % (self._object_type, info.name, info.namespace),
+                                      limit_once_per_x_secs=300, limit_key='duplicate-%s-%s' % (self._object_type, info.uid) )
 
             current[info.name] = info
 
         return result
 
 
-    def _process_pod( self, pod ):
+    def _expired( self, current_time ):
+        """ returns a boolean indicating whether the cache has expired
+        """
+        return self._last_full_update + self._cache_expiry_secs < current_time
+
+    def update_if_expired( self, current_time ):
+        """
+        If the cache has expired, perform a full update of all object information from the API
+        """
+        if self._expired( current_time ):
+            self._logger.log( scalyr_logging.DEBUG_LEVEL_1, "k8s %s cache expired, performing full update" % self._object_type )
+            self._update( current_time )
+
+
+    def _update_if_cache_miss_count_exceeds_threshold( self, current_time ):
+        """
+            If too many cache misses happen on single object queries within a short timespan
+            force an update of all objects.
+            return: True if updated, False otherwise
+        """
+
+        updated = False
+        if self._query_cache_miss > self._max_cache_misses:
+            self._logger.log( scalyr_logging.DEBUG_LEVEL_1, "Too many k8s %s cache misses, performing full update" % self._object_type )
+            self._update( current_time )
+            updated = True
+        return updated
+
+    def _lookup_object( self, namespace, name, current_time ):
+        """ Look to see if the object specified by the namespace and name
+        exists within the cached data.
+
+        Return the object info, or None if not found
+        """
+        result = None
+        self._lock.acquire()
+        try:
+            objects = self._objects.get( namespace, {} )
+            result = objects.get( name, None )
+
+            # check for cache misses
+            if result is None:
+                # if we are within the last cache miss interval, increment miss count
+                if current_time < self._last_cache_miss_update + self._cache_miss_interval:
+                    self._query_cache_miss += 1
+                else:
+                    # otherwise reset the interval and miss count
+                    self._query_cache_miss = 1
+                    self._last_cache_miss_update = current_time
+
+        finally:
+            self._lock.release()
+
+        return result
+
+    def lookup( self, namespace, name, current_time=None ):
+        """ returns info for the object specified by namespace and name
+        or None if no object is found in the cache.
+
+        Querying the information is thread-safe, but the returned object should
+        not be written to.
+        """
+
+        # update the cache if we are expired
+        if current_time is None:
+            current_time = time.time()
+
+        self.update_if_expired( current_time )
+
+        # see if the object exists in the cache and return it if so
+        result = self._lookup_object( namespace, name, current_time )
+        if result:
+            self._logger.log( scalyr_logging.DEBUG_LEVEL_2, "cache hit for %s %s/%s" % (self._object_type, namespace, name) )
+            return result
+
+        # do a full update if too many cache misses in a short period
+        # of time
+        if self._update_if_cache_miss_count_exceeds_threshold( current_time ):
+            # object might exist in the cache now, so check again
+            result = self._lookup_object( namespace, name, current_time )
+        else:
+            # otherwise query objects individually
+            self._logger.log( scalyr_logging.DEBUG_LEVEL_2, "cache miss for %s %s/%s" % (self._object_type, namespace, name) )
+            result = self._update_object( namespace, name )
+
+        return result
+
+class _K8sProcessor( object ):
+    """
+        An abstract interface used by _K8sCache for querying a specific type of
+        object from the k8s api, and generating python objects from the queried result JSON.
+    """
+
+    def __init__( self, k8s, logger, filter=None ):
+        """
+            @param: k8s - a KubernetesApi object for query the k8s api
+            @param: logger - a Scalyr logger object for logging
+            @param: filter - a field selector filter when doing bulk query items (e.g. to limit the results to the current node)
+        """
+        self._k8s = k8s
+        self._logger = logger
+        self._filter = filter
+
+    def _get_managing_controller( self, items, kind=None ):
+        """
+            Processes a list of items, searching to see if one of them
+            is a 'managing controller', which is determined by the 'controller' field
+
+            @param: items - a JsonArray containing 'ownerReferences' metadata for an object
+                            returned from the k8s api
+            @param: kind - a string containing the expected type of the managing controller.
+                           if the managing controller is not of this type then None will also be returned
+
+            @return: A JsonObject containing the managing controller of type `kind` or None if no such controller exists
+        """
+        for i in items:
+            controller = i.get_bool( 'controller', False )
+            if kind is not None:
+                controller_kind = i.get( 'kind', None )
+            if controller and controller_kind == kind:
+                return i
+
+        return None
+
+    def query_all_objects( self ):
+        """
+        Queries the k8s api for all objects of a specific type (determined by subclasses).
+        @return - a JsonObject containing at least one element called 'items' which is a JsonArray of JsonObjects
+                  returned by the query
+        """
+        return JsonObject( { 'items': JsonArray( [] ) } )
+
+    def query_object( self, namespace, name ):
+        """
+        Queries the k8s api for a single object of a specific type (determined by subclasses).
+        @param: namespace - the namespace to query in
+        @param: name - the name of the object
+        @return - a JsonObject returned by the query
+        """
+        return JsonObject( {} )
+
+    def process_object( self, obj ):
+        """
+        Creates a python object based of a JsonObject
+        @param obj: A JSON object returned as a response to querying
+                    the k8s API for a specific object type.
+        @return a python object relevant to the
+        """
+        pass
+
+class PodProcessor( _K8sProcessor ):
+
+    def __init__( self, k8s, logger, filter, replicasets ):
+        super( PodProcessor, self).__init__( k8s, logger, filter )
+        self._replicasets = replicasets
+
+    def query_all_objects( self ):
+        """
+        Queries the k8s api for all Pods that match self._filter
+        @return - a JsonObject containing an element called 'items' which is an JsonArray of Pods
+                  returned by the query
+        """
+        return self._k8s.query_pods( filter=self._filter )
+
+    def query_object( self, namespace, name ):
+        """
+        Queries the k8s api for a single pod
+        @param: namespace - the namespace to query in
+        @param: name - the name of the pod
+        @return - a JsonObject cointaining the Pod information returned by the query
+        """
+        return self._k8s.query_pod( namespace, name )
+
+    def _get_deployment_name_from_owners( self, owners, namespace ):
+        """
+            Processes a list of owner references returned from a Pod's metadata to see
+            if it is eventually owned by a Deployment, and if so, returns that DeploymentInfo
+
+            @return DeploymentInfo or None if not part of a deployment
+        """
+        replicaset = None
+        owner = self._get_managing_controller( owners, 'ReplicaSet' )
+
+        if owner:
+            name = owner.get( 'name', None )
+            if name is None:
+                return None
+            replicaset = self._replicasets.lookup( namespace, name )
+
+        if replicaset is None:
+            return None
+
+        return replicaset.deployment_name
+
+    def process_object( self, obj ):
         """ Generate a PodInfo object from a JSON object
         @param pod: The JSON object returned as a response to querying
             a specific pod from the k8s API
@@ -250,13 +472,16 @@ class KubernetesCache( object ):
 
         result = {}
 
-        metadata = pod.get( 'metadata', {} )
-        spec = pod.get( 'spec', {} )
+        metadata = obj.get( 'metadata', {} )
+        spec = obj.get( 'spec', {} )
         labels = metadata.get( 'labels', {} )
         annotations = metadata.get( 'annotations', {} )
+        owners = metadata.get( 'ownerReferences', [] )
 
         pod_name = metadata.get( "name", '' )
         namespace = metadata.get( "namespace", '' )
+
+        deployment_name = self._get_deployment_name_from_owners( owners, namespace )
 
         container_names = []
         for container in spec.get( 'containers', [] ):
@@ -279,96 +504,141 @@ class KubernetesCache( object ):
                           node_name=spec.get( "nodeName", '' ),
                           labels=labels,
                           container_names=container_names,
-                          annotations=annotations)
+                          annotations=annotations,
+                          deployment_name=deployment_name)
         return result
 
-    def _expired( self, current_time ):
-        """ returns a boolean indicating whether the cache has expired
+class ReplicaSetProcessor( _K8sProcessor ):
+
+    def __init__( self, k8s, logger, deployments ):
+        super( ReplicaSetProcessor, self).__init__( k8s, logger )
+        self._deployments = deployments
+
+    def query_all_objects( self ):
         """
-        return self._last_full_update + self._cache_expiry_secs < current_time
-
-    def update_if_expired( self, current_time ):
+        Queries the k8s api for all ReplicaSets that match self._filter
+        @return - a JsonObject containing an element called 'items' which is an JsonArray of ReplicaSets
+                  returned by the query
         """
-        If the cache has expired, perform a full update of all pod information from the API
+        return self._k8s.query_replicasets( filter=self._filter )
+
+    def query_object( self, namespace, name ):
         """
-        if self._expired( current_time ):
-            self._logger.log( scalyr_logging.DEBUG_LEVEL_1, "k8s cache expired, performing full update" )
-            self._update( current_time )
-
-
-    def _update_if_pod_cache_miss_count_exceeds_threshold( self, current_time ):
+        Queries the k8s api for a single ReplicaSet
+        @param: namespace - the namespace to query in
+        @param: name - the name of the ReplicaSet
+        @return - a JsonObject cointaining the ReplicaSet information returned by the query
         """
-            If too many cache misses happen on single pod queries within a short timespan
-            force an update of all pods.
-            return: True if updated, False otherwise
+        return self._k8s.query_replicaset( namespace, name )
+
+
+    def process_object( self, obj ):
+        """ Generate a ReplicaSetInfo object from a JSON object
+        @param obj: The JSON object returned as a response to querying
+            a specific replicaset from the k8s API
+
+        @return A ReplicaSetInfo object
         """
 
-        updated = False
-        if self._pod_query_cache_miss > self._max_cache_misses:
-            self._logger.log( scalyr_logging.DEBUG_LEVEL_1, "Too many k8s cache misses, performing full update " )
-            self._update( current_time )
-            updated = True
-        return updated
+        metadata = obj.get( 'metadata', {} )
+        owners = metadata.get( 'ownerReferences', [] )
+        namespace = metadata.get( "namespace", '' )
+        name = metadata.get( "name", '' )
+        deployment_name = None
 
-    def _lookup_pod( self, pod_namespace, pod_name, current_time ):
-        """ Look to see if the pod specified by the pod_namespace and pod_name
-        exist within the cached data.
+        owner = self._get_managing_controller( owners, 'Deployment' )
+        if owner is not None:
+            owner_name = owner.get( 'name', None )
+            if owner_name is not None:
+                deployment = self._deployments.lookup( namespace, owner_name )
+                if deployment:
+                    deployment_name = deployment.name
 
-        Return the pod info, or None if not found
+        return ReplicaSetInfo( name, namespace, deployment_name )
+
+class DeploymentProcessor( _K8sProcessor ):
+
+    def query_all_objects( self ):
         """
-        result = None
-        self._lock.acquire()
-        try:
-            namespace = self._pods.get( pod_namespace, {} )
-            result = namespace.get( pod_name, None )
+        Queries the k8s api for all Deployments that match self._filter
+        @return - a JsonObject containing an element called 'items' which is an JsonArray of Deployments
+                  returned by the query
+        """
+        return self._k8s.query_deployments( filter=self._filter )
 
-            # check for cache misses
-            if result is None:
-                # if we are within the last cache miss interval, increment miss count
-                if current_time < self._last_pod_cache_miss_update + self._cache_miss_interval:
-                    self._pod_query_cache_miss += 1
-                else:
-                    # otherwise reset the interval and miss count
-                    self._pod_query_cache_miss = 1
-                    self._last_pod_cache_miss_update = current_time
+    def query_object( self, namespace, name ):
+        """
+        Queries the k8s api for a single deployment
+        @param: namespace - the namespace to query in
+        @param: name - the name of the deployment
+        @return - a JsonObject cointaining the Deployment information returned by the query
+        """
+        return self._k8s.query_deployment( namespace, name )
 
-        finally:
-            self._lock.release()
 
-        return result
+    def process_object( self, obj ):
+        """ Generate a DeploymentInfo object from a JSON object
+        @param obj: The JSON object returned as a response to querying
+            a specific deployment from the k8s API
 
-    def pod( self, pod_namespace, pod_name, current_time=None ):
-        """ returns pod info for the pod specified by pod_namespace and pod_name
+        @return A DeploymentInfo object
+        """
+        metadata = obj.get( 'metadata', {} )
+        namespace = metadata.get( "namespace", '' )
+        name = metadata.get( "name", '' )
+        labels = metadata.get( 'labels', {} )
+
+        return DeploymentInfo( name, namespace, labels )
+
+class KubernetesCache( object ):
+
+    def __init__( self, k8s, logger, cache_expiry_secs=120, max_cache_misses=20, cache_miss_interval=10, filter=None ):
+
+        # create the deployment cache
+        deployment_processor = DeploymentProcessor( k8s, logger )
+        self._deployments = _K8sCache( logger, deployment_processor, 'deployment',
+                               cache_expiry_secs=cache_expiry_secs,
+                               max_cache_misses=max_cache_misses,
+                               cache_miss_interval=cache_miss_interval )
+
+        # create the replicaset cache
+        replicaset_processor = ReplicaSetProcessor( k8s, logger, self._deployments )
+        self._replicasets = _K8sCache( logger, replicaset_processor, 'replicaset',
+                               cache_expiry_secs=cache_expiry_secs,
+                               max_cache_misses=max_cache_misses,
+                               cache_miss_interval=cache_miss_interval )
+
+        # create the pod cache
+        pod_processor = PodProcessor( k8s, logger, filter, self._replicasets )
+        self._pods = _K8sCache( logger, pod_processor, 'pod',
+                               cache_expiry_secs=cache_expiry_secs,
+                               max_cache_misses=max_cache_misses,
+                               cache_miss_interval=cache_miss_interval )
+
+
+    def deployment( self, namespace, name, current_time=None ):
+        """
+            Returns cached deployment info for the deployment specified by namespace and name
+            or None if no deployment matches.
+
+            Querying the deployment information is thread-safe but the returned object should
+            not be written to.
+        """
+        return self._deployments.lookup( namespace, name, current_time )
+
+
+    def pod( self, namespace, name, current_time=None ):
+        """ returns pod info for the pod specified by namespace and name
         or None if no pad matches.
 
         Querying the pod information is thread-safe, but the returned object should
         not be written to.
         """
+        return self._pods.lookup( namespace, name, current_time )
 
-        # update the cache if we are expired
-        if current_time is None:
-            current_time = time.time()
-
-        self.update_if_expired( current_time )
-
-        # see if the pod exists in the cache and return it if so
-        result = self._lookup_pod( pod_namespace, pod_name, current_time )
-        if result:
-            self._logger.log( scalyr_logging.DEBUG_LEVEL_2, "cache hit for pod %s/%s" % (pod_namespace, pod_name) )
-            return result
-
-        # do a full update if too many cache misses in a short period
-        # of time
-        if self._update_if_pod_cache_miss_count_exceeds_threshold( current_time ):
-            # pod might exist in the cache now, so check again
-            result = self._lookup_pod( pod_namespace, pod_name, current_time )
-        else:
-            # otherwise query pod individually
-            self._logger.log( scalyr_logging.DEBUG_LEVEL_2, "cache miss for pod %s/%s" % (pod_namespace, pod_name) )
-            result = self._update_pod( pod_namespace, pod_name )
-
-        return result
-
+    def pods_shallow_copy(self):
+        """Retuns a shallow copy of the pod objects"""
+        return self._pods.shallow_copy()
 
 class KubernetesApi( object ):
     """Simple wrapper class for querying the k8s api
@@ -452,6 +722,41 @@ class KubernetesApi( object ):
             node = spec.get( 'nodeName' )
         return node
 
+    def get_cluster_name( self ):
+        """ Returns the name of the cluster running this agent.
+
+        There is no way to get this from the k8s API so we check the following:
+
+        If the environment variable SCALYR_K8S_CLUSTER_NAME is set, then use that.
+
+        Otherwise query the api for the pod running the agent container and check to see
+        if it has an annotation: agent.config.scalyr.com/cluster_name, and if so, use that.
+
+        Otherwise return None
+        """
+
+        cluster = os.environ.get( 'SCALYR_K8S_CLUSTER_NAME' )
+        if cluster:
+            return cluster
+
+        pod_name = self.get_pod_name()
+        pod = self.query_pod( self.namespace, pod_name )
+
+        if pod is None:
+            return None
+
+        metadata = pod.get( 'metadata', {} )
+        annotations = metadata.get( 'annotations', {} )
+
+        result = None
+        for key, value in annotations.iteritems():
+            if key == 'agent.config.scalyr.com/cluster_name':
+                result = value
+                break
+
+        return result
+
+
     def query_api( self, path, pretty=0 ):
         """ Queries the k8s API at 'path', and converts OK responses to JSON objects
         """
@@ -480,9 +785,37 @@ class KubernetesApi( object ):
 
     def query_pods( self, namespace=None, filter=None ):
         """Wrapper to query all pods in a namespace, or across the entire cluster"""
-        query = '/api/v1/pods'
+        return self.query_objects( '/api/v1/pods', '/api/v1/namespaces/%s/pods', namespace, filter )
+
+    def query_replicaset( self, namespace, name ):
+        """Wrapper to query a replicaset in a namespace"""
+        if not name or not namespace:
+            return JsonObject()
+
+        query = '/apis/apps/v1/namespaces/%s/replicasets/%s' % (namespace, name)
+        return self.query_api( query )
+
+    def query_replicasets( self, namespace=None, filter=None ):
+        """Wrapper to query all replicasets in a namespace, or across the entire cluster"""
+        return self.query_objects( '/apis/apps/v1/replicasets', '/apis/apps/v1/namespaces/%s/replicasets', namespace, filter )
+
+    def query_deployment( self, namespace, name ):
+        """Wrapper to query a deployment in a namespace"""
+        if not name or not namespace:
+            return JsonObject()
+
+        query = '/apis/apps/v1/namespaces/%s/deployments/%s' % (namespace, name)
+        return self.query_api( query )
+
+    def query_deployments( self, namespace=None, filter=None ):
+        """Wrapper to query all deployments in a namespace, or across the entire cluster"""
+        return self.query_objects( '/apis/apps/v1/deployments', '/apis/apps/v1/namespaces/%s/deployments', namespace, filter )
+
+    def query_objects( self, url, namespaced_url, namespace=None, filter=None ):
+        """Wrapper to query all objects at a url in a namespace, or across the entire cluster"""
+        query = url
         if namespace:
-            query = '/api/v1/namespaces/%s/pods' % (namespace)
+            query = namespaced_url % (namespace)
 
         if filter:
             query = "%s?fieldSelector=%s" % (query, urllib.quote( filter ))

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -1,10 +1,15 @@
 
+import hashlib
+import logging
 import os
+import scalyr_agent.monitor_utils.annotation_config as annotation_config
 import scalyr_agent.third_party.requests as requests
 import scalyr_agent.json_lib as json_lib
 from scalyr_agent.json_lib import JsonObject
 from scalyr_agent.json_lib import JsonConversionException, JsonMissingFieldException
-import logging
+import threading
+import time
+import traceback
 import scalyr_agent.scalyr_logging as scalyr_logging
 
 import urllib
@@ -16,6 +21,354 @@ class K8sApiException( Exception ):
     exceptions
     """
     pass
+
+class PodInfo( object ):
+    """
+        A collection class that stores label and other information about a kubernetes pod
+    """
+    def __init__( self, name='', namespace='', uid='', node_name='', labels={}, container_names=[], annotations={} ):
+
+        self.name = name
+        self.namespace = namespace
+        self.uid = uid
+        self.node_name = node_name
+        self.labels = labels
+        self.container_names = container_names
+        self.annotations = annotations
+
+        # generate a hash we can use to compare whether or not
+        # any of the pod info has changed
+        md5 = hashlib.md5()
+        md5.update( name )
+        md5.update( namespace )
+        md5.update( uid )
+        md5.update( node_name )
+
+        # flatten the labels dict in to a single string
+        flattened = []
+        for k,v in labels.iteritems():
+            flattened.append( k )
+            flattened.append( v )
+        md5.update( ''.join( flattened ) )
+
+        # flatten the container names
+        md5.update( ''.join( container_names ) )
+
+        # flatten the annotations dict in to a single string
+        flattened = []
+        for k,v in annotations.iteritems():
+            flattened.append( k )
+            flattened.append( str(v) )
+
+        md5.update( ''.join( flattened ) )
+
+        self.digest = md5.digest()
+
+    def exclude_pod( self, container_name=None, default=False ):
+        """
+            Returns whether or not this pod should be excluded based
+            on include/exclude annotations.  If an annotation 'exclude' exists
+            then this will be returned.  If an annotation 'include' exists, then
+            the boolean opposite of 'include' will be returned.  'include' will
+            always override 'exclude' if it exists.
+
+            param: container_name - if specified, and container_name exists in
+              the pod annotations, then the container specific annotations will
+              also be checked.  These will supercede the pod level include/exclude
+              annotations
+            param: default - Boolean the default value if no annotations are found
+
+            return Boolean - whether or not to exclude this pod
+        """
+
+        def exclude_status( annotations, default ):
+            exclude = annotations.get_bool('exclude', default_value=default)
+
+            # include will always override value of exclude if both exist
+            exclude = not annotations.get_bool('include', default_value=not exclude)
+
+            return exclude
+
+        result = exclude_status( self.annotations, default )
+
+        if container_name and container_name in self.annotations:
+            result = exclude_status( self.annotations[container_name], result )
+
+        return result
+
+class KubernetesCache( object ):
+    """
+        A lazily updated cache for k8s api queries
+
+        A full update of cached data occurs whenever the cache is queried and
+        `cache_expiry_secs` have passed since the last full update.
+
+        If a cache miss occurs e.g. pods were created since the last cache update but
+        that is not yet reflected in the cached data, individual queries to the
+        api are made that get the required data only, and no more.
+
+        If too many cache misses occur within `cache_miss_interval` (e.g. a large
+        number of pods were created since the last full cache update) this will also
+        trigger a full update of the cache.
+
+        This abstraction is thread-safe-ish, assuming objects returned
+        from querying the cache are never written to.
+    """
+
+    def __init__( self, k8s, logger, cache_expiry_secs=120, max_cache_misses=20, cache_miss_interval=10, filter=None ):
+        """
+            Initialises a Kubernees Cache
+            @param: k8s - a KubernetesApi object
+            @param: logger - a Scalyr logger
+            @param: cache_expiry_secs - the number of seconds to wait before doing a full update of data from the k8s api
+            @param: max_cache_misses - the maximum of number of cache misses that can occur in
+                                       `cache_miss_interval` before doing a full update of data from the k8s api
+            @param: cache_miss_interval - the number of seconds that `max_cache_misses` can occur in before a full
+                                          update of the cache occurs
+            @param: filter - a field selector filter when doing bulk query items (e.g. to limit the results to the current node)
+        """
+        # protects self.pods
+        self._lock = threading.Lock()
+
+        # dict of pods dicts.  The outer dict is hashed by namespace,
+        # and the inner dict is hashed by pod
+        self._pods = {}
+
+        self._k8s = k8s
+        self._logger = logger
+        self._filter = filter
+
+        self._cache_expiry_secs = cache_expiry_secs
+        self._last_full_update = time.time() - cache_expiry_secs - 1
+        self._last_pod_cache_miss_update = self._last_full_update
+        self._max_cache_misses = max_cache_misses
+        self._cache_miss_interval = cache_miss_interval
+        self._pod_query_cache_miss = 0
+
+
+    def pods_shallow_copy(self):
+        """Retuns a shallow copy of the pods dict"""
+        result = {}
+        self._lock.acquire()
+        try:
+            for k, v in self._pods.iteritems():
+                result[k] = v
+        finally:
+            self._lock.release()
+
+        return result
+
+    def _update( self, current_time ):
+        """ do a full update of all pod information from the API
+        """
+
+        try:
+            self._logger.log(scalyr_logging.DEBUG_LEVEL_1, 'Attempting to update k8s data from API' )
+            pods_result = self._k8s.query_pods( filter=self._filter )
+            pods = self._process_pods( pods_result )
+        except Exception, e:
+            self._logger.warning( "Exception occurred when updating k8s cache.  Cache was not updated %s\n%s" % (str( e ), traceback.format_exc()) )
+            # early return because we don't want to update our cache with bad data,
+            # but wait at least another full cache expiry before trying again
+            self._last_full_update = current_time
+            return
+
+        self._lock.acquire()
+        try:
+            self._pods = pods
+            self._last_full_update = current_time
+        finally:
+            self._lock.release()
+
+
+    def _update_pod( self, pod_namespace, pod_name ):
+        """ update a single pod, returns the pod if found, otherwise return None """
+        result = None
+        try:
+            # query k8s api and process pod
+            pod = self._k8s.query_pod( pod_namespace, pod_name )
+            result = self._process_pod( pod )
+        except K8sApiException, e:
+            # Don't do anything here.  This means the pod we are querying doensn't exist
+            # and it's up to the caller to handle this by detecting a None result
+            pass
+
+        # update our cache if we have a result
+        if result:
+            self._logger.log( scalyr_logging.DEBUG_LEVEL_2, "Processing single pod: %s/%s" % (result.namespace, result.name) )
+            self._lock.acquire()
+            try:
+                if result.namespace not in self._pods:
+                    self._pods[result.namespace] = {}
+                current = self._pods[result.namespace]
+                current[result.name] = result
+
+            finally:
+                self._lock.release()
+
+        return result
+
+    def _process_pods( self, pods ):
+        """
+            Processes the JsonObject returned from querying the pods and creates PodInfo object,
+
+            @param pods: The JSON object returned as a response from quering all pods
+
+            @return: a dict keyed by namespace, whose values are a dict of pods inside that namespace, keyed by pod name
+        """
+
+        # get all pods
+        items = pods.get( 'items', [] )
+
+        # iterate over all pods, getting PodInfo and storing it in the result
+        # dict, hashed by namespace and pod name
+        result = {}
+        for pod in items:
+            info = self._process_pod( pod )
+            self._logger.log( scalyr_logging.DEBUG_LEVEL_1, "Processing pod: %s:%s" % (info.namespace, info.name) )
+
+            if info.namespace not in result:
+                result[info.namespace] = {}
+
+            current = result[info.namespace]
+            if info.name in current:
+                self._logger.warning( "Duplicate pod '%s' found in namespace '%s', overwriting previous values" % (info.name, info.namespace),
+                                      limit_once_per_x_secs=300, limit_key='duplicate-pod-%s' % info.uid )
+
+            current[info.name] = info
+
+        return result
+
+
+    def _process_pod( self, pod ):
+        """ Generate a PodInfo object from a JSON object
+        @param pod: The JSON object returned as a response to querying
+            a specific pod from the k8s API
+
+        @return A PodInfo object
+        """
+
+        result = {}
+
+        metadata = pod.get( 'metadata', {} )
+        spec = pod.get( 'spec', {} )
+        labels = metadata.get( 'labels', {} )
+        annotations = metadata.get( 'annotations', {} )
+
+        pod_name = metadata.get( "name", '' )
+        namespace = metadata.get( "namespace", '' )
+
+        container_names = []
+        for container in spec.get( 'containers', [] ):
+            container_names.append( container.get( 'name', 'invalid-container-name' ) )
+
+        try:
+            annotations = annotation_config.process_annotations( annotations )
+        except BadAnnotationConfig, e:
+            self._logger.warning( "Bad Annotation config for %s/%s.  All annotations ignored. %s" % (namespace, pod_name, str( e )),
+                                  limit_once_per_x_secs=300, limit_key='bad-annotation-config-%s' % info.uid )
+            annotations = {}
+
+
+        self._logger.log( scalyr_logging.DEBUG_LEVEL_2, "Annotations: %s" % ( str( annotations ) ) )
+
+        # create the PodInfo
+        result = PodInfo( name=pod_name,
+                          namespace=namespace,
+                          uid=metadata.get( "uid", '' ),
+                          node_name=spec.get( "nodeName", '' ),
+                          labels=labels,
+                          container_names=container_names,
+                          annotations=annotations)
+        return result
+
+    def _expired( self, current_time ):
+        """ returns a boolean indicating whether the cache has expired
+        """
+        return self._last_full_update + self._cache_expiry_secs < current_time
+
+    def update_if_expired( self, current_time ):
+        """
+        If the cache has expired, perform a full update of all pod information from the API
+        """
+        if self._expired( current_time ):
+            self._logger.log( scalyr_logging.DEBUG_LEVEL_1, "k8s cache expired, performing full update" )
+            self._update( current_time )
+
+
+    def _update_if_pod_cache_miss_count_exceeds_threshold( self, current_time ):
+        """
+            If too many cache misses happen on single pod queries within a short timespan
+            force an update of all pods.
+            return: True if updated, False otherwise
+        """
+
+        updated = False
+        if self._pod_query_cache_miss > self._max_cache_misses:
+            self._logger.log( scalyr_logging.DEBUG_LEVEL_1, "Too many k8s cache misses, performing full update " )
+            self._update( current_time )
+            updated = True
+        return updated
+
+    def _lookup_pod( self, pod_namespace, pod_name, current_time ):
+        """ Look to see if the pod specified by the pod_namespace and pod_name
+        exist within the cached data.
+
+        Return the pod info, or None if not found
+        """
+        result = None
+        self._lock.acquire()
+        try:
+            namespace = self._pods.get( pod_namespace, {} )
+            result = namespace.get( pod_name, None )
+
+            # check for cache misses
+            if result is None:
+                # if we are within the last cache miss interval, increment miss count
+                if current_time < self._last_pod_cache_miss_update + self._cache_miss_interval:
+                    self._pod_query_cache_miss += 1
+                else:
+                    # otherwise reset the interval and miss count
+                    self._pod_query_cache_miss = 1
+                    self._last_pod_cache_miss_update = current_time
+
+        finally:
+            self._lock.release()
+
+        return result
+
+    def pod( self, pod_namespace, pod_name, current_time=None ):
+        """ returns pod info for the pod specified by pod_namespace and pod_name
+        or None if no pad matches.
+
+        Querying the pod information is thread-safe, but the returned object should
+        not be written to.
+        """
+
+        # update the cache if we are expired
+        if current_time is None:
+            current_time = time.time()
+
+        self.update_if_expired( current_time )
+
+        # see if the pod exists in the cache and return it if so
+        result = self._lookup_pod( pod_namespace, pod_name, current_time )
+        if result:
+            self._logger.log( scalyr_logging.DEBUG_LEVEL_2, "cache hit for pod %s/%s" % (pod_namespace, pod_name) )
+            return result
+
+        # do a full update if too many cache misses in a short period
+        # of time
+        if self._update_if_pod_cache_miss_count_exceeds_threshold( current_time ):
+            # pod might exist in the cache now, so check again
+            result = self._lookup_pod( pod_namespace, pod_name, current_time )
+        else:
+            # otherwise query pod individually
+            self._logger.log( scalyr_logging.DEBUG_LEVEL_2, "cache miss for pod %s/%s" % (pod_namespace, pod_name) )
+            result = self._update_pod( pod_namespace, pod_name )
+
+        return result
+
 
 class KubernetesApi( object ):
     """Simple wrapper class for querying the k8s api

--- a/scalyr_agent/monitor_utils/tests/annotation_config_test.py
+++ b/scalyr_agent/monitor_utils/tests/annotation_config_test.py
@@ -29,9 +29,9 @@ class TestAnnotationConfig(ScalyrTestCase):
 
     def test_plain_values(self):
         annotations = {
-            "config.agent.scalyr.com/someKey": "someValue",
-            "config.agent.scalyr.com/log_path": "/var/log/access.log",
-            "config.agent.scalyr.com/important_field": "important_value",
+            "log.config.scalyr.com/someKey": "someValue",
+            "log.config.scalyr.com/log_path": "/var/log/access.log",
+            "log.config.scalyr.com/important_field": "important_value",
         }
 
         result = annotation_config.process_annotations( annotations )
@@ -48,11 +48,11 @@ class TestAnnotationConfig(ScalyrTestCase):
 
     def test_dict_values(self):
         annotations = {
-            "config.agent.scalyr.com/attributes.parser": "accessLog",
-            "config.agent.scalyr.com/attributes.container": "my-container",
-            "config.agent.scalyr.com/attributes.amazing": "yes it is",
-            "config.agent.scalyr.com/rename_logfile.match": "/var/log/(.*).log",
-            "config.agent.scalyr.com/rename_logfile.replacement": "/scalyr/\\1.log",
+            "log.config.scalyr.com/attributes.parser": "accessLog",
+            "log.config.scalyr.com/attributes.container": "my-container",
+            "log.config.scalyr.com/attributes.amazing": "yes it is",
+            "log.config.scalyr.com/rename_logfile.match": "/var/log/(.*).log",
+            "log.config.scalyr.com/rename_logfile.replacement": "/scalyr/\\1.log",
         }
 
         result = annotation_config.process_annotations( annotations )
@@ -75,9 +75,9 @@ class TestAnnotationConfig(ScalyrTestCase):
     
     def test_list_value(self):
         annotations = {
-            "config.agent.scalyr.com/3": "three",
-            "config.agent.scalyr.com/2": "two",
-            "config.agent.scalyr.com/1": "one",
+            "log.config.scalyr.com/3": "three",
+            "log.config.scalyr.com/2": "two",
+            "log.config.scalyr.com/1": "one",
         }
 
         result = annotation_config.process_annotations( annotations )
@@ -92,14 +92,14 @@ class TestAnnotationConfig(ScalyrTestCase):
     def test_list_of_dicts(self):
 
         annotations = {
-            "config.agent.scalyr.com/10.match_expression": "fourth",
-            "config.agent.scalyr.com/10.sampling_rate": 4,
-            "config.agent.scalyr.com/2.match_expression": "third",
-            "config.agent.scalyr.com/2.sampling_rate": 3,
-            "config.agent.scalyr.com/0.match_expression": "first",
-            "config.agent.scalyr.com/0.sampling_rate": 1,
-            "config.agent.scalyr.com/1.match_expression": "second",
-            "config.agent.scalyr.com/1.sampling_rate": 2
+            "log.config.scalyr.com/10.match_expression": "fourth",
+            "log.config.scalyr.com/10.sampling_rate": 4,
+            "log.config.scalyr.com/2.match_expression": "third",
+            "log.config.scalyr.com/2.sampling_rate": 3,
+            "log.config.scalyr.com/0.match_expression": "first",
+            "log.config.scalyr.com/0.sampling_rate": 1,
+            "log.config.scalyr.com/1.match_expression": "second",
+            "log.config.scalyr.com/1.sampling_rate": 2
         }
 
         result = annotation_config.process_annotations( annotations )
@@ -122,14 +122,14 @@ class TestAnnotationConfig(ScalyrTestCase):
     def test_dict_with_list(self):
 
         annotations = {
-            "config.agent.scalyr.com/rules.10.match_expression": "fourth",
-            "config.agent.scalyr.com/rules.10.sampling_rate": 4,
-            "config.agent.scalyr.com/rules.2.match_expression": "third",
-            "config.agent.scalyr.com/rules.2.sampling_rate": 3,
-            "config.agent.scalyr.com/rules.0.match_expression": "first",
-            "config.agent.scalyr.com/rules.0.sampling_rate": 1,
-            "config.agent.scalyr.com/rules.1.match_expression": "second",
-            "config.agent.scalyr.com/rules.1.sampling_rate": 2
+            "log.config.scalyr.com/rules.10.match_expression": "fourth",
+            "log.config.scalyr.com/rules.10.sampling_rate": 4,
+            "log.config.scalyr.com/rules.2.match_expression": "third",
+            "log.config.scalyr.com/rules.2.sampling_rate": 3,
+            "log.config.scalyr.com/rules.0.match_expression": "first",
+            "log.config.scalyr.com/rules.0.sampling_rate": 1,
+            "log.config.scalyr.com/rules.1.match_expression": "second",
+            "log.config.scalyr.com/rules.1.sampling_rate": 2
         }
 
         result = annotation_config.process_annotations( annotations )
@@ -156,14 +156,14 @@ class TestAnnotationConfig(ScalyrTestCase):
     def test_list_of_lists(self):
 
         annotations = {
-            "config.agent.scalyr.com/2.10.match_expression": "fourth",
-            "config.agent.scalyr.com/2.10.sampling_rate": 4,
-            "config.agent.scalyr.com/2.2.match_expression": "third",
-            "config.agent.scalyr.com/2.2.sampling_rate": 3,
-            "config.agent.scalyr.com/1.0.match_expression": "first",
-            "config.agent.scalyr.com/1.0.sampling_rate": 1,
-            "config.agent.scalyr.com/1.1.match_expression": "second",
-            "config.agent.scalyr.com/1.1.sampling_rate": 2
+            "log.config.scalyr.com/2.10.match_expression": "fourth",
+            "log.config.scalyr.com/2.10.sampling_rate": 4,
+            "log.config.scalyr.com/2.2.match_expression": "third",
+            "log.config.scalyr.com/2.2.sampling_rate": 3,
+            "log.config.scalyr.com/1.0.match_expression": "first",
+            "log.config.scalyr.com/1.0.sampling_rate": 1,
+            "log.config.scalyr.com/1.1.match_expression": "second",
+            "log.config.scalyr.com/1.1.sampling_rate": 2
         }
 
         #import pdb; pdb.set_trace()
@@ -193,44 +193,44 @@ class TestAnnotationConfig(ScalyrTestCase):
    
     def test_mixed_list_and_dict_key(self):
         annotations = {
-            "config.agent.scalyr.com/test.2.match_expression": "third",
-            "config.agent.scalyr.com/test.2.sampling_rate": 3,
-            "config.agent.scalyr.com/test.bad.match_expression": "first",
-            "config.agent.scalyr.com/test.bad.sampling_rate": 1,
-            "config.agent.scalyr.com/test.1.match_expression": "second",
-            "config.agent.scalyr.com/test.1.sampling_rate": 2
+            "log.config.scalyr.com/test.2.match_expression": "third",
+            "log.config.scalyr.com/test.2.sampling_rate": 3,
+            "log.config.scalyr.com/test.bad.match_expression": "first",
+            "log.config.scalyr.com/test.bad.sampling_rate": 1,
+            "log.config.scalyr.com/test.1.match_expression": "second",
+            "log.config.scalyr.com/test.1.sampling_rate": 2
         }
 
         self.assertRaises(annotation_config.BadAnnotationConfig, lambda: annotation_config.process_annotations( annotations ) )
         
     def test_full_config(self):
         annotations = {
-            "config.agent.scalyr.com/path": "/some/path.log",
-            "config.agent.scalyr.com/attributes.parser": "accessLog",
-            "config.agent.scalyr.com/attributes.service": "memcache",
-            "config.agent.scalyr.com/sampling_rules.10.match_expression": "10-INFO",
-            "config.agent.scalyr.com/sampling_rules.10.sampling_rate": 10,
-            "config.agent.scalyr.com/sampling_rules.2.match_expression": "2-INFO",
-            "config.agent.scalyr.com/sampling_rules.2.sampling_rate": 2,
-            "config.agent.scalyr.com/line_groupers.4.start": "start4",
-            "config.agent.scalyr.com/line_groupers.4.continueThrough": "continueThrough",
-            "config.agent.scalyr.com/line_groupers.3.start": "start3",
-            "config.agent.scalyr.com/line_groupers.3.continuePast": "continuePast",
-            "config.agent.scalyr.com/line_groupers.2.start": "start2",
-            "config.agent.scalyr.com/line_groupers.2.haltBefore": "haltBefore",
-            "config.agent.scalyr.com/line_groupers.1.start": "start1",
-            "config.agent.scalyr.com/line_groupers.1.haltWith": "haltWith",
-            "config.agent.scalyr.com/exclude.1": "exclude1",
-            "config.agent.scalyr.com/exclude.2": "exclude2",
-            "config.agent.scalyr.com/exclude.3": "exclude3",
-            "config.agent.scalyr.com/rename_logfile.match": "rename",
-            "config.agent.scalyr.com/rename_logfile.replacement": "renamed",
-            "config.agent.scalyr.com/redaction_rules.1.match_expression": "redacted1",
-            "config.agent.scalyr.com/redaction_rules.2.match_expression": "redacted2",
-            "config.agent.scalyr.com/redaction_rules.2.replacement": "replaced2",
-            "config.agent.scalyr.com/redaction_rules.3.match_expression": "redacted3",
-            "config.agent.scalyr.com/redaction_rules.3.replacement": "replaced3",
-            "config.agent.scalyr.com/redaction_rules.3.hash_salt": "salt3",
+            "log.config.scalyr.com/path": "/some/path.log",
+            "log.config.scalyr.com/attributes.parser": "accessLog",
+            "log.config.scalyr.com/attributes.service": "memcache",
+            "log.config.scalyr.com/sampling_rules.10.match_expression": "10-INFO",
+            "log.config.scalyr.com/sampling_rules.10.sampling_rate": 10,
+            "log.config.scalyr.com/sampling_rules.2.match_expression": "2-INFO",
+            "log.config.scalyr.com/sampling_rules.2.sampling_rate": 2,
+            "log.config.scalyr.com/line_groupers.4.start": "start4",
+            "log.config.scalyr.com/line_groupers.4.continueThrough": "continueThrough",
+            "log.config.scalyr.com/line_groupers.3.start": "start3",
+            "log.config.scalyr.com/line_groupers.3.continuePast": "continuePast",
+            "log.config.scalyr.com/line_groupers.2.start": "start2",
+            "log.config.scalyr.com/line_groupers.2.haltBefore": "haltBefore",
+            "log.config.scalyr.com/line_groupers.1.start": "start1",
+            "log.config.scalyr.com/line_groupers.1.haltWith": "haltWith",
+            "log.config.scalyr.com/exclude.1": "exclude1",
+            "log.config.scalyr.com/exclude.2": "exclude2",
+            "log.config.scalyr.com/exclude.3": "exclude3",
+            "log.config.scalyr.com/rename_logfile.match": "rename",
+            "log.config.scalyr.com/rename_logfile.replacement": "renamed",
+            "log.config.scalyr.com/redaction_rules.1.match_expression": "redacted1",
+            "log.config.scalyr.com/redaction_rules.2.match_expression": "redacted2",
+            "log.config.scalyr.com/redaction_rules.2.replacement": "replaced2",
+            "log.config.scalyr.com/redaction_rules.3.match_expression": "redacted3",
+            "log.config.scalyr.com/redaction_rules.3.replacement": "replaced3",
+            "log.config.scalyr.com/redaction_rules.3.hash_salt": "salt3",
 
         }
 

--- a/scalyr_agent/monitor_utils/tests/annotation_config_test.py
+++ b/scalyr_agent/monitor_utils/tests/annotation_config_test.py
@@ -1,0 +1,319 @@
+# Copyright 2018 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+#
+# author: Imron Alston <imron@scalyr.com>
+
+__author__ = 'imron@scalyr.com'
+
+import scalyr_agent.monitor_utils.annotation_config as annotation_config
+from scalyr_agent.json_lib import JsonObject
+from scalyr_agent.json_lib import JsonArray
+from scalyr_agent.test_base import ScalyrTestCase
+
+
+class TestAnnotationConfig(ScalyrTestCase):
+    def setUp(self):
+        pass
+
+    def test_plain_values(self):
+        annotations = {
+            "config.agent.scalyr.com/someKey": "someValue",
+            "config.agent.scalyr.com/log_path": "/var/log/access.log",
+            "config.agent.scalyr.com/important_field": "important_value",
+        }
+
+        result = annotation_config.process_annotations( annotations )
+
+        self.assertEquals( 3, len( result ) )
+
+        self.assertTrue( 'someKey' in result )
+        self.assertTrue( 'log_path' in result )
+        self.assertTrue( 'important_field' in result )
+
+        self.assertEquals( "someValue", result['someKey'] )
+        self.assertEquals( "/var/log/access.log", result['log_path'] )
+        self.assertEquals( "important_value", result['important_field'] )
+
+    def test_dict_values(self):
+        annotations = {
+            "config.agent.scalyr.com/attributes.parser": "accessLog",
+            "config.agent.scalyr.com/attributes.container": "my-container",
+            "config.agent.scalyr.com/attributes.amazing": "yes it is",
+            "config.agent.scalyr.com/rename_logfile.match": "/var/log/(.*).log",
+            "config.agent.scalyr.com/rename_logfile.replacement": "/scalyr/\\1.log",
+        }
+
+        result = annotation_config.process_annotations( annotations )
+
+        self.assertEquals( 2, len( result ) )
+
+        self.assertTrue( 'attributes' in result )
+        self.assertTrue( 'rename_logfile' in result )
+
+        attrs = result['attributes']
+        self.assertEquals( 3, len( attrs ) )
+
+        self.assertTrue( 'parser' in attrs )
+        self.assertTrue( 'container' in attrs )
+        self.assertTrue( 'amazing' in attrs )
+
+        self.assertEquals( "accessLog", attrs['parser'] )
+        self.assertEquals( "my-container", attrs['container'] )
+        self.assertEquals( "yes it is", attrs['amazing'] )
+    
+    def test_list_value(self):
+        annotations = {
+            "config.agent.scalyr.com/3": "three",
+            "config.agent.scalyr.com/2": "two",
+            "config.agent.scalyr.com/1": "one",
+        }
+
+        result = annotation_config.process_annotations( annotations )
+
+        self.assertTrue( isinstance( result, JsonArray ) )
+        self.assertEqual( 3, len( result ) )
+        self.assertEqual( 'one', result[0] )
+        self.assertEqual( 'two', result[1] )
+        self.assertEqual( 'three', result[2] )
+        
+
+    def test_list_of_dicts(self):
+
+        annotations = {
+            "config.agent.scalyr.com/10.match_expression": "fourth",
+            "config.agent.scalyr.com/10.sampling_rate": 4,
+            "config.agent.scalyr.com/2.match_expression": "third",
+            "config.agent.scalyr.com/2.sampling_rate": 3,
+            "config.agent.scalyr.com/0.match_expression": "first",
+            "config.agent.scalyr.com/0.sampling_rate": 1,
+            "config.agent.scalyr.com/1.match_expression": "second",
+            "config.agent.scalyr.com/1.sampling_rate": 2
+        }
+
+        result = annotation_config.process_annotations( annotations )
+
+        self.assertEquals( 4, len( result ) )
+        self.assertTrue( isinstance( result, JsonArray ) )
+
+        self.assertEquals( "first", result[0]['match_expression'] )
+        self.assertEquals( 1, result[0]['sampling_rate'] )
+   
+        self.assertEquals( "second", result[1]['match_expression'] )
+        self.assertEquals( 2, result[1]['sampling_rate'] )
+   
+        self.assertEquals( "third", result[2]['match_expression'] )
+        self.assertEquals( 3, result[2]['sampling_rate'] )
+   
+        self.assertEquals( "fourth", result[3]['match_expression'] )
+        self.assertEquals( 4, result[3]['sampling_rate'] )
+
+    def test_dict_with_list(self):
+
+        annotations = {
+            "config.agent.scalyr.com/rules.10.match_expression": "fourth",
+            "config.agent.scalyr.com/rules.10.sampling_rate": 4,
+            "config.agent.scalyr.com/rules.2.match_expression": "third",
+            "config.agent.scalyr.com/rules.2.sampling_rate": 3,
+            "config.agent.scalyr.com/rules.0.match_expression": "first",
+            "config.agent.scalyr.com/rules.0.sampling_rate": 1,
+            "config.agent.scalyr.com/rules.1.match_expression": "second",
+            "config.agent.scalyr.com/rules.1.sampling_rate": 2
+        }
+
+        result = annotation_config.process_annotations( annotations )
+
+        self.assertEquals( 1, len( result ) )
+        result = result['rules']
+
+        self.assertEquals( 4, len( result ) )
+        self.assertTrue( isinstance( result, JsonArray ) )
+
+        self.assertEquals( "first", result[0]['match_expression'] )
+        self.assertEquals( 1, result[0]['sampling_rate'] )
+   
+        self.assertEquals( "second", result[1]['match_expression'] )
+        self.assertEquals( 2, result[1]['sampling_rate'] )
+   
+        self.assertEquals( "third", result[2]['match_expression'] )
+        self.assertEquals( 3, result[2]['sampling_rate'] )
+   
+        self.assertEquals( "fourth", result[3]['match_expression'] )
+        self.assertEquals( 4, result[3]['sampling_rate'] )
+        self.assertEquals( 4, result[3]['sampling_rate'] )
+
+    def test_list_of_lists(self):
+
+        annotations = {
+            "config.agent.scalyr.com/2.10.match_expression": "fourth",
+            "config.agent.scalyr.com/2.10.sampling_rate": 4,
+            "config.agent.scalyr.com/2.2.match_expression": "third",
+            "config.agent.scalyr.com/2.2.sampling_rate": 3,
+            "config.agent.scalyr.com/1.0.match_expression": "first",
+            "config.agent.scalyr.com/1.0.sampling_rate": 1,
+            "config.agent.scalyr.com/1.1.match_expression": "second",
+            "config.agent.scalyr.com/1.1.sampling_rate": 2
+        }
+
+        #import pdb; pdb.set_trace()
+        result = annotation_config.process_annotations( annotations )
+
+        self.assertEquals( 2, len( result ) )
+        first = result[0]
+
+        self.assertEquals( 2, len( first ) )
+        self.assertTrue( isinstance( first, JsonArray ) )
+
+        self.assertEquals( "first", first[0]['match_expression'] )
+        self.assertEquals( 1, first[0]['sampling_rate'] )
+   
+        self.assertEquals( "second", first[1]['match_expression'] )
+        self.assertEquals( 2, first[1]['sampling_rate'] )
+
+        second = result[1]
+        self.assertEquals( 2, len( second ) )
+        self.assertTrue( isinstance( second, JsonArray ) )
+   
+        self.assertEquals( "third", second[0]['match_expression'] )
+        self.assertEquals( 3, second[0]['sampling_rate'] )
+   
+        self.assertEquals( "fourth", second[1]['match_expression'] )
+        self.assertEquals( 4, second[1]['sampling_rate'] )
+   
+    def test_mixed_list_and_dict_key(self):
+        annotations = {
+            "config.agent.scalyr.com/test.2.match_expression": "third",
+            "config.agent.scalyr.com/test.2.sampling_rate": 3,
+            "config.agent.scalyr.com/test.bad.match_expression": "first",
+            "config.agent.scalyr.com/test.bad.sampling_rate": 1,
+            "config.agent.scalyr.com/test.1.match_expression": "second",
+            "config.agent.scalyr.com/test.1.sampling_rate": 2
+        }
+
+        self.assertRaises(annotation_config.BadAnnotationConfig, lambda: annotation_config.process_annotations( annotations ) )
+        
+    def test_full_config(self):
+        annotations = {
+            "config.agent.scalyr.com/path": "/some/path.log",
+            "config.agent.scalyr.com/attributes.parser": "accessLog",
+            "config.agent.scalyr.com/attributes.service": "memcache",
+            "config.agent.scalyr.com/sampling_rules.10.match_expression": "10-INFO",
+            "config.agent.scalyr.com/sampling_rules.10.sampling_rate": 10,
+            "config.agent.scalyr.com/sampling_rules.2.match_expression": "2-INFO",
+            "config.agent.scalyr.com/sampling_rules.2.sampling_rate": 2,
+            "config.agent.scalyr.com/line_groupers.4.start": "start4",
+            "config.agent.scalyr.com/line_groupers.4.continueThrough": "continueThrough",
+            "config.agent.scalyr.com/line_groupers.3.start": "start3",
+            "config.agent.scalyr.com/line_groupers.3.continuePast": "continuePast",
+            "config.agent.scalyr.com/line_groupers.2.start": "start2",
+            "config.agent.scalyr.com/line_groupers.2.haltBefore": "haltBefore",
+            "config.agent.scalyr.com/line_groupers.1.start": "start1",
+            "config.agent.scalyr.com/line_groupers.1.haltWith": "haltWith",
+            "config.agent.scalyr.com/exclude.1": "exclude1",
+            "config.agent.scalyr.com/exclude.2": "exclude2",
+            "config.agent.scalyr.com/exclude.3": "exclude3",
+            "config.agent.scalyr.com/rename_logfile.match": "rename",
+            "config.agent.scalyr.com/rename_logfile.replacement": "renamed",
+            "config.agent.scalyr.com/redaction_rules.1.match_expression": "redacted1",
+            "config.agent.scalyr.com/redaction_rules.2.match_expression": "redacted2",
+            "config.agent.scalyr.com/redaction_rules.2.replacement": "replaced2",
+            "config.agent.scalyr.com/redaction_rules.3.match_expression": "redacted3",
+            "config.agent.scalyr.com/redaction_rules.3.replacement": "replaced3",
+            "config.agent.scalyr.com/redaction_rules.3.hash_salt": "salt3",
+
+        }
+
+        result = annotation_config.process_annotations( annotations )
+
+        self.assertEquals( 7, len( result ) )
+
+        self.assertTrue( 'path' in result )
+        self.assertTrue( 'attributes' in result )
+        self.assertTrue( 'sampling_rules' in result )
+        self.assertTrue( 'line_groupers' in result )
+        self.assertTrue( 'exclude' in result )
+        self.assertTrue( 'rename_logfile' in result )
+        self.assertTrue( 'redaction_rules' in result )
+
+        attrs = result['attributes']
+        self.assertTrue( isinstance( attrs, JsonObject ) )
+        self.assertEquals( 2, len( attrs ) )
+        self.assertTrue( 'parser' in attrs )
+        self.assertTrue( 'service' in attrs )
+        self.assertEquals( 'accessLog', attrs['parser'] )
+        self.assertEquals( 'memcache', attrs['service'] )
+
+        sampling = result['sampling_rules']
+        self.assertTrue( isinstance( sampling, JsonArray ) )
+        self.assertEqual( 2, len( sampling ) )
+
+        self.assertEqual( '2-INFO', sampling[0]['match_expression'] )
+        self.assertEqual( 2, sampling[0]['sampling_rate'] )
+        self.assertEqual( '10-INFO', sampling[1]['match_expression'] )
+        self.assertEqual( 10, sampling[1]['sampling_rate'] )
+
+        groupers = result['line_groupers']
+        self.assertTrue( isinstance( groupers, JsonArray ) )
+        self.assertEqual( 4, len( groupers ) )
+
+        self.assertEqual( 'start1', groupers[0]['start'] )
+        self.assertEqual( 'haltWith', groupers[0]['haltWith'] )
+        self.assertEqual( 'start2', groupers[1]['start'] )
+        self.assertEqual( 'haltBefore', groupers[1]['haltBefore'] )
+        self.assertEqual( 'start3', groupers[2]['start'] )
+        self.assertEqual( 'continuePast', groupers[2]['continuePast'] )
+        self.assertEqual( 'start4', groupers[3]['start'] )
+        self.assertEqual( 'continueThrough', groupers[3]['continueThrough'] )
+
+        exclude = result['exclude']
+        self.assertTrue( isinstance( exclude, JsonArray ) )
+        self.assertEqual( 3, len( exclude ) )
+
+        self.assertEqual( 'exclude1', exclude[0] )
+        self.assertEqual( 'exclude2', exclude[1] )
+        self.assertEqual( 'exclude3', exclude[2] )
+
+        rename = result['rename_logfile']
+        self.assertTrue( isinstance( rename, JsonObject ) )
+
+        self.assertEqual( 'rename', rename['match'] )
+        self.assertEqual( 'renamed', rename['replacement'] )
+
+        redaction = result['redaction_rules']
+        self.assertTrue( isinstance( exclude, JsonArray ) )
+        self.assertEqual( 3, len( exclude ) )
+
+        self.assertEqual( 'redacted1', redaction[0]['match_expression'] )
+        self.assertEqual( 'redacted2', redaction[1]['match_expression'] )
+        self.assertEqual( 'replaced2', redaction[1]['replacement'] )
+        self.assertEqual( 'redacted3', redaction[2]['match_expression'] )
+        self.assertEqual( 'replaced3', redaction[2]['replacement'] )
+        self.assertEqual( 'salt3', redaction[2]['hash_salt'] )
+
+
+
+
+    def test_no_scalyr_annotations(self):
+        
+        annotations = {
+            "config.agent.not-scalyr.com/attributes.parser": "accessLog",
+            "config.agent.not-scalyr.com/log_path": "/var/log/access.log",
+            "config.agent.not-scalyr.com/sampling_rules.0.match_expression": "INFO",
+            "config.agent.not-scalyr.com/sampling_rules.0.sampling_rate": 0.1,
+        }
+
+        result = annotation_config.process_annotations( annotations )
+        self.assertFalse( result )
+
+

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -249,9 +249,9 @@ class AgentLogger(logging.Logger):
         self.__metric_handler = None
 
         # The regular expression that must match for metric and field names.  Essentially, it has to begin with
-        # a letter, and only contain letters, digits, periods, underscores, and dashes.  If you change this, be
+        # a letter or underscore, and only contain letters, digits, periods, underscores, and dashes.  If you change this, be
         # sure to fix the __force_valid_metric_or_field_name method below.
-        self.__metric_or_field_name_rule = re.compile('[a-zA-Z][\w\.\-]*$')
+        self.__metric_or_field_name_rule = re.compile('[_a-zA-Z][\w\.\-]*$')
 
         # A dict that maps limit_keys to the last time any record has been emitted that used that key.  This is
         # used to implement the limit_once_per_x_secs feature.
@@ -492,11 +492,11 @@ class AgentLogger(logging.Logger):
     def __force_valid_metric_or_field_name(self, name, is_metric=True):
         """Forces the given metric or field name to be valid.
 
-        A valid metric/field name must being with a letter and only contain alphanumeric characters including
+        A valid metric/field name must being with a letter or underscore and only contain alphanumeric characters including
         periods, underscores, and dashes.
 
         If it is not valid, it will replace invalid characters with underscores.  If it does not being with a letter
-        a sa_ is added as a prefix.
+        or underscore a sa_ is added as a prefix.
 
         If a modification had to be applied, a log warning is emitted, but it is only emitted once per day.
 
@@ -514,16 +514,16 @@ class AgentLogger(logging.Logger):
             self.warn('Invalid metric name "%s" seen.  Metric names must begin with a letter and only contain '
                       'alphanumeric characters as well as periods, underscores, and dashes.  The metric name has been '
                       'fixed by replacing invalid characters with underscores.  Other metric names may be invalid '
-                      '(only reporting first occurrence).', limit_once_per_x_secs=86400, limit_key='badmetricname',
+                      '(only reporting first occurrence).' % name, limit_once_per_x_secs=86400, limit_key='badmetricname',
                       error_code='client/badMetricName')
         else:
             self.warn('Invalid field name "%s" seen.  Field names must begin with a letter and only contain '
                       'alphanumeric characters as well as periods, underscores, and dashes.  The field name has been '
                       'fixed by replacing invalid characters with underscores.  Other field names may be invalid '
-                      '(only reporting first occurrence).', limit_once_per_x_secs=86400, limit_key='badfieldname',
+                      '(only reporting first occurrence).' % name, limit_once_per_x_secs=86400, limit_key='badfieldname',
                       error_code='client/badFieldName')
 
-        if not re.match('^[a-zA-Z]', name):
+        if not re.match('^[_a-zA-Z]', name):
             name = 'sa_' + name
         return re.sub("[^\w\-\.]", '_', name)
 

--- a/scalyr_agent/tests/annotation_config_test.py
+++ b/scalyr_agent/tests/annotation_config_test.py
@@ -1,0 +1,102 @@
+# Copyright 2018 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+#
+# author: Imron Alston <imron@scalyr.com>
+
+__author__ = 'imron@scalyr.com'
+
+from scalyr_agent.monitor_utils.annotation_config import process_annotations
+from scalyr_agent import json_lib
+from scalyr_agent.json_lib import JsonObject
+from scalyr_agent.json_lib import JsonArray
+
+from scalyr_agent.test_base import ScalyrTestCase
+
+class TestAnnotationConfig(ScalyrTestCase):
+
+    def test_invalid_annotations( self ):
+
+        annotations = {
+            "some.other.value": 10,
+            "not.a.scalyr.annotation": "no it's not",
+        }
+
+        result = process_annotations( annotations )
+
+        self.assertEquals( 0, len( result.keys() ) )
+                
+    def test_annotation_object( self ):
+        annotations = {
+            "config.agent.scalyr.com/item1" : "item1",
+            "config.agent.scalyr.com/item2" : "item2",
+            "config.agent.scalyr.com/item3" : "item3"
+        }
+
+        result = process_annotations( annotations )
+        self.assertEquals( 3, len( result.keys() ) )
+        self.assertEquals( 'item1', result['item1'] )
+        self.assertEquals( 'item2', result['item2'] )
+        self.assertEquals( 'item3', result['item3'] )
+
+    def test_annotation_nested_object( self ):
+        annotations = {
+            "config.agent.scalyr.com/item1.nest1" : "item1 nest1",
+            "config.agent.scalyr.com/item1.nest2" : "item1 nest2",
+            "config.agent.scalyr.com/item1.nest3" : "item1 nest3",
+            "config.agent.scalyr.com/item2.nest1" : "item2 nest1",
+            "config.agent.scalyr.com/item2.nest2" : "item2 nest2",
+            "config.agent.scalyr.com/item2.nest3" : "item2 nest3",
+            "config.agent.scalyr.com/item2.nest4" : "item2 nest4"
+        }
+
+        result = process_annotations( annotations )
+        self.assertEquals( 2, len( result.keys() ) )
+        self.assertEquals( 3, len( result['item1'] ) )
+        self.assertEquals( 4, len( result['item2'] ) )
+
+        self.assertEquals( 'item1 nest1', result['item1']['nest1'] )
+        self.assertEquals( 'item1 nest2', result['item1']['nest2'] )
+        self.assertEquals( 'item1 nest3', result['item1']['nest3'] )
+
+        self.assertEquals( 'item2 nest1', result['item2']['nest1'] )
+        self.assertEquals( 'item2 nest2', result['item2']['nest2'] )
+        self.assertEquals( 'item2 nest3', result['item2']['nest3'] )
+        self.assertEquals( 'item2 nest4', result['item2']['nest4'] )
+        
+    def test_annotation_array( self ):
+        annotations = {
+            "config.agent.scalyr.com/item1.20" : "item1 element 2",
+            "config.agent.scalyr.com/item1.0" : "item1 element 0",
+            "config.agent.scalyr.com/item1.10" : "item1 element 1",
+            "config.agent.scalyr.com/item2.0" : "item2 element 0",
+            "config.agent.scalyr.com/item2.1" : "item2 element 1",
+            "config.agent.scalyr.com/item2.2" : "item2 element 2",
+            "config.agent.scalyr.com/item2.3" : "item2 element 3",
+        }
+
+        result = process_annotations( annotations )
+        self.assertEquals( 2, len( result.keys() ) )
+        self.assertEquals( 3, len( result['item1'] ) )
+        self.assertEquals( 4, len( result['item2'] ) )
+
+        self.assertEquals( 'item1 element 0', result['item1'][0] )
+        self.assertEquals( 'item1 element 1', result['item1'][1] )
+        self.assertEquals( 'item1 element 2', result['item1'][2] )
+
+        self.assertEquals( 'item2 element 0', result['item2'][0] )
+        self.assertEquals( 'item2 element 1', result['item2'][1] )
+        self.assertEquals( 'item2 element 2', result['item2'][2] )
+        self.assertEquals( 'item2 element 3', result['item2'][3] )
+

--- a/scalyr_agent/tests/annotation_config_test.py
+++ b/scalyr_agent/tests/annotation_config_test.py
@@ -39,9 +39,9 @@ class TestAnnotationConfig(ScalyrTestCase):
                 
     def test_annotation_object( self ):
         annotations = {
-            "config.agent.scalyr.com/item1" : "item1",
-            "config.agent.scalyr.com/item2" : "item2",
-            "config.agent.scalyr.com/item3" : "item3"
+            "log.config.scalyr.com/item1" : "item1",
+            "log.config.scalyr.com/item2" : "item2",
+            "log.config.scalyr.com/item3" : "item3"
         }
 
         result = process_annotations( annotations )
@@ -52,13 +52,13 @@ class TestAnnotationConfig(ScalyrTestCase):
 
     def test_annotation_nested_object( self ):
         annotations = {
-            "config.agent.scalyr.com/item1.nest1" : "item1 nest1",
-            "config.agent.scalyr.com/item1.nest2" : "item1 nest2",
-            "config.agent.scalyr.com/item1.nest3" : "item1 nest3",
-            "config.agent.scalyr.com/item2.nest1" : "item2 nest1",
-            "config.agent.scalyr.com/item2.nest2" : "item2 nest2",
-            "config.agent.scalyr.com/item2.nest3" : "item2 nest3",
-            "config.agent.scalyr.com/item2.nest4" : "item2 nest4"
+            "log.config.scalyr.com/item1.nest1" : "item1 nest1",
+            "log.config.scalyr.com/item1.nest2" : "item1 nest2",
+            "log.config.scalyr.com/item1.nest3" : "item1 nest3",
+            "log.config.scalyr.com/item2.nest1" : "item2 nest1",
+            "log.config.scalyr.com/item2.nest2" : "item2 nest2",
+            "log.config.scalyr.com/item2.nest3" : "item2 nest3",
+            "log.config.scalyr.com/item2.nest4" : "item2 nest4"
         }
 
         result = process_annotations( annotations )
@@ -77,13 +77,13 @@ class TestAnnotationConfig(ScalyrTestCase):
         
     def test_annotation_array( self ):
         annotations = {
-            "config.agent.scalyr.com/item1.20" : "item1 element 2",
-            "config.agent.scalyr.com/item1.0" : "item1 element 0",
-            "config.agent.scalyr.com/item1.10" : "item1 element 1",
-            "config.agent.scalyr.com/item2.0" : "item2 element 0",
-            "config.agent.scalyr.com/item2.1" : "item2 element 1",
-            "config.agent.scalyr.com/item2.2" : "item2 element 2",
-            "config.agent.scalyr.com/item2.3" : "item2 element 3",
+            "log.config.scalyr.com/item1.20" : "item1 element 2",
+            "log.config.scalyr.com/item1.0" : "item1 element 0",
+            "log.config.scalyr.com/item1.10" : "item1 element 1",
+            "log.config.scalyr.com/item2.0" : "item2 element 0",
+            "log.config.scalyr.com/item2.1" : "item2 element 1",
+            "log.config.scalyr.com/item2.2" : "item2 element 2",
+            "log.config.scalyr.com/item2.3" : "item2 element 3",
         }
 
         result = process_annotations( annotations )

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -33,7 +33,7 @@ from scalyr_agent import json_lib
 from scalyr_agent.json_lib import JsonObject
 from scalyr_agent.json_lib import JsonArray
 from scalyr_agent.util import md5_digest
-from scalyr_agent.configuration import Configuration
+from scalyr_agent.configuration import Configuration, BadConfiguration
 from scalyr_agent.platform_controller import DefaultPaths
 
 from scalyr_agent.test_base import ScalyrTestCase
@@ -168,6 +168,18 @@ class TestLogFileIterator(ScalyrTestCase):
 
         for line in expected:
             self.assertEquals(line, self.readline().line)
+
+    def test_multiple_line_grouper_options(self):
+        log_config = {'path': self.__path,
+                      'lineGroupers': JsonArray( JsonObject({'start': '^--multi', 'continueThrough': "^--", 'continuePast': '\n'}) )
+                                       }
+        self.assertRaises( BadConfiguration, DEFAULT_CONFIG.parse_log_config, log_config )
+
+    def test_insufficient_line_grouper_options(self):
+        log_config = {'path': self.__path,
+                      'lineGroupers': JsonArray( JsonObject({'start': '^--multi'}) )
+                                       }
+        self.assertRaises( BadConfiguration, DEFAULT_CONFIG.parse_log_config, log_config )
 
     def test_multiple_scans(self):
         self.append_file(self.__path,


### PR DESCRIPTION
This pull request enables log file configuration using kubernetes annotations.

It processes all annotations, and for any annotations that start with the prefix `config.agent.scalyr.com/` it extracts the entries (minus the prefix) and maps them to a dict which is later applied to the log_config used by the log files processed by the k8s monitor.  See below for mapping behaviour.

Supported fields are:

* parser
* attributes
* sampling_rules
* rename_logfile
* redaction_rules

Which behave in the same way as specified in the main [Scalyr help docs](https://www.scalyr.com/help/scalyr-agent?teamToken=y_9E6DfWhCq%2FXYr7DN2zCw--#logUpload).  Items that do not work as specified in help are

* exclude (see below)
* lineGroupers (not supported at all)
* path (the path is always fixed for k8s container logs)

Excluding Logs
------

Containers and pods can be specifically included/excluded from logging.  Unlike the normal log_config `exclude` option which takes an array of log path exclusion globs, annotations simply support a Boolean true/false for a given container/pod.  Both `include` and `exclude` are supported, with `include` always overriding `exclude` if both are set. e.g.

    config.agent.scalyr.com/exclude: true

has the same effect as

    config.agent.scalyr.com/include: false

By default the agent monitors the logs of all pods/containers, and you have to manually exclude pods/containers you don't want.  You can also set a value in agent.json `k8s_include_all_containers: false`, in which case all containers are excluded by default and have to be manually included.

Mapping of Annotation Strings to Config Options
--------

Items separated by a period are mapped to dict keys e.g. if the annotation was specified as:

      config.agent.scalyr.com/attributes.parser: accessLog

It would be mapped to a dict

    result = {
        "attributes": {
            "parser": "accessLog"
        }
    }

Arrays can be specified by using one or more digits as the key, e.g. if the annotation was

      config.agent.scalyr.com/sampling_rules.0.match_expression: INFO
      config.agent.scalyr.com/sampling_rules.0.sampling_rate: 0.1
      config.agent.scalyr.com/sampling_rules.1.match_expression: FINE
      config.agent.scalyr.com/sampling_rules.1.sampling_rate: 0

This will be mapped to the following structure:

    result = {
        "sampling_rules": [
            {
                "match_expression": "INFO",
                "sampling_rate": 0.1
            },
            {
                "match_expression": "FINE",
                "sampling_rate": 0
            }
        ]
    }

Array keys are sorted by numeric order before processing and unique objects need to have different digits as the array key. If a sub-key has an identical array key as a previously seen sub-key, then the previous value of the sub-key is overwritten

There is no guarantee about the order of processing for items with the same numeric array key, so if the config was specified as:

      config.agent.scalyr.com/sampling_rules.0.match_expression: INFO
      config.agent.scalyr.com/sampling_rules.0.match_expression: FINE

It is not defined or guaranteed what the actual value will be (INFO or FINE).

Applying config options to specific containers in a pod
-------

If a pod has multiple containers and you only want to apply log configuration options to a specific container you can do so by prefixing the option with the container name, e.g. if you had a pod with two containers `nginx` and `helper1` and you wanted to exclude `helper1` logs you could specify the following annotation:

    config.agent.scalyr.com/helper1.exclude: true

Config items specified without a container name are applied to all containers in the pod, but container specific settings will override pod-level options, e.g. in this example:

    config.agent.scalyr.com/exclude: true
    config.agent.scalyr.com/nginx.include: true

All containers in the pod would be excluded *except* for the nginx container which is included.

This technique is applicable for all log_config options, not just include/exclude, so for example you could set line sampling rules for all containers in a pod, but use a different set of line sampling rules for one specific container in the pod if needed.

Dynamic Updates
------

Currently all annotation config options except `exclude: true`/`include: false` can be dynamically updated using the `kubectl annotate` command.

For `exclude: true`/`include: false` once a pod/container has started being logged, then while the container is still running, there is currently no way to dynamically start/stop logging of that container using annotations without updating the config yaml, and applying the updated config to the cluster.

Documentation is still to come, and will be included during the code review stage.