### PR TITLE
annotation config can be disabled, plus documentation

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -119,6 +119,11 @@ define_config_option( __monitor__, 'report_container_metrics',
                       'Optional (defaults to True). If true, metrics will be collected from the container and reported  '
                       'to Scalyr.', convert_to=bool, default=True)
 
+define_config_option( __monitor__, 'allow_annotation_config',
+                      'Optional (defaults to True). If true, then the log configuration settings for k8s containers can be '
+                      'configured with annotations.',
+                      convert_to=bool, default=True)
+
 define_config_option( __monitor__, 'k8s_include_all_containers',
                       'Optional (defaults to True). If True, all containers in all pods will be monitored by the kubernetes monitor '
                       'unless they have an include: false or exclude: true annotation. '
@@ -507,6 +512,8 @@ class ContainerChecker( StoppableThread ):
         self.__k8s_max_cache_misses = self._config.get( 'k8s_max_cache_misses' )
         self.__k8s_cache_miss_interval = self._config.get( 'k8s_cache_miss_interval' )
 
+        self.__allow_annotation_config = self._config.get( 'allow_annotation_config' )
+
         self.__k8s_filter = None
         self.k8s_cache = None
 
@@ -527,6 +534,7 @@ class ContainerChecker( StoppableThread ):
                 cache_expiry_secs=self.__k8s_cache_expiry_secs,
                 max_cache_misses=self.__k8s_max_cache_misses,
                 cache_miss_interval=self.__k8s_cache_miss_interval,
+                allow_annotations=self.__allow_annotation_config,
                 filter=self.__k8s_filter )
 
             self.containers = _get_containers(self.__client, ignore_container=self.container_id, glob_list=self.__glob_list, include_log_path=True, k8s_cache=self.k8s_cache, k8s_include_by_default=self.__include_all )
@@ -894,8 +902,10 @@ class ContainerChecker( StoppableThread ):
                 # get the annotations of this pod as a dict.
                 # by default all annotations will be applied to all containers
                 # in the pod
-                all_annotations = pod.annotations
                 container_specific_annotations = False
+                all_annotations = {}
+                if self.__allow_annotation_config:
+                    all_annotations = pod.annotations
 
                 # get any common annotations for all containers
                 for annotation, value in all_annotations.iteritems():
@@ -934,10 +944,14 @@ class ContainerChecker( StoppableThread ):
             result = self.__create_log_config( parser=parser, path=info['log_path'], attributes=container_attributes, parse_as_json=True )
             result['rename_logfile'] = '/docker/%s.log' % info['name']
 
-        # apply common annotations first
-        annotations = common_annotations
-        # set/override any container specific annotations
-        annotations.update( container_annotations )
+        if self.__allow_annotation_config:
+            # apply common annotations first
+            annotations = common_annotations
+            # set/override any container specific annotations
+            annotations.update( container_annotations )
+        else:
+            # no annotations
+            annotations = {}
 
         # ignore include/exclude options which have special
         # handling in the log_config verification that expects a different type than the one used in the nnotations
@@ -1214,12 +1228,142 @@ class ContainerIdResolver():
 
 
 class KubernetesMonitor( ScalyrMonitor ):
-    """Monitor plugin for kubernetes
+    """
+    # Kubernetes Monitor
 
-    This plugin is based of the docker_monitor plugin, and uses the raw logs mode of the docker
+    This monitor is based of the docker_monitor plugin, and uses the raw logs mode of the docker
     plugin to send kubernetes logs to Scalyr.  It also reads labels from the Kubernetes api and
     associates them with the appropriate logs.
-    TODO:  Back fill the instructions here.
+
+    ## Log Config via Annotations
+
+    The configuration of the logs added by the kubernetes monitor can be configured via annotations
+    added to the pod that owns the container.  For all pods, the monitor examins all annotations,
+    and for any annotation that begins with the prefix log.config.scalyr.com/ it extracts the
+    entries (minus the prefix) and maps them to a dict which is later applied to the log_config used
+    by the log files processed by the k8s monitor. See below for mapping behaviour.
+
+    Supported fields are:
+
+    * parser
+    * attributes
+    * sampling_rules
+    * rename_logfile
+    * redaction_rules
+
+    Which behave in the same way as specified in the main [Scalyr help
+    docs](https://www.scalyr.com/help/scalyr-agent#logUpload). Items that do not work as specified
+    in help are:
+
+    * exclude (see below)
+    * lineGroupers (not supported at all)
+    * path (the path is always fixed for k8s container logs)
+
+    ### Excluding Logs
+
+    Containers and pods can be specifically included/excluded from logging.  Unlike the normal
+    log_config `exclude` option which takes an array of log path exclusion globs, annotations simply
+    support a Boolean true/false for a given container/pod.  Both `include` and `exclude` are
+    supported, with `include` always overriding `exclude` if both are set. e.g.
+
+        config.agent.scalyr.com/exclude: true
+
+    has the same effect as
+
+        config.agent.scalyr.com/include: false
+
+    By default the agent monitors the logs of all pods/containers, and you have to manually exclude
+    pods/containers you don't want.  You can also set a value in agent.json
+    `k8s_include_all_containers: false`, in which case all containers are excluded by default and
+    have to be manually included.
+
+    ### Specifying Config Options
+
+    The kubernetes monitor takes the string value of each annotation and maps it to a dict, or
+    array value according to the following format:
+
+    Values separated by a period are mapped to dict keys e.g. if one annotation on a given pod was
+    specified as:
+
+          log.config.scalyr.com/attributes.parser: accessLog
+
+    Then this would be mapped to the following dict, which would then be applied to the log config
+    for all containers in that pod:
+
+        { "attributes": { "parser": "accessLog" } }
+
+    Arrays can be specified by using one or more digits as the key, e.g. if the annotation was
+
+          log.config.scalyr.com/sampling_rules.0.match_expression: INFO
+          log.config.scalyr.com/sampling_rules.0.sampling_rate: 0.1
+          log.config.scalyr.com/sampling_rules.1.match_expression: FINE
+          log.config.scalyr.com/sampling_rules.1.sampling_rate: 0
+
+    This will be mapped to the following structure:
+
+        { "sampling_rules":
+          [
+            { "match_expression": "INFO", "sampling_rate": 0.1 },
+            { "match_expression": "FINE", "sampling_rate": 0 }
+          ]
+        }
+
+    Array keys are sorted by numeric order before processing and unique objects need to have
+    different digits as the array key. If a sub-key has an identical array key as a previously seen
+    sub-key, then the previous value of the sub-key is overwritten
+
+    There is no guarantee about the order of processing for items with the same numeric array key,
+    so if the config was specified as:
+
+          log.config.scalyr.com/sampling_rules.0.match_expression: INFO
+          log.config.scalyr.com/sampling_rules.0.match_expression: FINE
+
+    It is not defined or guaranteed what the actual value will be (INFO or FINE).
+
+    ### Applying config options to specific containers in a pod
+
+    If a pod has multiple containers and you only want to apply log configuration options to a
+    specific container you can do so by prefixing the option with the container name, e.g. if you
+    had a pod with two containers `nginx` and `helper1` and you wanted to exclude `helper1` logs you
+    could specify the following annotation:
+
+        log.config.scalyr.com/helper1.exclude: true
+
+    Config items specified without a container name are applied to all containers in the pod, but
+    container specific settings will override pod-level options, e.g. in this example:
+
+        log.config.scalyr.com/exclude: true
+        log.config.scalyr.com/nginx.include: true
+
+    All containers in the pod would be excluded *except* for the nginx container which is included.
+
+    This technique is applicable for all log config options, not just include/exclude, so for
+    example you could set line sampling rules for all containers in a pod, but use a different set
+    of line sampling rules for one specific container in the pod if needed.
+
+    ### Dynamic Updates
+
+    Currently all annotation config options except `exclude: true`/`include: false` can be
+    dynamically updated using the `kubectl annotate` command.
+
+    For `exclude: true`/`include: false` once a pod/container has started being logged, then while the
+    container is still running, there is currently no way to dynamically start/stop logging of that
+    container using annotations without updating the config yaml, and applying the updated config to the
+    cluster.
+
+    ### Disabling Annotation Config
+
+    You can disable using annotations to configure the log files processed by the kubernetes monitor
+    by setting the following value in the config section of the kubernetes_monitor in
+    agent.d/docker.json
+
+        "monitors":[
+          {
+            "module": "scalyr_agent.builtin_monitors.kubernetes_monitor",
+            "allow_annotation_config": false
+          }
+        ]
+
     """
 
     def __get_socket_file( self ):

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -425,10 +425,9 @@ class _K8sProcessor( object ):
 
 class PodProcessor( _K8sProcessor ):
 
-    def __init__( self, k8s, logger, filter, replicasets, allow_annotations ):
+    def __init__( self, k8s, logger, filter, replicasets ):
         super( PodProcessor, self).__init__( k8s, logger, filter )
         self._replicasets = replicasets
-        self._allow_annotations = allow_annotations
 
     def query_all_objects( self ):
         """
@@ -493,15 +492,11 @@ class PodProcessor( _K8sProcessor ):
         for container in spec.get( 'containers', [] ):
             container_names.append( container.get( 'name', 'invalid-container-name' ) )
 
-        # check to see if we allow annotations
-        if self._allow_annotations:
-            try:
-                annotations = annotation_config.process_annotations( annotations )
-            except BadAnnotationConfig, e:
-                self._logger.warning( "Bad Annotation config for %s/%s.  All annotations ignored. %s" % (namespace, pod_name, str( e )),
-                                      limit_once_per_x_secs=300, limit_key='bad-annotation-config-%s' % info.uid )
-                annotations = {}
-        else:
+        try:
+            annotations = annotation_config.process_annotations( annotations )
+        except BadAnnotationConfig, e:
+            self._logger.warning( "Bad Annotation config for %s/%s.  All annotations ignored. %s" % (namespace, pod_name, str( e )),
+                                  limit_once_per_x_secs=300, limit_key='bad-annotation-config-%s' % info.uid )
             annotations = {}
 
 
@@ -602,7 +597,7 @@ class DeploymentProcessor( _K8sProcessor ):
 
 class KubernetesCache( object ):
 
-    def __init__( self, k8s, logger, cache_expiry_secs=120, max_cache_misses=20, cache_miss_interval=10, allow_annotations=True, filter=None ):
+    def __init__( self, k8s, logger, cache_expiry_secs=120, max_cache_misses=20, cache_miss_interval=10, filter=None ):
 
         # create the deployment cache
         deployment_processor = DeploymentProcessor( k8s, logger )
@@ -619,7 +614,7 @@ class KubernetesCache( object ):
                                cache_miss_interval=cache_miss_interval )
 
         # create the pod cache
-        pod_processor = PodProcessor( k8s, logger, filter, self._replicasets, allow_annotations )
+        pod_processor = PodProcessor( k8s, logger, filter, self._replicasets )
         self._pods = _K8sCache( logger, pod_processor, 'pod',
                                cache_expiry_secs=cache_expiry_secs,
                                max_cache_misses=max_cache_misses,


### PR DESCRIPTION
Here is the option for disable annotation configs.

I've also updated the inline documentation for the kubernetes monitor.

It's rebased of the current master (but not with the network stats).

Let me know if you'd like me do rebase it off the k8s network metrics changes instead.