### PR TITLE
Fix non-deterministic already_warm test failure

### DIFF
--- a/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
@@ -196,12 +196,18 @@ class ControlledCacheWarmerTest(ScalyrTestCase):
 
         warmer.begin_marking()
         warmer.mark_to_warm(self.CONTAINER_1, self.NAMESPACE_1, self.POD_1)
+
+        # In order to simulate already warm, we need to add the cache entry right after we mark it to be warmed (it is
+        # in the marking that we determine it is not yet warmed).
+        # We need to do it before end_marking because once we invoke end_marking, the ControlledCacheWarmer thread
+        # will try to request it via the api and will not get a chance to see it is already in the cache.  The test
+        # thread will be racing with it.
+        fake_cache.simulate_add_pod_to_cache( self.NAMESPACE_1, self.POD_1 )
+
+        # Now end the marking.
         warmer.end_marking()
 
         self.assertEqual(warmer.active_containers(), [self.CONTAINER_1])
-        self.assertEqual(warmer.warming_containers(), [self.CONTAINER_1])
-
-        fake_cache.simulate_add_pod_to_cache( self.NAMESPACE_1, self.POD_1 )
 
         warmer.block_until_idle( self.timeout )
 


### PR DESCRIPTION
Testing the `already_warm` case is tricky because the test
thread is racing against the ControlledCacheWarmer thread.

In particular, once the ControlledCacheWarmer thread notices
there is a pod to warm (because it was returned from the
`pick_next_pod` method) it (A) first checks if it is already
in the cache and (B) requests it from the API.  For the
`already_warm` case, the entry must in the cache before (A).
Also, if the thread gets to (B), it will block indefinitely
until we simulate an API response.. which we don't do in this
test.  So, we need to make sure it is in the cache before (A).
The easiest way to do this is not invoke `end_marking` until
we simulate placing it in the cache, since `end_marking` is what
adds the pod to the warming list and makes it eligible to
be returned from `pick_next_pod`.

This explains the test failures where `already_warm` failed
while blocking for the ControlledCacheWarmer to be idle.