### PR TITLE
AGENT-103: Reduce docker images (alpine + python27 + ujson)

### DIFF
--- a/build_package.py
+++ b/build_package.py
@@ -88,7 +88,7 @@ def build_package(package_type, variant, no_versioned_file_name):
             # backward compatibility.)  We also publish this under scalyr/scalyr-docker-agent-syslog to help
             # with the eventual migration.
             artifact_file_name = build_container_builder(variant, version, no_versioned_file_name,
-                                                         'scalyr-docker-agent.tar.gz', 'docker/Dockerfile',
+                                                         'scalyr-docker-agent.tar.gz', 'docker/Dockerfile.syslog',
                                                          'docker/docker-syslog-config',
                                                          'scalyr-docker-agent-syslog',
                                                          ['scalyr/scalyr-agent-docker-syslog',

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,5 @@
-FROM ubuntu:16.04
-ENV DEBIAN_FRONTEND noninteractive
+FROM python:2.7-alpine3.9 as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
-RUN apt-get update && \
-    apt-get install -y python && \
-    apt-get clean
 COPY scalyr-docker-agent.tar.gz /tmp/
 RUN tar --no-same-owner -C / -zxf /tmp/scalyr-docker-agent.tar.gz && \
   rm /tmp/scalyr-docker-agent.tar.gz

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,4 +4,7 @@ COPY scalyr-docker-agent.tar.gz /tmp/
 RUN tar --no-same-owner -C / -zxf /tmp/scalyr-docker-agent.tar.gz && \
   rm /tmp/scalyr-docker-agent.tar.gz
 
+EXPOSE 601/tcp
+EXPOSE 514/udp
+
 CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,17 @@
 FROM python:2.7-alpine3.9 as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
+
+RUN apk --update add --virtual build-dependencies build-base python-dev gcc \
+  && pip --no-cache-dir install ujson \
+  && apk del build-dependencies
+
 COPY scalyr-docker-agent.tar.gz /tmp/
 RUN tar --no-same-owner -C / -zxf /tmp/scalyr-docker-agent.tar.gz && \
   rm /tmp/scalyr-docker-agent.tar.gz
 
 EXPOSE 601/tcp
+
+# Please note Syslog UDP 1024 max packet length (rfc3164)
 EXPOSE 514/udp
 
 CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]

--- a/docker/Dockerfile.build_from_source
+++ b/docker/Dockerfile.build_from_source
@@ -1,23 +1,37 @@
+# base image that creates all necessary dependencies for
+# the scalyr-agent, and builds a tarball of the scalyr-agent
+# from the source code of the main scalyr-agent-2 repository
+# NOTE: multi-stage builds require Docker 17.05 or greater
+FROM python:2.7-alpine3.9 as scalyr-dependencies
+MAINTAINER Scalyr Inc <support@scalyr.com>
+
+# install dev dependencies.
+RUN apk --update add build-base python-dev gcc git bash
+RUN mkdir -p /tmp/scalyr/src
+
+# install python dependencies
+RUN pip --no-cache-dir install --root /tmp/dependencies ujson
+
+# clone the source from the master branch of the main scalyr repository
+WORKDIR /tmp/scalyr
+RUN git init
+RUN git config --local user.name "Scalyr" && git config --local user.email support@scalyr.com
+RUN git clone git://github.com/scalyr/scalyr-agent-2.git ./src
+
+# package up the source in a k8s compatible tarball
+WORKDIR ./src
+RUN python build_package.py --no-versioned-file-name k8s_builder
+RUN ./scalyr-k8s-agent --extract-packages
+
+# extract the tarball in a well-known location
+RUN mkdir -p /tmp/scalyr/install
+RUN tar --no-same-owner -C /tmp/scalyr/install -zxf /tmp/scalyr/src/scalyr-k8s-agent.tar.gz
+
+# main image - copies dependencies and the scalyr-agent from scalyr-dependencies
 FROM python:2.7-alpine3.9 as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
-RUN apk --update add --virtual build-dependencies build-base python-dev gcc \
-  && pip --no-cache-dir install ujson \
-  && apk del build-dependencies
-
-RUN cd /usr/bin && mkdir -p /tmp/scalyr/src && cd /tmp/scalyr && \
-  git init && \
-  git config --local user.name "Scalyr" && git config --local user.email support@scalyr.com && \
-  git clone -b k8s_preview git://github.com/scalyr/scalyr-agent-2.git ./src && \
-  cd ./src && \
-  python build_package.py --no-versioned-file-name docker_tarball && \
-  tar --no-same-owner -C / -zxf /tmp/scalyr/src/scalyr-docker-agent.tar.gz && \
-  cd / && \
-  rm -rf /tmp/scalyr
-
-EXPOSE 601/tcp
-
-# Please note Syslog UDP 1024 max packet length (rfc3164)
-EXPOSE 514/udp
+COPY --from=scalyr-dependencies  /tmp/dependencies/ /
+COPY --from=scalyr-dependencies  /tmp/scalyr/install/ /
 
 CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]

--- a/docker/Dockerfile.build_from_source
+++ b/docker/Dockerfile.build_from_source
@@ -13,4 +13,8 @@ RUN cd /usr/bin && mkdir -p /tmp/scalyr/src && cd /tmp/scalyr && \
   tar --no-same-owner -C / -zxf /tmp/scalyr/src/scalyr-docker-agent.tar.gz && \
   cd / && \
   rm -rf /tmp/scalyr
+
+EXPOSE 601/tcp
+EXPOSE 514/udp
+
 CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]

--- a/docker/Dockerfile.build_from_source
+++ b/docker/Dockerfile.build_from_source
@@ -1,14 +1,10 @@
-FROM ubuntu:16.04
-ENV DEBIAN_FRONTEND noninteractive
+FROM python:2.7-alpine3.9 as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
-RUN apt-get update && \
-  apt-get install -y git python && \
-  apt-get clean
 RUN cd /usr/bin && mkdir -p /tmp/scalyr/src && cd /tmp/scalyr && \
   git init && \
   git config --local user.name "Scalyr" && git config --local user.email support@scalyr.com && \
   git clone -b k8s_preview git://github.com/scalyr/scalyr-agent-2.git ./src && \
-  cd ./src && \ 
+  cd ./src && \
   python build_package.py --no-versioned-file-name docker_tarball && \
   tar --no-same-owner -C / -zxf /tmp/scalyr/src/scalyr-docker-agent.tar.gz && \
   cd / && \

--- a/docker/Dockerfile.build_from_source
+++ b/docker/Dockerfile.build_from_source
@@ -1,5 +1,10 @@
 FROM python:2.7-alpine3.9 as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
+
+RUN apk --update add --virtual build-dependencies build-base python-dev gcc \
+  && pip --no-cache-dir install ujson \
+  && apk del build-dependencies
+
 RUN cd /usr/bin && mkdir -p /tmp/scalyr/src && cd /tmp/scalyr && \
   git init && \
   git config --local user.name "Scalyr" && git config --local user.email support@scalyr.com && \
@@ -11,6 +16,8 @@ RUN cd /usr/bin && mkdir -p /tmp/scalyr/src && cd /tmp/scalyr && \
   rm -rf /tmp/scalyr
 
 EXPOSE 601/tcp
+
+# Please note Syslog UDP 1024 max packet length (rfc3164)
 EXPOSE 514/udp
 
 CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]

--- a/docker/Dockerfile.k8s
+++ b/docker/Dockerfile.k8s
@@ -1,11 +1,17 @@
 FROM python:2.7-alpine3.9 as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
-RUN pip --no-cache-dir install ujson
+
+RUN apk --update add --virtual build-dependencies build-base python-dev gcc \
+  && pip --no-cache-dir install ujson \
+  && apk del build-dependencies
+
 COPY scalyr-k8s-agent.tar.gz /tmp/
 RUN tar --no-same-owner -C / -zxf /tmp/scalyr-k8s-agent.tar.gz && \
   rm /tmp/scalyr-k8s-agent.tar.gz
 
 EXPOSE 601/tcp
+
+# Please note Syslog UDP 1024 max packet length (rfc3164)
 EXPOSE 514/udp
 
 CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]

--- a/docker/Dockerfile.k8s
+++ b/docker/Dockerfile.k8s
@@ -9,4 +9,7 @@ COPY scalyr-k8s-agent.tar.gz /tmp/
 RUN tar --no-same-owner -C / -zxf /tmp/scalyr-k8s-agent.tar.gz && \
   rm /tmp/scalyr-k8s-agent.tar.gz
 
+EXPOSE 601/tcp
+EXPOSE 514/udp
+
 CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]

--- a/docker/Dockerfile.k8s
+++ b/docker/Dockerfile.k8s
@@ -1,17 +1,19 @@
+# base image that creates all necessary dependencies for
+# the scalyr-agent
+# NOTE: multi-stage builds require Docker 17.05 or greater
+FROM python:2.7-alpine3.9 as scalyr-dependencies
+MAINTAINER Scalyr Inc <support@scalyr.com>
+
+RUN apk --update add build-base python-dev gcc
+RUN pip --no-cache-dir install --root /tmp/dependencies ujson
+
+# main image - copies dependencies from scalyr-dependencies and extracts
+# the tar-zipped file containing the scalyr-agent code
 FROM python:2.7-alpine3.9 as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
-RUN apk --update add --virtual build-dependencies build-base python-dev gcc \
-  && pip --no-cache-dir install ujson \
-  && apk del build-dependencies
-
-COPY scalyr-k8s-agent.tar.gz /tmp/
-RUN tar --no-same-owner -C / -zxf /tmp/scalyr-k8s-agent.tar.gz && \
-  rm /tmp/scalyr-k8s-agent.tar.gz
-
-EXPOSE 601/tcp
-
-# Please note Syslog UDP 1024 max packet length (rfc3164)
-EXPOSE 514/udp
+COPY --from=scalyr-dependencies  /tmp/dependencies/ /
+ADD scalyr-k8s-agent.tar.gz /
 
 CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]
+

--- a/docker/Dockerfile.k8s
+++ b/docker/Dockerfile.k8s
@@ -1,10 +1,6 @@
-FROM ubuntu:16.04
-ENV DEBIAN_FRONTEND noninteractive
+FROM python:2.7-alpine3.9 as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
-RUN apt-get update && \
-    apt-get install -y python-pip && \
-    apt-get clean && \
-    pip --no-cache-dir install ujson
+RUN pip --no-cache-dir install ujson
 COPY scalyr-k8s-agent.tar.gz /tmp/
 RUN tar --no-same-owner -C / -zxf /tmp/scalyr-k8s-agent.tar.gz && \
   rm /tmp/scalyr-k8s-agent.tar.gz

--- a/docker/Dockerfile.syslog
+++ b/docker/Dockerfile.syslog
@@ -15,4 +15,11 @@ MAINTAINER Scalyr Inc <support@scalyr.com>
 COPY --from=scalyr-dependencies  /tmp/dependencies/ /
 ADD scalyr-docker-agent.tar.gz /
 
+# expose syslog ports
+EXPOSE 601/tcp
+
+# Please note Syslog UDP 1024 max packet length (rfc3164)
+EXPOSE 514/udp
+
+
 CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -80,15 +80,15 @@ Or if setting API key via environment:
 
 #### scalyr-docker-agent-syslog
 
-To run the Syslog version, steps (1) and (2) are the same, but for step (3), you don't map in the
-containers directory.
+To run the Syslog version, steps (1) and (2) are the same, but for step (3), you instead map the
+Syslog port:
 
     docker run -d --name scalyr-docker-agent-syslog \
     -e SCALYR_API_KEY=<Your api key> \
     -v /run/docker.sock:/var/scalyr/docker.sock \
+    -p 601:601 \
     scalyr/scalyr-docker-agent-syslog
 
-Note: by default, the scalyr-agent-syslog container exposes tcp port 601 and udp port 501
 
 ## Configuring local containers to send their logs to Scalyr
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -65,7 +65,7 @@ you reference the actual socket and not a symlink to it.  Use `ls -l` to determi
 Here is an example of the complete command:
 
     docker run -d --name scalyr-docker-agent-json \
-    -v /tmp/api_key.json:/etc/scalyr-agent-2/agent.d/api_key.json \ 
+    -v /tmp/api_key.json:/etc/scalyr-agent-2/agent.d/api_key.json \
     -v /run/docker.sock:/var/scalyr/docker.sock \
     -v /var/lib/docker/containers:/var/lib/docker/containers \
     scalyr/scalyr-docker-agent-json
@@ -75,17 +75,20 @@ Or if setting API key via environment:
     docker run -d --name scalyr-docker-agent-json \
     -e SCALYR_API_KEY=<Your api key> \ 
     -v /run/docker.sock:/var/scalyr/docker.sock \
-    -v /var/lib/docker/containers:/var/lib/docker/containers   
+    -v /var/lib/docker/containers:/var/lib/docker/containers \
+    scalyr/scalyr-docker-agent-json
 
 #### scalyr-docker-agent-syslog
 
-To run the Syslog version, steps (1) and (2) are the same, but for step (3), you instead map the 
-Syslog port:
+To run the Syslog version, steps (1) and (2) are the same, but for step (3), you don't map in the
+containers directory.
 
     docker run -d --name scalyr-docker-agent-syslog \
     -e SCALYR_API_KEY=<Your api key> \
     -v /run/docker.sock:/var/scalyr/docker.sock \
-    -p 601:601
+    scalyr/scalyr-docker-agent-syslog
+
+Note: by default, the scalyr-agent-syslog container exposes tcp port 601 and udp port 501
 
 ## Configuring local containers to send their logs to Scalyr
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,9 +15,9 @@ In particular, the key integration features are:
 To build the Docker image, you must execute the following commands:
 
     cd scalyr-agent-2/docker
-    python ../build_package.py --no-versioned-file-name docker_tarball
-    docker build -t scalyr/scalyr-docker-agent .
-    
+    python ../build_package.py --no-versioned-file-name docker_syslog_builder
+    ./scalyr-docker-agent-syslog
+
 ## Running the Scalyr Agent in Docker
 
 To run a Scalyr Agent container, you must first create a file containing a write logs key from


### PR DESCRIPTION
@imron @czerwingithub I have incorporated @till's  and modified slightly to install ujson.

Latest more complete docker/README.md merged from master.

I ran the docker json/syslog smoketests locally and they passed.
Tested k8s manually and verified logs are uploaded to qatesting.