### PR TITLE
Allow unspecified Journal Paths

### DIFF
--- a/docs/monitors/journald_monitor.md
+++ b/docs/monitors/journald_monitor.md
@@ -60,7 +60,7 @@ config the journald monitor:
 
 |||# Option                        ||| Usage
 |||# ``module``                    ||| Always ``scalyr_agent.builtin_monitors.journald_monitor``
-|||# ``journal_path``              ||| Optional (defaults to ``/var/log/journal``). Location on the filesystem of the journald logs.
+|||# ``journal_path``              ||| Optional (defaults to ``/var/log/journal``). Location on the filesystem of the journald logs. If this is the empty string, resolves to the current (boot) journal.
 |||# ``journal_poll_interval``      ||| Optional (defaults to ``5``). The number of seconds to wait for data while polling \
                                        the journal file. Fractional values are supported.
 |||# ``journal_fields``            ||| Optional dict containing journal fields to upload with each message, \

--- a/scalyr_agent/builtin_monitors/journald_monitor.py
+++ b/scalyr_agent/builtin_monitors/journald_monitor.py
@@ -198,6 +198,8 @@ class JournaldMonitor(ScalyrMonitor):
 
     def _initialize(self):
         self._journal_path = self._config.get( 'journal_path' )
+        if len(self._journal_path) == 0:
+            self._journal_path = None
         if self._journal_path and not os.path.exists( self._journal_path ):
             raise BadMonitorConfiguration( "journal_path '%s' does not exist or is not a directory" % self._journal_path, 'journal_path' )
 

--- a/scalyr_agent/builtin_monitors/journald_monitor.py
+++ b/scalyr_agent/builtin_monitors/journald_monitor.py
@@ -198,7 +198,7 @@ class JournaldMonitor(ScalyrMonitor):
 
     def _initialize(self):
         self._journal_path = self._config.get( 'journal_path' )
-        if not os.path.exists( self._journal_path ):
+        if self._journal_path and not os.path.exists( self._journal_path ):
             raise BadMonitorConfiguration( "journal_path '%s' does not exist or is not a directory" % self._journal_path, 'journal_path' )
 
         self._id = self._config.get( 'id' )


### PR DESCRIPTION
According to the documentation for the journal.Reader class
https://www.freedesktop.org/software/systemd/python-systemd/journal.html#systemd.journal.Reader
the path flag is optional. If the path is set to `None` it defaults to the system journal.