### PR TITLE
AGENT-101: Pass errors='replace' as an arg for pre-2.7 compatibility.

### DIFF
--- a/scalyr_agent/builtin_monitors/redis_monitor.py
+++ b/scalyr_agent/builtin_monitors/redis_monitor.py
@@ -207,7 +207,7 @@ class RedisHost( object ):
         except UnicodeDecodeError, e:
             if self.utf8_warning_interval:
                 logger.warn( "Redis command contains invalid utf8: %s" % binascii.hexlify( entry['command'] ), limit_once_per_x_secs=self.utf8_warning_interval, limit_key="redis-utf8" )
-            command = entry['command'].decode('utf8', errors="replace")
+            command = entry['command'].decode('utf8', "replace")
 
         time_format = "%Y-%m-%d %H:%M:%SZ"
         logger.emit_value( 'redis', 'slowlog', extra_fields={


### PR DESCRIPTION
Python 2.6 unittests are failing because of 2 issues.

This addresses one of them, namely `str.decode` errors="replace" should be passed as an arg, not a kwarg (only 2.7 onwards supports kwargs)