### PR TITLE
Imron/performance update

### DIFF
--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -569,6 +569,11 @@ class Configuration(object):
         return self.__get_config().get_int('full_checkpoint_interval_in_seconds' )
 
     @property
+    def minimum_scan_interval(self):
+        """Returns the configuration value for 'minimum_scan_interval'."""
+        return self.__get_config().get_int('minimum_scan_interval', none_if_missing=True )
+
+    @property
     def close_old_files_duration_in_seconds(self):
         """Returns the configuration value for 'close_old_files_duration_in_seconds'."""
         return self.__get_config().get_int('close_old_files_duration_in_seconds')
@@ -857,6 +862,7 @@ class Configuration(object):
         self.__verify_or_set_optional_float(config, 'min_request_spacing_interval', 1.0, description, apply_defaults)
         self.__verify_or_set_optional_float(config, 'max_request_spacing_interval', 5.0, description, apply_defaults)
         self.__verify_or_set_optional_float(config, 'max_error_request_spacing_interval', 30.0, description, apply_defaults)
+        self.__verify_or_set_optional_int(config, 'minimum_scan_interval', None, description, apply_defaults)
 
         self.__verify_or_set_optional_int(config, 'low_water_bytes_sent', 20*1024, description, apply_defaults)
         self.__verify_or_set_optional_float(config, 'low_water_request_spacing_adjustment', 1.5, description, apply_defaults)
@@ -1040,6 +1046,8 @@ class Configuration(object):
 
         self.__verify_or_set_optional_bool(log_entry, 'ignore_stale_files', False, description)
         self.__verify_or_set_optional_float(log_entry, 'staleness_threshold_secs', 5*60, description)
+
+        self.__verify_or_set_optional_int(log_entry, 'minimum_scan_interval', None, description)
 
         # Verify that if it has a sampling_rules array, then it is an array of json objects.
         self.__verify_or_set_optional_array(log_entry, 'sampling_rules', description)

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -564,6 +564,11 @@ class Configuration(object):
         return self.__get_config().get_float('global_monitor_sample_interval')
 
     @property
+    def full_checkpoint_interval(self):
+        """Returns the configuration value for 'full_checkpoint_interval_in_seconds'."""
+        return self.__get_config().get_int('full_checkpoint_interval_in_seconds' )
+
+    @property
     def close_old_files_duration_in_seconds(self):
         """Returns the configuration value for 'close_old_files_duration_in_seconds'."""
         return self.__get_config().get_int('close_old_files_duration_in_seconds')
@@ -845,6 +850,7 @@ class Configuration(object):
 
         self.__verify_or_set_optional_float(config, 'global_monitor_sample_interval', 30.0, description, apply_defaults)
         self.__verify_or_set_optional_int(config, 'close_old_files_duration_in_seconds', 60*60*1, description, apply_defaults)
+        self.__verify_or_set_optional_int(config, 'full_checkpoint_interval_in_seconds', 60, description, apply_defaults)
 
         self.__verify_or_set_optional_int(config, 'max_allowed_request_size', 1*1024*1024, description, apply_defaults)
         self.__verify_or_set_optional_int(config, 'min_allowed_request_size', 100*1024, description, apply_defaults)

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -1305,6 +1305,9 @@ class LogFileProcessor(object):
         # Trackers whether or not close has been invoked on this processor.
         self.__is_closed = False
 
+        # Tracks whether the processor has recently logged data
+        self.__is_active = False
+
         # The processor should be closed if the staleness of this file exceeds this number of seconds (if not None)
         self.__close_when_staleness_exceeds = close_when_staleness_exceeds
 
@@ -1403,6 +1406,13 @@ class LogFileProcessor(object):
         result = self.__is_closed
         self.__lock.release()
         return result
+
+    @property
+    def is_active( self ):
+        return self.__is_active
+
+    def set_inactive( self ):
+        self.__is_active = False
 
     @property
     def log_path(self):
@@ -1561,6 +1571,9 @@ class LogFileProcessor(object):
                     total_redactions += 1L
                 bytes_copied += line_len
                 lines_copied += 1
+
+            if not self.__is_active:
+                self.__is_active = bytes_read > 0
 
             final_position = self.__log_file_iterator.tell()
 

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -1619,8 +1619,8 @@ class LogFileProcessor(object):
                     # If it was a success, then we update the counters and advance the iterator.
                     if result == LogFileProcessor.SUCCESS:
                         self.__total_bytes_copied += bytes_copied
-                        self.__total_bytes_skipped += self.__log_file_iterator.bytes_between_positions(
-                            original_position, final_position) - bytes_read
+                        bytes_between_positions = self.__log_file_iterator.bytes_between_positions( original_position, final_position)
+                        self.__total_bytes_skipped +=  bytes_between_positions - bytes_read
 
                         self.__total_bytes_dropped_by_sampling += bytes_dropped_by_sampling
                         self.__total_bytes_pending = self.__log_file_iterator.available
@@ -1631,7 +1631,10 @@ class LogFileProcessor(object):
 
                         # Do a mark to cleanup any state in the iterator.  We know we won't have to roll back
                         # to before this point now.
-                        self.__log_file_iterator.mark(final_position, current_time=current_time)
+                        # only mark files that have logged new bytes to prevent stat'ing unused files
+                        if bytes_between_positions > 0:
+                            self.__log_file_iterator.mark(final_position, current_time=current_time)
+
                         if self.__log_file_iterator.at_end or self.__should_close_because_stale(current_time):
                             self.__log_file_iterator.close()
                             self.__is_closed = True


### PR DESCRIPTION
This set of commits contains work from the performance improvement research done about a year ago, updated to merge cleanly with the current master, as well as new changes to disable json parsing of k8s logs on the client.

New configuration options
------

* k8s_parse_json - Defaults to True.  An option of the kubernetes_monitor.  If True log files will be parsed as json to extract the log message and timestamp.  If False, the raw json will be uploaded as the log message.  This option can be turned on to avoid json parsing on the client.

* minimum_scan_interval - Defaults to `None`.  This can be specified as either a global or a log_config option, and the log_config option will override the global one if specified.  This option is a value in seconds that controls how often to scan a log file for new bytes.   If not specified, logs are scanned every iteration of the main loop.  If you have a large number of low frequency logs and a handful of high frequency logs, you can set the minimum_scan_interval for the low frequency logs to a high value (e.g. 10-15 seconds or even longer).  That way the agent is mostly processing the high frequency logs, and only looks at the low frequency logs every `minimum_scan_interval` seconds.

* full_checkpoint_interval_in_seconds.  Defaults to 60 seconds, a global option specified in agent.json (or agent.d/*) that controls how often a full checkpoint is written to disk.  Previously, a full checkpoint was written at the end of each main loop.  Now each loop it will only write checkpoints for active files (i.e. those that have logged data), and then every `full_checkpoint_interval_in_seconds` it will write the full set of checkpoints.

Testing
------

To test performance improvements.  Firstly I would run the agent with this set of patches applied.  There should be some performance improvement gains in terms of reduced CPU usage.

After checking those results. I would then test with k8s_parse_json set as `False` to see if further gains can be had by not parsing json logs on the client.

Finally if the node has a large number of containers running on it, most of which log with a low frequency log, but one or two that log with a high frequency, I would try looking at configuring the minimum_scan_interval for low frequency logs.  This might be tricky to configure for individual logs under k8s due to needing to create `log` sections in the agent.d/* files.  Probably the best way to do this for testing purposes would be to set it at 5-10 seconds as a global option (which will apply to all log files) and then have a specific `log` rules to match the container id of high frequency logs, and for those logs setting the value to 0.  Setting this value will become much easier once #105 is merged, which allows setting log_config values in the k8s pod yaml files.  If a node mostly has containers that log with high frequency and only a handful that log with low frequency, it is probably not worth setting this option.