### PR TITLE
AGENT-125: Daemonset and configMap for envFrom

### DIFF
--- a/k8s/scalyr-agent-2-configmap.yaml
+++ b/k8s/scalyr-agent-2-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  SCALYR_K8S_CLUSTER_NAME: <your_cluster_name>
+  # Add any other Environment variables for environment-aware agent config variables
+  # Most environment variables start with SCALYR_
+  # See https://www.scalyr.com/help/scalyr-agent#environmentAware for more details.
+  # Examples:
+  # K8S_EVENTS_DISABLE: "true"
+metadata:
+  name: scalyr-config
+  namespace: default

--- a/k8s/scalyr-agent-2-envfrom.yaml
+++ b/k8s/scalyr-agent-2-envfrom.yaml
@@ -1,0 +1,57 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: scalyr-agent-2
+spec:
+  template:
+    metadata:
+      labels:
+        app: scalyr-agent-2
+    spec:
+      serviceAccountName: scalyr-service-account
+      containers:
+      - name: scalyr-agent
+        image: scalyr/scalyr-k8s-agent:2.0.46
+        imagePullPolicy: Always
+        env:
+          - name: SCALYR_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: scalyr-api-key
+                key: scalyr-api-key
+        envFrom:
+          - configMapRef:
+              name: scalyr-config
+        resources:
+          limits:
+            memory: 500Mi
+        volumeMounts:
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: varlogpods
+          mountPath: /var/log/pods
+          readOnly: true
+        - name: varlogcontainers
+          mountPath: /var/log/containers
+          readOnly: true
+        - name: dockersock
+          mountPath: /var/scalyr/docker.sock
+      volumes:
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: varlogpods
+        hostPath:
+          path: /var/log/pods
+      - name: varlogcontainers
+        hostPath:
+          path: /var/log/containers
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock
+      # comment this section if you do not want to run on the master
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"


### PR DESCRIPTION
Current k8s Daemonset and instructions for defining configMap do not use envFrom to import all environment variables in a configMap. (Instead, individual variables from a configMap are explicitly mapped to an environment variable) using the env directive.

Now that we support an expanded list of environment variables, we should be directing customers toward the strategy of defining all desired environment variables in the (same) scalyr-config configMap, but instead of selectively mapping the keyvals -> environment variable, we should just stock import all keyvals.

The difference is that the configMap keys must now be the actual environment variable name, not an arbitrary string.

I hope to release this with 2.0.47.
The reason I would like this with 2.0.47 is in a couple of days we will hopefully update Agent docs and I can then refer customers to use these YAMLs.

# Testing

Since this PR simply adds 2 unused YAMLs, it should pose no risk.

Additionally, I manually used these 2 files to launch a test k8s cluster (successfully).  All it took was to 
1) replace <your_cluster_name> 
2) add a SCALYR_SERVER env variable.