### PR TITLE
AGENT-94: Fix set init and dict comprehension in unit tests

### DIFF
--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -40,7 +40,7 @@ from scalyr_agent.test_base import ScalyrTestCase
 
 class TestConfiguration(ScalyrTestCase):
     def setUp(self):
-        self.original_os_env = {k:v for k, v in os.environ.iteritems()}
+        self.original_os_env = dict([(k, v) for k, v in os.environ.iteritems()])
         self.__config_dir = tempfile.mkdtemp()
         self.__config_file = os.path.join(self.__config_dir, 'agent.json')
         self.__config_fragments_dir = os.path.join(self.__config_dir, 'agent.d')

--- a/scalyr_agent/tests/linux_process_metrics_test.py
+++ b/scalyr_agent/tests/linux_process_metrics_test.py
@@ -151,10 +151,10 @@ class TestProcessListUtility(ScalyrTestCase):
         self.assertEqual(self.ps.get_child_processes('bad pid'), [])
         self.assertEqual(self.ps.get_child_processes(1), [2])
         # positive match
-        self.assertEqual(set(self.ps.get_matches_commandline('.*')), {1, 2})
+        self.assertEqual(set(self.ps.get_matches_commandline('.*')), set([1, 2]))
         self.assertEqual(self.ps.get_matches_commandline('.*bash.*'), [1])
         self.assertEqual(self.ps.get_matches_commandline('.*py.*'), [2])
-        self.assertEqual(set(self.ps.get_matches_commandline_with_children('.*')), {1, 2})
+        self.assertEqual(set(self.ps.get_matches_commandline_with_children('.*')), set([1, 2]))
 
     def test_single_process_with_children(self):
         # override
@@ -170,13 +170,13 @@ class TestProcessListUtility(ScalyrTestCase):
         self.ps.parent_to_children_map[0] = [1]
 
         self.assertEqual(self.ps.get_child_processes('bad pid'), [])
-        self.assertEqual(set(self.ps.get_child_processes(1)), {2, 3})
+        self.assertEqual(set(self.ps.get_child_processes(1)), set([2, 3]))
         self.assertEqual(self.ps.get_child_processes(2), [3])
         # positive match
-        self.assertEqual(set(self.ps.get_matches_commandline('.*')), {1, 2, 3})
+        self.assertEqual(set(self.ps.get_matches_commandline('.*')), set([1, 2, 3]))
         self.assertEqual(self.ps.get_matches_commandline('.*bash.*'), [1])
         self.assertEqual(self.ps.get_matches_commandline('.*py.*'), [2])
-        self.assertEqual(set(self.ps.get_matches_commandline_with_children('.*')), {1, 2, 3})
+        self.assertEqual(set(self.ps.get_matches_commandline_with_children('.*')), set([1, 2, 3]))
 
     def test_multiple_processes_with_children(self):
         # override
@@ -193,13 +193,13 @@ class TestProcessListUtility(ScalyrTestCase):
         self.ps.parent_to_children_map[0] = [1, 4]
 
         self.assertEqual(self.ps.get_child_processes('bad pid'), [])
-        self.assertEqual(set(self.ps.get_child_processes(1)), {2, 3})
+        self.assertEqual(set(self.ps.get_child_processes(1)), set([2, 3]))
         self.assertEqual(self.ps.get_child_processes(2), [3])
         # positive match
-        self.assertEqual(set(self.ps.get_matches_commandline('.*')), {1, 2, 3, 4})
+        self.assertEqual(set(self.ps.get_matches_commandline('.*')), set([1, 2, 3, 4]))
         self.assertEqual(self.ps.get_matches_commandline('.*bash.*'), [1])
         self.assertEqual(self.ps.get_matches_commandline('.*py.*'), [2])
-        self.assertEqual(set(self.ps.get_matches_commandline_with_children('.*')), {1, 2, 3, 4})
+        self.assertEqual(set(self.ps.get_matches_commandline_with_children('.*')), set([1, 2, 3, 4]))
 
 
 class TestProcessMonitorRunningTotal(ScalyrTestCase):


### PR DESCRIPTION
Low hanging fruit fixes for 26 test code compatibility.

1. Sets should be initialized as set([])
2. Dict comprehensions should not be used.