### PR TITLE
AGENT-121: Change default docker mode to raw-logs

### DIFF
--- a/docker/docker-json-config/agent.d/docker.json
+++ b/docker/docker-json-config/agent.d/docker.json
@@ -3,10 +3,9 @@
 // docker container log directory (which must be mounted into the
 // agent's container).
 {
- monitors: [
-   {
-    module: "scalyr_agent.builtin_monitors.docker_monitor",
-    docker_raw_logs: true
-   }
+  monitors: [
+    {
+      module: "scalyr_agent.builtin_monitors.docker_monitor"
+    }
   ]
 }

--- a/docker/docker-syslog-config/agent.d/docker.json
+++ b/docker/docker-syslog-config/agent.d/docker.json
@@ -4,13 +4,13 @@
 // logs into Scalyr.  Additionally, the Scalyr Agent will collect metrics
 // on all running containers.
 {
- monitors: [
-   {
-    module: "scalyr_agent.builtin_monitors.syslog_monitor",
-    mode: "docker"
-   }, {
-    module: "scalyr_agent.builtin_monitors.docker_monitor",
-    log_mode: "syslog"
-   }
+  monitors: [
+    {
+      module: "scalyr_agent.builtin_monitors.syslog_monitor",
+      mode: "docker"
+    }, {
+      module: "scalyr_agent.builtin_monitors.docker_monitor",
+      log_mode: "syslog"
+    }
   ]
 }


### PR DESCRIPTION
The current docker agent defaults to the legacy `docker-api` mode whereby raw logs mounted on the agent container are not directly monitored, rather stdout/err logs are gotten via docker api, written to disk once more, and those files monitored.

We originally kept the legacy mode as default in order not to impact existing customers. However, that approach is not only suboptimal but the docker api is not 100% reliable. 

The better approach is to directly monitor mounted other-container logs (raw logs mode). 

This PR changes the default mode to that and also emits a warning whenever a mounted container log file is missing (e.g. in the case where customer fails to mount the docker storage directory per instructions).

# How tested?

Manually: 

1. ensured `Starting docker monitor (raw_logs=True)` is emitted in agent.log.
2. purposefully omit the mounting of /var/lib/docker/containers, then verified the warning is 
emitted.
