### PR TITLE
AGENT-40 k8s user-agent info

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -44,6 +44,6 @@ physical host to send their logs to Scalyr through it.
 
 To do this, you must add the following options when you start a container: `--log-driver=syslog --log-opt syslog-address=tcp://127.0.0.1:601`
 
-The following is an example of a small container that will write `Hello Word` repeatedly to Scalyr:
+The following is an example of a small container that will write `Hello World` repeatedly to Scalyr:
 
     docker run  --log-driver=syslog --log-opt syslog-address=tcp://127.0.0.1:601 -d ubuntu /bin/sh -c "while true; do echo hello world; sleep 1; done"

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -1678,10 +1678,25 @@ class KubernetesMonitor( ScalyrMonitor ):
                                   limit_once_per_x_secs=300,
                                   limit_key='kubelet-api-query' )
 
-    def gather_sample( self ):
+    def __get_k8s_cache(self):
         k8s_cache = None
         if self.__container_checker:
             k8s_cache = self.__container_checker.k8s_cache
+        return k8s_cache
+
+    def get_user_agent_fragment(self):
+        """This method is periodically invoked by a separate (MonitorsManager) thread and must be thread safe.
+        """
+        k8s_cache = self.__get_k8s_cache()
+        ver = None
+        if k8s_cache:
+            ver = k8s_cache.get_api_server_version()
+            if ver:
+                ver = 'k8s=%s' % ver
+        return ver
+
+    def gather_sample( self ):
+        k8s_cache = self.__get_k8s_cache()
 
         cluster_name = None
         if k8s_cache is not None:

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -346,6 +346,10 @@ class Configuration(object):
         return self.__get_config().get_float('config_change_check_interval')
 
     @property
+    def user_agent_refresh_interval(self):
+        return self.__get_config().get_float('user_agent_refresh_interval')
+
+    @property
     def garbage_collect_interval(self):
         return self.__get_config().get_int('garbage_collect_interval')
 
@@ -997,6 +1001,7 @@ class Configuration(object):
         self.__verify_or_set_optional_string(config, 'http_proxy', None, description, apply_defaults)
         self.__verify_or_set_optional_string(config, 'https_proxy', None, description, apply_defaults)
 
+
         self.__verify_or_set_optional_string(config, 'k8s_ignore_namespaces', 'kube-system', description, apply_defaults )
         self.__verify_or_set_optional_string(config, 'k8s_api_url', 'https://kubernetes.default', description, apply_defaults )
         self.__verify_or_set_optional_bool(config, 'k8s_verify_api_queries', True, description, apply_defaults )
@@ -1023,6 +1028,7 @@ class Configuration(object):
         self.__verify_or_set_optional_int(config, 'disable_leak_config_reload', None, description, apply_defaults)
 
         self.__verify_or_set_optional_float(config, 'config_change_check_interval', 30, description, apply_defaults)
+        self.__verify_or_set_optional_int(config, 'user_agent_refresh_interval', 60, description, apply_defaults)
         self.__verify_or_set_optional_int(config, 'garbage_collect_interval', 300, description, apply_defaults)
 
         self.__verify_or_set_optional_int(config, 'disable_leak_verify_config_create_monitors_manager', None, description, apply_defaults)

--- a/scalyr_agent/copying_manager.py
+++ b/scalyr_agent/copying_manager.py
@@ -443,7 +443,7 @@ class CopyingManager(StoppableThread, LogWatcher):
     def stop_manager(self, wait_on_join=True, join_timeout=5):
         """Stops the manager.
 
-        @param wait_on_join: If True, will block on a join of of the thread running the manager.
+        @param wait_on_join: If True, will block on a join of the thread running the manager.
         @param join_timeout: The maximum number of seconds to block for the join.
         """
         self.stop(wait_on_join=wait_on_join, join_timeout=join_timeout)

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -963,7 +963,7 @@ class AutoFlushingRotatingFileHandler( logging.handlers.RotatingFileHandler ):
     def set_flush_delay(self, flushDelay):
         """Sets the flush delay.
 
-        Warning, this method is not thread safe.  You should invoke it soon after the constructore and before the
+        Warning, this method is not thread safe.  You should invoke it soon after the constructor and before the
         handler is actually in use.
 
         @param flushDelay: The maximum number of seconds to wait to flush the underlying file handle.

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -250,6 +250,17 @@ class ScalyrMonitor(StoppableThread):
             # right now join on the monitor threads, so no one would catch it.  We should change that.
             self._logger.exception('Monitor died from due to exception:', error_code='failedMonitor')
 
+    def get_user_agent_fragment(self):
+        """Derived classes may optionally return a string fragment to be appended to the User-Agent header for all
+        data sent to Scalyr.  Note: User-Agent augmentation applies to all data (not restricted to data from this
+        monitor).
+
+        You must ensure that this method is thread-safe as it will be invoked by a different thread (MonitorsManager).
+
+        @return: A string fragment or None (Empty strings are treated as None)
+        """
+        return None
+
     def gather_sample(self):
         """Derived classes should implement this method to gather a data sample for this monitor plugin
         and report it.

--- a/scalyr_agent/tests/monitors_manager_test.py
+++ b/scalyr_agent/tests/monitors_manager_test.py
@@ -19,13 +19,22 @@
 __author__ = 'czerwin@scalyr.com'
 
 
+import logging
 import os
+import re
 import tempfile
+import threading
+import time
+
+from collections import Counter
+
+import scalyr_agent.util as scalyr_util
 
 from scalyr_agent.configuration import Configuration
 from scalyr_agent.monitors_manager import MonitorsManager
 from scalyr_agent.platform_controller import DefaultPaths
 from scalyr_agent.json_lib import JsonObject, JsonArray
+from scalyr_agent.scalyr_logging import AgentLogger
 from scalyr_agent import json_lib
 
 from scalyr_agent.test_base import ScalyrTestCase
@@ -74,7 +83,163 @@ class MonitorsManagerTest(ScalyrTestCase):
         self.assertEquals(test_manager.monitors[0].monitor_name, 'test_monitor(first)')
         self.assertEquals(test_manager.monitors[1].monitor_name, 'test_monitor(2)')
 
-    def __create_test_instance(self, config_monitors, platform_monitors):
+    def test_user_agent_polling(self):
+        """Test polling of user-agent fragments and invocation of the callback (only on change)
+
+        A MonitorsManager + 2 monitors are started (each has their own threads).
+        1 monitor returns non-empty frags. 1 returns None.
+        We then verify that the callback is invoked correctly, only if the fragments change.
+
+        Notes:
+        - FakeClocks are used to avoid having to wait for thread loops.
+        - A FakeAgentLogger is defined so we can modify local test state
+        - Even though this test could have been broken up into 2 smaller ones, it is kept as one to minimize overhead
+            time taken by stop_manager()
+        """
+        counter = Counter()
+        test_frag = 'some_frag'
+        poll_interval = 30
+
+        # Create MonitorsManager + 2 monitors. Set each to daemon otherwise unit test doesn't terminate
+        test_manager = self.__create_test_instance([
+            {
+                'module': 'scalyr_agent.builtin_monitors.test_monitor',
+                'gauss_mean': 0,
+            },
+            {
+                'module': 'scalyr_agent.builtin_monitors.test_monitor',
+                'gauss_mean': 0,
+            },
+            {
+                'module': 'scalyr_agent.builtin_monitors.test_monitor',
+                'gauss_mean': 0,
+            },
+        ], [], extra_toplevel_config={'user_agent_refresh_interval': poll_interval})
+        self.assertEquals(test_manager._user_agent_refresh_interval, 30)  # ensure config setting works
+        self.assertEquals(len(test_manager.monitors), 3)
+        patched_monitor_0 = test_manager.monitors[0]
+        patched_monitor_1 = test_manager.monitors[1]
+        unpatched_monitor = test_manager.monitors[2]
+
+        # Fake the clock to fast-forward MonitorsManager sleep loop
+        fake_clock = scalyr_util.FakeClock()
+        for obj in [test_manager, patched_monitor_0, unpatched_monitor]:
+            obj._run_state = scalyr_util.RunState(fake_clock=fake_clock)
+
+        class FragmentPolls(object):
+            def __init__(self):
+                self.__polls = 0
+                self.__condition = threading.Condition()
+
+            def count(self):
+                self.__condition.acquire()
+                try:
+                    return self.__polls
+                finally:
+                    self.__condition.release()
+
+            def increment(self):
+                self.__condition.acquire()
+                try:
+                    self.__polls += 1
+                    self.__condition.notifyAll()
+                finally:
+                    self.__condition.release()
+
+            def wait_for_increment(self, old_count, timeout=None):
+                remaining = timeout
+                self.__condition.acquire()
+                try:
+                    while self.__polls == old_count and remaining > 0:
+                        t1 = time.time()
+                        self.__condition.wait(remaining)
+                        remaining -= time.time() - t1
+                finally:
+                    self.__condition.release()
+
+            def poll_until_target(self, target_polls, maxwait):
+                """Blocks until n fragment polls are simulated by the MonitorsManager, or an absolute cutoff time.
+                whichever comes first.
+
+                @param target_polls: Number of polls to reach
+                @param maxwait: Time (seconds) to wait for target to be reached
+                @return: True if number of polls reaches target_polls, else False
+                """
+                deadline = time.time() + maxwait
+                while self.count() < target_polls and time.time() < deadline:
+                    fake_clock.block_until_n_waiting_threads(1)  # wait for monitor thread loop to complete
+                    old_count = self.count()
+                    fake_clock.advance_time(increment_by=poll_interval)
+                    self.wait_for_increment(old_count, timeout=deadline-time.time())
+
+                return self.count() == target_polls
+
+        fragment_polls = FragmentPolls()
+
+        # Mock the function that returns user_agent_fragment (normally invoked on a Monitor)
+        def mock_get_user_agent_fragment():
+            # Will be called on 2 patched monitors concurrently
+            fragment_polls.increment()
+            return test_frag
+        for mon in [patched_monitor_0, patched_monitor_1]:
+            mon.get_user_agent_fragment = mock_get_user_agent_fragment
+            self.assertEquals(mon.get_user_agent_fragment(), test_frag)  # monkey patched
+        self.assertEquals(unpatched_monitor.get_user_agent_fragment(), None)  # not patched
+
+        # Mock the callback (that would normally be invoked on ScalyrClientSession)
+        # Check that the exact fragment returned by the 2 patched monitors are deduplicated.
+        def augment_user_agent(fragments):
+            counter['callback_invocations'] += 1
+            self.assertEquals(fragments, [test_frag])
+        test_manager.set_user_agent_augment_callback(augment_user_agent)
+
+        # Override Agent Logger to prevent writing to disk
+        class FakeAgentLogger(AgentLogger):
+            def __init__(self, name):
+                super(FakeAgentLogger, self).__init__(name)
+                if not len(self.handlers):
+                    self.addHandler(logging.NullHandler())
+
+        for monitor in [patched_monitor_0, patched_monitor_1, unpatched_monitor]:
+            monitor._logger = FakeAgentLogger('fake_agent_logger')
+
+        # We're finally ready start all threads and assert correct behavior.
+        # Wait for MonitorsManager to poll for user-agent fragments 10x
+        # Since 2 monitors are being polled for fragments, num polls should reach 2 x 10 = 20.
+        # However, the monitors always returned a non-changing frag so the callback should be invoked only once.
+        # (Note: FakeClock ensures all the above happen within a split second)
+        test_manager.start_manager()
+        self.assertTrue(fragment_polls.poll_until_target(20, 1))
+        self.assertEquals(counter['callback_invocations'], 1)
+
+        # Rerun the above test but this time have monitors return changing fragments.
+        # This will cause the user agent callback to be invoked during each round of polling.
+        # (The manager polls monitors 10x, and each poll results in a callback invocation).
+        fragment_polls = FragmentPolls()
+        counter['callback_invocations'] = 0
+
+        def mock_get_user_agent_fragment_2():
+            fragment_polls.increment()
+            return test_frag + str(fragment_polls.count())
+
+        # patched_monitor_0.get_user_agent_fragment = mock_get_user_agent_fragment_2
+        for mon in [patched_monitor_0, patched_monitor_1]:
+            mon.get_user_agent_fragment = mock_get_user_agent_fragment_2
+
+        variable_frag_pattern = re.compile(test_frag + r'\d+')
+
+        def augment_user_agent_2(fragments):
+            counter['callback_invocations'] += 1
+            self.assertIsNotNone(variable_frag_pattern.match(fragments[0]))
+        test_manager.set_user_agent_augment_callback(augment_user_agent_2)
+
+        self.assertTrue(fragment_polls.poll_until_target(20, 5))
+        self.assertEquals(counter['callback_invocations'], 10)
+
+        test_manager.stop_manager(wait_on_join=False)
+        fake_clock.advance_time(increment_by=poll_interval)
+
+    def __create_test_instance(self, config_monitors, platform_monitors, extra_toplevel_config=None):
         config_dir = tempfile.mkdtemp()
         config_file = os.path.join(config_dir, 'agentConfig.json')
         config_fragments_dir = os.path.join(config_dir, 'configs.d')
@@ -86,7 +251,13 @@ class MonitorsManagerTest(ScalyrTestCase):
             monitors_json_array.add(JsonObject(content=entry))
 
         fp = open(config_file, 'w')
-        fp.write(json_lib.serialize(JsonObject(api_key='fake', monitors=monitors_json_array)))
+        toplevel_config = {
+            'api_key': 'fake',
+            'monitors': monitors_json_array
+        }
+        if extra_toplevel_config:
+            toplevel_config.update(extra_toplevel_config)
+        fp.write(json_lib.serialize(JsonObject(**toplevel_config)))
         fp.close()
 
         default_paths = DefaultPaths('/var/log/scalyr-agent-2', '/etc/scalyr-agent-2/agent.json',
@@ -101,7 +272,7 @@ class MonitorsManagerTest(ScalyrTestCase):
 class FakePlatform(object):
     """Fake implementation of PlatformController.
 
-    Only implements the one methd required for testing MonitorsManager.
+    Only implements the one method required for testing MonitorsManager.
     """
     def __init__(self, default_monitors):
         self.__monitors = default_monitors

--- a/scalyr_agent/tests/scalyr_client_test.py
+++ b/scalyr_agent/tests/scalyr_client_test.py
@@ -19,8 +19,10 @@ __author__ = 'czerwin@scalyr.com'
 
 from cStringIO import StringIO
 
+from scalyr_agent.__scalyr__ import SCALYR_VERSION
+
 from scalyr_agent import scalyr_client
-from scalyr_agent.scalyr_client import AddEventsRequest, PostFixBuffer, EventSequencer, Event
+from scalyr_agent.scalyr_client import AddEventsRequest, PostFixBuffer, EventSequencer, Event, ScalyrClientSession
 from scalyr_agent import json_lib
 from scalyr_agent.test_base import ScalyrTestCase
 import unittest
@@ -644,3 +646,16 @@ class PostFixBufferTest(ScalyrTestCase):
 
         self.assertEquals(test_buffer.content(), """], threads: [{"id":"log_5","name":"histogram_builder"}], """
                                                  """client_time: 1 }""")
+
+class ClientSessionTest(ScalyrTestCase):
+
+    def test_user_agent_callback(self):
+        session = ScalyrClientSession("https://dummserver.com", "DUMMY API KEY", SCALYR_VERSION)
+
+        def get_user_agent():
+            return session._ScalyrClientSession__standard_headers['User-Agent']
+
+        base_ua = get_user_agent()
+        frags = ['frag1', 'frag2', 'frag3']
+        session.augment_user_agent(frags)
+        self.assertEquals(get_user_agent(), base_ua + ';' + ';'.join(frags))


### PR DESCRIPTION
Fixes k8s aspect of AGENT-40, wherein additional `user-agent` fragments are periodically polled from monitors and added to global connection settings.

# Background

Marketing team wants additional insight as to whether events are coming from k8s, docker. Currently, the `user-agent` only contains local host platform info. This PR seeks to refactor the code to enable extraction of said info from monitors. Additionally, a fix is implemented for k8s.

# Changes

1. Refactor the monitor manager/monitors such that `MonitorsManager` periodically polls all agents for additional user-agent "fragments". Fragments are immediately applied to global connection settings. Thereafter, all events from this agent will reflect those fragments.

2. Unless I'm missing something, `MonitorsManager` was not a thread (it merely started up monitors, each running in their own threads). This PR gives `MonitorsManager`  it's own thread. I have tried to think of potential pitfalls such as:
    - what happens if `SystemExit` signal is encountered. 
    - is coordination/barriers needed to control startup flow between this thread and others (I don't think so).
    - pitfalls of catching broad `Exception` (ie if system errors occur and are swallowed? But it seems to me we have to catch broadly when dealing with monitors that may be written by customers).
   Kindly review this section carefully!

3. Added callback mechanism so `MonitorsManager` can modify user agent without needing to know anything about `ScalyrClientSession` (these classes should not know about each other).

4. Helper inner-function to startup `WorkerThread`. Why?
     - to setup aforementioned callback
     - eliminate code duplication and avoid future mistakes where we forget to update startup logic in 2 different places.

5. As discussed, `MonitorsManager` should poll more frequently than on every config change. I thought about each monitor having it's own cadence (for modifying user-agent -- and in future, modifying other kinds of state). However, I decided to keep things simple and minimize knobs. So I fixed polling frequency to 60s. We should document this and maybe advise monitor implementers to performing caching if necessary if this period is too frequent (just as k8s monitor does).

6. Modified `k8s_monitor` to access `/version` endpoint ([as described in AGENT-40](https://scalyr.myjetbrains.com/youtrack/issue/AGENT-40)). 
   - Tried to follow existing `KubernetesCache` code (hope I'm doing it right)
   - user-agent fragment is then extracted from the simple dict that `/version` returns.

# How was this tested?

- Created an EKS cluster in AWS dev account.
- built the k8s docker image with dev code, pointing to `qatesting`
- deployed DaemonSet
- observed user agent in qatesting search UI
![image](https://user-images.githubusercontent.com/48775713/54874160-f14e6c00-4da2-11e9-8796-a9b356e4926e.png)

# TODO

- get initial feedback that above approach is acceptable
- unit tests for `MonitorsManager` thread (in terms of agent lifecycle)
- other unit tests