### PR TITLE
AGENT-65 and AGENT-66 - Broken unit test (json encoding)

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,6 @@ mock==2.0.0
 nose==1.3.7
 nose-exclude
 nose_xunitmp==0.4.0
-parameterized==0.7.0
 pg8000==1.11.0
 pysnmp
 requests==2.20.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,11 +7,13 @@ mock==2.0.0
 nose==1.3.7
 nose-exclude
 nose_xunitmp==0.4.0
+parameterized==0.7.0
 pg8000==1.11.0
 pysnmp
 requests==2.20.0
 redis==2.10.6
 Twisted==17.9.0
+ujson==1.35
 unittest2==1.1.0
 virtualenv==15.1.0
 webapp2==2.5.2

--- a/scalyr_agent/json_lib/objects.py
+++ b/scalyr_agent/json_lib/objects.py
@@ -55,9 +55,6 @@ class JsonObject(object):
         for key, value in key_values.iteritems():
             self.__map[key] = value
 
-    def asDict(self):
-        return self.__map
-
     def to_json(self):
         """Returns a string containing the JSON representation of this object.
 
@@ -550,9 +547,6 @@ class JsonArray(object):
     def __len__(self):
         """Returns the number of elements in the JsonArray"""
         return len(self.__items)
-
-    def asList(self):
-        return self.__items
 
     def get_json_object(self, index):
         """Returns the value at the specified index as a JsonObject.

--- a/scalyr_agent/json_lib/objects.py
+++ b/scalyr_agent/json_lib/objects.py
@@ -55,6 +55,9 @@ class JsonObject(object):
         for key, value in key_values.iteritems():
             self.__map[key] = value
 
+    def asDict(self):
+        return self.__map
+
     def to_json(self):
         """Returns a string containing the JSON representation of this object.
 
@@ -547,6 +550,9 @@ class JsonArray(object):
     def __len__(self):
         """Returns the number of elements in the JsonArray"""
         return len(self.__items)
+
+    def asList(self):
+        return self.__items
 
     def get_json_object(self, index):
         """Returns the value at the specified index as a JsonObject.

--- a/scalyr_agent/json_lib/parser.py
+++ b/scalyr_agent/json_lib/parser.py
@@ -320,7 +320,6 @@ class JsonParser(object):
             # Check for end-of-array.
             if self.__peek_next_non_whitespace() == ']':
                 self.__scanner.read_ubyte()
-                print('returning array %s' % array)
                 return array
       
             self.__peek_next_non_whitespace()  # skip any whitespace

--- a/scalyr_agent/json_lib/parser.py
+++ b/scalyr_agent/json_lib/parser.py
@@ -176,7 +176,7 @@ class JsonParser(object):
     """Parses raw byte input into JsonObjects and supports Scalyr's extensions.
 
     JsonParser is the main abstraction for parsing raw byte input
-    into JsonObject and other related objects.  It also supports Scaylr's
+    into JsonObject and other related objects.  It also supports Scalyr's
     extensions to the Json format, including comments and binary data.
     Specifically, the following are allowed:
 
@@ -320,6 +320,7 @@ class JsonParser(object):
             # Check for end-of-array.
             if self.__peek_next_non_whitespace() == ']':
                 self.__scanner.read_ubyte()
+                print('returning array %s' % array)
                 return array
       
             self.__peek_next_non_whitespace()  # skip any whitespace
@@ -708,7 +709,7 @@ class JsonParser(object):
 def parse(input_bytes, check_duplicate_keys=False):
     """Parses the input as JSON and returns its contents.
 
-    It supports Scaylr's extensions to the Json format, including comments and
+    It supports Scalyr's extensions to the Json format, including comments and
     binary data. Specifically, the following are allowed:
 
      - // and /* comments

--- a/scalyr_agent/json_lib/tests/encode_decode_test.py
+++ b/scalyr_agent/json_lib/tests/encode_decode_test.py
@@ -28,8 +28,6 @@ from scalyr_agent.test_base import ScalyrTestCase
 JSON = 1
 UJSON = 2
 FALLBACK = 3
-ALL_JSON_LIBS = [FALLBACK]
-ALL_JSON_LIBS_AS_TUPLES = [(lib,) for lib in ALL_JSON_LIBS]
 
 
 class EncodeDecodeTest(ScalyrTestCase):

--- a/scalyr_agent/json_lib/tests/encode_decode_test.py
+++ b/scalyr_agent/json_lib/tests/encode_decode_test.py
@@ -41,6 +41,10 @@ class EncodeDecodeTest(ScalyrTestCase):
         else:
             util._set_json_lib('json_lib')
 
+    def test_invalid_lib(self):
+        with self.assertRaises(ValueError):
+            util._set_json_lib('BAD JSON LIBRARY NAME')
+
     def test_dict(self):
         self.__test_encode_decode('{"a":1,"b":2}', {u'a': 1, u'b': 2})
 

--- a/scalyr_agent/json_lib/tests/encode_decode_test.py
+++ b/scalyr_agent/json_lib/tests/encode_decode_test.py
@@ -1,0 +1,111 @@
+# Copyright 2014 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+#
+# author:  Edward Chee <echee@scalyr.com>
+
+__author__ = 'echee@scalyr.com'
+
+import json
+import ujson
+import unittest
+
+from functools import partial
+
+from scalyr_agent import util
+from scalyr_agent.json_lib import JsonObject
+from scalyr_agent.json_lib import JsonArray
+from scalyr_agent.test_base import ScalyrTestCase
+
+JSON = 1
+UJSON = 2
+FALLBACK = 3
+ALL_JSON_LIBS = [FALLBACK]
+ALL_JSON_LIBS_AS_TUPLES = [(lib,) for lib in ALL_JSON_LIBS]
+
+class EncodeDecodeTest(ScalyrTestCase):
+    """This test ensures that JsonObject and JsonArray can be correctly encoded/decoded with different JSON libraries"""
+
+    def _setlib(self, library):
+        if library == JSON:
+            util._json_encode = partial(json.dumps, separators=(',', ':'))
+            util._json_decode = json.loads
+        elif library == UJSON:
+            util._json_encode = ujson.dumps
+            util._json_decode = ujson.loads
+        else:
+            util._json_encode = util._fallback_json_encode
+            util._json_decode = util._fallback_json_decode
+
+    def test_dict(self):
+        self.__test_encode_decode('{"a":1,"b":2}', {u'a': 1, u'b': 2})
+
+    def test_dict2(self):
+        self.__test_encode_decode('{"a":1,"b":{"c":2}}', {u'a': 1, u'b': {u'c': 2}})
+
+    # def test_str(self):
+    #     self.__test_encode_decode(r'"a"', u'a')
+    #
+    # def test_int(self):
+    #     self.__test_encode_decode(r'1', 1)
+    #
+    # def test_bool(self):
+    #     self.__test_encode_decode(r'false', False)
+    #     self.__test_encode_decode(r'true', True)
+    #
+    # def test_float(self):
+    #     self.__test_encode_decode(r'1.0003', 1.0003)
+    #
+    # def test_list(self):
+    #     self.__test_encode_decode(r'[1,2,3]', [1, 2, 3])
+    #
+    # def test_list2(self):
+    #     self.__test_encode_decode(r'[1,2,"a"]', [1, 2, u'a'])
+    #
+    # def test_dict(self):
+    #     self.__test_encode_decode(r'{"a":1,"b":2}', JsonObject({u'a': 1, u'b': 2}))
+    #
+    # def test_dict_nested_dict(self):
+    #     self.__test_encode_decode(r'{"a":{"b":{"c":3}}}', JsonObject({u'a': JsonObject({u'b': JsonObject({u'c': 3})})}))
+    #
+    # def test_dict_nested_list(self):
+    #     self.__test_encode_decode(r'{"a":[1,2,3]}', JsonObject({u'a': JsonArray(1, 2, 3)}))
+    #
+    # def test_dict_nested_list2(self):
+    #     self.__test_encode_decode(r'{"a":[1,2,3,[1,2,3]]}', JsonObject({u'a': JsonArray(1, 2, 3, JsonArray(1, 2, 3))}))
+
+    def __test_encode_decode(self, text, obj):
+        def __runtest(library):
+            self._setlib(library)
+            text2 = util.json_encode(obj)
+            self.assertEquals(text, text2)
+
+            obj2 = util.json_decode(text2)
+            self.assertEquals(type(obj2), type(obj))
+            self.assertEquals(obj2, obj)
+
+            text3 = util.json_encode(obj2)
+            self.assertEquals(text, text3)
+
+        __runtest(JSON)
+        __runtest(UJSON)
+        # __runtest(FALLBACK)
+
+
+def main():
+    unittest.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/scalyr_agent/json_lib/tests/encode_decode_test.py
+++ b/scalyr_agent/json_lib/tests/encode_decode_test.py
@@ -68,28 +68,34 @@ class EncodeDecodeTest(ScalyrTestCase):
     def test_list2(self):
         self.__test_encode_decode(r'[1,2,"a"]', [1, 2, u'a'])
 
-    def test_dict(self):
+    def test_jsonarray(self):
+        self.__test_encode_decode(r'[1,2,3]', JsonArray(1, 2, 3))
+
+    def test_jsonobject(self):
         self.__test_encode_decode(r'{"a":1,"b":2}', JsonObject({u'a': 1, u'b': 2}))
 
-    def test_dict_nested_dict(self):
+    def test_jsonobject_nested_dict(self):
         self.__test_encode_decode(r'{"a":{"b":{"c":3}}}', JsonObject({u'a': JsonObject({u'b': JsonObject({u'c': 3})})}))
 
-    def test_dict_nested_list(self):
+    def test_jsonobject_nested_jsonarray(self):
         self.__test_encode_decode(r'{"a":[1,2,3]}', JsonObject({u'a': JsonArray(1, 2, 3)}))
 
-    def test_dict_nested_list2(self):
+    def test_jsonobject_nested_jsonarray2(self):
         self.__test_encode_decode(r'{"a":[1,2,3,[1,2,3]]}', JsonObject({u'a': JsonArray(1, 2, 3, JsonArray(1, 2, 3))}))
 
     def __test_encode_decode(self, text, obj):
         def __runtest(library):
             self._setlib(library)
-            text2 = util.json_encode(obj)
-            self.assertEquals(text, text2)
 
-            obj2 = util.json_decode(text2)
-
-            text3 = util.json_encode(obj2)
-            self.assertEquals(text, text3)
+            if library == FALLBACK or not isinstance(obj, (JsonArray, JsonObject)):
+                text2 = util.json_encode(obj)
+                self.assertEquals(text, text2)
+                obj2 = util.json_decode(text2)
+                text3 = util.json_encode(obj2)
+                self.assertEquals(text, text3)
+            else:
+                with self.assertRaises(TypeError):
+                    util.json_encode(obj)
 
         __runtest(JSON)
         __runtest(UJSON)

--- a/scalyr_agent/json_lib/tests/encode_decode_test.py
+++ b/scalyr_agent/json_lib/tests/encode_decode_test.py
@@ -17,11 +17,8 @@
 
 __author__ = 'echee@scalyr.com'
 
-import json
-import ujson
-import unittest
 
-from functools import partial
+import unittest
 
 from scalyr_agent import util
 from scalyr_agent.json_lib import JsonObject
@@ -34,19 +31,17 @@ FALLBACK = 3
 ALL_JSON_LIBS = [FALLBACK]
 ALL_JSON_LIBS_AS_TUPLES = [(lib,) for lib in ALL_JSON_LIBS]
 
+
 class EncodeDecodeTest(ScalyrTestCase):
     """This test ensures that JsonObject and JsonArray can be correctly encoded/decoded with different JSON libraries"""
 
     def _setlib(self, library):
         if library == JSON:
-            util._json_encode = partial(json.dumps, separators=(',', ':'))
-            util._json_decode = json.loads
+            util._set_json_lib('json')
         elif library == UJSON:
-            util._json_encode = ujson.dumps
-            util._json_decode = ujson.loads
+            util._set_json_lib('ujson')
         else:
-            util._json_encode = util._fallback_json_encode
-            util._json_decode = util._fallback_json_decode
+            util._set_json_lib('json_lib')
 
     def test_dict(self):
         self.__test_encode_decode('{"a":1,"b":2}', {u'a': 1, u'b': 2})
@@ -54,36 +49,36 @@ class EncodeDecodeTest(ScalyrTestCase):
     def test_dict2(self):
         self.__test_encode_decode('{"a":1,"b":{"c":2}}', {u'a': 1, u'b': {u'c': 2}})
 
-    # def test_str(self):
-    #     self.__test_encode_decode(r'"a"', u'a')
-    #
-    # def test_int(self):
-    #     self.__test_encode_decode(r'1', 1)
-    #
-    # def test_bool(self):
-    #     self.__test_encode_decode(r'false', False)
-    #     self.__test_encode_decode(r'true', True)
-    #
-    # def test_float(self):
-    #     self.__test_encode_decode(r'1.0003', 1.0003)
-    #
-    # def test_list(self):
-    #     self.__test_encode_decode(r'[1,2,3]', [1, 2, 3])
-    #
-    # def test_list2(self):
-    #     self.__test_encode_decode(r'[1,2,"a"]', [1, 2, u'a'])
-    #
-    # def test_dict(self):
-    #     self.__test_encode_decode(r'{"a":1,"b":2}', JsonObject({u'a': 1, u'b': 2}))
-    #
-    # def test_dict_nested_dict(self):
-    #     self.__test_encode_decode(r'{"a":{"b":{"c":3}}}', JsonObject({u'a': JsonObject({u'b': JsonObject({u'c': 3})})}))
-    #
-    # def test_dict_nested_list(self):
-    #     self.__test_encode_decode(r'{"a":[1,2,3]}', JsonObject({u'a': JsonArray(1, 2, 3)}))
-    #
-    # def test_dict_nested_list2(self):
-    #     self.__test_encode_decode(r'{"a":[1,2,3,[1,2,3]]}', JsonObject({u'a': JsonArray(1, 2, 3, JsonArray(1, 2, 3))}))
+    def test_str(self):
+        self.__test_encode_decode(r'"a"', u'a')
+
+    def test_int(self):
+        self.__test_encode_decode(r'1', 1)
+
+    def test_bool(self):
+        self.__test_encode_decode(r'false', False)
+        self.__test_encode_decode(r'true', True)
+
+    def test_float(self):
+        self.__test_encode_decode(r'1.0003', 1.0003)
+
+    def test_list(self):
+        self.__test_encode_decode(r'[1,2,3]', [1, 2, 3])
+
+    def test_list2(self):
+        self.__test_encode_decode(r'[1,2,"a"]', [1, 2, u'a'])
+
+    def test_dict(self):
+        self.__test_encode_decode(r'{"a":1,"b":2}', JsonObject({u'a': 1, u'b': 2}))
+
+    def test_dict_nested_dict(self):
+        self.__test_encode_decode(r'{"a":{"b":{"c":3}}}', JsonObject({u'a': JsonObject({u'b': JsonObject({u'c': 3})})}))
+
+    def test_dict_nested_list(self):
+        self.__test_encode_decode(r'{"a":[1,2,3]}', JsonObject({u'a': JsonArray(1, 2, 3)}))
+
+    def test_dict_nested_list2(self):
+        self.__test_encode_decode(r'{"a":[1,2,3,[1,2,3]]}', JsonObject({u'a': JsonArray(1, 2, 3, JsonArray(1, 2, 3))}))
 
     def __test_encode_decode(self, text, obj):
         def __runtest(library):
@@ -92,15 +87,13 @@ class EncodeDecodeTest(ScalyrTestCase):
             self.assertEquals(text, text2)
 
             obj2 = util.json_decode(text2)
-            self.assertEquals(type(obj2), type(obj))
-            self.assertEquals(obj2, obj)
 
             text3 = util.json_encode(obj2)
             self.assertEquals(text, text3)
 
         __runtest(JSON)
         __runtest(UJSON)
-        # __runtest(FALLBACK)
+        __runtest(FALLBACK)
 
 
 def main():

--- a/scalyr_agent/json_lib/tests/serializer_test.py
+++ b/scalyr_agent/json_lib/tests/serializer_test.py
@@ -18,7 +18,7 @@
 __author__ = 'czerwin@scalyr.com'
 
 import unittest
-from scalyr_agent.json_lib import serialize, serialize_as_length_prefixed_string
+from scalyr_agent.json_lib import serialize
 
 from scalyr_agent.test_base import ScalyrTestCase
 
@@ -106,8 +106,8 @@ class SerializeTests(ScalyrTestCase):
         self.assertEquals('`s\x00\x00\x00\x10Howdy \xe8\x92\xb8 folks!', serialize(u'Howdy \u84b8 folks!',
                                                                                    use_length_prefix_string=True))
 
-    def write(self, value):
-        return serialize(value, use_fast_encoding=True)
+    def write(self, value, sort_keys=False):
+        return serialize(value, use_fast_encoding=True, sort_keys=sort_keys)
 
     def __run_string_test_case(self, input_string, expected_result):
         self.assertEquals(serialize(input_string, use_fast_encoding=True), expected_result)

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -1297,6 +1297,9 @@ class LogFileProcessor(object):
             file_system = FileSystem()
         if log_attributes is None:
             log_attributes = {}
+        else:
+            if not isinstance(log_attributes, dict):
+                raise Exception('log_attributes must be of type dict.')
 
         self.__path = file_path
         # To mimic the behavior of the old agent which would use the ``thread_id`` feature of the Scalyr API to

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -1442,10 +1442,11 @@ class TestLogFileProcessor(ScalyrTestCase):
         self.assertTrue(completion_callback(LogFileProcessor.SUCCESS))
 
     def test_log_attributes(self):
-        vals = {'path': self.__path, 'attributes': JsonObject({'host': 'scalyr-1'})}
+        attribs = {'host': 'scalyr-1'}
+        vals = {'path': self.__path, 'attributes': JsonObject(attribs)}
         log_config = DEFAULT_CONFIG.parse_log_config(vals)
         log_processor = LogFileProcessor(self.__path, DEFAULT_CONFIG, log_config, file_system=self.__file_system,
-                                         log_attributes=vals['attributes'])
+                                         log_attributes=attribs)
         log_processor.perform_processing(TestLogFileProcessor.TestAddEventsRequest(), current_time=self.__fake_time)
 
         self.append_file(self.__path, 'First line\nSecond line\n')

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -82,7 +82,10 @@ def get_json_implementation(lib_name):
 
         return lib_name, ujson_dumps_custom, ujson.loads
 
-    if lib_name == 'json':
+    else:
+        if lib_name != 'json':
+            raise ValueError('Unsupported json library %s' % lib_name)
+
         import json
 
         def json_dumps_custom(*args, **kwargs):

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -108,18 +108,14 @@ def _set_json_lib(lib_name):
     _json_lib, _json_encode, _json_decode = get_json_implementation(lib_name)
 
 
-force_json_lib = os.getenv('SCALYR_FORCE_JSON_LIB')
-if force_json_lib:
-    _set_json_lib(force_json_lib)
-else:
-    _set_json_lib('json_lib')
+_set_json_lib('json_lib')
+try:
+    _set_json_lib('ujson')
+except ImportError:
     try:
-        _set_json_lib('ujson')
-    except ImportError:
-        try:
-            _set_json_lib('json')
-        except:
-            pass
+        _set_json_lib('json')
+    except:
+        pass
 
 
 def get_json_lib():

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -55,7 +55,8 @@ try:
 except ImportError:
     uuid = None
 
-def _fallback_json_encode( obj ):
+def _fallback_json_encode( obj, sort_keys=False ):
+    # json_lib.serialize() always ignores sort_keys
     return json_lib.serialize( obj )
 
 def _fallback_json_decode( text ):

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -119,7 +119,9 @@ def get_json_lib():
     return _json_lib
 
 def json_encode( obj ):
-    """Encodes an object into a JSON string.  All underlying implementations handle our custom JsonObject/JsonArray"""
+    """Encodes an object into a JSON string.  The underlying implementation either handles JsonObject/JsonArray
+    or else complains loudly (raises Exception) if they do not correctly support encoding.
+    """
     return _json_encode( obj, sort_keys=True )
 
 def json_decode( text ):
@@ -127,7 +129,7 @@ def json_decode( text ):
     depending on which underlying decoder is used.
 
     If json or ujson are used, a dict is returned.
-    If the scalyr _fallback decoder is used, a JsonObject is returned
+    If the Scalyr custom json_lib decoder is used, a JsonObject is returned
     """
     return _json_decode( text )
 


### PR DESCRIPTION
1. Json encoder/decoder issue breaking `TestLogFileProcessor.test_log_attributes`
2. _fallback_json_encode missing `sort_keys` 

Error for (1) is 
```
======================================================================
ERROR: test_log_attributes (scalyr_agent.tests.log_processing_test.TestLogFileProcessor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/echee/Documents/code/scalyr/scalyr-agent-2/scalyr_agent/tests/log_processing_test.py", line 1448, in test_log_attributes
    log_attributes=vals['attributes'])
  File "/Users/echee/Documents/code/scalyr/scalyr-agent-2/scalyr_agent/log_processing.py", line 1330, in __init__
    self.__base_event = Event(thread_id=self.__thread_id, attrs=log_attributes)
  File "/Users/echee/Documents/code/scalyr/scalyr-agent-2/scalyr_agent/scalyr_client.py", line 1217, in __init__
    self.__set_attributes( thread_id, attrs )
  File "/Users/echee/Documents/code/scalyr/scalyr-agent-2/scalyr_agent/scalyr_client.py", line 1250, in __set_attributes
    tmp_buffer.write( scalyr_util.json_encode(attributes) )
  File "/Users/echee/Documents/code/scalyr/scalyr-agent-2/scalyr_agent/util.py", line 88, in json_encode
    return _json_encode( obj, sort_keys=True )
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 250, in dumps
    sort_keys=sort_keys, **kw).encode(obj)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 209, in encode
    chunks = list(chunks)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 442, in _iterencode
    o = _default(o)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: {'host': 'scalyr-1'} is not JSON serializable
```

# ANALYSIS

`scalyr_agent.util.json_encode` does not know how to encode our custom `JsonArray` and `JsonObject` by default, if the underlying lib is `json` or `ujson`.  (If the underlying lib is the fallback `json_lib`, we're OK)

Furthermore,  if underlying is `json`, we get the loud `TypeError` as above.  But if underlying is `ujson`, `json_encode()` insiduously does not raise exception **but encodes incorrectly**

# STATUS

Per discussion with Steven, I have:

1. Made ujson complain loudly if you try to make it encode a JsonArray/Object
2. Modified the failing test to correctly pass native dict instead of JsonObject
3. Added a check to `LogFileProcessor` to raise exception if you incorrectly pass in a JsonArray/Object
