### PR TITLE
AGENT-99: docker syslog/json smoketests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.7 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:v1.1 /tmp/smoketest_standalone.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.7 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:1 /tmp/smoketest_standalone.sh
 
   smoke-standalone-26:
     docker:
@@ -59,7 +59,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.6 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:v1.1 /tmp/smoketest_standalone.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.6 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:1 /tmp/smoketest_standalone.sh
 
   smoke-standalone-25:
     docker:
@@ -68,7 +68,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.5 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:v1.1 /tmp/smoketest_standalone.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.5 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:1 /tmp/smoketest_standalone.sh
 
   smoke-standalone-24:
     docker:
@@ -77,7 +77,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.4 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:v1.1 /tmp/smoketest_standalone.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.4 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:1 /tmp/smoketest_standalone.sh
 
   smoke-docker-json:
     docker:
@@ -98,7 +98,7 @@ jobs:
           paths:
             - "venv"
       - run:
-          command: source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-smoketest:v1.1 json 300
+          command: source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-smoketest:1 json 300
 
   smoke-docker-syslog:
     docker:
@@ -119,7 +119,7 @@ jobs:
           paths:
             - "venv"
       - run:
-          command: source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-smoketest:v1.1 syslog 300
+          command: source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-smoketest:1 syslog 300
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 jobs:
-  test27:
+  unittest-27:
     working_directory: ~/scalyr-agent-2
     docker:
       - image: circleci/python:2.7-jessie-browsers
@@ -27,7 +27,6 @@ jobs:
           command: |
             source venv/bin/activate
             python run_tests.py
-            # nosetests --with-cov --cover- erase --cover-html scalyr_agent/tests/ --verbose --with-xunit --xunit-file xunit.xml --ignore-files=.*log_processing_test.*
 
       - store_artifacts:
           path: xunit.xml
@@ -35,7 +34,7 @@ jobs:
       - store_artifacts:
           path: cover/
 
-  test26:
+  unittest-26:
     docker:
       - image: circleci/python:2.7-jessie-browsers
     steps:
@@ -44,49 +43,93 @@ jobs:
       - run:
           command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} edwardchee/scalyr-agent-ci:python26 /tmp/run_unittests.sh
 
-  smoke27:
+  smoke-standalone-27:
     docker:
       - image: circleci/python:2.7-jessie-browsers
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e SCALYR_MAX_QUERY_SEC=300 -e PYTHON_VERSION=2.7 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest /tmp/smoketest.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.7 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:v1.1 /tmp/smoketest_standalone.sh
 
-  smoke26:
+  smoke-standalone-26:
     docker:
       - image: circleci/python:2.7-jessie-browsers
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e SCALYR_MAX_QUERY_SEC=300 -e PYTHON_VERSION=2.6 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest /tmp/smoketest.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.6 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:v1.1 /tmp/smoketest_standalone.sh
 
-  smoke25:
+  smoke-standalone-25:
     docker:
       - image: circleci/python:2.7-jessie-browsers
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e SCALYR_MAX_QUERY_SEC=300 -e PYTHON_VERSION=2.5 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest /tmp/smoketest.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.5 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:v1.1 /tmp/smoketest_standalone.sh
 
-  smoke24:
+  smoke-standalone-24:
     docker:
       - image: circleci/python:2.7-jessie-browsers
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e SCALYR_MAX_QUERY_SEC=300 -e PYTHON_VERSION=2.4 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest /tmp/smoketest.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.4 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:v1.1 /tmp/smoketest_standalone.sh
+
+  smoke-docker-json:
+    docker:
+      - image: circleci/python:2.7-jessie-browsers
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - checkout
+      - restore_cache:
+          key: deps1-{{ .Branch }}-docker-json-{{ checksum "dev-requirements.txt" }}
+      - run:
+          command: |
+            virtualenv venv
+            source venv/bin/activate
+            pip install -r dev-requirements.txt
+      - save_cache:
+          key: deps1-{{ .Branch }}-docker-json-{{ checksum "dev-requirements.txt" }}
+          paths:
+            - "venv"
+      - run:
+          command: source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-smoketest:v1.1 json 300
+
+  smoke-docker-syslog:
+    docker:
+      - image: circleci/python:2.7-jessie-browsers
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - checkout
+      - restore_cache:
+          key: deps1-{{ .Branch }}-docker-json-{{ checksum "dev-requirements.txt" }}
+      - run:
+          command: |
+            virtualenv venv
+            source venv/bin/activate
+            pip install -r dev-requirements.txt
+      - save_cache:
+          key: deps1-{{ .Branch }}-docker-json-{{ checksum "dev-requirements.txt" }}
+          paths:
+            - "venv"
+      - run:
+          command: source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-smoketest:v1.1 syslog 300
 
 workflows:
   version: 2
   unittest:
     jobs:
-      - test27
-      - test26
-      - smoke27
-      - smoke26
-      - smoke25
-      - smoke24
+      - unittest-27
+      - unittest-26
+      - smoke-standalone-27
+      - smoke-standalone-26
+      - smoke-standalone-25
+      - smoke-standalone-24
+      - smoke-docker-json
+      - smoke-docker-syslog

--- a/.circleci/smoketest_docker.sh
+++ b/.circleci/smoketest_docker.sh
@@ -1,0 +1,126 @@
+#----------------------------------------------------------------------------------------
+# Runs agent smoketest for docker:
+#    - Assumes that the current scalyr-agent-2 root directory contains the test branch and that
+#       the VERSION file can be overwritten (ie. the scalyr-agent-2 directory is a "throwaway" copy.
+#    - Launch agent docker image
+#    - Launch uploader docker image (writes lines to stdout)
+#    - Launch verifier docker image (polls for liveness of agent and
+#       uploader as well as verifies expected uploaded lines)
+#
+# Expects the following env vars:
+#   SCALYR_API_KEY
+#   SCALYR_SERVER
+#   READ_API_KEY (Read api key. 'SCALYR_' prefix intentionally omitted to suppress in status -v)
+#
+# Expects following positional args:
+#   $1 : smoketest image tag
+#   $2 : 'syslog' or 'json' agent docker mode to test
+#   $3 : max secs until test hard fails
+#
+# e.g. usage
+#   smoketest_docker.sh scalyr/scalyr-agent-ci-smoketest:v1.1 json 300
+#----------------------------------------------------------------------------------------
+
+# The following variables are needed
+# Docker image in which runs smoketest python3 code
+# smoketest_image="scalyr/scalyr-agent-ci-smoketest:v1.1"
+smoketest_image=$1
+
+# Chooses json or syslog docker test.  Incorporated into container name which is then used by
+# Verifier to choose the appropriate code to execute).
+# syslog_or_json="json"
+syslog_or_json=$2
+
+# Max seconds before the test hard fails
+max_wait=$3
+
+#----------------------------------------------------------------------------------------
+# Everything below this script should be fully controlled by above variables
+#----------------------------------------------------------------------------------------
+
+# Smoketest code (built into smoketest image)
+smoketest_script="/usr/bin/python3 /tmp/smoketest.py"
+
+# Erase variables (to avoid subtle config bugs in development)
+syslog_driver_option=""
+syslog_driver_portmap=""
+jsonlog_containers_mount=""
+if [[ $syslog_or_json == "syslog" ]]; then
+    syslog_driver_option="--log-driver=syslog --log-opt syslog-address=tcp://127.0.0.1:601"
+    syslog_driver_portmap="-p 601:601"
+else
+    jsonlog_containers_mount="-v /var/lib/docker/containers:/var/lib/docker/containers"
+fi
+
+# container names for all test containers
+# The suffixes MUST be one of (agent, uploader, verifier) to match verify_upload::DOCKER_CONTNAME_SUFFIXES
+contname_agent="ci_agent_docker_${syslog_or_json}_agent"
+contname_uploader="ci_agent_docker_${syslog_or_json}_uploader"
+contname_verifier="ci_agent_docker_${syslog_or_json}_verifier"
+
+
+# Kill leftover containers
+function kill_and_delete_docker_test_containers() {
+    for cont in $contname_agent $contname_uploader $contname_verifier
+    do
+        if [[ -n `docker ps | grep $cont` ]]; then
+            docker kill $cont
+        fi
+        if [[ -n `docker ps -a | grep $cont` ]]; then
+            docker rm $cont;
+        fi
+    done
+}
+kill_and_delete_docker_test_containers
+echo `pwd`
+
+# Build agent docker image packager with fake version
+fakeversion=`cat VERSION`
+fakeversion="${fakeversion}.ci"
+echo $fakeversion > ./VERSION
+echo "Building docker image"
+python build_package.py docker_${syslog_or_json}_builder
+
+# Extract and build agent docker image
+./scalyr-docker-agent-${syslog_or_json}-${fakeversion} --extract-packages
+agent_image="agent-ci/scalyr-agent-docker-${syslog_or_json}:${fakeversion}"
+docker build -t ${agent_image} .
+
+
+# Launch Agent container (which begins gathering stdout logs)
+docker run -d --name ${contname_agent} \
+-e SCALYR_API_KEY=${SCALYR_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} \
+-v /var/run/docker.sock:/var/scalyr/docker.sock \
+${jsonlog_containers_mount} ${syslog_driver_portmap} \
+${agent_image}
+
+# Capture agent short container ID
+short_cid_agent=$(docker ps --format "{{.ID}}" --filter "name=$contname_agent")
+echo "Agent container ID == ${short_cid_agent}"
+
+# Launch Uploader container (only writes to stdout, but needs to query Scalyr to verify agent liveness)
+# You MUST provide scalyr server, api key and importantly, the short_cid_agent container ID for the agent-liveness
+# query to work
+docker run ${syslog_driver_option}  -d --name ${contname_uploader} ${smoketest_image} \
+${smoketest_script} ${contname_uploader} ${max_wait} \
+--mode uploader \
+--scalyr_server ${SCALYR_SERVER} \
+--read_api_key ${READ_API_KEY} \
+--short_cid_agent ${short_cid_agent}
+
+# Capture uploader short container ID
+short_cid_uploader=$(docker ps --format "{{.ID}}" --filter "name=$contname_uploader")
+echo "Uploader container ID == ${short_cid_uploader}"
+
+# Launch synchronous Verifier image (writes to stdout and also queries Scalyr)
+docker run ${syslog_driver_option} -it --name ${contname_verifier} ${smoketest_image} \
+${smoketest_script} ${contname_verifier} ${max_wait} \
+--mode verifier \
+--scalyr_server ${SCALYR_SERVER} \
+--read_api_key ${READ_API_KEY} \
+--short_cid_agent ${short_cid_agent} \
+--short_cid_uploader ${short_cid_uploader}
+
+
+kill_and_delete_docker_test_containers
+

--- a/.circleci/smoketest_docker.sh
+++ b/.circleci/smoketest_docker.sh
@@ -18,12 +18,11 @@
 #   $3 : max secs until test hard fails
 #
 # e.g. usage
-#   smoketest_docker.sh scalyr/scalyr-agent-ci-smoketest:v1.1 json 300
+#   smoketest_docker.sh scalyr/scalyr-agent-ci-smoketest:1 json 300
 #----------------------------------------------------------------------------------------
 
 # The following variables are needed
 # Docker image in which runs smoketest python3 code
-# smoketest_image="scalyr/scalyr-agent-ci-smoketest:v1.1"
 smoketest_image=$1
 
 # Chooses json or syslog docker test.  Incorporated into container name which is then used by


### PR DESCRIPTION
This PR adds smoketests for docker json & docker syslog.

CircleCi launches 3 images -- agent, uploader, verifier.  All processes synchronize on scalyr backend state in qatesting.

Note: The python3 `smoketest.py` code is not included in this PR, pending further stabilization and inclusion of k8s testing capability.  In the near future, we will move `smoketest.py` into this repo.  (This PR is really about getting CircleCI to launch the currently self-contained docker image that in turn contains `smoketest.py`.)
