### PR TITLE
AGENT-136: Audit global config params for __verify_or_set

### DIFF
--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -883,6 +883,7 @@ class Configuration(object):
         self.__verify_or_set_optional_bool(config, 'allow_http', False, description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_bool(config, 'check_remote_if_no_tty', True, description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_string(config, 'compression_type', '', description, apply_defaults, env_aware=True)
+        self.__verify_or_set_optional_int(config, 'compression_level', 9, description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_attributes(config, 'server_attributes', description, apply_defaults)
         self.__verify_or_set_optional_string(config, 'agent_log_path', self.__default_paths.agent_log_path,
                                              description, apply_defaults, env_aware=True)


### PR DESCRIPTION
While firefighting Bukalapak's problems we looked into changing compression_type via environment but realized it wasn't environment aware because there is no __verify_or_set_optional_string call on it.

Audit all global config variables to eliminate this problem.

I have gone through configuration.py and found only 2 config params that do not have verify_or_set_xxx called on them. They are:
1. raw_scalyr_server
2. compression_level

I think compression_level should be made env_aware.
raw_scalyr_server seems to just be the original value of scalyr_server so I don't think a verify_or_set is needed/appropriate.