### PR TITLE
AGENT-147: Add extra_attributes to copying_manager

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -1948,6 +1948,10 @@ class KubernetesMonitor( ScalyrMonitor ):
             k8s_cache = self.__container_checker.k8s_cache
         return k8s_cache
 
+    def get_extra_server_attributes(self):
+        # Immutable, hence thread safe
+        return {'_k8s_ver': 'star'}
+
     def get_user_agent_fragment(self):
         """This method is periodically invoked by a separate (MonitorsManager) thread and must be thread safe.
         """

--- a/scalyr_agent/builtin_monitors/tests/docker_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/docker_monitor_test.py
@@ -161,7 +161,7 @@ class DockerMonitorTest(ScalyrTestCase):
 
             manager_poll_interval = 30
             fake_clock = FakeClock()
-            manager = ScalyrTestUtils.create_test_monitors_manager(
+            manager, _ = ScalyrTestUtils.create_test_monitors_manager(
                 config_monitors=[
                     {
                         'module': "scalyr_agent.builtin_monitors.docker_monitor",

--- a/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
@@ -23,9 +23,11 @@ import mock
 from mock import patch
 
 from scalyr_agent.builtin_monitors.kubernetes_monitor import KubernetesMonitor
+from scalyr_agent.copying_manager import CopyingManager
 from scalyr_agent.util import FakeClock, FakeClockCounter
 from scalyr_agent.test_base import ScalyrTestCase
 from scalyr_agent.test_util import ScalyrTestUtils
+from scalyr_agent.tests.copying_manager_test import CopyingManagerInitializationTest
 
 
 class KubernetesMonitorTest(ScalyrTestCase):
@@ -53,7 +55,7 @@ class KubernetesMonitorTest(ScalyrTestCase):
 
             manager_poll_interval = 30
             fake_clock = FakeClock()
-            manager = ScalyrTestUtils.create_test_monitors_manager(
+            manager, _ = ScalyrTestUtils.create_test_monitors_manager(
                 config_monitors=[
                     {
                         'module': "scalyr_agent.builtin_monitors.kubernetes_monitor",
@@ -127,3 +129,39 @@ class KubernetesMonitorTest(ScalyrTestCase):
                 manager.stop_manager(wait_on_join=False)
                 fake_clock.advance_time(increment_by=manager_poll_interval)
             start_test()
+
+
+class TestExtraServerAttributes(CopyingManagerInitializationTest):
+
+    def test_no_extra_server_attributes(self):
+        copying_manager = self._create_test_instance([], [])
+        attribs = copying_manager._CopyingManager__expanded_server_attributes
+        self.assertIsNone(attribs.get('_k8s_ver', none_if_missing=True))
+
+    def test_extra_server_attributes(self):
+
+        def fake_init(self):
+            # Initialize variables that would have been
+            self._KubernetesMonitor__container_checker = None
+            self._KubernetesMonitor__namespaces_to_ignore = []
+            self._KubernetesMonitor__include_controller_info = None
+            self._KubernetesMonitor__report_container_metrics = None
+            self._KubernetesMonitor__metric_fetcher = None
+
+        @mock.patch.object(KubernetesMonitor, '_initialize', fake_init)
+        def run_test():
+            manager_poll_interval = 30
+            fake_clock = FakeClock()
+            monitors_manager, config = ScalyrTestUtils.create_test_monitors_manager(
+                config_monitors=[
+                    {
+                        'module': "scalyr_agent.builtin_monitors.kubernetes_monitor",
+                    }
+                ],
+                extra_toplevel_config={'user_agent_refresh_interval': manager_poll_interval},
+                null_logger=True,
+                fake_clock=fake_clock,
+            )
+            copying_manager = CopyingManager(config, monitors_manager.monitors)
+            self.assertEquals(copying_manager._CopyingManager__expanded_server_attributes.get('_k8s_ver'), 'star')
+        run_test()

--- a/scalyr_agent/copying_manager.py
+++ b/scalyr_agent/copying_manager.py
@@ -18,6 +18,7 @@
 
 __author__ = 'czerwin@scalyr.com'
 
+import copy
 import datetime
 import fnmatch
 import os
@@ -198,6 +199,26 @@ class CopyingManager(StoppableThread, LogWatcher):
         self.__config = configuration
         # Keep track of monitors
         self.__monitors = monitors
+
+        # collect monitor-specific extra server-attributes
+        self.__monitor_2_extra_server_attribs = dict(
+            (monitor, monitor.get_extra_server_attributes()) for monitor in monitors
+        )
+
+        self.__expanded_server_attributes = copy.deepcopy(self.__config.server_attributes)
+        for monitor in self.__monitor_2_extra_server_attribs:
+            monitor_attribs = self.__monitor_2_extra_server_attribs.get(monitor)
+            if not monitor_attribs:
+                continue
+            for key, value in monitor_attribs.items():
+                if key in self.__config.server_attributes:
+                    log.log(scalyr_logging.DEBUG_LEVEL_0,
+                            "Extra server attribute already defined. Cannot add extra server attribute from monitor %s"
+                            % monitor.module_name,
+                            limit_once_per_x_secs=300,
+                            limit_key='extra-server-attrib-%s' % key)
+                else:
+                    self.__expanded_server_attributes[key] = value
 
         # We keep track of which paths we have configs for so that when we add in the configuration for the monitor
         # log files we don't re-add in the same path.  This can easily happen if a monitor is used multiple times
@@ -877,7 +898,7 @@ class CopyingManager(StoppableThread, LogWatcher):
         # Whether or not the max bytes allowed to send has been reached.
         buffer_filled = False
 
-        add_events_request = self._create_add_events_request(session_info=self.__config.server_attributes,
+        add_events_request = self._create_add_events_request(session_info=self.__expanded_server_attributes,
                                                              max_size=bytes_allowed_to_send)
 
         if for_pipelining:

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -251,6 +251,16 @@ class ScalyrMonitor(StoppableThread):
             # right now join on the monitor threads, so no one would catch it.  We should change that.
             self._logger.exception('Monitor died from due to exception:', error_code='failedMonitor')
 
+    def get_extra_server_attributes(self):
+        """Derived classes may optionally return a dict of server attributes to be added to the main config
+        server attributes.  Keys already defined by server attributes or other monitors will be dropped with a warning.
+
+        You must ensure that this method is thread-safe as it will be invoked by a different thread (MonitorsManager).
+
+        @return: A dict or None
+        """
+        return None
+
     def get_user_agent_fragment(self):
         """Derived classes may optionally return a string fragment to be appended to the User-Agent header for all
         data sent to Scalyr.  Note: User-Agent augmentation applies to all data (not restricted to data from this

--- a/scalyr_agent/test_util.py
+++ b/scalyr_agent/test_util.py
@@ -73,7 +73,7 @@ class ScalyrTestUtils(object):
 
     @staticmethod
     def create_test_monitors_manager(config_monitors=None, platform_monitors=None, extra_toplevel_config=None,
-                                     null_logger=False, fake_clock=False, set_daemon=False):
+                                     null_logger=False, fake_clock=False):
         """Create a test MonitorsManager
 
         @param config_monitors: config monitors
@@ -114,7 +114,7 @@ class ScalyrTestUtils(object):
             if isinstance(monitor, threading.Thread):
                 monitor.setDaemon(True)
 
-        return test_manager
+        return test_manager, config
 
 
 class NullHandler(logging.Handler):

--- a/scalyr_agent/tests/copying_manager_test.py
+++ b/scalyr_agent/tests/copying_manager_test.py
@@ -24,7 +24,6 @@ import tempfile
 
 import logging
 import sys
-import unittest
 
 root = logging.getLogger()
 root.setLevel(logging.DEBUG)
@@ -136,7 +135,7 @@ class CopyingParamsTest(ScalyrTestCase):
 class CopyingManagerInitializationTest(ScalyrTestCase):
 
     def test_from_config_file(self):
-        test_manager = self.__create_test_instance([
+        test_manager = self._create_test_instance([
             {
                 'path': '/tmp/hi.log'
             }
@@ -146,7 +145,7 @@ class CopyingManagerInitializationTest(ScalyrTestCase):
         self.assertEquals(test_manager.log_matchers[1].config['path'], '/var/log/scalyr-agent-2/agent.log')
 
     def test_from_monitors(self):
-        test_manager = self.__create_test_instance([
+        test_manager = self._create_test_instance([
         ], [
             {
                 'path': '/tmp/hi_monitor.log',
@@ -158,7 +157,7 @@ class CopyingManagerInitializationTest(ScalyrTestCase):
         self.assertEquals(test_manager.log_matchers[1].config['attributes']['parser'], 'agent-metrics')
 
     def test_multiple_monitors_for_same_file(self):
-        test_manager = self.__create_test_instance([
+        test_manager = self._create_test_instance([
         ], [
             {'path': '/tmp/hi_monitor.log'},
             {'path': '/tmp/hi_monitor.log'},
@@ -172,7 +171,7 @@ class CopyingManagerInitializationTest(ScalyrTestCase):
         self.assertEquals(test_manager.log_matchers[2].config['attributes']['parser'], 'agent-metrics')
 
     def test_monitor_log_config_updated(self):
-        test_manager = self.__create_test_instance([
+        test_manager = self._create_test_instance([
         ], [
             {'path': 'hi_monitor.log'},
         ])
@@ -184,14 +183,14 @@ class CopyingManagerInitializationTest(ScalyrTestCase):
         self.assertEquals(self.__monitor_fake_instances[0].log_config['path'], '/var/log/scalyr-agent-2/hi_monitor.log')
 
     def test_remove_log_path_with_non_existing_path(self):
-        test_manager = self.__create_test_instance([
+        test_manager = self._create_test_instance([
         ], [
             {'path': 'test.log'},
         ])
         # check that removing a non-existent path runs without throwing an exception
         test_manager.remove_log_path( 'test_monitor', 'blahblah.log' )
 
-    def __create_test_instance(self, configuration_logs_entry, monitors_log_configs):
+    def _create_test_instance(self, configuration_logs_entry, monitors_log_configs):
         logs_json_array = JsonArray()
         for entry in configuration_logs_entry:
             logs_json_array.add(JsonObject(content=entry))
@@ -741,3 +740,6 @@ class FakeMonitor(object):
 
     def set_log_watcher(self, log_watcher):
         pass
+
+    def get_extra_server_attributes(self):
+        return None

--- a/scalyr_agent/tests/monitors_manager_test.py
+++ b/scalyr_agent/tests/monitors_manager_test.py
@@ -30,7 +30,7 @@ from scalyr_agent.util import FakeClockCounter
 
 class MonitorsManagerTest(ScalyrTestCase):
     def test_single_module(self):
-        test_manager = ScalyrTestUtils.create_test_monitors_manager([
+        test_manager, _ = ScalyrTestUtils.create_test_monitors_manager([
             {
                 'module': 'scalyr_agent.builtin_monitors.test_monitor',
                 'gauss_mean': 0
@@ -40,7 +40,7 @@ class MonitorsManagerTest(ScalyrTestCase):
         self.assertEquals(test_manager.monitors[0].monitor_name, 'test_monitor()')
 
     def test_multiple_modules(self):
-        test_manager = ScalyrTestUtils.create_test_monitors_manager([
+        test_manager, _ = ScalyrTestUtils.create_test_monitors_manager([
             {
                 'module': 'scalyr_agent.builtin_monitors.test_monitor',
                 'gauss_mean': 0
@@ -56,7 +56,7 @@ class MonitorsManagerTest(ScalyrTestCase):
         self.assertEquals(test_manager.monitors[1].monitor_name, 'test_monitor(2)')
 
     def test_module_with_id(self):
-        test_manager = ScalyrTestUtils.create_test_monitors_manager([
+        test_manager, _ = ScalyrTestUtils.create_test_monitors_manager([
             {
                 'module': 'scalyr_agent.builtin_monitors.test_monitor',
                 'id': 'first',
@@ -91,7 +91,7 @@ class MonitorsManagerTest(ScalyrTestCase):
         # Create MonitorsManager + 2 monitors. Set each to daemon otherwise unit test doesn't terminate
         # Fake the clock to fast-forward MonitorsManager sleep loop
         fake_clock = scalyr_util.FakeClock()
-        test_manager = ScalyrTestUtils.create_test_monitors_manager(
+        test_manager, _ = ScalyrTestUtils.create_test_monitors_manager(
             config_monitors=[
                 {
                     'module': 'scalyr_agent.builtin_monitors.test_monitor',


### PR DESCRIPTION
We need to _not_ show all scalyr-agent-xxxx hosts in the main UI (since there could be a very large number of agents such as in k8s clusters).

This PR introduces the `extra_server_attributes` construct in the `CopyingManager`.
At init time, it will query the provided list of monitors for extra server attributes which it will 
add to its local copy of server attributes.  

The expanded set of server attributes is then supplied to the `_create_add_events_request` call (instead of the original config.server_attributes).

In this way, monitors can define extra server attributes that will be applied to all log lines uploaded by the agent. An example use case is the Kubernetes Monitor sets a server attribute which the backend can then use to modify the UI as needed.

# How tested?

Added a unit test but that does not check for addEvents()

So I added a temporary print statement just before [this line](https://github.com/scalyr/scalyr-agent-2/blob/master/scalyr_agent/copying_manager.py#L880):

It printed out the text "EXPANDED attribute = ...".

As you can see from the following screenshot it seems to work:

![image](https://user-images.githubusercontent.com/48775713/58929589-90310600-870c-11e9-912a-4167b7fe5f5a.png)

If you know of a better way to test this aspect please LMK.