### PR TITLE
Imron/k8s profiling

### DIFF
--- a/docker/Dockerfile.profile
+++ b/docker/Dockerfile.profile
@@ -1,0 +1,18 @@
+# base image that creates all necessary dependencies for
+# the scalyr-agent
+# NOTE: multi-stage builds require Docker 17.05 or greater
+FROM python:2.7-alpine3.9 as scalyr-dependencies
+MAINTAINER Scalyr Inc <support@scalyr.com>
+
+RUN apk --update add build-base python-dev gcc
+RUN pip --no-cache-dir install --root /tmp/dependencies ujson yappi
+
+# main image - copies dependencies from scalyr-dependencies and extracts
+# the tar-zipped file containing the scalyr-agent code
+FROM python:2.7-alpine3.9 as scalyr
+MAINTAINER Scalyr Inc <support@scalyr.com>
+
+COPY --from=scalyr-dependencies  /tmp/dependencies/ /
+ADD scalyr-k8s-agent.tar.gz /
+
+CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -62,6 +62,7 @@ scalyr_logging.set_log_destination(use_stdout=True)
 
 from optparse import OptionParser
 
+from scalyr_agent.profiler import Profiler
 from scalyr_agent.scalyr_client import ScalyrClientSession
 from scalyr_agent.copying_manager import CopyingManager
 from scalyr_agent.configuration import Configuration
@@ -757,10 +758,14 @@ class ScalyrAgent(object):
 
                 prev_server = scalyr_server
 
+                profiler = Profiler( self.__config )
+
                 while not self.__run_state.sleep_but_awaken_if_stopped( config_change_check_interval ):
 
                     current_time = time.time()
                     self.__last_config_check_time = current_time
+
+                    profiler.update( self.__config, current_time )
 
                     if self.__config.disable_overall_stats:
                         log.log( scalyr_logging.DEBUG_LEVEL_0, "overall stats disabled" )

--- a/scalyr_agent/builtin_monitors/docker_monitor.py
+++ b/scalyr_agent/builtin_monitors/docker_monitor.py
@@ -703,9 +703,9 @@ class ContainerChecker( StoppableThread ):
         for log in docker_logs:
             if self.__log_watcher:
                 try:
-                    log['log_config'] = self.__log_watcher.add_log_config( self.__module, log['log_config'] )
+                    log['log_config'] = self.__log_watcher.add_log_config( self.__module.module_name, log['log_config'] )
                 except Exception, e:
-                    global_log.info( "Error adding log '%s' to log watcher - %s", log['log_config']['path'], str(e) )
+                    global_log.info( "Error adding log '%s' to log watcher - %s" % (log['log_config']['path'], e) )
 
             if self._use_raw_logs:
                 self.raw_logs.append( log )

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -1119,7 +1119,7 @@ class ContainerChecker( StoppableThread ):
     def __start_docker_logs( self, docker_logs ):
         for log in docker_logs:
             if self.__log_watcher:
-                log['log_config'] = self.__log_watcher.add_log_config( self.__module, log['log_config'] )
+                log['log_config'] = self.__log_watcher.add_log_config( self.__module.module_name, log['log_config'] )
 
             self.raw_logs.append( log )
 
@@ -1845,6 +1845,8 @@ class KubernetesMonitor( ScalyrMonitor ):
                 if k8s_extra is not None:
                     k8s_extra.update( cluster_info )
                     k8s_extra.update({'pod_uid': info['name']})
+                else:
+                    k8s_extra = {}
             self.__gather_metrics_from_api_for_container( info['name'], k8s_extra )
 
     def __gather_k8s_metrics_for_node( self, node, extra ):

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -809,7 +809,7 @@ class SyslogHandler(object):
                     if info['logger']:
                         # add it to the main scalyr log watcher
                         if watcher and module:
-                            info['log_config'] = watcher.add_log_config( module, info['log_config'] )
+                            info['log_config'] = watcher.add_log_config( module.module_name, info['log_config'] )
 
                         # and keep a record for ourselves
                         self.__docker_loggers[cname] = info

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1045,11 +1045,11 @@ class Configuration(object):
 
         self.__verify_or_set_optional_bool(config, 'disable_send_requests', False, description, apply_defaults, env_aware=True)
 
-        self.__verify_or_set_optional_bool(config, 'enable_profiling', True, description, apply_defaults)
-        self.__verify_or_set_optional_int(config, 'max_profile_interval_minutes', 60, description, apply_defaults)
-        self.__verify_or_set_optional_int(config, 'profile_duration_minutes', 2, description, apply_defaults)
-        self.__verify_or_set_optional_string(config, 'profile_clock', 'random', description, apply_defaults)
-        self.__verify_or_set_optional_string(config, 'profile_log_name', 'agent.callgrind', description, apply_defaults)
+        self.__verify_or_set_optional_bool(config, 'enable_profiling', True, description, apply_defaults, env_aware=True)
+        self.__verify_or_set_optional_int(config, 'max_profile_interval_minutes', 60, description, apply_defaults, env_aware=True)
+        self.__verify_or_set_optional_int(config, 'profile_duration_minutes', 2, description, apply_defaults, env_aware=True)
+        self.__verify_or_set_optional_string(config, 'profile_clock', 'random', description, apply_defaults, env_aware=True)
+        self.__verify_or_set_optional_string(config, 'profile_log_name', 'agent.callgrind', description, apply_defaults, env_aware=True)
 
         #Debug leak flags
         self.__verify_or_set_optional_bool(config, 'disable_leak_monitor_threads', False, description, apply_defaults)

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -183,6 +183,12 @@ class Configuration(object):
             if agent_log is not None:
                 self.__log_configs.append(agent_log)
 
+            # add in the profile log if we have enabled profiling
+            if self.enable_profiling:
+                profile_config = JsonObject(path=self.profile_log_name, copy_from_start=True, staleness_threshold_secs=20*60, parser='scalyrAgentProfiling')
+                self.__verify_log_entry_and_set_defaults(profile_config, description='profile log config')
+                self.__log_configs.append( profile_config )
+
             self.__monitor_configs = list(self.__config.get_json_array('monitors'))
 
         except BadConfiguration, e:
@@ -285,6 +291,27 @@ class Configuration(object):
     def k8s_cache_purge_secs(self):
         return self.__get_config().get_int('k8s_cache_purge_secs')
 
+    @property
+    def enable_profiling( self ):
+        return self.__get_config().get_bool( 'enable_profiling' )
+
+    @property
+    def max_profile_interval_minutes( self ):
+        return self.__get_config().get_int( 'max_profile_interval_minutes' )
+
+    @property
+    def profile_duration_minutes( self ):
+        return self.__get_config().get_int( 'profile_duration_minutes' )
+
+    @property
+    def profile_clock( self ):
+        return self.__get_config().get_string( 'profile_clock' )
+
+    @property
+    def profile_log_name( self ):
+        return self.__get_config().get_string( 'profile_log_name' )
+
+    # Debug leak flags
     @property
     def disable_send_requests(self):
         return self.__get_config().get_bool('disable_send_requests')
@@ -1017,6 +1044,13 @@ class Configuration(object):
         self.__verify_or_set_optional_int(config, 'k8s_cache_purge_secs', 300, description, apply_defaults, env_aware=True)
 
         self.__verify_or_set_optional_bool(config, 'disable_send_requests', False, description, apply_defaults, env_aware=True)
+
+        self.__verify_or_set_optional_bool(config, 'enable_profiling', True, description, apply_defaults)
+        self.__verify_or_set_optional_int(config, 'max_profile_interval_minutes', 120, description, apply_defaults)
+        self.__verify_or_set_optional_int(config, 'profile_duration_minutes', 10, description, apply_defaults)
+        self.__verify_or_set_optional_string(config, 'profile_clock', 'random', description, apply_defaults)
+        self.__verify_or_set_optional_string(config, 'profile_log_name', 'agent.callgrind', description, apply_defaults)
+
 
         #Debug leak flags
         self.__verify_or_set_optional_bool(config, 'disable_leak_monitor_threads', False, description, apply_defaults)

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1046,11 +1046,10 @@ class Configuration(object):
         self.__verify_or_set_optional_bool(config, 'disable_send_requests', False, description, apply_defaults, env_aware=True)
 
         self.__verify_or_set_optional_bool(config, 'enable_profiling', True, description, apply_defaults)
-        self.__verify_or_set_optional_int(config, 'max_profile_interval_minutes', 120, description, apply_defaults)
-        self.__verify_or_set_optional_int(config, 'profile_duration_minutes', 10, description, apply_defaults)
+        self.__verify_or_set_optional_int(config, 'max_profile_interval_minutes', 60, description, apply_defaults)
+        self.__verify_or_set_optional_int(config, 'profile_duration_minutes', 2, description, apply_defaults)
         self.__verify_or_set_optional_string(config, 'profile_clock', 'random', description, apply_defaults)
         self.__verify_or_set_optional_string(config, 'profile_log_name', 'agent.callgrind', description, apply_defaults)
-
 
         #Debug leak flags
         self.__verify_or_set_optional_bool(config, 'disable_leak_monitor_threads', False, description, apply_defaults)

--- a/scalyr_agent/copying_manager.py
+++ b/scalyr_agent/copying_manager.py
@@ -289,23 +289,24 @@ class CopyingManager(StoppableThread, LogWatcher):
 
         return None
 
-    def add_log_config( self, monitor, log_config ):
+    def add_log_config( self, monitor_name, log_config ):
         """Add the log_config item to the list of paths being watched
-        params: log_config - a log_config object containing the path to be added
+        param: monitor_name - the name of the monitor adding the log config
+        param: log_config - a log_config object containing the path to be added
         returns: an updated log_config object
         """
-        log_config = self.__config.parse_log_config( log_config, default_parser='agent-metrics', context_description='Additional log entry requested by module "%s"' % monitor.module_name).copy()
+        log_config = self.__config.parse_log_config( log_config, default_parser='agent-metrics', context_description='Additional log entry requested by module "%s"' % monitor_name).copy()
 
         self.__lock.acquire()
         try:
             path = self.__path_in_globs( log_config['path'], self.__all_paths.keys() )
             if path is None:
-                log.log(scalyr_logging.DEBUG_LEVEL_0, 'Adding new log file \'%s\' for monitor \'%s\'' % (log_config['path'], monitor.module_name ) )
+                log.log(scalyr_logging.DEBUG_LEVEL_0, 'Adding new log file \'%s\' for monitor \'%s\'' % (log_config['path'], monitor_name ) )
                 self.__pending_log_matchers.append( LogMatcher( self.__config, log_config ) )
                 self.__all_paths[log_config['path']] = 1
                 path = log_config['path']
             else:
-                log.log(scalyr_logging.DEBUG_LEVEL_0, 'New log file \'%s\' already matches \'%s\' for monitor \'%s\'' % (log_config['path'], path, monitor.module_name ) )
+                log.log(scalyr_logging.DEBUG_LEVEL_0, 'New log file \'%s\' already matches \'%s\' for monitor \'%s\'' % (log_config['path'], path, monitor_name ) )
                 # log_config['path'] and path will not be equal if log_config['path'] matched path
                 # because of a glob pattern.  They will only be equal if they are the exact same path.
                 # We want to ignore any added paths that match a glob pattern, and so we skip over incrementing the path count

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -1559,15 +1559,16 @@ class LogFileProcessor(object):
             self.__last_scan_time = current_time
             self.__lock.release()
 
-        # Check to see if we haven't had a success in enough time.  If so, then we just skip ahead.
-        if current_time - self.__last_success > self.__copy_staleness_threshold:
-            self.skip_to_end('Too long since last success.  Last success was \'%s\'' % scalyr_util.format_time(
-                self.__last_success), 'skipForStaleness', current_time=current_time)
-        # Also make sure we are at least within 5MB of the tail of the log.  If not, then we skip ahead.
-        elif self.__log_file_iterator.available > self.__max_log_offset_size:
-            self.skip_to_end(
-                'Too far behind end of log.  Num of bytes to end is %ld' % self.__log_file_iterator.available,
-                'skipForTooFarBehind', current_time=current_time)
+        if not self.__path.endswith( 'agent.callgrind' ):
+            # Check to see if we haven't had a success in enough time.  If so, then we just skip ahead.
+            if current_time - self.__last_success > self.__copy_staleness_threshold:
+                self.skip_to_end('Too long since last success.  Last success was \'%s\'' % scalyr_util.format_time(
+                    self.__last_success), 'skipForStaleness', current_time=current_time)
+            # Also make sure we are at least within 5MB of the tail of the log.  If not, then we skip ahead.
+            elif self.__log_file_iterator.available > self.__max_log_offset_size:
+                self.skip_to_end(
+                    'Too far behind end of log.  Num of bytes to end is %ld' % self.__log_file_iterator.available,
+                    'skipForTooFarBehind', current_time=current_time)
 
         # Keep track of both the position in the iterator and where we are about to add new events to the request,
         # in case we have to roll it back.

--- a/scalyr_agent/log_watcher.py
+++ b/scalyr_agent/log_watcher.py
@@ -22,9 +22,9 @@ class LogWatcher( object ):
     to add/remove a set of log paths
     """
 
-    def add_log_config( self, monitor, log_config ):
+    def add_log_config( self, monitor_name, log_config ):
         """Add the path specified by the log_config to the list of paths being watched
-        param: monitor - the monitor adding the log_config
+        param: monitor_name - the name of the monitor adding the log_config
         param: log_config - a log_config object containing at least a path
         returns: the log_config variable with updated path and default information
         """

--- a/scalyr_agent/profiler.py
+++ b/scalyr_agent/profiler.py
@@ -1,0 +1,153 @@
+# Copyright 2018 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+# author:  Imron Alston <imron@scalyr.com>
+
+__author__ = 'imron@scalyr.com'
+
+import errno
+import os
+import random
+from scalyr_agent.json_lib import JsonObject
+import scalyr_agent.scalyr_logging as scalyr_logging
+import time
+import traceback
+
+try:
+    import yappi
+except ImportError:
+    yappi = None
+
+global_log = scalyr_logging.getLogger(__name__)
+
+class Profiler( object ):
+    """
+        Profiles the agent
+    """
+
+    def __init__( self, config ):
+
+        enable_profiling = config.enable_profiling
+
+        if enable_profiling:
+            if yappi is None:
+                global_log.warning( "Profiling is enabled, but the `yappi` module couldn't be loaded. "
+                                    "You need to install `yappi` in order to use profiling.  This can be done "
+                                    "via pip:  pip install yappi" )
+
+        self._is_enabled = False
+        self._allowed_clocks = [ 'wall', 'cpu', 'random' ]
+        self._profile_clock = self._get_clock_type( config.profile_clock, self._allowed_clocks, config.profile_clock )
+
+        # random is only allowed during initialization, and not via config file changes to
+        # ensure the random clock is consistent for the life of the agent.
+        # random clocks can still be manually overridden in the agent.json
+        self._allowed_clocks = self._allowed_clocks[:2]
+
+        self._profile_start = 0
+        self._profile_end = 0
+
+    def _get_clock_type( self, clock_type, allowed, default_value ):
+        """
+            gets the clock type.  If clock type is `random` then
+            randomly choose from the first 2 elements of the `allowed` array.
+        """
+        result = default_value
+        if clock_type in allowed:
+            result = clock_type
+
+        if result == 'random':
+            r = random.randint( 0, 1 )
+            result = allowed[r]
+
+        return result
+
+    def _get_random_start_time( self, current_time, maximum_interval_minutes ):
+        if maximum_interval_minutes < 1:
+            maximum_interval_minutes = 1
+        r = random.randint( 1, maximum_interval_minutes ) * 60
+        return current_time + r
+
+    def _update_start_interval( self, config, current_time ):
+        self._profile_start = self._get_random_start_time( current_time, config.max_profile_interval_minutes )
+        self._profile_end = self._profile_start + (config.profile_duration_minutes * 60)
+
+    def _start( self, config, current_time ):
+
+        yappi.clear_stats()
+        clock = self._get_clock_type( config.profile_clock, self._allowed_clocks, self._profile_clock )
+        if clock != self._profile_clock:
+            self._profile_clock = clock
+            yappi.set_clock_type( self._profile_clock )
+        global_log.log( scalyr_logging.DEBUG_LEVEL_0, "Starting profiling using '%s' clock. Duration: %d seconds" % (self._profile_clock, self._profile_end - self._profile_start) )
+        yappi.start()
+
+    def _stop( self, config, current_time ):
+        yappi.stop()
+        global_log.log( scalyr_logging.DEBUG_LEVEL_0, 'Stopping profiling' )
+        stats = yappi.get_func_stats()
+        path = os.path.join( config.agent_log_path, config.profile_log_name )
+        if os.path.exists( path ):
+            os.remove( path )
+        stats.save( path, 'callgrind' )
+
+        f = open( path, "a" )
+        if f:
+            f.write( "\n" )
+            f.close()
+
+        yappi.clear_stats()
+        del stats
+
+    def update( self, config, current_time=None ):
+        """
+            Updates the state of the profiler - either enabling or disabling it, based on
+            the current time and whether or not the current profiling interval has started/stopped
+        """
+        # no profiling if the profiler isn't available
+        if yappi is None:
+            return
+
+        if current_time is None:
+            current_time = time.time()
+
+        try:
+            # check if profiling is enabled in the config and turn it on/off if necessary
+            if config.enable_profiling:
+                if not self._is_enabled:
+                    self._update_start_interval( config, current_time )
+                    self._is_enabled = True
+            else:
+                if yappi.is_running():
+                    self._stop( config, current_time )
+                self._is_enabled = False
+
+            # only do profiling if we are still enabled
+            if not self._is_enabled:
+                return
+
+            # check if the current profiling interval needs to start or stop
+            if yappi.is_running():
+                if current_time > self._profile_end:
+                    self._stop( config, current_time )
+                    self._update_start_interval( config, current_time )
+
+            else:
+                if current_time > self._profile_start:
+                    self._start( config, current_time )
+        except Exception, e:
+            global_log.log( scalyr_logging.DEBUG_LEVEL_0, 'Failed to update profiler: %s, %s' % (str(e), traceback.format_exc() ),
+                            limit_once_per_x_secs=300,
+                            limit_key='profiler-update')
+

--- a/scalyr_agent/profiler.py
+++ b/scalyr_agent/profiler.py
@@ -102,10 +102,16 @@ class Profiler( object ):
             os.remove( path )
         stats.save( path, 'callgrind' )
 
-        f = open( path, "a" )
-        if f:
-            f.write( "\n" )
-            f.close()
+        lines = 0
+
+        # count the lines
+        with open(path) as f:
+            for line in f:
+                lines += 1
+
+        # write a status message to make it easy to find the end of each profile session
+        with open( path, "a" ) as f:
+            f.write( "\n# %s, %s clock, total lines: %d\n" % (path, self._profile_clock, lines) )
 
         yappi.clear_stats()
         del stats


### PR DESCRIPTION
This pull request adds the profiling code from our last round of profiling.  At the time it was decided not to merge it in to master, but perhaps that something to consider going forward?

Anyway, profiling can be turned on via the `enable_profiling` global configuration option.  There are also configuration options that can set the amount of time to profile for (`profile_duration_minutes` defaults to `2`) and the interval to wait between profiling sessions (`max_profile_interval_minutes` defaults to `60`)

There are a couple of other options, for setting the name of the log file containing profiling data (defaults to `agent.callgrind`) and also which clock to use for profiling (defaults to `random`, other options are `wall` and `cpu`.  Random will randomly pick `wall` or `cpu`).