### PR TITLE
AGENT-55: Negative int config variables are incorrectly parsed as longs.

### DIFF
--- a/scalyr_agent/json_lib/tests/encode_decode_test.py
+++ b/scalyr_agent/json_lib/tests/encode_decode_test.py
@@ -57,12 +57,24 @@ class EncodeDecodeTest(ScalyrTestCase):
     def test_int(self):
         self.__test_encode_decode(r'1', 1)
 
+    def test_negative_int(self):
+        self.__test_encode_decode(r'-1', -1)
+
+    def test_long( self ):
+        self.__test_encode_decode( r'1234567890123456789', 1234567890123456789 )
+
+    def test_negative_long( self ):
+        self.__test_encode_decode( r'-1234567890123456789', -1234567890123456789 )
+
     def test_bool(self):
         self.__test_encode_decode(r'false', False)
         self.__test_encode_decode(r'true', True)
 
     def test_float(self):
         self.__test_encode_decode(r'1.0003', 1.0003)
+
+    def test_negative_float( self ):
+        self.__test_encode_decode(r'-1.0003', -1.0003)
 
     def test_list(self):
         self.__test_encode_decode(r'[1,2,3]', [1, 2, 3])

--- a/scalyr_agent/tests/configuration_k8s_test.py
+++ b/scalyr_agent/tests/configuration_k8s_test.py
@@ -7,10 +7,10 @@ from scalyr_agent.copying_manager import CopyingManager
 from scalyr_agent.monitors_manager import MonitorsManager
 from scalyr_agent.json_lib.objects import ArrayOfStrings
 from scalyr_agent.test_util import FakeAgentLogger, FakePlatform
-from scalyr_agent.tests.configuration_test import TestConfiguration
+from scalyr_agent.tests.configuration_test import TestConfigurationBase
 
 
-class TestConfigurationK8s(TestConfiguration):
+class TestConfigurationK8s(TestConfigurationBase):
     """This test subclasses from TestConfiguration for easier exclusion in python 2.5 and below"""
 
     @patch('scalyr_agent.builtin_monitors.kubernetes_monitor.docker')

--- a/scalyr_agent/tests/linux_system_metrics_test.py
+++ b/scalyr_agent/tests/linux_system_metrics_test.py
@@ -1,0 +1,46 @@
+# Copyright 2017 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+#
+# author: Edward Chee <echee@scalyr.com>
+
+__author__ = 'echee@scalyr.com'
+
+from scalyr_agent.monitors_manager import MonitorsManager
+from scalyr_agent.tests.configuration_test import TestConfigurationBase
+from scalyr_agent.test_util import FakePlatform
+
+
+class TestSystemMetricConfiguration(TestConfigurationBase):
+
+    def test_log_write_rate(self):
+        self._write_file_with_separator_conversion(""" { 
+            api_key: "hi there",
+            logs: [ { path:"/var/log/tomcat6/access.log" }],
+            monitors: [
+                {
+                    module: "scalyr_agent.builtin_monitors.linux_system_metrics",
+                    "monitor_log_write_rate": -1,
+                    "monitor_log_max_write_burst": -1
+                }
+            ]
+          }
+        """)
+        config = self._create_test_configuration_instance()
+        config.parse()
+        test_manager = MonitorsManager(config, FakePlatform([]))
+        system_metrics_monitor = test_manager.monitors[0]
+        self.assertEquals(system_metrics_monitor._log_write_rate, -1)
+        self.assertEquals(system_metrics_monitor._log_max_write_burst, -1)
+


### PR DESCRIPTION
While attempting to remove rate limits on linux system metrics monitor for AGENT-175, I discovered that setting -1 for int config variables raises a type conversion error.   Apparently, -1s are parsed into longs and subsequently fail type-conversion to int.

This PR fixes the json parser library to handle negative ints.