### PR TITLE
AGENT-74: Eliminate unnecessary pause in MonitorsManager.stop_manager 

### DIFF
--- a/scalyr_agent/monitors_manager.py
+++ b/scalyr_agent/monitors_manager.py
@@ -18,6 +18,7 @@
 __author__ = 'czerwin@scalyr.com'
 
 import os
+import time
 
 from scalyr_agent.agent_status import MonitorManagerStatus
 from scalyr_agent.agent_status import MonitorStatus
@@ -132,6 +133,9 @@ class MonitorsManager(StoppableThread):
         @param join_timeout: The maximum number of seconds to block for the join.
         """
         # TODO:  Move these try statements out of here.  Let higher layers catch it.
+
+        start_time = time.time()
+
         for monitor in self.__running_monitors:
             # noinspection PyBroadException
             try:
@@ -142,9 +146,12 @@ class MonitorsManager(StoppableThread):
 
         if wait_on_join:
             for monitor in self.__running_monitors:
+                max_wait = start_time + join_timeout - time.time()
+                if max_wait <= 0:
+                    break
                 # noinspection PyBroadException
                 try:
-                    monitor.stop(join_timeout=1)
+                    monitor.stop(join_timeout=max_wait)
                 except:
                     log.exception('Failed to stop the metric log due to an exception')
 

--- a/scalyr_agent/monitors_manager.py
+++ b/scalyr_agent/monitors_manager.py
@@ -140,12 +140,13 @@ class MonitorsManager(StoppableThread):
             except:
                 log.exception('Failed to stop the metric log without join due to an exception')
 
-        for monitor in self.__running_monitors:
-            # noinspection PyBroadException
-            try:
-                monitor.stop(join_timeout=1)
-            except:
-                log.exception('Failed to stop the metric log due to an exception')
+        if wait_on_join:
+            for monitor in self.__running_monitors:
+                # noinspection PyBroadException
+                try:
+                    monitor.stop(join_timeout=1)
+                except:
+                    log.exception('Failed to stop the metric log due to an exception')
 
         for monitor in self.__running_monitors:
             # noinspection PyBroadException


### PR DESCRIPTION
# Background

AGENT-74 documents the initiative to eliminate unnecessary pauses in unit test.

I tracked one cause to when the `MonitorManager` waits for each monitor to shutdown, even if `wait_on_join` is False.

# Details

`MonitorsManager.stop_manager` currently accepts a wait_on_join parameter. This parameter defaults to True.  Some unit tests set this to False (I don't think we need to wait for all threads to shutdown in orderly fashion since `stop_manager` is typically called at the end of a unit test).

I don't fully understand why there are 2 loops here that call `monitor.stop()`.  I assume there is a reason for this.  Even so, I don't see the need to call `monitor.stop()` a second time when `wait_on_join` is False.
https://github.com/scalyr/scalyr-agent-2/pull/163/files#diff-9aba7b5c6dac7e1f8002bc4dd5fbe524R147

Do you agree or am I missing something?