### PR TITLE
AGENT-139: Make k8s_events_disable an environment-aware global param

### DIFF
--- a/k8s/scalyr-agent-2-configmap.yaml
+++ b/k8s/scalyr-agent-2-configmap.yaml
@@ -6,7 +6,7 @@ data:
   # Most environment variables start with SCALYR_
   # See https://www.scalyr.com/help/scalyr-agent#environmentAware for more details.
   # Examples:
-  # K8S_EVENTS_DISABLE: "true"
+  # SCALYR_K8S_EVENTS_DISABLE: "true"
 metadata:
   name: scalyr-config
   namespace: default

--- a/k8s/scalyr-agent-2.yaml
+++ b/k8s/scalyr-agent-2.yaml
@@ -31,7 +31,7 @@ spec:
                  name: scalyr-config
                  key: scalyr_server
                  optional: true
-          - name: K8S_EVENTS_DISABLE
+          - name: SCALYR_K8S_EVENTS_DISABLE
             valueFrom:
               configMapKeyRef:
                  name: scalyr-config

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -278,6 +278,10 @@ class Configuration(object):
         return self.__get_config().get_int('k8s_cache_purge_secs')
 
     @property
+    def k8s_events_disable(self):
+        return self.__get_config().get_bool('k8s_events_disable')
+
+    @property
     def disable_send_requests(self):
         return self.__get_config().get_bool('disable_send_requests')
 
@@ -1005,6 +1009,7 @@ class Configuration(object):
         self.__verify_or_set_optional_bool(config, 'k8s_verify_api_queries', True, description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_int(config, 'k8s_cache_expiry_secs', 30, description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_int(config, 'k8s_cache_purge_secs', 300, description, apply_defaults, env_aware=True)
+        self.__verify_or_set_optional_bool(config, 'k8s_events_disable', False, description, apply_defaults, env_aware=True)
 
         self.__verify_or_set_optional_bool(config, 'disable_send_requests', False, description, apply_defaults, env_aware=True)
 

--- a/scalyr_agent/tests/configuration_k8s_test.py
+++ b/scalyr_agent/tests/configuration_k8s_test.py
@@ -55,7 +55,7 @@ class TestConfigurationK8s(TestConfiguration):
             "ignore_master": ("SCALYR_K8S_IGNORE_MASTER", False, bool),
         }
 
-        # Fake the environment varaibles
+        # Fake the environment variables
         for map in [k8s_testmap, k8s_events_testmap]:
             for key, value in map.items():
                 custom_name = value[0]
@@ -210,3 +210,39 @@ class TestConfigurationK8s(TestConfiguration):
         self.assertNotEquals(elems, event_object_filter)  # list != ArrayOfStrings
         self.assertEquals(type(event_object_filter), ArrayOfStrings)
         self.assertEquals(elems, list(event_object_filter))
+
+    def test_k8s_events_disable(self):
+        def _assert_environment_variable(env_var_name, env_var_value, expected_value):
+            os.environ[env_var_name] = env_var_value
+            self._write_file_with_separator_conversion(""" { 
+                api_key: "hi there",
+                logs: [ { path:"/var/log/tomcat6/access.log" }],
+                monitors: [
+                    {
+                        module: "scalyr_agent.builtin_monitors.kubernetes_events_monitor",
+                    }
+                ]
+              }
+            """)
+            config = self._create_test_configuration_instance()
+            config.parse()
+
+            test_manager = MonitorsManager(config, FakePlatform([]))
+            k8s_event_monitor = test_manager.monitors[0]
+            self.assertEquals(expected_value, k8s_event_monitor._KubernetesEventsMonitor__disable_monitor)
+
+        # Legacy env variable is supported
+        _assert_environment_variable('K8S_EVENTS_DISABLE', 't', True)
+        _assert_environment_variable('K8S_EVENTS_DISABLE', 'T', True)
+        _assert_environment_variable('K8S_EVENTS_DISABLE', 'true', True)
+        _assert_environment_variable('K8S_EVENTS_DISABLE', 'True', True)
+        _assert_environment_variable('K8S_EVENTS_DISABLE', 'TRUE', True)
+        _assert_environment_variable('K8S_EVENTS_DISABLE', 'X', False)
+
+        # And new environment variable likewise
+        _assert_environment_variable('SCALYR_K8S_EVENTS_DISABLE', 'true', True)
+        _assert_environment_variable('SCALYR_K8S_EVENTS_DISABLE', 'True', True)
+        _assert_environment_variable('SCALYR_K8S_EVENTS_DISABLE', 'T', False)
+        _assert_environment_variable('SCALYR_K8S_EVENTS_DISABLE', 'false', False)
+        _assert_environment_variable('SCALYR_K8S_EVENTS_DISABLE', 'False', False)
+        _assert_environment_variable('SCALYR_K8S_EVENTS_DISABLE', 'F', False)


### PR DESCRIPTION
Currently there is ad-hoc code that looks for `K8S_EVENTS_DISABLE` environment variable. 

There was a todo to make this a global param that's environment-aware. 

This PR adds that global param, taking in from `SCALYR_K8S_EVENTS_DISABLE`. 
It leaves `K8S_EVENTS_DISABLE` in place, thus allowing legacy customers to specify either.
It changes the k8s configmap to set `SCALYR_K8S_EVENTS_DISABLE`.

Additionally, I have updated AGENT-132 to signify the need to adjust documentation. 


# How tested

Unit tests. Also successful ran in minikube using the updated daemonset yaml that takes in from `SCALYR_K8S_EVENTS_DISABLE`

![image](https://user-images.githubusercontent.com/48775713/58744838-011aaa00-83fd-11e9-9ede-1d5cacdfbd94.png)
