### PR TITLE
Fix unit tests by including ujson in development

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,7 +12,6 @@ pysnmp
 requests==2.20.0
 redis==2.10.6
 Twisted==17.9.0
-ujson==1.35
 unittest2==1.1.0
 virtualenv==15.1.0
 webapp2==2.5.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,6 +12,7 @@ pysnmp
 requests==2.20.0
 redis==2.10.6
 Twisted==17.9.0
+ujson==1.35
 unittest2==1.1.0
 virtualenv==15.1.0
 webapp2==2.5.2

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -75,7 +75,14 @@ except ImportError:
     try:
         import json
         _json_lib = 'json'
-        _json_encode = json.dumps
+
+        def dumps_no_space(*args, **kwargs):
+            """Eliminate spaces by default. Python 2.4 does not support partials."""
+            if 'separators' not in kwargs:
+                kwargs['separators'] = (',', ':')
+            return json.dumps(*args, **kwargs)
+
+        _json_encode = dumps_no_space
         _json_decode = json.loads
     except:
         pass


### PR DESCRIPTION
IIUC the json lib includes have to account for various situations where json lib may or may not exist. If Json lib doesn't exist, use the fallback `json_lib`.

`scalyr_client_test.py` are currently breaking because of extra space. I think this occurs in the following scenario in development/CI:

- `ujson` library is missing
- `json` lib version adds spaces by default when encoding (to eliminate spaces, you need to add 
```
json.dumps(separators=(',', ':'))
```

The solution, I _think_, is to include ujson in `dev-requirements.txt`. Doing so now results in all tests passing.

Question: if a customer setup mimics the current breaking tests (i.e. customer has `json` installed, there will be extra spaces in the JSON. Does this break anything when it's sent over? (I would not think so?)