### PR TITLE
Ticket #AGENT-115

### DIFF
--- a/scalyr_agent/builtin_monitors/tests/data/containers-running.json
+++ b/scalyr_agent/builtin_monitors/tests/data/containers-running.json
@@ -1,0 +1,50 @@
+[
+  {
+    "Id": "87d533137e70601d17a4bf9d563b11d528ba81e31e2299eb8d4ab2ef5a54f0c0",
+    "Names": [
+      "/scalyr"
+    ]
+  },
+  {
+    "Id": "84afc8ee4d726544e77dcfe22c6f5be04f36b115ea99c0510d612666f83da1ce",
+    "Names": [
+      "/include3-exclude"
+    ]
+  },
+  {
+    "Id": "e511aaf76add81d41c1536b2a93a17448d9f9d3c6a3f8a5abab1d9a582c397fc",
+    "Names": [
+      "/include2-exclude"
+    ]
+  },
+  {
+    "Id": "cfcb7f7d1481c805f91fd6c8c120300a586978fa2541a58026bd930eeeda3e36",
+    "Names": [
+      "/include1-exclude"
+    ]
+  },
+  {
+    "Id": "b8757266fd6a9efcb40a2881215d8d3642e6f8a0cfdcbb941382d002f31dcca4",
+    "Names": [
+      "/include4-yes"
+    ]
+  },
+  {
+    "Id": "343c05b55c1b0cebca6df0309a4892974c5ed3013731433461ffe7442223659a",
+    "Names": [
+      "/include3-yes"
+    ]
+  },
+  {
+    "Id": "58ded582ebf14063bff3b15cd3962035be9904b73318796f1119d71472801d23",
+    "Names": [
+      "/include2-yes"
+    ]
+  },
+  {
+    "Id": "c4eacccbf687f408c708b12fa875ab55f4d6d0aad8e2eec489ba9712e041bd14",
+    "Names": [
+      "/include1-yes"
+    ]
+  }
+]

--- a/scalyr_agent/builtin_monitors/tests/docker_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/docker_monitor_test.py
@@ -19,16 +19,20 @@
 __author__ = 'echee@scalyr.com'
 
 
+import os
 import threading
 
 import mock
 from mock import patch
+from mock import Mock
+
+import scalyr_agent.util as scalyr_util
 
 from scalyr_agent.builtin_monitors.docker_monitor import DockerMonitor
+from scalyr_agent.builtin_monitors.docker_monitor import _get_containers
 from scalyr_agent.test_base import ScalyrTestCase
 from scalyr_agent.test_util import ScalyrTestUtils
 from scalyr_agent.util import FakeClock, FakeClockCounter
-
 
 class DockerMonitorTest(ScalyrTestCase):
     """This test exercises various different user-agent fragments returned by DockerMonitor.
@@ -38,6 +42,111 @@ class DockerMonitorTest(ScalyrTestCase):
     Implemntation:  A MonitorsManager and DockerMonitor is started.  But the docker api lib is completely mocked out.
     The _initialize() method is also mocked with a fake method
     """
+
+    def parse_file_as_json( self, filename ):
+        result = {}
+        with open( filename, 'r' ) as f:
+            content = f.read()
+            result = scalyr_util.json_decode( content )
+        return result
+
+    def get_data_filename( self, name ):
+        base = os.path.dirname( os.path.realpath( __file__ ) )
+        return os.path.join( base, 'data', name )
+
+    def get_mock_docker_client( self, data_file ):
+        filename = self.get_data_filename( data_file )
+        data = self.parse_file_as_json( filename )
+        client = Mock()
+        client.containers.return_value = data
+        return client
+
+    def test_get_containers_no_include_no_exclude( self ):
+        """ Test get containers when no glob filters are applied """
+
+        expected_ids = [
+            "87d533137e70601d17a4bf9d563b11d528ba81e31e2299eb8d4ab2ef5a54f0c0",
+            "84afc8ee4d726544e77dcfe22c6f5be04f36b115ea99c0510d612666f83da1ce",
+            "e511aaf76add81d41c1536b2a93a17448d9f9d3c6a3f8a5abab1d9a582c397fc",
+            "cfcb7f7d1481c805f91fd6c8c120300a586978fa2541a58026bd930eeeda3e36",
+            "b8757266fd6a9efcb40a2881215d8d3642e6f8a0cfdcbb941382d002f31dcca4",
+            "343c05b55c1b0cebca6df0309a4892974c5ed3013731433461ffe7442223659a",
+            "58ded582ebf14063bff3b15cd3962035be9904b73318796f1119d71472801d23",
+            "c4eacccbf687f408c708b12fa875ab55f4d6d0aad8e2eec489ba9712e041bd14",
+        ]
+
+        client = self.get_mock_docker_client( 'containers-running.json' )
+        containers = _get_containers( client )
+
+        self.assertEqual( len(expected_ids), len(containers) )
+
+        for cid in expected_ids:
+            self.assertTrue( cid in containers )
+
+    def test_get_containers_include_no_exclude( self ):
+        """ Test get_containers when an include filter but no exclude filter is applied """
+        expected_ids = [
+            "e511aaf76add81d41c1536b2a93a17448d9f9d3c6a3f8a5abab1d9a582c397fc",
+            "cfcb7f7d1481c805f91fd6c8c120300a586978fa2541a58026bd930eeeda3e36",
+            "58ded582ebf14063bff3b15cd3962035be9904b73318796f1119d71472801d23",
+            "c4eacccbf687f408c708b12fa875ab55f4d6d0aad8e2eec489ba9712e041bd14",
+        ]
+
+        glob_list = {
+            'include': ['*include1*', '*include2*']
+        }
+
+        client = self.get_mock_docker_client( 'containers-running.json' )
+        containers = _get_containers( client, glob_list=glob_list )
+
+        self.assertEqual( len(expected_ids), len(containers) )
+
+        for cid in expected_ids:
+            self.assertTrue( cid in containers )
+
+    def test_get_containers_no_include_exclude( self ):
+        """ Test get_containers when no include filter is applied but an exclude filter is"""
+        expected_ids = [
+            "87d533137e70601d17a4bf9d563b11d528ba81e31e2299eb8d4ab2ef5a54f0c0",
+            "84afc8ee4d726544e77dcfe22c6f5be04f36b115ea99c0510d612666f83da1ce",
+            "b8757266fd6a9efcb40a2881215d8d3642e6f8a0cfdcbb941382d002f31dcca4",
+            "343c05b55c1b0cebca6df0309a4892974c5ed3013731433461ffe7442223659a",
+            "58ded582ebf14063bff3b15cd3962035be9904b73318796f1119d71472801d23",
+            "c4eacccbf687f408c708b12fa875ab55f4d6d0aad8e2eec489ba9712e041bd14",
+        ]
+
+        glob_list = {
+            'exclude': ['*include1-exclude*', '*include2-exclude*']
+        }
+
+        client = self.get_mock_docker_client( 'containers-running.json' )
+        containers = _get_containers( client, glob_list=glob_list )
+
+        self.assertEqual( len(expected_ids), len(containers) )
+
+        for cid in expected_ids:
+            self.assertTrue( cid in containers )
+
+    def test_get_containers_include_exclude( self ):
+        """ Test get_containers when both an include and an exclude filter are applied"""
+        expected_ids = [
+            "b8757266fd6a9efcb40a2881215d8d3642e6f8a0cfdcbb941382d002f31dcca4",
+            "343c05b55c1b0cebca6df0309a4892974c5ed3013731433461ffe7442223659a",
+            "58ded582ebf14063bff3b15cd3962035be9904b73318796f1119d71472801d23",
+            "c4eacccbf687f408c708b12fa875ab55f4d6d0aad8e2eec489ba9712e041bd14",
+        ]
+
+        glob_list = {
+            'include': ['*include*'],
+            'exclude': ['*exclude*']
+        }
+
+        client = self.get_mock_docker_client( 'containers-running.json' )
+        containers = _get_containers( client, glob_list=glob_list )
+        self.assertEqual( len(expected_ids), len(containers) )
+
+        for cid in expected_ids:
+            self.assertTrue( cid in containers )
 
     @mock.patch('scalyr_agent.builtin_monitors.docker_monitor.docker')
     def test_user_agent_fragment(self, mocked_docker):
@@ -153,3 +262,4 @@ class DockerMonitorTest(ScalyrTestCase):
                 manager.stop_manager(wait_on_join=False)
                 fake_clock.advance_time(increment_by=manager_poll_interval)
             start_test()
+


### PR DESCRIPTION
Added the `container_globs_exclude` option to the docker monitor, which is a
blacklist of containers to exclude from monitoring, based on container name.

The blacklist is applied *after* processing `container_globs` to see which
containers should be included.

If `None` then no additional exclusions will be applied.