### PR TITLE
AGENT-40: Docker user-agent fragment

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -1676,9 +1676,7 @@ class KubernetesMonitor( ScalyrMonitor ):
         ver = None
         if k8s_cache:
             ver = k8s_cache.get_api_server_version()
-            if ver:
-                ver = 'k8s=%s' % ver
-        return ver
+        return 'k8s=%s' % (ver if ver else 'true')
 
     def gather_sample( self ):
         k8s_cache = self.__get_k8s_cache()

--- a/scalyr_agent/builtin_monitors/tests/__init__.py
+++ b/scalyr_agent/builtin_monitors/tests/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2019, Scalyr, Inc.

--- a/scalyr_agent/builtin_monitors/tests/docker_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/docker_monitor_test.py
@@ -1,0 +1,158 @@
+# Copyright 2019 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+#
+# author: Edward Chee <echee@scalyr.com>
+
+
+__author__ = 'echee@scalyr.com'
+
+
+import threading
+from collections import Counter
+
+import mock
+from mock import patch
+
+from scalyr_agent.builtin_monitors.docker_monitor import DockerMonitor
+from scalyr_agent.test_base import ScalyrTestCase
+from scalyr_agent.test_util import ScalyrTestUtils
+from scalyr_agent.util import FakeClock, FakeClockCounter
+
+
+class DockerMonitorTest(ScalyrTestCase):
+    """This test exercises various different user-agent fragments returned by DockerMonitor.
+    It also captures the situation where the monitor is polled before it has obtained a version, in which case it must
+    return a base fragment indicating docker but no version.
+
+    Implemntation:  A MonitorsManager and DockerMonitor is started.  But the docker api lib is completely mocked out.
+    The _initialize() method is also mocked with a fake method
+    """
+
+    @mock.patch('scalyr_agent.builtin_monitors.docker_monitor.docker')
+    def test_user_agent_fragment(self, mocked_docker):
+
+        def fake_init(self):
+            """Simulate syslog mode (null container checker). Init the version variable and it's lock"""
+            self._DockerMonitor__container_checker = None
+            self._DockerMonitor__version_lock = threading.RLock()
+            self._DockerMonitor__version = None
+
+        with mock.patch.object(DockerMonitor, '_initialize', fake_init):
+
+            manager_poll_interval = 30
+            fake_clock = FakeClock()
+            manager = ScalyrTestUtils.create_test_monitors_manager(
+                config_monitors=[
+                    {
+                        'module': "scalyr_agent.builtin_monitors.docker_monitor",
+                        'log_mode': "syslog"
+                    }
+                ],
+                extra_toplevel_config={'user_agent_refresh_interval': manager_poll_interval},
+                null_logger=True,
+                fake_clock=fake_clock,
+            )
+
+            fragment_polls = FakeClockCounter(fake_clock, num_waiters=2)
+            counter = Counter()
+            detected_fragment_changes = []
+
+            # Mock the callback (that would normally be invoked on ScalyrClientSession
+            def augment_user_agent(fragments):
+                counter['callback_invocations'] += 1
+                detected_fragment_changes.append(fragments[0])
+
+            # Decorate the get_user_agent_fragment() function as follows:
+            # Each invocation increments the FakeClockCounter
+            # Simulate the following race condition:
+            # 1. The first 10 polls by MonitorsManager is such that DockerMonitor has not yet started. Therefore,
+            #     the docker version is None
+            # 2. After the 20th poll, docker version is set
+            # 3. After the 30th poll, docker mode changes to docker_api|raw
+            # 4. After the 40th poll, docker mode changes to docker_api|api
+            #
+            # Note: (3) and (4) do not happen in real life.  We force these config changes to test permutations
+            # of user agent fragments for different config scenarios
+            #
+            # Total number of times the user_agent_callback is called should be twice:
+            # - once for when docker version is None (fragment is 'docker=true')
+            # - once for when docker version changes to a real number
+            fake_docker_version = '18.09.2'
+            docker_mon = manager.monitors[0]
+            original_get_user_agent_fragment = docker_mon.get_user_agent_fragment
+            original_monitor_config_get = docker_mon._config.get
+
+            def fake_get_user_agent_fragment():
+                result = original_get_user_agent_fragment()
+                fragment_polls.increment()
+                return result
+
+            def fake_fetch_and_set_version():
+                # Simulate slow-to-start DockerMonitor where version is set only after 10th poll by MonitorsManager
+                # Thus, polls 0-9 return in version=None which ultimately translates to 'docker=true' fragment
+                docker_mon._DockerMonitor__version_lock.acquire()
+                try:
+                    if fragment_polls.count() < 10:
+                        docker_mon._DockerMonitor__version = None
+                    else:
+                        docker_mon._DockerMonitor__version = fake_docker_version
+                finally:
+                    docker_mon._DockerMonitor__version_lock.release()
+
+            def fake_monitor_config_get(key):
+                # Fake the return values from MonitorConfig.get in order to exercise different permutations of
+                # user_agent fragment.
+                if key == 'log_mode':
+                    if fragment_polls.count() < 20:
+                        return 'syslog'
+                    else:
+                        return 'docker_api'
+                elif key == 'docker_raw_logs':
+                    if fragment_polls.count() < 30:
+                        return True
+                    else:
+                        return False
+                else:
+                    return original_monitor_config_get(key)
+
+            with patch.object(
+                docker_mon, 'get_user_agent_fragment'
+            ) as m1, patch.object(
+                docker_mon, '_fetch_and_set_version'
+            ) as m2, patch.object(
+                docker_mon._config, 'get'
+            ) as m3:
+                m1.side_effect = fake_get_user_agent_fragment
+                m2.side_effect = fake_fetch_and_set_version
+                m3.side_effect = fake_monitor_config_get
+                manager.set_user_agent_augment_callback(augment_user_agent)
+
+                manager.start_manager()
+                fragment_polls.sleep_until_count_or_maxwait(40, manager_poll_interval, maxwait=1)
+
+                m1.assert_called()
+                m2.assert_called()
+                m3.assert_called()
+                self.assertEquals(fragment_polls.count(), 40)
+                self.assertEquals(counter['callback_invocations'], 4)
+                self.assertEquals(detected_fragment_changes, [
+                    'docker=true',
+                    'docker=18.09.2|syslog',
+                    'docker=18.09.2|docker_api|raw',
+                    'docker=18.09.2|docker_api|api',
+                ])
+
+                manager.stop_manager(wait_on_join=False)
+                fake_clock.advance_time(increment_by=manager_poll_interval)

--- a/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
@@ -1,0 +1,130 @@
+# Copyright 2019 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+#
+# author: Edward Chee <echee@scalyr.com>
+
+
+__author__ = 'echee@scalyr.com'
+
+
+from collections import Counter
+
+import mock
+from mock import patch
+
+from scalyr_agent.builtin_monitors.kubernetes_monitor import KubernetesMonitor
+from scalyr_agent.util import FakeClock, FakeClockCounter
+from scalyr_agent.test_base import ScalyrTestCase
+from scalyr_agent.test_util import ScalyrTestUtils
+
+
+class KubernetesMonitorTest(ScalyrTestCase):
+    """Exercises various different user-agent fragments returned by KubernetesMonitor.
+    Also captures the situation where the monitor is polled before the k8s cache has obtained a version,
+    in which case it must a version string indicating presence of k8s but no actual version.
+
+    Implemntation:  A MonitorsManager and KubernetesMonitor is started.  The docker api lib is completely mocked out.
+    The _initialize() method is also replaced with a fake method that simply initializes empty variables
+    to enable the main loop to run.
+    """
+
+    @patch('scalyr_agent.builtin_monitors.kubernetes_monitor.docker')
+    def test_user_agent_fragment(self, mock_docker):
+
+        def fake_init(self):
+            # Initialize variables that would have been
+            self._KubernetesMonitor__container_checker = None
+            self._KubernetesMonitor__namespaces_to_ignore = []
+            self._KubernetesMonitor__include_controller_info = None
+            self._KubernetesMonitor__report_container_metrics = None
+            self._KubernetesMonitor__metric_fetcher = None
+
+        with mock.patch.object(KubernetesMonitor, '_initialize', fake_init):
+
+            manager_poll_interval = 30
+            fake_clock = FakeClock()
+            manager = ScalyrTestUtils.create_test_monitors_manager(
+                config_monitors=[
+                    {
+                        'module': "scalyr_agent.builtin_monitors.kubernetes_monitor",
+                    }
+                ],
+                extra_toplevel_config={'user_agent_refresh_interval': manager_poll_interval},
+                null_logger=True,
+                fake_clock=fake_clock,
+            )
+
+            fragment_polls = FakeClockCounter(fake_clock, num_waiters=2)
+            counter = Counter()
+            detected_fragment_changes = []
+
+            # Mock the callback (that would normally be invoked on ScalyrClientSession
+            def augment_user_agent(fragments):
+                counter['callback_invocations'] += 1
+                detected_fragment_changes.append(fragments[0])
+
+            # Decorate the get_user_agent_fragment() function as follows:
+            # Each invocation increments the FakeClockCounter
+            # Simulate the following race condition:
+            # 1. The first 10 polls by MonitorsManager is such that KubernetesMonitor has not yet started. Therefore,
+            #     the version is None
+            # 2. After the 20th poll, version is set
+            # 3. After the 30th poll, version changes (does not normally happen, but we ensure this repeated check)
+            #
+            # Total number of times the user_agent_callback is called should be twice:
+            # - once for when docker version is None (fragment is 'k8s=true')
+            # - once for when docker version changes to a real number
+            version1 = '1.13.4'
+            version2 = '1.14.1'
+            k8s_mon = manager.monitors[0]
+            original_get_user_agent_fragment = k8s_mon.get_user_agent_fragment
+
+            def fake_get_user_agent_fragment():
+                result = original_get_user_agent_fragment()
+                fragment_polls.increment()
+                return result
+
+            def fake_get_api_server_version():
+                if fragment_polls.count() < 10:
+                    return None
+                elif fragment_polls.count() < 20:
+                    return version1
+                else:
+                    return version2
+
+            with patch.object(
+                k8s_mon, 'get_user_agent_fragment'
+            ) as m1, patch.object(
+                k8s_mon, '_KubernetesMonitor__get_k8s_cache'  # return Mock obj instead of a KubernetesCache
+            ) as m2:
+                m1.side_effect = fake_get_user_agent_fragment
+                m2.return_value.get_api_server_version.side_effect = fake_get_api_server_version
+                manager.set_user_agent_augment_callback(augment_user_agent)
+
+                manager.start_manager()
+                fragment_polls.sleep_until_count_or_maxwait(40, manager_poll_interval, maxwait=1)
+
+                m1.assert_called()
+                m2.assert_called()
+                self.assertEqual(fragment_polls.count(), 40)
+                self.assertEqual(counter['callback_invocations'], 3)
+                self.assertEquals(detected_fragment_changes, [
+                    'k8s=true',
+                    'k8s=%s' % version1,
+                    'k8s=%s' % version2,
+                ])
+
+                manager.stop_manager(wait_on_join=False)
+                fake_clock.advance_time(increment_by=manager_poll_interval)

--- a/scalyr_agent/test_base.py
+++ b/scalyr_agent/test_base.py
@@ -19,7 +19,6 @@
 __author__ = 'czerwin@scalyr.com'
 
 import sys
-
 import unittest
 
 

--- a/scalyr_agent/test_util.py
+++ b/scalyr_agent/test_util.py
@@ -1,0 +1,129 @@
+# Copyright 2019 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+#
+#
+# author: Edward Chee <echee@scalyr.com>
+
+__author__ = 'echee@scalyr.com'
+
+
+import atexit
+import logging
+import os
+import shutil
+import tempfile
+
+import scalyr_agent.util as scalyr_util
+
+from scalyr_agent import json_lib
+from scalyr_agent.configuration import Configuration
+from scalyr_agent.platform_controller import DefaultPaths
+from scalyr_agent.json_lib import JsonArray, JsonObject
+from scalyr_agent.monitors_manager import MonitorsManager
+from scalyr_agent.scalyr_logging import AgentLogger
+
+
+class ScalyrTestUtils(object):
+
+    @staticmethod
+    def create_configuration(extra_toplevel_config=None):
+        """Creates a blank configuration file with default values. Optionally overwrites top-level key/values.
+        Sets api_key to 'fake' unless defined in extra_toplevel_config
+
+        @param extra_toplevel_config: Dict of top-level key/value objects to overwrite.
+        @return: The configuration object
+        @rtype: Configuration
+        """
+        config_dir = tempfile.mkdtemp()
+        config_file = os.path.join(config_dir, 'agentConfig.json')
+        config_fragments_dir = os.path.join(config_dir, 'configs.d')
+        os.makedirs(config_fragments_dir)
+
+        toplevel_config = {'api_key': 'fake'}
+        if extra_toplevel_config:
+            toplevel_config.update(extra_toplevel_config)
+
+        fp = open(config_file, 'w')
+        fp.write(json_lib.serialize(JsonObject(**toplevel_config)))
+        fp.close()
+
+        default_paths = DefaultPaths('/var/log/scalyr-agent-2', '/etc/scalyr-agent-2/agent.json',
+                                     '/var/lib/scalyr-agent-2')
+
+        config = Configuration(config_file, default_paths, None)
+        config.parse()
+
+        # we need to delete the config dir when done
+        atexit.register(shutil.rmtree, config_dir)
+
+        return config
+
+    @staticmethod
+    def create_test_monitors_manager(config_monitors=None, platform_monitors=None, extra_toplevel_config=None,
+                                     null_logger=False, fake_clock=False, set_daemon=False):
+        """Create a test MonitorsManager
+
+        @param config_monitors: config monitors
+        @param platform_monitors: platform monitors
+        @param extra_toplevel_config: dict of extra top-level key value objects
+        @param null_logger: If True, set all monitors to log to Nullhandler
+        @param fake_clock: If non-null, the manager and all it's monitors' _run_state's will use the provided fake_clock
+        """
+        monitors_json_array = JsonArray()
+        if config_monitors:
+            for entry in config_monitors:
+                monitors_json_array.add(JsonObject(content=entry))
+
+        extras = {'monitors': monitors_json_array}
+        if extra_toplevel_config:
+            extras.update(extra_toplevel_config)
+
+        config = ScalyrTestUtils.create_configuration(extra_toplevel_config=extras)
+        config.parse()
+
+        if not platform_monitors:
+            platform_monitors = []
+        # noinspection PyTypeChecker
+        test_manager = MonitorsManager(config, FakePlatform(platform_monitors))
+
+        if null_logger:
+            # Override Agent Logger to prevent writing to disk
+            for monitor in test_manager.monitors:
+                monitor._logger = FakeAgentLogger('fake_agent_logger')
+
+        if fake_clock:
+            for monitor in test_manager.monitors + [test_manager]:
+                monitor._run_state = scalyr_util.RunState(fake_clock=fake_clock)
+
+        return test_manager
+
+
+class FakeAgentLogger(AgentLogger):
+    def __init__(self, name):
+        super(FakeAgentLogger, self).__init__(name)
+        if not len(self.handlers):
+            self.addHandler(logging.NullHandler())
+
+
+class FakePlatform(object):
+    """Fake implementation of PlatformController.
+
+    Only implements the one method required for testing MonitorsManager.
+    """
+    def __init__(self, default_monitors):
+        self.__monitors = default_monitors
+
+    def get_default_monitors(self, _):
+        return self.__monitors

--- a/scalyr_agent/tests/copying_manager_test.py
+++ b/scalyr_agent/tests/copying_manager_test.py
@@ -40,6 +40,7 @@ from scalyr_agent.copying_manager import CopyingParameters, CopyingManager
 from scalyr_agent.platform_controller import DefaultPaths
 from scalyr_agent.scalyr_client import AddEventsRequest
 from scalyr_agent.test_base import ScalyrTestCase
+from scalyr_agent.test_util import ScalyrTestUtils
 from scalyr_agent.json_lib import JsonObject, JsonArray
 from scalyr_agent import json_lib
 
@@ -183,25 +184,11 @@ class CopyingManagerInitializationTest(ScalyrTestCase):
         self.assertEquals(self.__monitor_fake_instances[0].log_config['path'], '/var/log/scalyr-agent-2/hi_monitor.log')
 
     def __create_test_instance(self, configuration_logs_entry, monitors_log_configs):
-        config_dir = tempfile.mkdtemp()
-        config_file = os.path.join(config_dir, 'agentConfig.json')
-        config_fragments_dir = os.path.join(config_dir, 'configs.d')
-        os.makedirs(config_fragments_dir)
-
         logs_json_array = JsonArray()
-
         for entry in configuration_logs_entry:
             logs_json_array.add(JsonObject(content=entry))
 
-        fp = open(config_file, 'w')
-        fp.write(json_lib.serialize(JsonObject(api_key='fake', logs=logs_json_array)))
-        fp.close()
-
-        default_paths = DefaultPaths('/var/log/scalyr-agent-2', '/etc/scalyr-agent-2/agent.json',
-                                     '/var/lib/scalyr-agent-2')
-
-        config = Configuration(config_file, default_paths, None)
-        config.parse()
+        config = ScalyrTestUtils.create_configuration(extra_toplevel_config={'logs': logs_json_array})
 
         self.__monitor_fake_instances = []
         for monitor_log_config in monitors_log_configs:

--- a/scalyr_agent/tests/monitors_manager_test.py
+++ b/scalyr_agent/tests/monitors_manager_test.py
@@ -19,30 +19,20 @@
 __author__ = 'czerwin@scalyr.com'
 
 
-import logging
-import os
 import re
-import tempfile
-import threading
-import time
 
 from collections import Counter
 
 import scalyr_agent.util as scalyr_util
 
-from scalyr_agent.configuration import Configuration
-from scalyr_agent.monitors_manager import MonitorsManager
-from scalyr_agent.platform_controller import DefaultPaths
-from scalyr_agent.json_lib import JsonObject, JsonArray
-from scalyr_agent.scalyr_logging import AgentLogger
-from scalyr_agent import json_lib
-
 from scalyr_agent.test_base import ScalyrTestCase
+from scalyr_agent.test_util import ScalyrTestUtils
+from scalyr_agent.util import FakeClockCounter
 
 
 class MonitorsManagerTest(ScalyrTestCase):
     def test_single_module(self):
-        test_manager = self.__create_test_instance([
+        test_manager = ScalyrTestUtils.create_test_monitors_manager([
             {
                 'module': 'scalyr_agent.builtin_monitors.test_monitor',
                 'gauss_mean': 0
@@ -52,7 +42,7 @@ class MonitorsManagerTest(ScalyrTestCase):
         self.assertEquals(test_manager.monitors[0].monitor_name, 'test_monitor()')
 
     def test_multiple_modules(self):
-        test_manager = self.__create_test_instance([
+        test_manager = ScalyrTestUtils.create_test_monitors_manager([
             {
                 'module': 'scalyr_agent.builtin_monitors.test_monitor',
                 'gauss_mean': 0
@@ -68,7 +58,7 @@ class MonitorsManagerTest(ScalyrTestCase):
         self.assertEquals(test_manager.monitors[1].monitor_name, 'test_monitor(2)')
 
     def test_module_with_id(self):
-        test_manager = self.__create_test_instance([
+        test_manager = ScalyrTestUtils.create_test_monitors_manager([
             {
                 'module': 'scalyr_agent.builtin_monitors.test_monitor',
                 'id': 'first',
@@ -101,80 +91,36 @@ class MonitorsManagerTest(ScalyrTestCase):
         poll_interval = 30
 
         # Create MonitorsManager + 2 monitors. Set each to daemon otherwise unit test doesn't terminate
-        test_manager = self.__create_test_instance([
-            {
-                'module': 'scalyr_agent.builtin_monitors.test_monitor',
-                'gauss_mean': 0,
-            },
-            {
-                'module': 'scalyr_agent.builtin_monitors.test_monitor',
-                'gauss_mean': 0,
-            },
-            {
-                'module': 'scalyr_agent.builtin_monitors.test_monitor',
-                'gauss_mean': 0,
-            },
-        ], [], extra_toplevel_config={'user_agent_refresh_interval': poll_interval})
+        # Fake the clock to fast-forward MonitorsManager sleep loop
+        fake_clock = scalyr_util.FakeClock()
+        test_manager = ScalyrTestUtils.create_test_monitors_manager(
+            config_monitors=[
+                {
+                    'module': 'scalyr_agent.builtin_monitors.test_monitor',
+                    'gauss_mean': 0,
+                },
+                {
+                    'module': 'scalyr_agent.builtin_monitors.test_monitor',
+                    'gauss_mean': 0,
+                },
+                {
+                    'module': 'scalyr_agent.builtin_monitors.test_monitor',
+                    'gauss_mean': 0,
+                },
+            ],
+            platform_monitors=[],
+            extra_toplevel_config={'user_agent_refresh_interval': poll_interval},
+            null_logger=True,
+            fake_clock=fake_clock,
+        )
         self.assertEquals(test_manager._user_agent_refresh_interval, 30)  # ensure config setting works
         self.assertEquals(len(test_manager.monitors), 3)
         patched_monitor_0 = test_manager.monitors[0]
         patched_monitor_1 = test_manager.monitors[1]
         unpatched_monitor = test_manager.monitors[2]
 
-        # Fake the clock to fast-forward MonitorsManager sleep loop
-        fake_clock = scalyr_util.FakeClock()
-        for obj in [test_manager, patched_monitor_0, unpatched_monitor]:
-            obj._run_state = scalyr_util.RunState(fake_clock=fake_clock)
-
-        class FragmentPolls(object):
-            def __init__(self):
-                self.__polls = 0
-                self.__condition = threading.Condition()
-
-            def count(self):
-                self.__condition.acquire()
-                try:
-                    return self.__polls
-                finally:
-                    self.__condition.release()
-
-            def increment(self):
-                self.__condition.acquire()
-                try:
-                    self.__polls += 1
-                    self.__condition.notifyAll()
-                finally:
-                    self.__condition.release()
-
-            def wait_for_increment(self, old_count, timeout=None):
-                remaining = timeout
-                self.__condition.acquire()
-                try:
-                    while self.__polls == old_count and remaining > 0:
-                        t1 = time.time()
-                        self.__condition.wait(remaining)
-                        remaining -= time.time() - t1
-                finally:
-                    self.__condition.release()
-
-            def poll_until_target(self, target_polls, maxwait):
-                """Blocks until n fragment polls are simulated by the MonitorsManager, or an absolute cutoff time.
-                whichever comes first.
-
-                @param target_polls: Number of polls to reach
-                @param maxwait: Time (seconds) to wait for target to be reached
-                @return: True if number of polls reaches target_polls, else False
-                """
-                deadline = time.time() + maxwait
-                while self.count() < target_polls and time.time() < deadline:
-                    fake_clock.block_until_n_waiting_threads(1)  # wait for monitor thread loop to complete
-                    old_count = self.count()
-                    fake_clock.advance_time(increment_by=poll_interval)
-                    self.wait_for_increment(old_count, timeout=deadline-time.time())
-
-                return self.count() == target_polls
-
-        fragment_polls = FragmentPolls()
+        # The MonitorsManager + 3 monitor threads will wait on the fake clock
+        fragment_polls = FakeClockCounter(fake_clock, num_waiters=4)
 
         # Mock the function that returns user_agent_fragment (normally invoked on a Monitor)
         def mock_get_user_agent_fragment():
@@ -193,36 +139,25 @@ class MonitorsManagerTest(ScalyrTestCase):
             self.assertEquals(fragments, [test_frag])
         test_manager.set_user_agent_augment_callback(augment_user_agent)
 
-        # Override Agent Logger to prevent writing to disk
-        class FakeAgentLogger(AgentLogger):
-            def __init__(self, name):
-                super(FakeAgentLogger, self).__init__(name)
-                if not len(self.handlers):
-                    self.addHandler(logging.NullHandler())
-
-        for monitor in [patched_monitor_0, patched_monitor_1, unpatched_monitor]:
-            monitor._logger = FakeAgentLogger('fake_agent_logger')
-
         # We're finally ready start all threads and assert correct behavior.
         # Wait for MonitorsManager to poll for user-agent fragments 10x
         # Since 2 monitors are being polled for fragments, num polls should reach 2 x 10 = 20.
-        # However, the monitors always returned a non-changing frag so the callback should be invoked only once.
+        # However, the monitors always return a non-changing frag, so the callback should be invoked only once.
         # (Note: FakeClock ensures all the above happen within a split second)
         test_manager.start_manager()
-        self.assertTrue(fragment_polls.poll_until_target(20, 1))
+        self.assertTrue(fragment_polls.sleep_until_count_or_maxwait(20, poll_interval, 1))
         self.assertEquals(counter['callback_invocations'], 1)
 
         # Rerun the above test but this time have monitors return changing fragments.
         # This will cause the user agent callback to be invoked during each round of polling.
         # (The manager polls monitors 10x, and each poll results in a callback invocation).
-        fragment_polls = FragmentPolls()
+        fragment_polls = FakeClockCounter(fake_clock, num_waiters=4)
         counter['callback_invocations'] = 0
 
         def mock_get_user_agent_fragment_2():
             fragment_polls.increment()
             return test_frag + str(fragment_polls.count())
 
-        # patched_monitor_0.get_user_agent_fragment = mock_get_user_agent_fragment_2
         for mon in [patched_monitor_0, patched_monitor_1]:
             mon.get_user_agent_fragment = mock_get_user_agent_fragment_2
 
@@ -233,49 +168,9 @@ class MonitorsManagerTest(ScalyrTestCase):
             self.assertIsNotNone(variable_frag_pattern.match(fragments[0]))
         test_manager.set_user_agent_augment_callback(augment_user_agent_2)
 
-        self.assertTrue(fragment_polls.poll_until_target(20, 5))
+        self.assertTrue(fragment_polls.sleep_until_count_or_maxwait(20, poll_interval, 1))
         self.assertEquals(counter['callback_invocations'], 10)
 
+        # set_daemon=True obviates the following (saves a few seconds in cleanup):
         test_manager.stop_manager(wait_on_join=False)
         fake_clock.advance_time(increment_by=poll_interval)
-
-    def __create_test_instance(self, config_monitors, platform_monitors, extra_toplevel_config=None):
-        config_dir = tempfile.mkdtemp()
-        config_file = os.path.join(config_dir, 'agentConfig.json')
-        config_fragments_dir = os.path.join(config_dir, 'configs.d')
-        os.makedirs(config_fragments_dir)
-
-        monitors_json_array = JsonArray()
-
-        for entry in config_monitors:
-            monitors_json_array.add(JsonObject(content=entry))
-
-        fp = open(config_file, 'w')
-        toplevel_config = {
-            'api_key': 'fake',
-            'monitors': monitors_json_array
-        }
-        if extra_toplevel_config:
-            toplevel_config.update(extra_toplevel_config)
-        fp.write(json_lib.serialize(JsonObject(**toplevel_config)))
-        fp.close()
-
-        default_paths = DefaultPaths('/var/log/scalyr-agent-2', '/etc/scalyr-agent-2/agent.json',
-                                     '/var/lib/scalyr-agent-2')
-
-        config = Configuration(config_file, default_paths, None)
-        config.parse()
-        # noinspection PyTypeChecker
-        return MonitorsManager(config, FakePlatform(platform_monitors))
-
-
-class FakePlatform(object):
-    """Fake implementation of PlatformController.
-
-    Only implements the one method required for testing MonitorsManager.
-    """
-    def __init__(self, default_monitors):
-        self.__monitors = default_monitors
-
-    def get_default_monitors(self, _):
-        return self.__monitors


### PR DESCRIPTION
# Background

This is a follow up to recently merged PR https://github.com/scalyr/scalyr-agent-2/pull/150.

In this PR, I add the following:

1. user-agent support for docker
     -  returns fragment as `docker=true` if docker_monitor is running but version cannot be determined.
     - no specific support for ECS yet

2. modify user-agent support for k8s by returning `k8s=true` if k8s_monitor is running but version cannot be determined.

3. Unit tests to lock-down expected behavior for what k8s & docker monitors are expected to return.

# Details

In this PR, I add user-agent fragment support for Docker.  As discussed with @imron, there is potential for race condition between manager and monitor.  To handle this as well as potential failure during version API call, I follow a lazy-instantiation "self-healing" approach that's aligned with the rest of the monitor behavior.

The basic idea is once the version is successfully obtained (non-null), it will never be checked again for the lifetime of the agent.  The rationale being that the docker version cannot change without an agent reboot.

The version, once set, is then decorated with extra info (syslog vs docker_api mode, raw vs api) etc. 

Finally, if the version is not set, we still return `docker=true` since it tells us that _some_ docker version is running. Note:  I also piggy back a similar modification to the k8s_monitor in this PR and will add a unit test for that.

# How was this tested?

1. Created docker image using `python build_package.py docker_syslog_builder`
2. Launched docker image with API key pointing to `qatesting`
3. Verified `docker=xxxx` appeared in user agent as follows:

![image](https://user-images.githubusercontent.com/48775713/55537122-54c47d80-5670-11e9-8043-1b89076d5fe7.png)

Note: I did not manual-test the different config permutations (syslog vs dockerapi-raw vs dockerapi-api).   However, my unit test cover the permutations.

