### PR TITLE
Make docker config params environment-aware

### DIFF
--- a/scalyr_agent/all_tests.py
+++ b/scalyr_agent/all_tests.py
@@ -57,6 +57,7 @@ PYTHON24_WHITELIST = [
 ]
 
 PRE_PYTHON27_WHITELIST = [
+    'scalyr_agent.tests.configuration_docker_test',
     'scalyr_agent.tests.configuration_k8s_test',
     'scalyr_agent.builtin_monitors.tests.docker_monitor_test',
     'scalyr_agent.builtin_monitors.tests.kubernetes_monitor_test',

--- a/scalyr_agent/builtin_monitors/docker_monitor.py
+++ b/scalyr_agent/builtin_monitors/docker_monitor.py
@@ -80,13 +80,13 @@ define_config_option( __monitor__, 'docker_log_prefix',
 define_config_option( __monitor__, 'max_previous_lines',
                      'Optional (defaults to 5000). The maximum number of lines to read backwards from the end of the stdout/stderr logs\n'
                      'when starting to log a containers stdout/stderr to find the last line that was sent to Scalyr.',
-                     convert_to=int, default=5000, env_aware=True, env_name='SCALYR_DOCKER_MAX_PREVIOUS_LINES')
+                     convert_to=int, default=5000)
 
 define_config_option( __monitor__, 'readback_buffer_size',
                      'Optional (defaults to 5k). The maximum number of bytes to read backwards from the end of any log files on disk\n'
                      'when starting to log a containers stdout/stderr.  This is used to find the most recent timestamp logged to file '
                      'was sent to Scalyr.',
-                     convert_to=int, default=5*1024, env_aware=True, env_name='SCALYR_DOCKER_READBACK_BUFFER_SIZE')
+                     convert_to=int, default=5*1024)
 
 define_config_option( __monitor__, 'log_mode',
                      'Optional (defaults to "docker_api"). Determine which method is used to gather logs from the '

--- a/scalyr_agent/builtin_monitors/docker_monitor.py
+++ b/scalyr_agent/builtin_monitors/docker_monitor.py
@@ -57,7 +57,7 @@ define_config_option( __monitor__, 'container_name',
 
 define_config_option( __monitor__, 'container_check_interval',
                      'Optional (defaults to 5). How often (in seconds) to check if containers have been started or stopped.',
-                     convert_to=int, default=5)
+                     convert_to=int, default=5, env_aware=True)
 
 define_config_option( __monitor__, 'api_socket',
                      'Optional (defaults to /var/scalyr/docker.sock). Defines the unix socket used to communicate with '
@@ -71,22 +71,22 @@ define_config_option( __monitor__, 'docker_api_version',
                      'Optional (defaults to \'auto\'). The version of the Docker API to use.  WARNING, if you have '
                      '`mode` set to `syslog`, you must also set the `docker_api_version` configuration option in the '
                      'syslog monitor to this same value\n',
-                     convert_to=str, default='auto')
+                     convert_to=str, default='auto', env_aware=True)
 
 define_config_option( __monitor__, 'docker_log_prefix',
                      'Optional (defaults to docker). Prefix added to the start of all docker logs. ',
-                     convert_to=str, default='docker')
+                     convert_to=str, default='docker', env_aware=True)
 
 define_config_option( __monitor__, 'max_previous_lines',
                      'Optional (defaults to 5000). The maximum number of lines to read backwards from the end of the stdout/stderr logs\n'
                      'when starting to log a containers stdout/stderr to find the last line that was sent to Scalyr.',
-                     convert_to=int, default=5000)
+                     convert_to=int, default=5000, env_aware=True, env_name='SCALYR_DOCKER_MAX_PREVIOUS_LINES')
 
 define_config_option( __monitor__, 'readback_buffer_size',
                      'Optional (defaults to 5k). The maximum number of bytes to read backwards from the end of any log files on disk\n'
                      'when starting to log a containers stdout/stderr.  This is used to find the most recent timestamp logged to file '
                      'was sent to Scalyr.',
-                     convert_to=int, default=5*1024)
+                     convert_to=int, default=5*1024, env_aware=True, env_name='SCALYR_DOCKER_READBACK_BUFFER_SIZE')
 
 define_config_option( __monitor__, 'log_mode',
                      'Optional (defaults to "docker_api"). Determine which method is used to gather logs from the '
@@ -95,64 +95,63 @@ define_config_option( __monitor__, 'log_mode',
                      'to push logs to this one using the Docker syslog logging driver.  Currently, "syslog" is the '
                      'preferred method due to bugs/issues found with the docker API (To protect legacy behavior, '
                      'the default method is "docker_api").',
-                     convert_to=str, default="docker_api")
+                     convert_to=str, default="docker_api", env_aware=True, env_name='SCALYR_DOCKER_LOG_MODE')
 
 define_config_option( __monitor__, 'docker_raw_logs',
                      'Optional (defaults to False). If True, the docker monitor will use the raw log files on disk to read logs.'
                      'The location of the raw log file is obtained by querying the path from the Docker API. '
                      'If false, the logs will be streamed over the Docker API.',
-                     convert_to=bool,
-                     default=False)
+                     convert_to=bool, default=False, env_aware=True)
 
 define_config_option( __monitor__, 'metrics_only',
                      'Optional (defaults to False). If true, the docker monitor will only log docker metrics and not any other information '
                      'about running containers.  If set to true, this value overrides the config item \'report_container_metrics\'\n',
-                     convert_to=bool, default=False)
+                     convert_to=bool, default=False, env_aware=True, env_name='SCALYR_DOCKER_METRICS_ONLY')
 
 define_config_option( __monitor__, 'container_globs',
                      'Optional (defaults to None). A whitelist of container name glob patterns to monitor.  Only containers whose name '
                      'matches one of the glob patterns will be monitored.  If `None`, all container names are matched.  This value '
                      'is applied *before* `container_globs_exclude`',
-                      convert_to=ArrayOfStrings, default=None)
+                      convert_to=ArrayOfStrings, default=None, env_aware=True)
 
 define_config_option( __monitor__, 'container_globs_exclude',
                      'Optional (defaults to None). A blacklist of container name glob patterns to exclude from monitoring.  Any container whose name '
                      'matches one of the glob patterns will not be monitored.  If `None`, all container names matched by `container_globs` are monitored.  This value '
                      'is applied *after* `container_globs`',
-                      convert_to=ArrayOfStrings, default=None)
+                      convert_to=ArrayOfStrings, default=None, env_aware=True)
 
 define_config_option( __monitor__, 'report_container_metrics',
                       'Optional (defaults to True). If true, metrics will be collected from the container and reported  '
-                      'to Scalyr.', convert_to=bool, default=True)
+                      'to Scalyr.', convert_to=bool, default=True, env_aware=True)
 
 define_config_option( __monitor__, 'label_include_globs',
                      'Optional (defaults to [\'*\']). If `labels_as_attributes` is True then this option is a list of glob strings used to '
-                     'include labels that should be uploadeded as log attributes.  The docker monitor first gets all container labels that '
+                     'include labels that should be uploaded as log attributes.  The docker monitor first gets all container labels that '
                      'match any glob in this list and then filters out any labels that match any glob in `label_exclude_globs`, and the final list is then '
                      'uploaded as log attributes. ',
-                      default=['*'])
+                      convert_to=ArrayOfStrings, default=['*'], env_aware=True)
 
 define_config_option( __monitor__, 'label_exclude_globs',
                      'Optional (defaults to [\'com.scalyr.config.*\']). If `labels_as_attributes` is True, then this is a list of glob strings used to '
                      'exclude labels from being uploaded as log attributes.  Any label whose key matches any glob on this list will not be added as a '
                      'log attribute.  Note: the globs in this list are applied *after* `label_include_globs`',
-                      default=['com.scalyr.config.*'])
+                      convert_to=ArrayOfStrings, default=['com.scalyr.config.*'], env_aware=True)
 
 define_config_option( __monitor__, 'labels_as_attributes',
                      'Optional (defaults to False). If true, the docker monitor will add any labels found on the container as log attributes, after '
                      'applying `label_include_globs` and `label_exclude_globs`.',
-                     convert_to=bool, default=False)
+                     convert_to=bool, default=False, env_aware=True)
 
 define_config_option( __monitor__, 'label_prefix',
                      'Optional (defaults to ""). If `labels_as_attributes` is true, then append this prefix to the start of each label before '
                      'adding it to the log attributes ',
-                     convert_to=str, default="")
+                     convert_to=str, default="", env_aware=True)
 
 define_config_option( __monitor__, 'use_labels_for_log_config',
                      'Optional (defaults to True). If true, the docker monitor will check each container for any labels that begin with '
                      '`com.scalyr.config.log.` and use those labels (minus the prefix) as fields in the containers log_config.  Keys that '
                      'contain hyphens will automatically be converted to underscores.',
-                     convert_to=bool, default=True)
+                     convert_to=bool, default=True, env_aware=True)
 
 # for now, always log timestamps to help prevent a race condition
 #define_config_option( __monitor__, 'log_timestamps',

--- a/scalyr_agent/tests/configuration_docker_test.py
+++ b/scalyr_agent/tests/configuration_docker_test.py
@@ -49,8 +49,6 @@ class TestConfigurationDocker(TestConfiguration):
             "container_check_interval": (STANDARD_PREFIX, TEST_INT, int),
             "docker_api_version": (STANDARD_PREFIX, TEST_STRING, str),
             "docker_log_prefix": (STANDARD_PREFIX, TEST_STRING, str),
-            "max_previous_lines": ('SCALYR_DOCKER_MAX_PREVIOUS_LINES', TEST_INT, int),
-            "readback_buffer_size": ('SCALYR_DOCKER_READBACK_BUFFER_SIZE', TEST_INT, int),
             "log_mode": ('SCALYR_DOCKER_LOG_MODE', TEST_STRING, str),
             "docker_raw_logs": (STANDARD_PREFIX, False, bool),  # test config file is set to True
             "metrics_only": ('SCALYR_DOCKER_METRICS_ONLY', True, bool),

--- a/scalyr_agent/tests/configuration_docker_test.py
+++ b/scalyr_agent/tests/configuration_docker_test.py
@@ -1,0 +1,187 @@
+import os
+from mock import patch, Mock
+
+from scalyr_agent import scalyr_monitor
+from scalyr_agent.builtin_monitors.docker_monitor import DockerMonitor
+from scalyr_agent.copying_manager import CopyingManager
+from scalyr_agent.monitors_manager import MonitorsManager
+from scalyr_agent.json_lib.objects import ArrayOfStrings
+from scalyr_agent.test_util import FakeAgentLogger, FakePlatform
+from scalyr_agent.tests.configuration_test import TestConfiguration
+
+
+class TestConfigurationDocker(TestConfiguration):
+    """This test subclasses from TestConfiguration for easier exclusion in python 2.5 and below"""
+
+    @patch('scalyr_agent.builtin_monitors.docker_monitor.docker')
+    def test_environment_aware_module_params(self, mock_docker):
+
+        # Define test values here for all k8s and k8s_event monitor config params that are environment aware.
+        # Be sure to use non-default test values
+        TEST_INT = 123456789
+        TEST_STRING = 'dummy string'
+        TEST_ARRAY_OF_STRINGS = ['s1', 's2', 's3']
+        STANDARD_PREFIX = '_STANDARD_PREFIX_'  # env var is SCALYR_<param_name>
+
+        # The following map contains config params to be tested
+        # config_param_name: (custom_env_name, test_value)
+        docker_testmap = {
+            "container_check_interval": (STANDARD_PREFIX, TEST_INT, int),
+            "docker_api_version": (STANDARD_PREFIX, TEST_STRING, str),
+            "docker_log_prefix": (STANDARD_PREFIX, TEST_STRING, str),
+            "max_previous_lines": ('SCALYR_DOCKER_MAX_PREVIOUS_LINES', TEST_INT, int),
+            "readback_buffer_size": ('SCALYR_DOCKER_READBACK_BUFFER_SIZE', TEST_INT, int),
+            "log_mode": ('SCALYR_DOCKER_LOG_MODE', TEST_STRING, str),
+            "docker_raw_logs": (STANDARD_PREFIX, False, bool),  # test config file is set to True
+            "metrics_only": ('SCALYR_DOCKER_METRICS_ONLY', True, bool),
+            "container_globs": (STANDARD_PREFIX, TEST_ARRAY_OF_STRINGS, ArrayOfStrings),
+            "container_globs_exclude": (STANDARD_PREFIX, TEST_ARRAY_OF_STRINGS, ArrayOfStrings),
+            "report_container_metrics": (STANDARD_PREFIX, False, bool),
+            "label_include_globs": (STANDARD_PREFIX, TEST_ARRAY_OF_STRINGS, ArrayOfStrings),
+            "label_exclude_globs": (STANDARD_PREFIX, TEST_ARRAY_OF_STRINGS, ArrayOfStrings),
+            "labels_as_attributes": (STANDARD_PREFIX, True, bool),
+            "label_prefix": (STANDARD_PREFIX, TEST_STRING, str),
+            "use_labels_for_log_config": (STANDARD_PREFIX, False, bool),
+        }
+
+        # Fake the environment varaibles
+        for key, value in docker_testmap.items():
+            custom_name = value[0]
+            env_name = ('SCALYR_%s' % key).upper() if custom_name == STANDARD_PREFIX else custom_name.upper()
+            envar_value = str(value[1])
+            if value[2] == ArrayOfStrings:
+                # Array of strings should be entered into environment in the user-preferred format
+                # which is without square brackets and quotes around each element
+                envar_value = envar_value[1:-1]  # strip square brackets
+                envar_value = envar_value.replace("'", '')
+            else:
+                envar_value = envar_value.lower()  # lower() needed for proper bool encoding
+            os.environ[env_name] = envar_value
+
+        self._write_file_with_separator_conversion(""" {
+            logs: [ { path:"/var/log/tomcat6/$DIR_VAR.log" }],
+            api_key: "abcd1234",
+        }      
+        """)
+        self._write_config_fragment_file_with_separator_conversion('docker.json', """ {
+            "monitors": [
+                {
+                    module: "scalyr_agent.builtin_monitors.docker_monitor",
+                    docker_raw_logs: true
+                }
+            ]
+        }
+        """)
+
+        config = self._create_test_configuration_instance()
+        config.parse()
+
+        # echee TODO: once AGENT-40 docker PR merges in, some of the test-setup code below can be eliminated and
+        # reused from that PR (I moved common code into scalyr_agent/test_util
+        def fake_init(self):
+            # Initialize some requisite variables so that the k8s monitor loop can run
+            self._DockerMonitor__socket_file = None
+            self._DockerMonitor__container_checker = None
+            self._DockerMonitor__namespaces_to_ignore = []
+            self._DockerMonitor__include_controller_info = None
+            self._DockerMonitor__report_container_metrics = None
+            self._DockerMonitor__metric_fetcher = None
+
+        mock_logger = Mock()
+
+        @patch.object(DockerMonitor, '_initialize', new=fake_init)
+        def create_manager():
+            scalyr_monitor.log = mock_logger
+            return MonitorsManager(config, FakePlatform([]))
+
+        monitors_manager = create_manager()
+        docker_monitor = monitors_manager.monitors[0]
+
+        # All environment-aware params defined in the docker monitor must be gested
+        self.assertEquals(
+            set(docker_testmap.keys()),
+            set(docker_monitor._config._environment_aware_map.keys()))
+
+        # Verify module-level conflicts between env var and config file are logged at module-creation time
+        mock_logger.warn.assert_called_with(
+            'Conflicting values detected between scalyr_agent.builtin_monitors.docker_monitor config file '
+            'parameter `docker_raw_logs` and the environment variable `SCALYR_DOCKER_RAW_LOGS`. '
+            'Ignoring environment variable.',
+            limit_once_per_x_secs=300,
+            limit_key='config_conflict_scalyr_agent.builtin_monitors.docker_monitor_docker_raw_logs_SCALYR_DOCKER_RAW_LOGS',
+        )
+
+
+
+        CopyingManager(config, monitors_manager.monitors)
+        # Override Agent Logger to prevent writing to disk
+        for monitor in monitors_manager.monitors:
+            monitor._logger = FakeAgentLogger('fake_agent_logger')
+
+        # Verify environment variable values propagate into DockerMonitor monitor MonitorConfig
+        monitor_2_testmap = {
+            docker_monitor: docker_testmap,
+        }
+        for monitor, testmap in monitor_2_testmap.items():
+            for key, value in testmap.items():
+                test_val, convert_to = value[1:]
+                if key in ['docker_raw_logs']:
+                    # Keys were defined in config files so should not have changed
+                    self.assertNotEquals(test_val, monitor._config.get(key, convert_to=convert_to))
+                else:
+                    # Keys were empty in config files so they take on environment values
+                    materialized_value = monitor._config.get(key, convert_to=convert_to)
+                    if hasattr(test_val, '__iter__'):
+                        self.assertEquals([x1 for x1 in test_val], [x2 for x2 in materialized_value])
+                    else:
+                        self.assertEquals(test_val, materialized_value)
+
+    def test_label_include_globs_from_config(self):
+        self._write_file_with_separator_conversion(""" { 
+            api_key: "hi there",
+            logs: [ { path:"/var/log/tomcat6/access.log" }],
+            monitors: [
+                {
+                    module: "scalyr_agent.builtin_monitors.docker_monitor",
+                    docker_raw_logs: true
+                    label_include_globs: ["*glob1*", "*glob2*", "*glob3*"]
+                }
+            ]
+          }
+        """)
+        config = self._create_test_configuration_instance()
+        config.parse()
+
+        test_manager = MonitorsManager(config, FakePlatform([]))
+        k8s_event_monitor = test_manager.monitors[0]
+        event_object_filter = k8s_event_monitor._config.get('label_include_globs')
+        elems = ["*glob1*", "*glob2*", "*glob3*"]
+        self.assertNotEquals(elems, event_object_filter)  # list != JsonArray
+        self.assertEquals(elems, [x for x in event_object_filter])
+
+    def test_label_include_globs_from_environment_0(self):
+        self.test_label_include_globs_from_environment('["*env_glob1*", "*env_glob2*"]')
+
+    def test_label_include_globs_from_environment(self, environment_value):
+        elems = ["*env_glob1*", "*env_glob2*"]
+        os.environ['DOCKER_LABEL_INCLUDE_GLOBS'] = environment_value
+        self._write_file_with_separator_conversion(""" { 
+            api_key: "hi there",
+            logs: [ { path:"/var/log/tomcat6/access.log" }],
+            monitors: [
+                {
+                    module: "scalyr_agent.builtin_monitors.docker_monitor",                    
+                    docker_raw_logs: true
+                }
+            ]
+          }
+        """)
+        config = self._create_test_configuration_instance()
+        config.parse()
+
+        test_manager = MonitorsManager(config, FakePlatform([]))
+        docker_monitor = test_manager.monitors[0]
+        globs_list = docker_monitor._config.get('label_include_globs')
+        self.assertNotEquals(elems, globs_list)  # list != ArrayOfStrings
+        self.assertEquals(type(globs_list), ArrayOfStrings)
+        self.assertEquals(elems, list(globs_list))

--- a/scalyr_agent/tests/configuration_k8s_test.py
+++ b/scalyr_agent/tests/configuration_k8s_test.py
@@ -11,7 +11,7 @@ from scalyr_agent.tests.configuration_test import TestConfiguration
 
 
 class TestConfigurationK8s(TestConfiguration):
-    """This test is subclasses from TestConfiguration for easier exclusion in python 2.5 and below"""
+    """This test subclasses from TestConfiguration for easier exclusion in python 2.5 and below"""
 
     @patch('scalyr_agent.builtin_monitors.kubernetes_monitor.docker')
     def test_environment_aware_module_params(self, mock_docker):


### PR DESCRIPTION
# Background

We recently added expanded support to make global config params as well as k8s-related config params "environment-aware"

This needs to be expanded to docker config params as it is a major pain point for docker customers.

This PR makes docker config params environment-aware and also installs unit tests.