### PR TITLE
Add fuzz factors in K8s cache

### DIFF
--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -274,6 +274,14 @@ class Configuration(object):
         return self.__get_config().get_int('k8s_cache_expiry_secs')
 
     @property
+    def k8s_cache_expiry_fuzz_secs(self):
+        return self.__get_config().get_int('k8s_fuzz_cache_expiry_fuzz_secs')
+
+    @property
+    def k8s_cache_start_fuzz_secs(self):
+        return self.__get_config().get_int('k8s_cache_start_fuzz_secs')
+
+    @property
     def k8s_cache_purge_secs(self):
         return self.__get_config().get_int('k8s_cache_purge_secs')
 
@@ -1004,6 +1012,8 @@ class Configuration(object):
         self.__verify_or_set_optional_string(config, 'k8s_api_url', 'https://kubernetes.default', description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_bool(config, 'k8s_verify_api_queries', True, description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_int(config, 'k8s_cache_expiry_secs', 30, description, apply_defaults, env_aware=True)
+        self.__verify_or_set_optional_int(config, 'k8s_cache_expiry_fuzz_secs', 0, description, apply_defaults, env_aware=True)
+        self.__verify_or_set_optional_int(config, 'k8s_cache_start_fuzz_secs', 0, description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_int(config, 'k8s_cache_purge_secs', 300, description, apply_defaults, env_aware=True)
 
         self.__verify_or_set_optional_bool(config, 'disable_send_requests', False, description, apply_defaults, env_aware=True)

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -275,7 +275,7 @@ class Configuration(object):
 
     @property
     def k8s_cache_expiry_fuzz_secs(self):
-        return self.__get_config().get_int('k8s_fuzz_cache_expiry_fuzz_secs')
+        return self.__get_config().get_int('k8s_cache_expiry_fuzz_secs')
 
     @property
     def k8s_cache_start_fuzz_secs(self):

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -997,7 +997,7 @@ class KubernetesCache( object ):
             # Fuzz how much time we spend until the next cycle.  This should spread out when the agents query the
             # API master over time in clusters with a larger number of agents.
             if local_state.cache_expiry_fuzz_secs > 0:
-                fuzz_factor = random.uniform(0, local_state.cache_expiry_fuzz_secs)
+                fuzz_factor = max(random.uniform(0, local_state.cache_expiry_fuzz_secs), 0)
             else:
                 fuzz_factor = 0
             run_state.sleep_but_awaken_if_stopped( local_state.cache_expiry_secs - fuzz_factor )


### PR DESCRIPTION
To avoid query stampeding the API master, fuzz when
we issue queries to fill and revalidate the cache.

We have two separate controls, one for the start delay
and one for the revalidation.

These are default to off.  We will evaulate if we need
to set them based on K8s cluster size.