### PR TITLE
AGENT-166: Default compression_type to bz2

### DIFF
--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -921,7 +921,7 @@ class Configuration(object):
         self.__verify_or_set_optional_string(config, 'api_key', '', description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_bool(config, 'allow_http', False, description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_bool(config, 'check_remote_if_no_tty', True, description, apply_defaults, env_aware=True)
-        self.__verify_or_set_optional_string(config, 'compression_type', '', description, apply_defaults, env_aware=True)
+        self.__verify_or_set_optional_string(config, 'compression_type', 'bz2', description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_int(config, 'compression_level', 9, description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_attributes(config, 'server_attributes', description, apply_defaults)
         self.__verify_or_set_optional_string(config, 'agent_log_path', self.__default_paths.agent_log_path,

--- a/scalyr_agent/tests/util_test.py
+++ b/scalyr_agent/tests/util_test.py
@@ -22,15 +22,71 @@ import os
 import tempfile
 import struct
 import threading
+from mock import patch, MagicMock
 
 import scalyr_agent.util as scalyr_util
 
 from scalyr_agent.util import JsonReadFileException, RateLimiter, BlockingRateLimiter, FakeRunState, ScriptEscalator
 from scalyr_agent.util import FakeClockCounter
 from scalyr_agent.util import StoppableThread, RedirectorServer, RedirectorClient, RedirectorError
+from scalyr_agent.util import verify_and_get_compress_func
 from scalyr_agent.json_lib import JsonObject
 
 from scalyr_agent.test_base import ScalyrTestCase
+
+
+class TestUtilCompression(ScalyrTestCase):
+    def setUp(self):
+        self._data = 'The rain in spain. ' * 1000
+
+    def test_zlib(self):
+        """Successful zlib compression"""
+        data = self._data
+        compress = verify_and_get_compress_func('deflate')
+        import zlib
+        self.assertEqual(data, zlib.decompress(compress(data)))
+
+    def test_bz2(self):
+        """Successful bz2 compression"""
+        data = self._data
+        compress = verify_and_get_compress_func('bz2')
+        import bz2
+        self.assertEqual(data, bz2.decompress(compress(data)))
+
+    def test_bad_compression_type(self):
+        """User enters unsupported compression type"""
+        self.assertIsNone(verify_and_get_compress_func('bad_compression_type'))
+
+    def test_bad_compression_lib_exception_on_import(self):
+        """Pretend that import bz2/zlib raises exception"""
+
+        def _mock_get_compress_module(compression_type):
+            raise Exception('Mimic exception when importing compression lib')
+
+        @patch('scalyr_agent.util.get_compress_module', new=_mock_get_compress_module)
+        def _test(compression_type):
+            self.assertIsNone(verify_and_get_compress_func(compression_type))
+
+        _test('deflate')
+        _test('bz2')
+
+    def test_bad_compression_lib_no_compression(self):
+        """Pretend that the zlib/bz2 library compress() method doesn't perform any comnpression"""
+
+        def _mock_get_compress_module(compression_type):
+            m = MagicMock()
+            # simulate module.compress() method that does not compress input data string
+            m.compress = lambda data, compression_level: data
+            return m
+
+        @patch('scalyr_agent.util.get_compress_module', new=_mock_get_compress_module)
+        def _test(compression_type):
+            self.assertIsNone(verify_and_get_compress_func(compression_type))
+
+        _test('deflate')
+        _test('bz2')
+
+
 
 class TestUtil(ScalyrTestCase):
 

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -1343,6 +1343,45 @@ class RedirectorClient(StoppableThread):
             pass
 
 
+COMPRESSION_TEST_STR = 'a' * 100
+
+
+def get_compress_module(compression_type):
+    if compression_type == 'zlib':
+        import zlib
+        return zlib
+    elif compression_type == 'bz2':
+        import bz2
+        return bz2
+    else:
+        raise ValueError('Unsupported compression type')
+
+
+def verify_and_get_compress_func(compression_type):
+    """Given a compression_type (bz2, zlib), verify that compression works and return the compress() function
+
+    @param compression_type: Compression type
+    @type compression_type: str
+
+    @returns: The compress() function for the specified compression_type. None, if compression_type is not supported or
+        if underlying libs are not installed properly,
+    """
+    compression_type_to_module_name = {
+        'bz2': 'bz2',
+        'deflate': 'zlib',
+    }
+    if compression_type not in compression_type_to_module_name:
+        return None
+    try:
+        compression_module = get_compress_module(compression_type_to_module_name[compression_type])
+        cdata = compression_module.compress(COMPRESSION_TEST_STR, 9)
+        if len(cdata) < len(COMPRESSION_TEST_STR):
+            return compression_module.compress
+    except Exception:
+        pass
+    return None
+
+
 class RateLimiterToken(object):
     def __init__(self, token_id):
         self._token_id = token_id


### PR DESCRIPTION
# Background

Currently, the agent does not compress uploaded data by default. Even though it does _not_ affect customer billing, I propose changing this to use bz2 compression by default as there is no reason not to.

Some customer machines may not have requisite compression libraries installed on their systems. Therefore the agent must check to ensure compression works correctly.

# Tests

- New unit tests that require positive confirmation of compression capabilities (not just import) before turning compression on.
- Smoketests verify upload works.