### PR TITLE
Allow configuration scalyr_server via k8s configmap

### DIFF
--- a/k8s/scalyr-agent-2.yaml
+++ b/k8s/scalyr-agent-2.yaml
@@ -26,6 +26,18 @@ spec:
               configMapKeyRef:
                  name: scalyr-config
                  key: k8s_cluster
+          - name: SCALYR_SERVER
+            valueFrom:
+              configMapKeyRef:
+                 name: scalyr-config
+                 key: scalyr_server
+                 optional: true
+          - name: SCALYR_DAEMONSETS_AS_DEPLOYMENTS
+            valueFrom:
+              configMapKeyRef:
+                 name: scalyr-config
+                 key: daemonsets_as_deployments
+                 optional: true
         resources:
           limits:
             memory: 500Mi


### PR DESCRIPTION
Allows easier configuration if your Scalyr account is in the EU.
Also added option for the include_daemonsets_as_deployments fix
though should only be needed if customers wish to disable
this behavior.