### PR TITLE
AGENT-174: Add SCALYR_SERVER to config map and docker readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -73,10 +73,15 @@ Here is an example of the complete command:
 Or if setting API key via environment:    
     
     docker run -d --name scalyr-docker-agent-json \
-    -e SCALYR_API_KEY=<Your api key> \ 
+    -e SCALYR_API_KEY=<Your api key> \
     -v /run/docker.sock:/var/scalyr/docker.sock \
     -v /var/lib/docker/containers:/var/lib/docker/containers \
     scalyr/scalyr-docker-agent-json
+
+Note: EU customers must also set the SCALYR_SERVER environment variable by adding this line:
+
+    -e SCALYR_SERVER=https://upload.eu.scalyr.com
+
 
 #### scalyr-docker-agent-syslog
 
@@ -88,6 +93,10 @@ Syslog port:
     -v /run/docker.sock:/var/scalyr/docker.sock \
     -p 601:601 \
     scalyr/scalyr-docker-agent-syslog
+
+Note: EU customers must also set the SCALYR_SERVER environment variable by adding this line:
+
+    -e SCALYR_SERVER=https://upload.eu.scalyr.com
 
 
 ## Configuring local containers to send their logs to Scalyr

--- a/k8s/scalyr-agent-2-configmap.yaml
+++ b/k8s/scalyr-agent-2-configmap.yaml
@@ -2,11 +2,17 @@ apiVersion: v1
 kind: ConfigMap
 data:
   SCALYR_K8S_CLUSTER_NAME: <your_cluster_name>
-  # Add any other Environment variables for environment-aware agent config variables
-  # Most environment variables start with SCALYR_
+  #
+  # EU customers must uncomment this next line:
+  # SCALYR_SERVER: "https://upload.eu.scalyr.com"
+  #
+  # Define any other environment variables for config variables that are "environment aware".
+  # Most environment variables start with "SCALYR_"
   # See https://www.scalyr.com/help/scalyr-agent#environmentAware for more details.
-  # Examples:
+  #
+  # Example:
   # SCALYR_K8S_EVENTS_DISABLE: "true"
+  #
 metadata:
   name: scalyr-config
   namespace: default


### PR DESCRIPTION
Recent agent-related document changes fail to account for EU customers who need to set scalyr-server. 

AFAICT the affected areas are:
1. k8s example config map
2. docker README