### PR TITLE
AGENT-113 : Unittests still hang non-deterministically (infrequent)

### DIFF
--- a/scalyr_agent/test_util.py
+++ b/scalyr_agent/test_util.py
@@ -24,6 +24,7 @@ import logging
 import os
 import shutil
 import tempfile
+import threading
 
 import scalyr_agent.util as scalyr_util
 
@@ -106,6 +107,12 @@ class ScalyrTestUtils(object):
         if fake_clock:
             for monitor in test_manager.monitors + [test_manager]:
                 monitor._run_state = scalyr_util.RunState(fake_clock=fake_clock)
+
+        # AGENT-113 set all monitors and the monitors_manager threads to daemon to eliminate occasionally hanging tests
+        test_manager.setDaemon(True)
+        for monitor in test_manager.monitors:
+            if isinstance(monitor, threading.Thread):
+                monitor.setDaemon(True)
 
         return test_manager
 


### PR DESCRIPTION
A month back I introduced unit tests that create multithreaded monitors_manager.

I thought I had solved a hanging issue by deterministically shutting down all started threads (that were blocking the unit test from finishing).

My fix involved passing num_waiters threads to FakeClockCounter and then in sleep_until_count_or_maxwait, we block until those threads all complete.

The fix definitely eliminated the _**frequent**_ hanging. However, now, there is very very occasional hanging. I don't know if this remnant hanging is related but in case it is, I'm going to try to set threads to daemon threads (only in test). This might help eliminate the problem.

# How to test

No good way to tell except to check this in and observe over time. 
Note that the broken unittest-27 is orthogonal and fixed in [AGENT-116 PR](https://github.com/scalyr/scalyr-agent-2/pull/193)
