### PR TITLE
AGENT-93: circle python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 jobs:
-  test:
+  test27:
     working_directory: ~/scalyr-agent-2
     docker:
       - image: circleci/python:2.7-jessie-browsers
@@ -35,8 +35,19 @@ jobs:
       - store_artifacts:
           path: cover/
 
+  test26:
+    docker:
+      - image: circleci/python:2.7-jessie-browsers
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} edwardchee/scalyr-agent-ci:python26 /tmp/run_unittests.sh
+
+
 workflows:
   version: 2
   unittest:
     jobs:
-      - test
+      - test27
+      - test26

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,18 +3,18 @@
 # running test suites, and mocking Python Objects for the Scalyr Agent.
 asyncio==3.4.3
 coverage==4.4.1
-mock==2.0.0
+mock==0.8.0
 nose==1.3.7
 nose-exclude
 nose_xunitmp==0.4.0
 parameterized==0.7.0
 pg8000==1.11.0
 pysnmp
-requests==2.20.0
 redis==2.10.6
-Twisted==17.9.0
 ujson==1.35
 unittest2==1.1.0
 virtualenv==15.1.0
 webapp2==2.5.2
 WebTest==2.0.28
+unittest2==1.1.0
+future==0.17.1

--- a/scalyr_agent/all_tests.py
+++ b/scalyr_agent/all_tests.py
@@ -19,7 +19,7 @@
 
 __author__ = 'czerwin@scalyr.com'
 
-import unittest
+import unittest2 as unittest
 import os
 import sys
 import traceback

--- a/scalyr_agent/builtin_monitors/redis_monitor.py
+++ b/scalyr_agent/builtin_monitors/redis_monitor.py
@@ -20,6 +20,7 @@
 __author__ = 'imron@scalyr.com'
 
 import binascii
+import codecs
 import re
 import time
 
@@ -206,7 +207,7 @@ class RedisHost( object ):
         except UnicodeDecodeError, e:
             if self.utf8_warning_interval:
                 logger.warn( "Redis command contains invalid utf8: %s" % binascii.hexlify( entry['command'] ), limit_once_per_x_secs=self.utf8_warning_interval, limit_key="redis-utf8" )
-            command = entry['command'].decode( 'utf8', errors="replace" )
+            command = entry['command'].decode('utf8', errors="replace")
 
         time_format = "%Y-%m-%d %H:%M:%SZ"
         logger.emit_value( 'redis', 'slowlog', extra_fields={

--- a/scalyr_agent/json_lib/tests/encode_decode_test.py
+++ b/scalyr_agent/json_lib/tests/encode_decode_test.py
@@ -18,7 +18,7 @@
 __author__ = 'echee@scalyr.com'
 
 
-import unittest
+import unittest2 as unittest
 
 from scalyr_agent import util
 from scalyr_agent.json_lib import JsonObject

--- a/scalyr_agent/json_lib/tests/objects_test.py
+++ b/scalyr_agent/json_lib/tests/objects_test.py
@@ -17,7 +17,7 @@
 
 __author__ = 'czerwin@scalyr.com'
 
-import unittest
+import unittest2 as unittest
 
 from scalyr_agent.json_lib import JsonArray, JsonObject
 from scalyr_agent.json_lib import JsonConversionException, JsonMissingFieldException

--- a/scalyr_agent/json_lib/tests/parser_test.py
+++ b/scalyr_agent/json_lib/tests/parser_test.py
@@ -17,7 +17,7 @@
 
 __author__ = 'czerwin@scalyr.com'
 
-import unittest
+import unittest2 as unittest
 
 from scalyr_agent.json_lib.parser import ByteScanner, JsonParser, JsonParseException
 

--- a/scalyr_agent/json_lib/tests/serializer_test.py
+++ b/scalyr_agent/json_lib/tests/serializer_test.py
@@ -17,7 +17,7 @@
 
 __author__ = 'czerwin@scalyr.com'
 
-import unittest
+import unittest2 as unittest
 from scalyr_agent.json_lib import serialize
 
 from scalyr_agent.test_base import ScalyrTestCase

--- a/scalyr_agent/platform_tests/run_platform_test.py
+++ b/scalyr_agent/platform_tests/run_platform_test.py
@@ -31,7 +31,7 @@ We do this by:
 
 """
 
-import unittest
+import unittest2 as unittest
 from subprocess import call
 import os
 

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -175,7 +175,7 @@ if hasattr(sys, '_getframe'):
 
 
 # noinspection PyPep8Naming
-class AgentLogger(logging.Logger):
+class AgentLogger(logging.Logger, object):
     """Custom logger to use for logging information, errors, and metrics from the Scalyr agent.
 
     These instances are returned by scalyr_agent.getLogger.  You should use that method in place of logging.getLogger.

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -175,7 +175,7 @@ if hasattr(sys, '_getframe'):
 
 
 # noinspection PyPep8Naming
-class AgentLogger(logging.Logger, object):
+class AgentLogger(logging.Logger):
     """Custom logger to use for logging information, errors, and metrics from the Scalyr agent.
 
     These instances are returned by scalyr_agent.getLogger.  You should use that method in place of logging.getLogger.

--- a/scalyr_agent/test_base.py
+++ b/scalyr_agent/test_base.py
@@ -19,7 +19,7 @@
 __author__ = 'czerwin@scalyr.com'
 
 import sys
-import unittest
+import unittest2 as unittest
 
 
 if sys.version_info < (2, 5, 0):

--- a/scalyr_agent/test_util.py
+++ b/scalyr_agent/test_util.py
@@ -115,7 +115,7 @@ class NullHandler(logging.Handler):
         pass
 
 
-class FakeAgentLogger(AgentLogger):
+class FakeAgentLogger(AgentLogger, object):
     def __init__(self, name):
         super(FakeAgentLogger, self).__init__(name)
         if not len(self.handlers):

--- a/scalyr_agent/test_util.py
+++ b/scalyr_agent/test_util.py
@@ -110,11 +110,16 @@ class ScalyrTestUtils(object):
         return test_manager
 
 
+class NullHandler(logging.Handler):
+    def emit(self, record):
+        pass
+
+
 class FakeAgentLogger(AgentLogger):
     def __init__(self, name):
         super(FakeAgentLogger, self).__init__(name)
         if not len(self.handlers):
-            self.addHandler(logging.NullHandler())
+            self.addHandler(NullHandler())
 
 
 class FakePlatform(object):

--- a/scalyr_agent/tests/auto_flushing_rotating_file_test.py
+++ b/scalyr_agent/tests/auto_flushing_rotating_file_test.py
@@ -17,7 +17,7 @@
 
 __author__ = 'imron@scalyr.com'
 
-import unittest
+import unittest2 as unittest
 import os
 import shutil
 import tempfile

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -1428,7 +1428,7 @@ class NullHandler(logging.Handler):
         pass
 
 
-class FakeAgentLogger(AgentLogger):
+class FakeAgentLogger(AgentLogger, object):
     def __init__(self, name):
         super(FakeAgentLogger, self).__init__(name)
         if not len(self.handlers):

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -1423,11 +1423,16 @@ class TestConfiguration(ScalyrTestCase):
         return self.make_path(None, path)
 
 
+class NullHandler(logging.Handler):
+    def emit(self, record):
+        pass
+
+
 class FakeAgentLogger(AgentLogger):
     def __init__(self, name):
         super(FakeAgentLogger, self).__init__(name)
         if not len(self.handlers):
-            self.addHandler(logging.NullHandler())
+            self.addHandler(NullHandler())
 
 
 class FakePlatform(object):

--- a/scalyr_agent/tests/copying_manager_test.py
+++ b/scalyr_agent/tests/copying_manager_test.py
@@ -24,7 +24,7 @@ import tempfile
 
 import logging
 import sys
-import unittest
+import unittest2 as unittest
 
 root = logging.getLogger()
 root.setLevel(logging.DEBUG)

--- a/scalyr_agent/tests/line_matcher_test.py
+++ b/scalyr_agent/tests/line_matcher_test.py
@@ -18,7 +18,7 @@
 __author__ = 'imron@scalyr.com'
 
 import time
-import unittest
+import unittest2 as unittest
 
 import pdb
 

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -22,7 +22,7 @@ import atexit
 import os
 import shutil
 import tempfile
-import unittest
+import unittest2 as unittest
 import sys
 
 from scalyr_agent.scalyr_client import EventSequencer

--- a/scalyr_agent/tests/monitors_manager_test.py
+++ b/scalyr_agent/tests/monitors_manager_test.py
@@ -21,8 +21,6 @@ __author__ = 'czerwin@scalyr.com'
 
 import re
 
-from collections import Counter
-
 import scalyr_agent.util as scalyr_util
 
 from scalyr_agent.test_base import ScalyrTestCase
@@ -86,7 +84,7 @@ class MonitorsManagerTest(ScalyrTestCase):
         - Even though this test could have been broken up into 2 smaller ones, it is kept as one to minimize overhead
             time taken by stop_manager()
         """
-        counter = Counter()
+        counter = {'callback_invocations': 0}
         test_frag = 'some_frag'
         poll_interval = 30
 

--- a/scalyr_agent/tests/redis_monitor_test.py
+++ b/scalyr_agent/tests/redis_monitor_test.py
@@ -18,7 +18,7 @@
 __author__ = 'imron@scalyr.com'
 
 import time
-import unittest
+import unittest2 as unittest
 from struct import pack
 
 from scalyr_agent.builtin_monitors.redis_monitor import RedisMonitor

--- a/scalyr_agent/tests/scalyr_client_test.py
+++ b/scalyr_agent/tests/scalyr_client_test.py
@@ -25,7 +25,7 @@ from scalyr_agent import scalyr_client
 from scalyr_agent.scalyr_client import AddEventsRequest, PostFixBuffer, EventSequencer, Event, ScalyrClientSession
 from scalyr_agent import json_lib
 from scalyr_agent.test_base import ScalyrTestCase
-import unittest
+import unittest2 as unittest
 
 
 class AddEventsRequestTest(ScalyrTestCase):

--- a/scalyr_agent/tests/syslog_monitor_test.py
+++ b/scalyr_agent/tests/syslog_monitor_test.py
@@ -20,7 +20,7 @@ __author__ = 'imron@scalyr.com'
 import time
 import sys
 import socket
-import unittest
+import unittest2 as unittest
 import logging
 import uuid
 import os

--- a/scalyr_agent/tests/syslog_request_parser_test.py
+++ b/scalyr_agent/tests/syslog_request_parser_test.py
@@ -19,7 +19,7 @@ __author__ = 'imron@scalyr.com'
 
 import time
 import sys
-import unittest
+import unittest2 as unittest
 
 from scalyr_agent.builtin_monitors.syslog_monitor import SyslogRequestParser
 

--- a/scalyr_agent/tests/url_monitor_test.py
+++ b/scalyr_agent/tests/url_monitor_test.py
@@ -17,7 +17,7 @@
 
 __author__ = 'saurabh@scalyr.com'
 
-import unittest
+import unittest2 as unittest
 import mock
 from scalyr_agent.builtin_monitors.url_monitor import UrlMonitor
 from scalyr_agent.scalyr_monitor import MonitorConfig

--- a/scalyr_agent/tests/util_test.py
+++ b/scalyr_agent/tests/util_test.py
@@ -20,7 +20,7 @@ __author__ = 'czerwin@scalyr.com'
 import datetime
 import os
 import tempfile
-import unittest
+import unittest2 as unittest
 import struct
 import threading
 


### PR DESCRIPTION
# WHAT

This PR establishes the framework for multi-python-version unit tests.

It's not meant to fix all tests to be python 24,25,26 compatible. But I do fix one problem (using unittest2 instead of unittest) as an example.  One outstanding incompatibility for python26 has been noted with a comment (pertains to `str.decode`) and I've requested input from @imron 

# BACKGROUND

We need testing across versions.  After attempting various permutations including statically vs dynamically compiled versions of older python, I believe this is best tradeoff that I can get working that will move us forward:

1. create a custom docker image with pre-compiled python 2.x  (for now stored in edwardchee public docker repo but easily moved to scalyr repo later)
2. parallelize CircleCI to run different version tests
3. Include all pip packages IN the build to save startup time (we can modify this later to run dynamic pip installs of missing packages.  This reduces startup time from 2-3 mins -> 1min. But for now, at least this gets us going.)

This PR only has 27 and 26, but establishes the framework for when I can build the 25 and 24 images.

Note, I also studied caching of docker images (without paying for CircleCI's Docker layer caching).  It's certainly doable but current startup without caching is only 1 min. With parallel jobs, it's not urgent.

# HOW TESTED

Python27 - no additional unit test failures
Python26 - A persisting failure is the aforementioned `str.decode` incompatibility.  There are some others like dictionary comprehensions and usage of multiple `with mock as x`

# Notes

Pointers on implementing caching:
https://blog.jondh.me.uk/2018/04/strategies-for-docker-layer-caching-in-circleci/

CircleCI docker layer caching
https://circleci.com/docs/2.0/docker-layer-caching/