### PR TITLE
AGENT-122: K8s smoke test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.7 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:2 /tmp/smoketest_standalone.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.7 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:9 /tmp/smoketest_standalone.sh
 
   smoke-standalone-26:
     docker:
@@ -77,7 +77,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.6 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:2 /tmp/smoketest_standalone.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.6 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:9 /tmp/smoketest_standalone.sh
 
   smoke-standalone-25:
     docker:
@@ -86,7 +86,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.5 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:2 /tmp/smoketest_standalone.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.5 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:9 /tmp/smoketest_standalone.sh
 
   smoke-standalone-24:
     docker:
@@ -95,7 +95,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.4 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:2 /tmp/smoketest_standalone.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.4 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:9 /tmp/smoketest_standalone.sh
 
   smoke-docker-json:
     docker:
@@ -116,7 +116,7 @@ jobs:
           paths:
             - "venv"
       - run:
-          command: source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-smoketest:2 json 300
+          command: source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-smoketest:9 json 300
 
   smoke-docker-syslog:
     docker:
@@ -137,7 +137,123 @@ jobs:
           paths:
             - "venv"
       - run:
-          command: source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-smoketest:2 syslog 300
+          command: source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-smoketest:9 syslog 300
+
+  smoke-k8s:
+    machine:
+      image: circleci/classic:201808-01
+    environment:
+      K8S_VERSION: v1.10.0
+      KUBECONFIG: /home/circleci/.kube/config
+      MINIKUBE_VERSION: v0.30.0
+      MINIKUBE_WANTUPDATENOTIFICATION: false
+      MINIKUBE_WANTREPORTERRORPROMPT: false
+      MINIKUBE_HOME: /home/circleci
+      CHANGE_MINIKUBE_NONE_USER: true
+    steps:
+      - checkout
+      - run:
+          name: setup kubectl
+          command: |
+            curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+            mkdir -p ${HOME}/.kube
+            touch ${HOME}/.kube/config
+      - run:
+          name: setup minikube
+          command: |
+            curl -Lo minikube https://github.com/kubernetes/minikube/releases/download/${MINIKUBE_VERSION}/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+      - run:
+          name: start minikube
+          command: |
+            sudo -E minikube start --vm-driver=none --cpus 2 --memory 2048 --kubernetes-version=${K8S_VERSION} &> $HOME/minikube.log 2>&1 < /dev/null
+      - run:
+          name: wait for minikube
+          command: |
+            JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}';
+            until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
+              sleep 1;
+            done
+      - run:
+          name: fix RBAC
+          command: |
+            # make default account cluster-admin
+            kubectl create clusterrolebinding add-on-cluster-admin --clusterrole cluster-admin --serviceaccount=kube-system:default
+      - run:
+          name: dump cluster-info
+          command: |
+            kubectl cluster-info
+            kubectl get po --all-namespaces
+      - run:
+          name: build k8s agent and run smoketest
+          command: |
+            source ./.circleci/smoketest_k8s.sh scalyr/scalyr-agent-ci-smoketest:9 300
+
+  smoke-k8s-helm:
+    machine:
+      image: circleci/classic:201808-01
+    environment:
+      K8S_VERSION: v1.10.0
+      KUBECONFIG: /home/circleci/.kube/config
+      MINIKUBE_VERSION: v0.30.0
+      MINIKUBE_WANTUPDATENOTIFICATION: false
+      MINIKUBE_WANTREPORTERRORPROMPT: false
+      MINIKUBE_HOME: /home/circleci
+      CHANGE_MINIKUBE_NONE_USER: true
+    steps:
+      - checkout
+      - run:
+          name: setup kubectl
+          command: |
+            curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+            mkdir -p ${HOME}/.kube
+            touch ${HOME}/.kube/config
+      - run:
+          name: setup minikube
+          command: |
+            curl -Lo minikube https://github.com/kubernetes/minikube/releases/download/${MINIKUBE_VERSION}/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+      - run:
+          name: setup helm
+          command: curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash
+      - run:
+          name: start minikube
+          command: |
+            sudo -E minikube start --vm-driver=none --cpus 2 --memory 2048 --kubernetes-version=${K8S_VERSION} &> $HOME/minikube.log 2>&1 < /dev/null
+      - run:
+          name: wait for minikube
+          command: |
+            JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}';
+            until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
+              sleep 1;
+            done
+      - run:
+          name: fix RBAC
+          command: |
+            # make default account cluster-admin
+            kubectl create clusterrolebinding add-on-cluster-admin --clusterrole cluster-admin --serviceaccount=kube-system:default
+      - run:
+          name: dump cluster-info
+          command: |
+            kubectl cluster-info
+            kubectl get po --all-namespaces
+      - run:
+          name: install helm in cluster
+          command: |
+            kubectl -n kube-system create sa tiller
+            kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
+            helm init --wait --service-account tiller
+      - run:
+          name: deploy sample nginx
+          command: kubectl run circleci-example --image=nginx
+      - run:
+          name: dump pods & services
+          command: |
+            # wait for all pods to start
+            sleep 30
+            # dump pods
+            kubectl get po  --all-namespaces | grep -vE '(kube-sys|docker)'
+            echo
+            # dump services
+            kubectl get svc  --all-namespaces | grep -vE '(kube-sys|docker)'
 
 workflows:
   version: 2
@@ -153,3 +269,4 @@ workflows:
       - smoke-standalone-24
       - smoke-docker-json
       - smoke-docker-syslog
+      - smoke-k8s

--- a/.circleci/smoketest_k8s.sh
+++ b/.circleci/smoketest_k8s.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+#----------------------------------------------------------------------------------------
+# Runs agent smoketest for k8s in Minikube:
+#    - Assumes that the current scalyr-agent-2 root directory contains the test branch and that
+#       the VERSION file can be overwritten (ie. the scalyr-agent-2 directory is a "throwaway" copy.
+#    - Launch agent k8s pod
+#    - Launch uploader pod (writes lines to stdout)
+#    - Launch verifier pod (polls for liveness of agent and uploader as well as verifies expected uploaded lines)
+#
+# Build local k8s image from code and launch a DaemonSet with it
+# - modifies production daemonset spec file
+#
+# Expects the following env vars:
+#   SCALYR_API_KEY
+#   SCALYR_SERVER
+#   READ_API_KEY (Read api key. 'SCALYR_' prefix intentionally omitted to suppress in status -v)
+#   CIRCLE_BUILD_NUM
+#
+# Expects following positional args:
+#   $1 : smoketest image tag
+#   $2 : max secs until test hard fails
+#
+# e.g. usage
+#   smoketest_k8s.sh scalyr/scalyr-agent-ci-smoketest:3 300
+#----------------------------------------------------------------------------------------
+
+# The following variables are needed
+# Docker image in which runs smoketest python3 code
+smoketest_image=$1
+
+# Max seconds before the test hard fails
+max_wait=$3
+
+
+# Smoketest code (built into smoketest image)
+smoketest_script="/usr/bin/python3 /tmp/smoketest.py"
+
+# Create service account
+kubectl create -f https://raw.githubusercontent.com/scalyr/scalyr-agent-2/release/k8s/scalyr-service-account.yaml
+
+# Define api key
+kubectl create secret generic scalyr-api-key --from-literal=scalyr-api-key=${SCALYR_API_KEY}
+
+# Create configmap
+kubectl create configmap scalyr-config \
+--from-literal=SCALYR_K8S_CLUSTER_NAME=ci-agent-k8s-${CIRCLE_BUILD_NUM} \
+--from-literal=SCALYR_SERVER=qatesting.scalyr.com
+
+# The following line should be commented out for CircleCI, but it necessary for local debugging
+# eval $(minikube docker-env)
+
+# Build local image (add .ci.k8s to version)
+TEMP_DIRECTORY=~/temp_directory
+mkdir $TEMP_DIRECTORY
+perl -pi.bak -e 's/\s*(\S+)/$1\.ci\.k8s/' VERSION
+python build_package.py k8s_builder
+TARBALL=$(ls scalyr-k8s-agent-*)
+mv $TARBALL $TEMP_DIRECTORY
+pushd $TEMP_DIRECTORY
+./${TARBALL} --extract-packages
+docker build -t local_k8s_image .
+
+
+# container names for all test containers
+# The suffixes MUST be one of (agent, uploader, verifier) to match verify_upload::DOCKER_CONTNAME_SUFFIXES
+contname_agent="ci-agent-k8s-${CIRCLE_BUILD_NUM}-agent"
+contname_uploader="ci-agent-k8s-${CIRCLE_BUILD_NUM}-uploader"
+contname_verifier="ci-agent-k8s-${CIRCLE_BUILD_NUM}-verifier"
+
+
+# Create DaemonSet, referring to local image.  Launch agent.
+curl -Lo scalyr-agent-2-envfrom.yaml https://raw.githubusercontent.com/scalyr/scalyr-agent-2/release/k8s/scalyr-agent-2-envfrom.yaml
+perl -pi.bak -e 's/image\:\s+(\S+)/image: local_k8s_image/' scalyr-agent-2-envfrom.yaml
+perl -pi.bak -e 's/imagePullPolicy\:\s+(\S+)/imagePullPolicy: Never/' scalyr-agent-2-envfrom.yaml
+kubectl create -f scalyr-agent-2-envfrom.yaml
+# Capture agent pod
+agent_hostname=$(kubectl get pods | fgrep scalyr-agent-2 | awk {'print $1'})
+echo "Agent pod == ${agent_hostname}"
+
+
+# Launch Uploader container (only writes to stdout, but needs to query Scalyr to verify agent liveness)
+# You MUST provide scalyr server, api key and importantly, the agent_hostname container ID for the agent-liveness
+# query to work (uploader container waits for agent to be alive before uploading data)
+kubectl run ${contname_uploader} --image=${smoketest_image} -- ${smoketest_script} \
+${contname_uploader} ${max_wait} \
+--mode uploader \
+--scalyr_server ${SCALYR_SERVER} \
+--read_api_key ${READ_API_KEY} \
+--agent_hostname ${agent_hostname}
+# Capture uploader pod
+uploader_hostname=$(kubectl get pods | fgrep ${contname_uploader} | awk {'print $1'})
+echo "Uploader pod == ${uploader_hostname}"
+
+
+# Launch synchronous Verifier image (writes to stdout and also queries Scalyr)
+# Like the Uploader, the Verifier also waits for agent to be alive before uploading data
+kubectl run ${contname_verifier} --image=${smoketest_image} -- ${smoketest_script} \
+${contname_verifier} ${max_wait} \
+--mode verifier \
+--scalyr_server ${SCALYR_SERVER} \
+--read_api_key ${READ_API_KEY} \
+--agent_hostname ${agent_hostname} \
+--uploader_hostname ${uploader_hostname}


### PR DESCRIPTION
K8s smoke test operational.
- starts an `agent` pod to monitor cluster
- starts an `uploader` pod that writes to stdout/stderr (uploader pod queries qatesting to verify agent is working before it starts uploading)
- starts a `verifier` pod that  (verifier pod queries qatesting to verify agent is working before then querying for uploader log data)

As before, these smoke/unit tests are not code-reviewed pending cleanup/organization of various scripts and Dockerfiles used to construct test docker images.