### PR TITLE
Ticket: #AGENT-54

### DIFF
--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -280,11 +280,11 @@ class Configuration(object):
     def k8s_cache_purge_secs(self):
         return self.__get_config().get_int('k8s_cache_purge_secs')
 
-    # Debug leak flags
     @property
     def disable_send_requests(self):
-        return self.__get_config().get_bool('disable_leak_send_requests')
+        return self.__get_config().get_bool('disable_send_requests')
 
+    # Debug leak flags
     @property
     def disable_monitor_threads(self):
         return self.__get_config().get_bool('disable_leak_monitor_threads')
@@ -1003,8 +1003,9 @@ class Configuration(object):
         self.__verify_or_set_optional_int(config, 'k8s_cache_expiry_secs', 30, description, apply_defaults )
         self.__verify_or_set_optional_int(config, 'k8s_cache_purge_secs', 300, description, apply_defaults )
 
+        self.__verify_or_set_optional_bool(config, 'disable_send_requests', False, description, apply_defaults)
+
         #Debug leak flags
-        self.__verify_or_set_optional_bool(config, 'disable_leak_send_requests', False, description, apply_defaults)
         self.__verify_or_set_optional_bool(config, 'disable_leak_monitor_threads', False, description, apply_defaults)
         self.__verify_or_set_optional_bool(config, 'disable_leak_monitors_creation', False, description, apply_defaults)
         self.__verify_or_set_optional_bool(config, 'disable_leak_new_file_matches', False, description, apply_defaults)

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -255,7 +255,8 @@ class ScalyrClientSession(object):
             # noinspection PyBroadException
             try:
                 if self.__disable_send_requests:
-                    log.log( scalyr_logging.DEBUG_LEVEL_0, "Send requests disabled.  %d bytes dropped" % self.total_request_bytes_sent )
+                    log.log( scalyr_logging.DEBUG_LEVEL_0, "Send requests disabled.  %d bytes dropped" % self.total_request_bytes_sent,
+                             limit_once_per_x_secs=60, limit_key='send-requests-disabled')
                 else:
                     if is_post:
                         log.log(scalyr_logging.DEBUG_LEVEL_5, 'Sending POST %s with body \"%s\"', request_path, body_str)


### PR DESCRIPTION
The ability to disable send requests already exists in the agent, but under an
obscure flag `disable_leak_send_requests`.

Rather than have users specify an option with `disable_leak...` I've changed the
name of this option to `disable_send_requests`.