### PR TITLE
AGENT-95: Backport mock/patch syntax & remove Counter

### DIFF
--- a/scalyr_agent/builtin_monitors/tests/docker_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/docker_monitor_test.py
@@ -20,7 +20,6 @@ __author__ = 'echee@scalyr.com'
 
 
 import threading
-from collections import Counter
 
 import mock
 from mock import patch
@@ -66,7 +65,7 @@ class DockerMonitorTest(ScalyrTestCase):
             )
 
             fragment_polls = FakeClockCounter(fake_clock, num_waiters=2)
-            counter = Counter()
+            counter = {'callback_invocations': 0}
             detected_fragment_changes = []
 
             # Mock the callback (that would normally be invoked on ScalyrClientSession
@@ -127,13 +126,10 @@ class DockerMonitorTest(ScalyrTestCase):
                 else:
                     return original_monitor_config_get(key)
 
-            with patch.object(
-                docker_mon, 'get_user_agent_fragment'
-            ) as m1, patch.object(
-                docker_mon, '_fetch_and_set_version'
-            ) as m2, patch.object(
-                docker_mon._config, 'get'
-            ) as m3:
+            @patch.object(docker_mon, 'get_user_agent_fragment')
+            @patch.object(docker_mon, '_fetch_and_set_version')
+            @patch.object(docker_mon._config, 'get')
+            def start_test(m3, m2, m1):
                 m1.side_effect = fake_get_user_agent_fragment
                 m2.side_effect = fake_fetch_and_set_version
                 m3.side_effect = fake_monitor_config_get
@@ -156,3 +152,4 @@ class DockerMonitorTest(ScalyrTestCase):
 
                 manager.stop_manager(wait_on_join=False)
                 fake_clock.advance_time(increment_by=manager_poll_interval)
+            start_test()

--- a/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
@@ -19,8 +19,6 @@
 __author__ = 'echee@scalyr.com'
 
 
-from collections import Counter
-
 import mock
 from mock import patch
 
@@ -67,7 +65,7 @@ class KubernetesMonitorTest(ScalyrTestCase):
             )
 
             fragment_polls = FakeClockCounter(fake_clock, num_waiters=2)
-            counter = Counter()
+            counter = {'callback_invocations': 0}
             detected_fragment_changes = []
 
             # Mock the callback (that would normally be invoked on ScalyrClientSession
@@ -104,11 +102,9 @@ class KubernetesMonitorTest(ScalyrTestCase):
                 else:
                     return version2
 
-            with patch.object(
-                k8s_mon, 'get_user_agent_fragment'
-            ) as m1, patch.object(
-                k8s_mon, '_KubernetesMonitor__get_k8s_cache'  # return Mock obj instead of a KubernetesCache
-            ) as m2:
+            @patch.object(k8s_mon, 'get_user_agent_fragment')
+            @patch.object(k8s_mon, '_KubernetesMonitor__get_k8s_cache')  # return Mock obj instead of a KubernetesCache)
+            def start_test(m2, m1):
                 m1.side_effect = fake_get_user_agent_fragment
                 m2.return_value.get_api_server_version.side_effect = fake_get_api_server_version
                 manager.set_user_agent_augment_callback(augment_user_agent)
@@ -128,3 +124,4 @@ class KubernetesMonitorTest(ScalyrTestCase):
 
                 manager.stop_manager(wait_on_join=False)
                 fake_clock.advance_time(increment_by=manager_poll_interval)
+            start_test()

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -893,16 +893,11 @@ class TestConfiguration(ScalyrTestCase):
         original_verify_or_set_optional_float = config._Configuration__verify_or_set_optional_float
         original_verify_or_set_optional_string = config._Configuration__verify_or_set_optional_string
 
-        with patch.object(
-            config, '_Configuration__verify_or_set_optional_bool'
-        ) as p0, patch.object(
-            config, '_Configuration__verify_or_set_optional_int'
-        ) as p1, patch.object(
-            config, '_Configuration__verify_or_set_optional_float'
-        ) as p2, patch.object(
-            config, '_Configuration__verify_or_set_optional_string'
-        ) as p3:
-
+        @patch.object(config, '_Configuration__verify_or_set_optional_bool')
+        @patch.object(config, '_Configuration__verify_or_set_optional_int')
+        @patch.object(config, '_Configuration__verify_or_set_optional_float')
+        @patch.object(config, '_Configuration__verify_or_set_optional_string')
+        def patch_and_start_test(p3, p2, p1, p0):
             # Decorate the Configuration.__verify_or_set_optional_xxx methods as follows:
             # 1) capture fields that are environment-aware
             # 2) allow setting of the corresponding environment variable
@@ -1007,6 +1002,7 @@ class TestConfiguration(ScalyrTestCase):
                     # But those not defined in config file will take on environment values.
                     self.assertEquals(value, fake_env[field])
                     self.assertNotEquals(value, config_file_value)
+        patch_and_start_test()
 
     @patch('scalyr_agent.builtin_monitors.kubernetes_monitor.docker')
     def test_environment_aware_module_params(self, mock_docker):


### PR DESCRIPTION
Remove Counter and context manager usage from unit tests
for 2.4, 2.5 compatibility.
