### PR TITLE
Ticket #AGENT-20

### DIFF
--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -2128,7 +2128,7 @@ class RedactionRule(object):
 
     @property
     def hash_redacted_data(self):
-        return "\{}".format(LogLineRedacter.HASH_GROUP_INDICATOR) in self.replacement_text
+        return "\{0}".format(LogLineRedacter.HASH_GROUP_INDICATOR) in self.replacement_text
 
 
 class LogMatcher(object):


### PR DESCRIPTION
Fixed the redaction formatter to use explicit parameter values for the hash
because python 2.6 doesn't support implicit parameter values.