### PR TITLE
AGENT-105: Fix docker readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -12,38 +12,96 @@ In particular, the key integration features are:
 
 ## Building
 
-To build the Docker image, you must execute the following commands:
+We support two Docker images:
+- **scalyr-docker-agent-json**: uploads Docker logs captured by the Docker JSON File logging driver.
+- **scalyr-docker-agent-syslog**: uploads Docker logs captured by the Docker Syslog File logging driver.  
+
+We recommend customers use the **scalyr-docker-agent-json** image.
+
+Use the following commands to build the respective images:
+
+#### scalyr-docker-agent-json
 
     cd scalyr-agent-2/docker
-    python ../build_package.py --no-versioned-file-name docker_tarball
-    docker build -t scalyr/scalyr-docker-agent .
-    
+    python ../build_package.py --no-versioned-file-name docker_json_builder
+    ./scalyr-docker-agent-json --extract-packages
+    docker build -t scalyr/scalyr-docker-agent-json .
+
+#### scalyr-docker-agent-syslog
+
+    cd scalyr-agent-2/docker
+    python ../build_package.py --no-versioned-file-name docker_syslog_builder
+    ./scalyr-docker-agent-syslog --extract-packages
+    docker build -t scalyr/scalyr-docker-agent-syslog .
+
 ## Running the Scalyr Agent in Docker
 
-To run a Scalyr Agent container, you must first create a file containing a write logs key from
-your Scalyr account.  The file should look like:
+To run a Scalyr Agent container, you must do the following 3 things:
 
-    {
-      api_key: "YOUR KEY HERE"
-    }
+#### scalyr-docker-agent-json
 
-In this example, we will store the file in /tmp/api_key.json
+1) Pass the API key in one of two ways:
 
-You must also verify the location of the docker daemon unix socket.  In the example below, we assume
-it is stored in `/run/docker.sock`.  Another common location is `/var/run/docker.sock`.  Be sure that
+    a) Through the `SCALYR_API_KEY` environment variable
+    
+    b) Through config file as follows: 
+       
+       First create a file containing a write logs key from your Scalyr account.  The file should look like:
+    
+        {
+          api_key: "YOUR KEY HERE"
+        }
+    
+        In this example, we will store the file in /tmp/api_key.json
+    
+2) Verify and map the location of the docker daemon unix socket.  In the example below, we assume
+it is located at `/run/docker.sock`.  Another common location is `/var/run/docker.sock`.  Be sure 
 you reference the actual socket and not a symlink to it.  Use `ls -l` to determine that.
 
-To run the Scalyr Agent container, execute the following commands:
+3) Map `/var/lib/docker/containers` to the Docker containers directory.
+    
+    `-v /var/lib/docker/containers:/var/lib/docker/containers`
 
-    docker run -d --name scalyr-docker-agent -v /tmp/api_key.json:/etc/scalyr-agent-2/agent.d/api_key.json -v /run/docker.sock:/var/scalyr/docker.sock -p 601:601
+Here is an example of the complete command:
+
+    docker run -d --name scalyr-docker-agent-json \
+    -v /tmp/api_key.json:/etc/scalyr-agent-2/agent.d/api_key.json \ 
+    -v /run/docker.sock:/var/scalyr/docker.sock \
+    -v /var/lib/docker/containers:/var/lib/docker/containers \
+    scalyr/scalyr-docker-agent-json
+    
+Or if setting API key via environment:    
+    
+    docker run -d --name scalyr-docker-agent-json \
+    -e SCALYR_API_KEY=<Your api key> \ 
+    -v /run/docker.sock:/var/scalyr/docker.sock \
+    -v /var/lib/docker/containers:/var/lib/docker/containers   
+
+#### scalyr-docker-agent-syslog
+
+To run the Syslog version, steps (1) and (2) are the same, but for step (3), you instead map the 
+Syslog port:
+
+    docker run -d --name scalyr-docker-agent-syslog \
+    -e SCALYR_API_KEY=<Your api key> \
+    -v /run/docker.sock:/var/scalyr/docker.sock \
+    -p 601:601
 
 ## Configuring local containers to send their logs to Scalyr
 
-Once you have the Scalyr Agent container running, you may configure other containers on the same
-physical host to send their logs to Scalyr through it.
+Once you have the Scalyr Agent container running, other containers on the same physical host can then send their 
+logs to Scalyr through the Scalyr Agent container.  The following is an example of a small container that will write `Hello World` repeatedly to Scalyr:
 
-To do this, you must add the following options when you start a container: `--log-driver=syslog --log-opt syslog-address=tcp://127.0.0.1:601`
+    docker run -d ubuntu /bin/sh -c "while true; do echo hello world; sleep 1; done"
 
-The following is an example of a small container that will write `Hello World` repeatedly to Scalyr:
+Note that no extra configuration was needed if you're running the `scalyr-docker-agent-json` image. 
 
-    docker run  --log-driver=syslog --log-opt syslog-address=tcp://127.0.0.1:601 -d ubuntu /bin/sh -c "while true; do echo hello world; sleep 1; done"
+In contrast, if you're running the `scalyr-docker-agent-syslog` version, you will need to configure all containers 
+to send logs via the Syslog protocol. To do this, add the following options when starting a container: 
+
+    `--log-driver=syslog --log-opt syslog-address=tcp://127.0.0.1:601`
+
+    Thus, the docker run command becomes:
+
+    docker run --log-driver=syslog --log-opt syslog-address=tcp://127.0.0.1:601 \
+    -d ubuntu /bin/sh -c "while true; do echo hello world; sleep 1; done"


### PR DESCRIPTION
# BACKGROUND

A community-posted PR alerted us to the fact that our docker README.md is outdated. 

This PR explains in detail how to run both json/syslog versions.

# HOW TESTED

I have tested the instructions locally and verified end-to-end logging.

