### PR TITLE
Ticket: #AGENT-20

### DIFF
--- a/scalyr_agent/builtin_monitors/url_monitor.py
+++ b/scalyr_agent/builtin_monitors/url_monitor.py
@@ -105,7 +105,7 @@ class UrlMonitor(ScalyrMonitor):
 
         if self.request_headers and type(self.request_headers) != JsonArray:
             raise Exception(
-                'URL Monitor has malformed optional headers: {}'.format(repr(self.request_headers))
+                'URL Monitor has malformed optional headers: %s' % (repr(self.request_headers))
             )
 
         extract_expression = self._config.get("extract")

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -2051,10 +2051,7 @@ class LogLineRedacter(object):
                 for _group_index, _group in enumerate(_groups):
                     # for each group in a match, replace the `replacement_ex` with either its `group` content, or
                     # the hash of the `group` depending on the hash indicator \\1 vs \\H1 etc.
-                    group_hash_indicator = "\{}{}".format(
-                        LogLineRedacter.HASH_GROUP_INDICATOR,
-                        _group_index + 1
-                    )
+                    group_hash_indicator = "\\%s%s" % (LogLineRedacter.HASH_GROUP_INDICATOR, _group_index + 1)
                     replacement_matches += 1
                     if group_hash_indicator in replacement_ex:
                         # the group needs to be hashed
@@ -2066,7 +2063,7 @@ class LogLineRedacter(object):
                         )
                     else:
                         # the group does not need to be hashed
-                        replaced_group = replaced_group.replace("\{}".format(_group_index + 1), _group, 1)
+                        replaced_group = replaced_group.replace("\\%s" % (_group_index + 1), _group, 1)
                 # once we have formed the replacement expression, we just need to replace the matched
                 # portion of the `line` with the `replaced_group` that we just built
                 replaced_string = replaced_string + line[last_match_index: _match.start()]
@@ -2128,7 +2125,7 @@ class RedactionRule(object):
 
     @property
     def hash_redacted_data(self):
-        return "\{0}".format(LogLineRedacter.HASH_GROUP_INDICATOR) in self.replacement_text
+        return ("\\%s" % (LogLineRedacter.HASH_GROUP_INDICATOR)) in self.replacement_text
 
 
 class LogMatcher(object):

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -2051,19 +2051,19 @@ class LogLineRedacter(object):
                 for _group_index, _group in enumerate(_groups):
                     # for each group in a match, replace the `replacement_ex` with either its `group` content, or
                     # the hash of the `group` depending on the hash indicator \\1 vs \\H1 etc.
-                    group_hash_indicator = "\\%s%s" % (LogLineRedacter.HASH_GROUP_INDICATOR, _group_index + 1)
+                    group_hash_indicator = "\\%s%d" % (LogLineRedacter.HASH_GROUP_INDICATOR, _group_index + 1)
                     replacement_matches += 1
                     if group_hash_indicator in replacement_ex:
                         # the group needs to be hashed
                         replaced_group = replaced_group.encode('utf8')
                         replaced_group = replaced_group.replace(
                             group_hash_indicator,
-                            scalyr_util.md5_digest(_group + redaction_rule.hash_salt),
+                            scalyr_util.md5_hexdigest(_group + redaction_rule.hash_salt),
                             1
                         )
                     else:
                         # the group does not need to be hashed
-                        replaced_group = replaced_group.replace("\\%s" % (_group_index + 1), _group, 1)
+                        replaced_group = replaced_group.replace("\\%d" % (_group_index + 1), _group, 1)
                 # once we have formed the replacement expression, we just need to replace the matched
                 # portion of the `line` with the `replaced_group` that we just built
                 replaced_string = replaced_string + line[last_match_index: _match.start()]

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -825,10 +825,10 @@ class TestLogLineRedactor(ScalyrTestCase):
         redactor = LogLineRedacter('/var/fake_log')
         redactor.add_redaction_rule('(password)', '\\H1')
 
-        self._run_case(redactor, "auth=password", "auth={}".format(md5_digest("password")), True)
+        self._run_case(redactor, "auth=password", "auth=%s" % (md5_digest("password")), True)
         self._run_case(
             redactor, "another line password",
-            "another line {}".format(md5_digest("password")),
+            "another line %s" % (md5_digest("password")),
             True
         )
 
@@ -839,12 +839,12 @@ class TestLogLineRedactor(ScalyrTestCase):
         self._run_case(
             redactor,
             "auth=password",
-            "auth={}".format(md5_digest("password" + "himalayan-salt")),
+            "auth=%s" % (md5_digest("password" + "himalayan-salt")),
             True
         )
         self._run_case(
             redactor, "another line password",
-            "another line {}".format(md5_digest("password" + "himalayan-salt")),
+            "another line %s" % (md5_digest("password" + "himalayan-salt")),
             True
         )
 
@@ -854,7 +854,7 @@ class TestLogLineRedactor(ScalyrTestCase):
 
         self._run_case(
             redactor,
-            "auth=password foo=password", "auth={} foo={}".format(
+            "auth=password foo=password", "auth=%s foo=%s" % (
                 md5_digest("password"), md5_digest("password")),
             True
         )
@@ -865,7 +865,7 @@ class TestLogLineRedactor(ScalyrTestCase):
         self._run_case(
             redactor,
             "sometext.... secretoption=czerwin",
-            "sometext.... secretoption={}".format(md5_digest("czerwin")),
+            "sometext.... secretoption=%s" % (md5_digest("czerwin")),
             True
         )
 
@@ -923,7 +923,7 @@ class TestLogLineRedactor(ScalyrTestCase):
         self._run_case(
             redactor,
             "userInfo=saurabh abcd1234",
-            "userInfo={}".format(md5_digest("saurabh")),
+            "userInfo=%s" % (md5_digest("saurabh")),
             True
         )
 

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -32,7 +32,7 @@ from scalyr_agent.log_processing import FileSystem
 from scalyr_agent import json_lib
 from scalyr_agent.json_lib import JsonObject
 from scalyr_agent.json_lib import JsonArray
-from scalyr_agent.util import md5_digest
+from scalyr_agent.util import md5_hexdigest
 from scalyr_agent.configuration import Configuration, BadConfiguration
 from scalyr_agent.platform_controller import DefaultPaths
 
@@ -825,10 +825,10 @@ class TestLogLineRedactor(ScalyrTestCase):
         redactor = LogLineRedacter('/var/fake_log')
         redactor.add_redaction_rule('(password)', '\\H1')
 
-        self._run_case(redactor, "auth=password", "auth=%s" % (md5_digest("password")), True)
+        self._run_case(redactor, "auth=password", "auth=%s" % (md5_hexdigest("password")), True)
         self._run_case(
             redactor, "another line password",
-            "another line %s" % (md5_digest("password")),
+            "another line %s" % (md5_hexdigest("password")),
             True
         )
 
@@ -839,12 +839,12 @@ class TestLogLineRedactor(ScalyrTestCase):
         self._run_case(
             redactor,
             "auth=password",
-            "auth=%s" % (md5_digest("password" + "himalayan-salt")),
+            "auth=%s" % (md5_hexdigest("password" + "himalayan-salt")),
             True
         )
         self._run_case(
             redactor, "another line password",
-            "another line %s" % (md5_digest("password" + "himalayan-salt")),
+            "another line %s" % (md5_hexdigest("password" + "himalayan-salt")),
             True
         )
 
@@ -855,7 +855,7 @@ class TestLogLineRedactor(ScalyrTestCase):
         self._run_case(
             redactor,
             "auth=password foo=password", "auth=%s foo=%s" % (
-                md5_digest("password"), md5_digest("password")),
+                md5_hexdigest("password"), md5_hexdigest("password")),
             True
         )
 
@@ -865,7 +865,7 @@ class TestLogLineRedactor(ScalyrTestCase):
         self._run_case(
             redactor,
             "sometext.... secretoption=czerwin",
-            "sometext.... secretoption=%s" % (md5_digest("czerwin")),
+            "sometext.... secretoption=%s" % (md5_hexdigest("czerwin")),
             True
         )
 
@@ -876,9 +876,9 @@ class TestLogLineRedactor(ScalyrTestCase):
             redactor,
             "sometext.... secretoption=czerwin moretextsecretbar=xxx andsecret123=saurabh",
             "sometext.... secretoption=%smoretextsecretbar=%sandsecret123=%s" % (
-                md5_digest("czerwin "),
-                md5_digest("xxx "),
-                md5_digest("saurabh"),
+                md5_hexdigest("czerwin "),
+                md5_hexdigest("xxx "),
+                md5_hexdigest("saurabh"),
             ),
             True
         )
@@ -890,8 +890,8 @@ class TestLogLineRedactor(ScalyrTestCase):
             redactor,
             "sometext.... secretoption=czerwin andsecret123=saurabh",
             "sometext.... secretczerwin =%sandsecretsaurabh=%s" % (
-                md5_digest("option"),
-                md5_digest("123"),
+                md5_hexdigest("option"),
+                md5_hexdigest("123"),
             ),
             True
         )
@@ -923,7 +923,7 @@ class TestLogLineRedactor(ScalyrTestCase):
         self._run_case(
             redactor,
             "userInfo=saurabh abcd1234",
-            "userInfo=%s" % (md5_digest("saurabh")),
+            "userInfo=%s" % (md5_hexdigest("saurabh")),
             True
         )
 

--- a/scalyr_agent/tests/syslog_monitor_test.py
+++ b/scalyr_agent/tests/syslog_monitor_test.py
@@ -303,7 +303,7 @@ class SyslogMonitorConnectTest(SyslogMonitorTestCase):
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sockets.append(s)
 
-        expected = "UDP Test {}".format(uuid.uuid4())
+        expected = "UDP Test %s" % (uuid.uuid4())
         s.sendto(expected, ('localhost', 5514))
         time.sleep(1)
         self.monitor.stop(wait_on_join=False)

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -196,11 +196,14 @@ def create_unique_id():
     return result
 
 
-def md5_digest(data):
+def md5_digest(data, hexdigest=True):
     """
     Returns the md5 digest of the input data
     @param data: data to be digested(hashed)
+    @param hexdigest: if True return the digest as a hex string.  If False return the raw bytes which may contain non-ASCII characters,
+                      including null bytes
     @type data: str
+    @type hexdigest: bool
     @rtype: str
     """
 
@@ -212,6 +215,10 @@ def md5_digest(data):
     else:
         m = md5()
     m.update(data)
+
+    if hexdigest:
+        return m.hexdigest()
+
     return m.digest()
 
 

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -196,14 +196,11 @@ def create_unique_id():
     return result
 
 
-def md5_digest(data, hexdigest=True):
+def md5_hexdigest(data):
     """
     Returns the md5 digest of the input data
     @param data: data to be digested(hashed)
-    @param hexdigest: if True return the digest as a hex string.  If False return the raw bytes which may contain non-ASCII characters,
-                      including null bytes
     @type data: str
-    @type hexdigest: bool
     @rtype: str
     """
 
@@ -216,11 +213,7 @@ def md5_digest(data, hexdigest=True):
         m = md5()
     m.update(data)
 
-    if hexdigest:
-        return m.hexdigest()
-
-    return m.digest()
-
+    return m.hexdigest()
 
 def remove_newlines_and_truncate(input_string, char_limit):
     """Returns the input string but with all newlines removed and truncated.


### PR DESCRIPTION
Removes python 2.7 specific formatting code from the log processor and related
tests.

Also updates the `md5_digest` utility function to return a hex string by default
rather than returning the raw md5 bytes, which could contain null-bytes and
other invalid ASCII.