### PR TITLE
Downcast Metric hash long to int for python 2.4

### DIFF
--- a/scalyr_agent/builtin_monitors/linux_process_metrics.py
+++ b/scalyr_agent/builtin_monitors/linux_process_metrics.py
@@ -29,6 +29,7 @@ __author__ = 'czerwin@scalyr.com'
 import os
 import errno
 import re
+import sys
 import time
 from subprocess import Popen, PIPE
 
@@ -114,7 +115,8 @@ class Metric(object):
     __slots__ = 'name', 'type', '_frozen'
 
     def __hash__(self):
-        return hash(self.name) + 13 * hash(self.type)
+        x = hash(self.name) + 13 * hash(self.type)
+        return x % sys.maxint
 
     def __eq__(self, other):
         return other.name == self.name and other.type == self.type


### PR DESCRIPTION
Unittest 24 are failing from recent Metric memory leak.
This PR fixes that for 2.4 by limiting via modulo.