### PR TITLE
Ticket: #AGENT-100

### DIFF
--- a/scalyr_agent/copying_manager.py
+++ b/scalyr_agent/copying_manager.py
@@ -369,7 +369,7 @@ class CopyingManager(StoppableThread, LogWatcher):
                     self.__logs_pending_removal.pop( log_path, None )
 
             else:
-                log.log(scalyr_logging.DEBUG_LEVEL_0, "'%s' - trying to remove non-existent path from copy manager: '%s'" % ( monitor.module_name, log_path) )
+                log.log(scalyr_logging.DEBUG_LEVEL_0, "'%s' - trying to remove non-existent path from copy manager: '%s'" % ( monitor_name, log_path) )
         finally:
             self.__lock.release()
 

--- a/scalyr_agent/tests/copying_manager_test.py
+++ b/scalyr_agent/tests/copying_manager_test.py
@@ -183,6 +183,14 @@ class CopyingManagerInitializationTest(ScalyrTestCase):
         # We also verify the monitor instance itself's log config object was updated to have the full path.
         self.assertEquals(self.__monitor_fake_instances[0].log_config['path'], '/var/log/scalyr-agent-2/hi_monitor.log')
 
+    def test_remove_log_path_with_non_existing_path(self):
+        test_manager = self.__create_test_instance([
+        ], [
+            {'path': 'test.log'},
+        ])
+        # check that removing a non-existent path runs without throwing an exception
+        test_manager.remove_log_path( 'test_monitor', 'blahblah.log' )
+
     def __create_test_instance(self, configuration_logs_entry, monitors_log_configs):
         logs_json_array = JsonArray()
         for entry in configuration_logs_entry:


### PR DESCRIPTION
Changed monitor.module_name to monitor_name - this was a side effect of some
refactoring (we used to pass in the monitor) that didn't get picked up.