### PR TITLE
Ticket: AGENT-44

### DIFF
--- a/scalyr_agent/copying_manager.py
+++ b/scalyr_agent/copying_manager.py
@@ -281,14 +281,13 @@ class CopyingManager(StoppableThread, LogWatcher):
         """
         return self.__log_matchers
 
-    def __path_in_all_paths( self, path, all_paths ):
-        """ Returns the key in `all_paths` if `path` is in `all_paths` or if `path` matches any globs in `all_paths` """
-        result = None
-        for p in all_paths.keys():
+    def __path_in_globs( self, path, path_globs ):
+        """ Returns the first glob pattern in 'path_globs' that matches 'path' if one exists."""
+        for p in path_globs:
             if fnmatch.fnmatch( path, p ):
-                result = p
-                break
-        return result
+                return p
+
+        return None
 
     def add_log_config( self, monitor, log_config ):
         """Add the log_config item to the list of paths being watched
@@ -299,7 +298,7 @@ class CopyingManager(StoppableThread, LogWatcher):
 
         self.__lock.acquire()
         try:
-            path = self.__path_in_all_paths( log_config['path'], self.__all_paths )
+            path = self.__path_in_globs( log_config['path'], self.__all_paths.keys() )
             if path is None:
                 log.log(scalyr_logging.DEBUG_LEVEL_0, 'Adding new log file \'%s\' for monitor \'%s\'' % (log_config['path'], monitor.module_name ) )
                 self.__pending_log_matchers.append( LogMatcher( self.__config, log_config ) )
@@ -307,6 +306,10 @@ class CopyingManager(StoppableThread, LogWatcher):
                 path = log_config['path']
             else:
                 log.log(scalyr_logging.DEBUG_LEVEL_0, 'New log file \'%s\' already matches \'%s\' for monitor \'%s\'' % (log_config['path'], path, monitor.module_name ) )
+                # log_config['path'] and path will not be equal if log_config['path'] matched path
+                # because of a glob pattern.  They will only be equal if they are the exact same path.
+                # We want to ignore any added paths that match a glob pattern, and so we skip over incrementing the path count
+                # unless they are the exact same path.
                 if path == log_config['path']:
                     self.__all_paths[path] += 1
 


### PR DESCRIPTION
Don't add logs dynamically if a log path or glob already exist that match the
path.

The purpose of this is so that log entries specified in `agent.json` or
`agent.d/*.json` can override the parser and other attributes of dynamically
added logs.

This is a temporary solution.  The real solution is to allow people to override
log config options in docker labels, similar to how it works with k8s
annotations.