### PR TITLE
Ticket: #AGENT-83

### DIFF
--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -2069,10 +2069,12 @@ class LogLineRedacter(object):
                         replaced_group = replaced_group.replace("\\%d" % (_group_index + 1), _group, 1)
                 # once we have formed the replacement expression, we just need to replace the matched
                 # portion of the `line` with the `replaced_group` that we just built
-                replaced_string = replaced_string + line[last_match_index: _match.start()]
+                replaced_string += line[last_match_index: _match.start()]
                 replaced_string += replaced_group
                 # forward the last match index to the end of the match group
                 last_match_index = _match.end()
+
+            replaced_string += line[last_match_index:]
             return replaced_string, replacement_matches
 
         try:

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -1357,6 +1357,51 @@ class TestLogFileProcessor(ScalyrTestCase):
         self.assertFalse(completion_callback(LogFileProcessor.SUCCESS))
         self.assertEquals(events.get_message(0), 'GET /foo&password=foo&start=true\n')
 
+    def test_hashed_redaction_in_middle_of_line(self):
+        # Testing for #AGENT-83 indicated that redaction rules with hashing was truncating
+        # lines after the end of the final hash.  This is an explicit test to catch that
+        # problem
+        log_processor = self.log_processor
+        log_processor.add_redacter( "\"([A-F0-9]{32})(\\.app1.)\"", "\"*****\\H2\"" )
+
+        line_base = '127.0.0.1 - - [15/Apr/2019:16:30:42 -0700] "GET /10/ HTTP/1.1" 200 113020 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36" D=63388 R=app1b/- '
+
+        line_unredacted = line_base + '"0123456789ABCDEF0123456789ABCDEF.app1b" something extra\n'
+        line_expected = line_base + '"*****9e174c63530b55ef27fcbfdbdde9c403" something extra\n'
+        self.append_file( self.__path,
+            line_unredacted
+            )
+
+        events = TestLogFileProcessor.TestAddEventsRequest()
+        (completion_callback, buffer_full) = log_processor.perform_processing(
+            events, current_time=self.__fake_time)
+
+        self.assertEquals(1, events.total_events())
+        self.assertEquals( line_expected, events.get_message(0) )
+
+    def test_hashed_redaction_with_non_redacted_lines(self):
+        # Test for when a redaction rule with hashing is used, to make sure that
+        # lines that don't match the hash are still returned.  See #AGENT-83
+        log_processor = self.log_processor
+        log_processor.add_redacter( "\"([A-F0-9]{32})(\\.app1.)\"", "\"*****\\H2\"" )
+
+        line_base = '127.0.0.1 - - [15/Apr/2019:16:30:42 -0700] "GET /10/ HTTP/1.1" 200 113020 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36" D=63388 R=app1b/- '
+
+        line_unredacted = line_base + '"0123456789ABCDEF0123456789ABCDEF.app1b"\n'
+        line_expected = line_base + '"*****9e174c63530b55ef27fcbfdbdde9c403"\n'
+        self.append_file( self.__path,
+            'ello\n',
+            line_unredacted
+            )
+
+        events = TestLogFileProcessor.TestAddEventsRequest()
+        (completion_callback, buffer_full) = log_processor.perform_processing(
+            events, current_time=self.__fake_time)
+
+        self.assertEquals(2, events.total_events())
+        self.assertEquals( 'ello\n', events.get_message(0) )
+        self.assertEquals( line_expected, events.get_message(1) )
+
     def test_redacting_utf8(self):
 
         # build this manually following a similar process to the main agent, because this will create

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -1368,9 +1368,7 @@ class TestLogFileProcessor(ScalyrTestCase):
 
         line_unredacted = line_base + '"0123456789ABCDEF0123456789ABCDEF.app1b" something extra\n'
         line_expected = line_base + '"*****9e174c63530b55ef27fcbfdbdde9c403" something extra\n'
-        self.append_file( self.__path,
-            line_unredacted
-            )
+        self.append_file( self.__path, line_unredacted )
 
         events = TestLogFileProcessor.TestAddEventsRequest()
         (completion_callback, buffer_full) = log_processor.perform_processing(
@@ -1389,10 +1387,7 @@ class TestLogFileProcessor(ScalyrTestCase):
 
         line_unredacted = line_base + '"0123456789ABCDEF0123456789ABCDEF.app1b"\n'
         line_expected = line_base + '"*****9e174c63530b55ef27fcbfdbdde9c403"\n'
-        self.append_file( self.__path,
-            'ello\n',
-            line_unredacted
-            )
+        self.append_file( self.__path, 'ello\n', line_unredacted )
 
         events = TestLogFileProcessor.TestAddEventsRequest()
         (completion_callback, buffer_full) = log_processor.perform_processing(


### PR DESCRIPTION
Fixed problem with hashed redaction rules, where lines that didn't match any
rule were discarded, and also problems where lines were truncated after the
final matched group of a line.

I'm not sure how many customers use this feature, but from what I can tell, it's
been broken like this since the very beginning.