### PR TITLE
Ticket #AGENT-32

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -213,7 +213,7 @@ class ScalyrAgent(object):
         self.__config_file_path = config_file_path
 
         try:
-            self.__config = self.__read_and_verify_config(config_file_path)
+            self.__config = self.__read_and_verify_config(config_file_path, force_http=command_options.force_http )
 
             # check if not a tty and override the no check remote variable
             if not sys.stdout.isatty():
@@ -275,21 +275,24 @@ class ScalyrAgent(object):
                 raise Exception('Caught exception when attempt to execute command %s.  Exception was %s' %
                                 (command, str(e)))
 
-    def __read_and_verify_config(self, config_file_path):
+    def __read_and_verify_config(self, config_file_path, force_http ):
         """Reads the configuration and verifies it can be successfully parsed including the monitors existing and
         having valid configurations.
 
         @param config_file_path: The path to read the configuration from.
         @type config_file_path: str
 
+        @param force_http: Whether or not to force the scalyr server to use 'http'
+        @type force_http: boolean
+
         @return: The configuration object.
         @rtype: scalyr_agent.Configuration
         """
-        config = self.__read_config(config_file_path)
+        config = self.__read_config(config_file_path, force_http )
         self.__verify_config(config)
         return config
 
-    def __read_config(self, config_file_path):
+    def __read_config(self, config_file_path, force_http ):
         """Reads the configuration from the file path but does not do a full verification.
 
         This will only throw an error if the files themselves cannot be read.  This includes the configuration
@@ -300,10 +303,13 @@ class ScalyrAgent(object):
         @param config_file_path: The path to read the configuration from.
         @type config_file_path: str
 
+        @param force_http: Whether or not to force the scalyr server to use 'http'
+        @type force_http: boolean
+
         @return: The configuration object.
         @rtype: scalyr_agent.Configuration
         """
-        return Configuration(config_file_path, self.__default_paths)
+        return Configuration(config_file_path, self.__default_paths, force_http=force_http)
 
     def __verify_config(self, config, disable_create_monitors_manager=False,
                                       disable_create_copying_manager=False,
@@ -1214,6 +1220,9 @@ if __name__ == '__main__':
                       help="For status command, prints detailed information about running agent.")
     parser.add_option("", "--no-fork", action="store_true", dest="no_fork", default=False,
                       help="For the run command, does not fork the program to the background.")
+    parser.add_option("", "--force-http", action="store_true", dest="force_http", default=False,
+                      help="Forces the agent to use an http connection.  Without this flag the agent will *always* use an https connection, even "
+                           "if the URL for the remote server specifics an http link" )
     parser.add_option("", "--no-check-remote-server", action="store_true", dest="no_check_remote",
                       help="For the start command, does not perform the first check to see if the agent can "
                            "communicate with the Scalyr servers.  The agent will just keep trying to contact it in "

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -50,7 +50,7 @@ class Configuration(object):
     This also handles reporting status information about the configuration state, including what time it was
     read and what error (if any) was raised.
     """
-    def __init__(self, file_path, default_paths, force_http=False):
+    def __init__(self, file_path, default_paths):
         self.__file_path = os.path.abspath(file_path)
         # Paths for additional configuration files that were read (from the config directory).
         self.__additional_paths = []
@@ -71,8 +71,6 @@ class Configuration(object):
         # The DefaultPaths object that specifies the default paths for things like the data and log directory
         # based on platform.
         self.__default_paths = default_paths
-
-        self.__force_http = force_http
 
         # FIX THESE:
         # Add documentation, verify, etc.
@@ -156,8 +154,10 @@ class Configuration(object):
             self.__verify_or_set_optional_string(self.__config, 'scalyr_server', 'https://agent.scalyr.com',
                                                  'configuration file %s' % self.__file_path)
 
+            self.__config['raw_scalyr_server'] = self.__config['scalyr_server']
+
             # force https unless otherwise instructed not to
-            if not self.__force_http:
+            if not self.__config['allow_http']:
                 server = self.__config['scalyr_server'].strip()
 
                 parts = urlparse.urlparse( server )
@@ -168,8 +168,6 @@ class Configuration(object):
 
                 if https_server != server:
                     self.__config['scalyr_server'] = https_server
-                    if logger:
-                        logger.info( "Forcing https protocol for server url: %s -> %s.  You can override this with the --force-http flag, but be mindful that there are security implications with doing this, including tramsitting your Scalyr api key over an insecure connection." % (server, self.__config['scalyr_server'] ) )
 
             # Add in 'serverHost' to server_attributes if it is not set.  We must do this after merging any
             # server attributes from the config fragments.
@@ -407,6 +405,11 @@ class Configuration(object):
     def scalyr_server(self):
         """Returns the configuration value for 'scalyr_server'."""
         return self.__get_config().get_string('scalyr_server')
+
+    @property
+    def raw_scalyr_server(self):
+        """Returns the configuration value for 'raw_scalyr_server'."""
+        return self.__get_config().get_string('raw_scalyr_server')
 
     @property
     def check_remote_if_no_tty(self):
@@ -854,6 +857,7 @@ class Configuration(object):
     """
         description = 'configuration file "%s"' % file_path
 
+        self.__verify_or_set_optional_bool(config, 'allow_http', False, description, apply_defaults)
         self.__verify_or_set_optional_bool(config, 'check_remote_if_no_tty', True, description, apply_defaults)
         self.__verify_or_set_optional_attributes(config, 'server_attributes', description, apply_defaults)
         self.__verify_or_set_optional_string(config, 'agent_log_path', self.__default_paths.agent_log_path,

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -159,6 +159,7 @@ class Configuration(object):
             # force https unless otherwise instructed not to
             if not self.__config['allow_http']:
                 server = self.__config['scalyr_server'].strip()
+                https_server = server
 
                 parts = urlparse.urlparse( server )
                 if not parts.scheme:

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -133,6 +133,7 @@ class TestConfiguration(ScalyrTestCase):
             implicit_metric_monitor: false,
             implicit_agent_log_collection: false,
             use_unsafe_debugging: true,
+            allow_http: true,
             scalyr_server: "noland.scalyr.com",
             global_monitor_sample_interval: 60.0,
             max_allowed_request_size: 2000000,
@@ -238,6 +239,57 @@ class TestConfiguration(ScalyrTestCase):
 
         config = self.__create_test_configuration_instance()
         self.assertRaises(BadConfiguration, config.parse)
+
+    def test_force_https_no_scheme(self):
+        self.__write_file_with_separator_conversion(""" {
+            api_key: "hi there",
+            scalyr_server: "agent.scalyr.com",
+          }
+        """)
+        config = self.__create_test_configuration_instance()
+        config.parse()
+        self.assertEqual( "https://agent.scalyr.com", config.scalyr_server)
+
+    def test_force_https_http(self):
+        self.__write_file_with_separator_conversion(""" {
+            api_key: "hi there",
+            scalyr_server: "http://agent.scalyr.com",
+          }
+        """)
+        config = self.__create_test_configuration_instance()
+        config.parse()
+        self.assertEqual( "https://agent.scalyr.com", config.scalyr_server)
+
+    def test_force_https_https(self):
+        self.__write_file_with_separator_conversion(""" {
+            api_key: "hi there",
+            scalyr_server: "https://agent.scalyr.com",
+          }
+        """)
+        config = self.__create_test_configuration_instance()
+        config.parse()
+        self.assertEqual( "https://agent.scalyr.com", config.scalyr_server)
+
+    def test_force_https_leading_whitespace(self):
+        self.__write_file_with_separator_conversion(""" {
+            api_key: "hi there",
+            scalyr_server: "  http://agent.scalyr.com",
+          }
+        """)
+        config = self.__create_test_configuration_instance()
+        config.parse()
+        self.assertEqual( "https://agent.scalyr.com", config.scalyr_server)
+
+    def test_allow_http(self):
+        self.__write_file_with_separator_conversion(""" {
+            api_key: "hi there",
+            allow_http: true,
+            scalyr_server: "http://agent.scalyr.com",
+          }
+        """)
+        config = self.__create_test_configuration_instance()
+        config.parse()
+        self.assertEqual( "http://agent.scalyr.com", config.scalyr_server)
 
     def test_non_string_value(self):
         self.__write_file_with_separator_conversion(""" {
@@ -476,6 +528,7 @@ class TestConfiguration(ScalyrTestCase):
         self.__write_config_fragment_file_with_separator_conversion('nginx.json', """ {
            api_key: "hi there",
            scalyr_server: "foobar",
+           allow_http: true,
            logs: [ { path: "/var/log/nginx/access.log" } ],
           }
         """)


### PR DESCRIPTION
Forces https for the scalyr server, unless the `--force-http option` is
passed on the command line.

The code for this has been placed in the Configuration object, to ensure
that anywhere that queries the scalyr_server from the config will be
given the https version of the url.