### PR TITLE
Fix Metric object memory leak

### DIFF
--- a/scalyr_agent/builtin_monitors/linux_process_metrics.py
+++ b/scalyr_agent/builtin_monitors/linux_process_metrics.py
@@ -113,6 +113,12 @@ class Metric(object):
     """
     __slots__ = 'name', 'type', '_frozen'
 
+    def __hash__(self):
+        return hash(self.name) + 13 * hash(self.type)
+
+    def __eq__(self, other):
+        return other.name == self.name and other.type == self.type
+
     def __init__(self, name, _type):
         self.name = name
         self.type = _type


### PR DESCRIPTION
# Background

I forgot to implement __hash__ and __eq__ for the `Metric` class when fixing our unit tests to work with earlier versions of Python. 

The `Metric` object was being used as keys in a dictionary.  Without those proper dunder methods the dictionary just keeps growing.

This manifests as multiple duplicate metrics (of the same key), leading to eventual omission by the Agent (which has protections against too much metrics data).  This symptom can be seen in the uploaded logs as follows:

**/var/log/scalyr-agent-2/linux_process_metrics.log .... Warning, skipped writing 810 log lines due to limit set by `monitor_log_write_rate` option...`**

# Fix

Implement __eq__ and __hash__

# Tests

A straightforward unit test that asserts a dictionary doesn't grow with repeat puts to the same key

