### PR TITLE
AGENT-102: Use unittest docker image running as user Scalyr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,25 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} edwardchee/scalyr-agent-ci:python26 /tmp/run_unittests.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e PYTHON_VERSION=2.6 scalyr/scalyr-agent-ci-unittest:1 /tmp/unittest.sh
+
+  unittest-25:
+    docker:
+      - image: circleci/python:2.7-jessie-browsers
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e PYTHON_VERSION=2.5 scalyr/scalyr-agent-ci-unittest:1 /tmp/unittest.sh
+
+  unittest-24:
+    docker:
+      - image: circleci/python:2.7-jessie-browsers
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e PYTHON_VERSION=2.4 scalyr/scalyr-agent-ci-unittest:1 /tmp/unittest.sh
 
   smoke-standalone-27:
     docker:
@@ -127,6 +145,8 @@ workflows:
     jobs:
       - unittest-27
       - unittest-26
+      - unittest-25
+      - unittest-24
       - smoke-standalone-27
       - smoke-standalone-26
       - smoke-standalone-25

--- a/scalyr_agent/all_tests.py
+++ b/scalyr_agent/all_tests.py
@@ -52,6 +52,10 @@ def find_all_tests(directory=None, base_path=None):
     return result
 
 
+PYTHON24_WHITELIST = [
+    'scalyr_agent.tests.url_monitor_test',
+]
+
 PRE_PYTHON27_WHITELIST = [
     'scalyr_agent.tests.configuration_k8s_test',
     'scalyr_agent.builtin_monitors.tests.docker_monitor_test',
@@ -74,7 +78,11 @@ def run_all_tests():
             try:
                 suites.append(test_loader.loadTestsFromName(test_case))
             except Exception, ex:
-                if sys.version_info[:2] < (2, 7) and test_case in PRE_PYTHON27_WHITELIST:
+                if sys.version_info[:2] < (2, 5) and test_case in PYTHON24_WHITELIST:
+                    print("Warning. Skipping unloadable module '%s'.\n"
+                          "This module was whitelisted as non-critical for Python 2.4 testing.\n"
+                          "Module-load exception message: '%s'\n" % (test_case, ex))
+                elif sys.version_info[:2] < (2, 7) and test_case in PRE_PYTHON27_WHITELIST:
                     print("Warning. Skipping unloadable module '%s'.\n"
                           "This module was whitelisted as non-critical for pre-2.7 testing.\n"
                           "Module-load exception message: '%s'\n" % (test_case, ex))

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -953,15 +953,15 @@ class AutoFlushingRotatingFileHandler( logging.handlers.RotatingFileHandler ):
 
     This helps reduce the disk requests for high syslog traffic.
     """
-    def __init__(self, filename, mode='a', maxBytes=0, backupCount=0, encoding=None, delay=0, flushDelay=0.0):
+    def __init__(self, filename, mode='a', maxBytes=0, backupCount=0, delay=0, flushDelay=0.0):
         # We handle delay specially because it is not a valid option for the Python 2.4 logging libraries, so we
         # really only pass it if the caller is really trying to set it to something other than the default.
         if delay != 0:
             logging.handlers.RotatingFileHandler.__init__(self, filename, mode=mode, maxBytes=maxBytes,
-                                                          backupCount=backupCount, encoding=encoding, delay=delay)
+                                                          backupCount=backupCount, delay=delay)
         else:
             logging.handlers.RotatingFileHandler.__init__(self, filename, mode=mode, maxBytes=maxBytes,
-                                                          backupCount=backupCount, encoding=encoding)
+                                                          backupCount=backupCount)
 
         self.__flushDelay = flushDelay
         # If this is not None, then it is set to a timer that when it expires will flush the log handler.

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -25,10 +25,7 @@ from mock import patch, Mock
 from scalyr_agent.configuration import Configuration, BadConfiguration
 from scalyr_agent.json_lib import JsonObject, JsonArray
 from scalyr_agent.json_lib import parse as parse_json, serialize as serialize_json
-from scalyr_agent.monitors_manager import MonitorsManager
 from scalyr_agent.platform_controller import DefaultPaths
-from scalyr_agent.json_lib.objects import ArrayOfStrings
-from scalyr_agent.test_util import FakePlatform
 
 from scalyr_agent.test_base import ScalyrTestCase
 


### PR DESCRIPTION
I created a new `scalyr/scalyr-agent-ci-unittest` image which fixes the permissions problem.
This image installs python 2.4,5,6,7 using `pyenv`.
With this one image, we can unittest (and potentially smoketest) all versions.
(I will look to combining unittest/smoketest in one image shortly)

This now works for Python 26, 25 and 24.