### PR TITLE
Imron/agent 110 larger json buffer

### DIFF
--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -47,6 +47,7 @@ from scalyr_agent.agent_status import LogMatcherStatus
 from scalyr_agent.agent_status import LogProcessorStatus
 
 from scalyr_agent.line_matcher import LineMatcher
+from scalyr_agent.line_matcher import LogLine
 
 from scalyr_agent.scalyr_client import Event
 
@@ -78,24 +79,6 @@ LOG_DELETION_DELAY = 10 * 60
 COPY_STALENESS_THRESHOLD = 15 * 60
 
 log = scalyr_logging.getLogger(__name__)
-
-class LogLine(object):
-    """A class representing a line from a log file.
-    This object will always have a single field 'line' which contains the log line.
-    It can also contain two other attributes 'timestamp' which is the timestamp of the
-    the log line in nanoseconds since the epoch (defaults to None, in which case the
-    current time.time() will be used), and 'attrs' which are optional attributes for the line.
-    """
-    def __init__(self, line):
-        # line is a string
-        self.line = line
-
-        # timestamp is a long, counting nanoseconds since Epoch
-        # or None to use current time
-        self.timestamp = None
-
-        # attrs is a dict of optional attributes to attach to the log message
-        self.attrs = None
 
 class LogFileIterator(object):
     """Reads the bytes from a log file at a particular path, returning the lines.
@@ -477,8 +460,7 @@ class LogFileIterator(object):
         #            expected_buffer_index, original_buffer_index)
 
         # read a complete line from our line_matcher
-        next_line = self.__line_matcher.readline(self.__buffer, current_time)
-        result = LogLine(line=next_line)
+        result = self.__line_matcher.readline(self.__buffer, current_time)
 
         if len(result.line) == 0:
             return result

--- a/scalyr_agent/tests/line_matcher_test.py
+++ b/scalyr_agent/tests/line_matcher_test.py
@@ -51,7 +51,7 @@ class SingleLineMatcherTestCase( unittest.TestCase ):
 
         line_matcher = LineMatcher()
         actual = line_matcher.readline( line, time.time() )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
 
     def test_single_line_partial( self ):
@@ -60,12 +60,12 @@ class SingleLineMatcherTestCase( unittest.TestCase ):
 
         line_matcher = LineMatcher()
         actual = line_matcher.readline( line, time.time() )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         line = append_string( line, "\n" )
 
         actual = line_matcher.readline( line, time.time() )
-        self.assertEqual( expected + "\n", actual )
+        self.assertEqual( expected + "\n", actual.line )
 
     def test_single_line_partial_timeout( self ):
         expected = "Hello World"
@@ -74,10 +74,10 @@ class SingleLineMatcherTestCase( unittest.TestCase ):
         line_matcher = LineMatcher( line_completion_wait_time = 5 )
         current_time = time.time() - 6
         actual = line_matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = line_matcher.readline( line, time.time() )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
     def test_single_line_partial_too_long( self ):
         expected = "Hello World"
@@ -86,7 +86,7 @@ class SingleLineMatcherTestCase( unittest.TestCase ):
         line_matcher = LineMatcher( max_line_length=11 )
         current_time = time.time()
         actual = line_matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
 class ContinueThroughTestCase( unittest.TestCase ):
 
@@ -102,10 +102,10 @@ class ContinueThroughTestCase( unittest.TestCase ):
         matcher = ContinueThrough( self.start_pattern, self.continuation_pattern )
         current_time = time.time()
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = line.readline()
         self.assertEqual( expected_next, actual )
@@ -119,7 +119,7 @@ class ContinueThroughTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = line.readline()
         self.assertEqual( expected, actual )
@@ -134,12 +134,12 @@ class ContinueThroughTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         line = append_string( line, expected_next + expected_last )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected + expected_next, actual )
+        self.assertEqual( expected + expected_next, actual.line )
 
         actual = line.readline()
         self.assertEqual( expected_last, actual )
@@ -153,12 +153,12 @@ class ContinueThroughTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         line = append_string( line, expected_last )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
         
         actual = line.readline()
         self.assertEqual( expected_last, actual )
@@ -171,9 +171,9 @@ class ContinueThroughTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = line.readline()
         self.assertEqual( line1, actual )
@@ -185,15 +185,15 @@ class ContinueThroughTestCase( unittest.TestCase ):
         matcher = ContinueThrough( self.start_pattern, self.continuation_pattern, line_completion_wait_time = 5 )
         current_time = time.time()
         actual = matcher.readline( line, current_time - 6 )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         expected_next = "  starts with a space\n"
         line = append_string( line, expected_next )
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = line.readline()
         self.assertEqual( expected_next, actual )
@@ -205,15 +205,15 @@ class ContinueThroughTestCase( unittest.TestCase ):
         matcher = ContinueThrough( self.start_pattern, self.continuation_pattern, line_completion_wait_time = 5 )
         current_time = time.time()
         actual = matcher.readline( line, current_time - 6 )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         expected_next = "  starts with a space\n"
         line = append_string( line, expected_next )
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = line.readline()
         self.assertEqual( expected_next, actual )
@@ -227,7 +227,7 @@ class ContinueThroughTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( "Exception\n", actual )
@@ -241,7 +241,7 @@ class ContinueThroughTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( remainder, actual )
@@ -260,10 +260,10 @@ class ContinuePastTestCase( unittest.TestCase ):
         matcher = ContinuePast( self.start_pattern, self.continuation_pattern )
         current_time = time.time()
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = line.readline()
         self.assertEqual( expected_next, actual )
@@ -277,10 +277,10 @@ class ContinuePastTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = line.readline()
         self.assertEqual( expected_next, actual )
@@ -295,12 +295,12 @@ class ContinuePastTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         line = append_string( line, expected_next + expected_last )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected + expected_next, actual )
+        self.assertEqual( expected + expected_next, actual.line )
 
         actual = line.readline()
         self.assertEqual( expected_last, actual )
@@ -314,12 +314,12 @@ class ContinuePastTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         line = append_string( line, expected_last )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected + expected_last, actual )
+        self.assertEqual( expected + expected_last, actual.line )
         
         actual = line.readline()
         self.assertEqual( '', actual )
@@ -332,9 +332,9 @@ class ContinuePastTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = line.readline()
         self.assertEqual( line1, actual )
@@ -346,10 +346,10 @@ class ContinuePastTestCase( unittest.TestCase ):
         matcher = ContinuePast( self.start_pattern, self.continuation_pattern, line_completion_wait_time = 5 )
         current_time = time.time()
         actual = matcher.readline( line, current_time - 6 )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( '', actual )
@@ -361,10 +361,10 @@ class ContinuePastTestCase( unittest.TestCase ):
         matcher = ContinuePast( self.start_pattern, self.continuation_pattern, line_completion_wait_time = 5 )
         current_time = time.time()
         actual = matcher.readline( line, current_time - 6 )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( '', actual )
@@ -378,7 +378,7 @@ class ContinuePastTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( " multiline\\\n", actual )
@@ -392,7 +392,7 @@ class ContinuePastTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( remainder, actual )
@@ -411,10 +411,10 @@ class HaltBeforeTestCase( unittest.TestCase ):
         matcher = HaltBefore( self.start_pattern, self.continuation_pattern )
         current_time = time.time()
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = line.readline()
         self.assertEqual( expected_next, actual )
@@ -428,10 +428,10 @@ class HaltBeforeTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
     def test_partial_first_line_match( self ):
         expected = "--begin\n"
@@ -443,12 +443,12 @@ class HaltBeforeTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         line = append_string( line, expected_next + expected_last )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected + expected_next, actual )
+        self.assertEqual( expected + expected_next, actual.line )
 
         actual = line.readline()
         self.assertEqual( expected_last, actual )
@@ -462,12 +462,12 @@ class HaltBeforeTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         line = append_string( line, expected_last )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
         
         actual = line.readline()
         self.assertEqual( expected_last, actual )
@@ -480,9 +480,9 @@ class HaltBeforeTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = line.readline()
         self.assertEqual( line1, actual )
@@ -494,10 +494,10 @@ class HaltBeforeTestCase( unittest.TestCase ):
         matcher = HaltBefore( self.start_pattern, self.continuation_pattern, line_completion_wait_time = 5 )
         current_time = time.time()
         actual = matcher.readline( line, current_time - 6 )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( '', actual )
@@ -509,10 +509,10 @@ class HaltBeforeTestCase( unittest.TestCase ):
         matcher = HaltBefore( self.start_pattern, self.continuation_pattern, line_completion_wait_time = 5 )
         current_time = time.time()
         actual = matcher.readline( line, current_time - 6 )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( '', actual )
@@ -526,7 +526,7 @@ class HaltBeforeTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( " multiline\n", actual )
@@ -540,7 +540,7 @@ class HaltBeforeTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( remainder, actual )
@@ -554,7 +554,7 @@ class HaltBeforeTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( remainder, actual )
@@ -573,10 +573,10 @@ class HaltWithTestCase( unittest.TestCase ):
         matcher = HaltWith( self.start_pattern, self.continuation_pattern )
         current_time = time.time()
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = line.readline()
         self.assertEqual( expected_next, actual )
@@ -590,10 +590,10 @@ class HaltWithTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected + expected_next, actual )
+        self.assertEqual( expected + expected_next, actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
 
     def test_partial_first_line_match( self ):
@@ -606,12 +606,12 @@ class HaltWithTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         line = append_string( line, expected_next + expected_last )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected + expected_next, actual )
+        self.assertEqual( expected + expected_next, actual.line )
 
         actual = line.readline()
         self.assertEqual( expected_last, actual )
@@ -625,12 +625,12 @@ class HaltWithTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         line = append_string( line, expected_end )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected + expected_end, actual )
+        self.assertEqual( expected + expected_end, actual.line )
         
         actual = line.readline()
         self.assertEqual( '', actual )
@@ -643,9 +643,9 @@ class HaltWithTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
         actual = matcher.readline( line, current_time )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = line.readline()
         self.assertEqual( line1, actual )
@@ -657,10 +657,10 @@ class HaltWithTestCase( unittest.TestCase ):
         matcher = HaltWith( self.start_pattern, self.continuation_pattern, line_completion_wait_time = 5 )
         current_time = time.time()
         actual = matcher.readline( line, current_time - 6 )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( '', actual )
@@ -672,10 +672,10 @@ class HaltWithTestCase( unittest.TestCase ):
         matcher = HaltWith( self.start_pattern, self.continuation_pattern, line_completion_wait_time = 5 )
         current_time = time.time()
         actual = matcher.readline( line, current_time - 6 )
-        self.assertEqual( '', actual )
+        self.assertEqual( '', actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( '', actual )
@@ -689,7 +689,7 @@ class HaltWithTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( " multiline\n", actual )
@@ -703,7 +703,7 @@ class HaltWithTestCase( unittest.TestCase ):
         current_time = time.time()
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( remainder, actual )
@@ -755,7 +755,7 @@ class LineMatcherCollectionTestCase( unittest.TestCase ):
         current_time = time.time()
         line = make_string( expected + self.single_string() )
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( self.single_string(), actual )
@@ -768,7 +768,7 @@ class LineMatcherCollectionTestCase( unittest.TestCase ):
         current_time = time.time()
         line = make_string( expected + self.single_string() )
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( self.single_string(), actual )
@@ -781,7 +781,7 @@ class LineMatcherCollectionTestCase( unittest.TestCase ):
         current_time = time.time()
         line = make_string( expected + "--last\n" )
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( "--last\n", actual )
@@ -794,7 +794,7 @@ class LineMatcherCollectionTestCase( unittest.TestCase ):
         current_time = time.time()
         line = make_string( expected + self.single_string() )
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( self.single_string(), actual )
@@ -806,7 +806,7 @@ class LineMatcherCollectionTestCase( unittest.TestCase ):
         current_time = time.time()
         line = make_string( expected )
         actual = matcher.readline( line, current_time )
-        self.assertEqual( expected, actual )
+        self.assertEqual( expected, actual.line )
 
         actual = line.readline()
         self.assertEqual( '', actual )
@@ -819,25 +819,25 @@ class LineMatcherCollectionTestCase( unittest.TestCase ):
         current_time = time.time()
         line = make_string( expected )
         actual = matcher.readline( line, current_time )
-        self.assertEqual( self.single_string(), actual )
+        self.assertEqual( self.single_string(), actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( self.halt_with_string(), actual )
+        self.assertEqual( self.halt_with_string(), actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( self.halt_before_string(), actual )
+        self.assertEqual( self.halt_before_string(), actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( end_marker, actual )
+        self.assertEqual( end_marker, actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( self.continue_past_string(), actual )
+        self.assertEqual( self.continue_past_string(), actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( self.continue_through_string(), actual )
+        self.assertEqual( self.continue_through_string(), actual.line )
 
         actual = matcher.readline( line, current_time )
-        self.assertEqual( self.single_string(), actual )
+        self.assertEqual( self.single_string(), actual.line )
 
         actual = line.readline()
         self.assertEqual( '', actual )

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -87,7 +87,7 @@ class TestLogFileIterator(ScalyrTestCase):
 
         log_config = {'path': self.__path, 'lineGroupers': JsonArray(DEFAULT_CONTINUE_THROUGH)}
         log_config = DEFAULT_CONFIG.parse_log_config(log_config)
-        matcher = LineMatcher.create_line_matchers(log_config, 100, 60)
+        matcher = LineMatcher.create_line_matchers(log_config, 100, 100, 60)
         self.log_file.set_line_matcher(matcher)
         self.log_file.set_parameters(100, 100)
 
@@ -104,7 +104,7 @@ class TestLogFileIterator(ScalyrTestCase):
     def test_continue_past_matcher(self):
         log_config = {'path': self.__path, 'lineGroupers': JsonArray(DEFAULT_CONTINUE_PAST)}
         log_config = DEFAULT_CONFIG.parse_log_config(log_config)
-        matcher = LineMatcher.create_line_matchers(log_config, 100, 60)
+        matcher = LineMatcher.create_line_matchers(log_config, 100, 100, 60)
         self.log_file.set_line_matcher(matcher)
         self.log_file.set_parameters(100, 100)
 
@@ -121,7 +121,7 @@ class TestLogFileIterator(ScalyrTestCase):
     def test_halt_before_matcher(self):
         log_config = {'path': self.__path, 'lineGroupers': JsonArray(DEFAULT_HALT_BEFORE)}
         log_config = DEFAULT_CONFIG.parse_log_config(log_config)
-        matcher = LineMatcher.create_line_matchers(log_config, 100, 60)
+        matcher = LineMatcher.create_line_matchers(log_config, 100, 100, 60)
         self.log_file.set_line_matcher(matcher)
         self.log_file.set_parameters(100, 100)
 
@@ -139,7 +139,7 @@ class TestLogFileIterator(ScalyrTestCase):
     def test_halt_with_matcher(self):
         log_config = {'path': self.__path, 'lineGroupers': JsonArray(DEFAULT_HALT_WITH)}
         log_config = DEFAULT_CONFIG.parse_log_config(log_config)
-        matcher = LineMatcher.create_line_matchers(log_config, 100, 60)
+        matcher = LineMatcher.create_line_matchers(log_config, 100, 100, 60)
         self.log_file.set_line_matcher(matcher)
         self.log_file.set_parameters(100, 100)
 
@@ -158,7 +158,7 @@ class TestLogFileIterator(ScalyrTestCase):
                       'lineGroupers': JsonArray(DEFAULT_CONTINUE_THROUGH, DEFAULT_CONTINUE_PAST, DEFAULT_HALT_BEFORE,
                                                 DEFAULT_HALT_WITH)}
         log_config = DEFAULT_CONFIG.parse_log_config(log_config)
-        matcher = LineMatcher.create_line_matchers(log_config, 100, 60)
+        matcher = LineMatcher.create_line_matchers(log_config, 100, 100, 60)
         self.log_file.set_line_matcher(matcher)
         self.log_file.set_parameters(200, 200)
         expected = ["--multi\n--continue\n--some more\n",


### PR DESCRIPTION
Refactor of parsing as json so that json parsing is encapsulated in a `JsonLineMatcher`

This makes it easier to increase the buffer size for reading a full line of json independently from the maximum line size.

The json parser will now try to read at least `read_page_size` bytes from the file when parsing json lines, even if the `max_line_size` is less than this value (which it is by default).  Lines longer than `max_line_size` are still truncated to `max_line_size` bytes.
