### PR TITLE
Ticket #AGENT-88

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
@@ -599,7 +599,7 @@ class KubernetesEventsMonitor( ScalyrMonitor ):
 
                         # ignore events that belong to namespaces we are not interested in
                         if namespace in self.__k8s_namespaces_to_ignore:
-                            global_log.log( scalyr_logging.DEBUG_LEVEL_1, "Ignoring event due to belonging to an excluded namespace" % (namespace) )
+                            global_log.log( scalyr_logging.DEBUG_LEVEL_1, "Ignoring event due to belonging to an excluded namespace '%s'" % (namespace) )
                             continue
 
                         # get cluster and deployment information


### PR DESCRIPTION
Fixes a problem where we were checking the existence of a key in a dict, but the
variable could sometimes be None.

I'm still not sure of the root cause of this, but I suspect it could be caused
if there is a container that uses a non-json logging driver, meaning it won't
have a log path, and the lack of the log path was causing the monitor not to
create the abovementioned dict.

I've fixed the stack trace and also added extra debug information to help
identify the root cause of the issue.