### PR TITLE
Make sure cached pod information get refreshed

### DIFF
--- a/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
@@ -162,10 +162,12 @@ class ControlledCacheWarmerTest(ScalyrTestCase):
             # The set of pods that have been warmed, identified by pod key
             self.__warmed_pods = set()
 
-        def is_pod_cached(self, pod_namespace, pod_name):
+        def is_pod_cached(self, pod_namespace, pod_name, current_time):
             """Faked KubernetesCache method that returns if the pod has been warmed from the cache's perspective.
             @param pod_namespace: The namespace for the pod
             @param pod_name:  The name for the pod
+            @param current_time:  The current time since the epoch - not used for testing, but listed here to maintain compatibility
+                                  with the actual method definition
             @type pod_namespace: str
             @type pod_name: str
             @return True if the pod has been warmed.
@@ -176,11 +178,12 @@ class ControlledCacheWarmerTest(ScalyrTestCase):
             finally:
                 self.__lock.release()
 
-        def pod(self, pod_namespace, pod_name, current_time=None, query_options=None ):
+        def pod(self, pod_namespace, pod_name, current_time=None, query_options=None, force_lookup=False ):
             """Faked KubernetesCache method that simulates blocking for the specified pod's cached entry.
 
             @param pod_namespace: The namespace for the pod
             @param pod_name:  The name for the pod
+            @param force_lookup: Not used for testing.  Added to keep method signature consistent with actual code
 
             @type pod_namespace: str
             @type pod_name: str

--- a/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
@@ -162,6 +162,13 @@ class ControlledCacheWarmerTest(ScalyrTestCase):
             # The set of pods that have been warmed, identified by pod key
             self.__warmed_pods = set()
 
+        class FakeState( object ):
+            def __init__(self):
+                self.cache_expiry_secs = 300
+
+        def local_state( self ):
+            return self.FakeState()
+
         def is_pod_cached(self, pod_namespace, pod_name, current_time):
             """Faked KubernetesCache method that returns if the pod has been warmed from the cache's perspective.
             @param pod_namespace: The namespace for the pod

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -37,9 +37,6 @@ import scalyr_agent.json_lib as json_lib
 from scalyr_agent.compat import custom_any as any
 from scalyr_agent.json_lib import parse, JsonParseException
 from scalyr_agent.platform_controller import CannotExecuteAsUser
-import scalyr_agent.scalyr_logging as scalyr_logging
-
-
 
 # Use sha1 from hashlib (Python 2.5 or greater) otherwise fallback to the old sha module.
 try:
@@ -1502,6 +1499,8 @@ class BlockingRateLimiter(object):
         """
         self._cluster_rate_lock.acquire()
         try:
+            import scalyr_agent.scalyr_logging as scalyr_logging
+
             if success:
                 self._consecutive_successes += 1
             else:


### PR DESCRIPTION
Previously, cached pod information could be refreshed by purging all entries
from the cache, which would trigger a new query for those values.

With the addition of the cache warmer (which limits the rate at which queries to
the API can occur) purging the cache entries means that they that are not in the
cache and therefore get removed from the list of running containers until the
(possibly rate limited) API call returns.

This was causing values to be removed from the list of running containers during
one cycle of the main loop, which caused the agent to stop monitoring those logs
- only to be re-added again in the next iteration of the loo.

To prevent this from happening entries are now only purged from the main k8s
cache if they have not been queried (either by the main code or by the cache
warmer) within the `cache_purge_secs` interval.

The cache warmer now has additional logic to determine if a WarmerEntry is
'stale' and if so, it treats it the same as if the entry was not warm, by
querying out to the API.

This has the effect that:

* entries in the k8s cache are not purged so long as either the main code or the
  cache warmer are querying to see if they exist in the cache
* entries that have not been queried at all in `cache_purge_sec` seconds are
  purged (this ensures the cache isn't full of entries from
  short-running/one-off pods)
* The cache warmer will periodically re-queue and query any pods that go 'stale'
  i.e. they haven't been refreshed by an API call within the `cache_expiry_secs`
  interval.  These stale pods will still stay in the cache so long as the rest
  of the code is still querying for them, and they'll eventually be updated once
  the rate limited query returns.