### PR TITLE
Ticket AGENT-42

### DIFF
--- a/k8s/scalyr-agent-2.yaml
+++ b/k8s/scalyr-agent-2.yaml
@@ -44,12 +44,24 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
+        - name: varlogpods
+          mountPath: /var/log/pods
+          readOnly: true
+        - name: varlogcontainers
+          mountPath: /var/log/containers
+          readOnly: true
         - name: dockersock
           mountPath: /var/scalyr/docker.sock
       volumes:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+      - name: varlogpods
+        hostPath:
+          path: /var/log/pods
+      - name: varlogcontainers
+        hostPath:
+          path: /var/log/containers
       - name: dockersock
         hostPath:
           path: /var/run/docker.sock

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -180,7 +180,7 @@ define_config_option( __monitor__, 'k8s_always_use_cri',
                      convert_to=bool, default=False, env_aware=True)
 
 define_config_option( __monitor__, 'k8s_cri_query_filesystem',
-                     'Optional (defaults to False). If True, then when in CRI mode, the monitor will query the filesystem for the list of active containers, rather than the Kubelet API.  This is useful in environments where the Kubelet API has been disabled.',
+                     'Optional (defaults to False). If True, then when in CRI mode, the monitor will only query the filesystem for the list of active containers, rather than first querying the Kubelet API. This is a useful optimization when the Kubelet API is known to be disabled.',
                      convert_to=bool, default=False, env_aware=True)
 
 define_config_option( __monitor__, 'k8s_verify_api_queries',

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -1935,7 +1935,7 @@ class KubernetesMonitor( ScalyrMonitor ):
 
         except ConnectionError, e:
             self._logger.warning( "Error connecting to kubelet API: %s.  No Kubernetes stats will be available" % str( e ),
-                                  limit_once_per_x_secs=300,
+                                  limit_once_per_x_secs=3600,
                                   limit_key='kubelet-api-connection-stats' )
         except KubeletApiException, e:
             self._logger.warning( "Error querying kubelet API: %s" % str( e ),

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1167,7 +1167,8 @@ class Configuration(object):
             i += 1
 
         self.__verify_or_set_optional_bool(log_entry, 'copy_from_start', False, description)
-        self.__verify_or_set_optional_bool(log_entry, 'parse_lines_as_json', False, description)
+        self.__verify_or_set_optional_bool(log_entry, 'parse_lines_as_json', None, description, apply_defaults=False)
+        self.__verify_or_set_optional_string(log_entry, 'parse_format', 'raw', description)
         self.__verify_or_set_optional_string(log_entry, 'json_message_field', 'log', description)
         self.__verify_or_set_optional_string(log_entry, 'json_timestamp_field', 'time', description)
 

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -222,7 +222,11 @@ class LogFileIterator(object):
         self.__page_size = config.read_page_size  # Defaults to 64 * 1024
 
         self.__parse_format = log_config.get( 'parse_format' )
-        parse_as_json = log_config.get('parse_lines_as_json', None, none_if_missing=True)
+        parse_as_json = None
+        if type(log_config) is dict:
+            parse_as_json = log_config.get('parse_lines_as_json', None)
+        else:
+            parse_as_json = log_config.get('parse_lines_as_json', None, none_if_missing=True)
         if parse_as_json is not None:
             if parse_as_json:
                 self.__parse_format = 'json'

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -121,7 +121,7 @@ class K8sApiAuthorizationException( K8sApiException ):
     """A wrapper around Exception that makes it easier to catch k8s specific
     exceptions
     """
-    def __init( self, path ):
+    def __init__( self, path ):
         super(K8sApiAuthorizationException, self).__init__( "You don't have permission to access %s.  Please ensure you have correctly configured the RBAC permissions for the scalyr-agent's service account" % path )
 
 class KubeletApiException( Exception ):
@@ -887,7 +887,7 @@ class KubernetesCache( object ):
         pod_name = k8s.get_pod_name()
         pod = k8s.query_pod( k8s.namespace, pod_name )
         if pod is None:
-            return '<none>', '<none>'
+            return None, None
 
         status = pod.get( 'status', {} )
         containers = status.get( 'containerStatuses', [] )
@@ -899,7 +899,7 @@ class KubernetesCache( object ):
                 if m:
                     return m.group(2), m.group(1)
 
-        return '<none>', '<none>'
+        return None, None
 
     def update_cache( self, run_state ):
         """

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -816,6 +816,8 @@ class KubernetesCache( object ):
         self._api_server_version = None
         self._last_full_update = time.time() - cache_expiry_secs - 1
 
+        self._container_runtime = None
+        self._agent_container_id = None
         self._initialized = False
 
         self._thread = None

--- a/scalyr_agent/monitor_utils/tests/k8s_test.py
+++ b/scalyr_agent/monitor_utils/tests/k8s_test.py
@@ -115,7 +115,6 @@ class TestDockerMetricFetcher(ScalyrTestCase):
         self.assertEqual(1, self._fetcher.idle_workers())
         self.assertEqual(10, value)
 
-
 class DockerClientFaker(object):
     """A fake DockerClient that only supports the `stats` call.  Used for tests to control when a `stats` call
     should finish and what it should return.

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -1013,6 +1013,7 @@ class TestConfiguration(ScalyrTestCase):
         TEST_INT = 123456789
         TEST_FLOAT = 1234567.89
         TEST_STRING = 'dummy string'
+        TEST_PARSE_FORMAT = 'cri'
         TEST_ARRAY_OF_STRINGS = ['s1', 's2', 's3']
         STANDARD_PREFIX = '_STANDARD_PREFIX_'  # env var is SCALYR_<param_name>
 
@@ -1026,7 +1027,9 @@ class TestConfiguration(ScalyrTestCase):
             "report_k8s_metrics": (STANDARD_PREFIX, True, bool),
             "k8s_ignore_pod_sandboxes": (STANDARD_PREFIX, False, bool),
             "k8s_include_all_containers": (STANDARD_PREFIX, False, bool),
-            "k8s_parse_json": (STANDARD_PREFIX, False, bool),
+            "k8s_parse_format": (STANDARD_PREFIX, TEST_PARSE_FORMAT, str),
+            "k8s_always_use_cri": (STANDARD_PREFIX, True, bool),
+            "k8s_cri_query_filesystem": (STANDARD_PREFIX, True, bool),
             "gather_k8s_pod_info": (STANDARD_PREFIX, True, bool),
         }
 


### PR DESCRIPTION
This commit adds support for container runtimes other than docker.

By default, the monitor will detect whether docker is being used or whether
another CRI compatible runtime (e.g. containerd) is running.  You can force the
use of the CRI codepath with the option `k8s_always_use_cri`.

When using the CRI codepath, you need to map in both `/var/log/containers` and
`/var/log/pods` so that the agent can read the log files from disk.