### PR TITLE
Fix 2 bugs and add a unit test to feature/improvedTrackWarmingTimes

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -38,7 +38,7 @@ from scalyr_agent.monitor_utils.k8s import K8sApiPermanentError, DockerMetricFet
 import scalyr_agent.monitor_utils.k8s as k8s_utils
 from scalyr_agent.third_party.requests.exceptions import ConnectionError
 
-from scalyr_agent.util import StoppableThread
+from scalyr_agent.util import StoppableThread, HistogramTracker
 
 
 global_log = scalyr_logging.getLogger(__name__)
@@ -467,6 +467,7 @@ class ControlledCacheWarmer(StoppableThread):
         # `total`, `success`, `already_warm`, `temp_error`, `perm_error`, `unknown_error`.
         self.__warming_attempts = dict()
         self.__last_reported_warming_attempts = dict()
+        self.__warming_times = HistogramTracker([1, 5, 30, 60, 120, 300, 600])
 
     def start(self):
         self.__lock.acquire()
@@ -533,10 +534,11 @@ class ControlledCacheWarmer(StoppableThread):
         @type pod_namespace: str
         @type pod_name: str
         """
+        start_time = time.time()
         self.__lock.acquire()
         try:
             if not container_id in self.__active_pods:
-                self.__active_pods[container_id] = ControlledCacheWarmer.WarmingEntry(pod_namespace, pod_name)
+                self.__active_pods[container_id] = ControlledCacheWarmer.WarmingEntry(pod_namespace, pod_name, start_time)
             else:
                 warming_entry = self.__active_pods[container_id]
                 warming_entry.is_warm = self.is_warm(pod_namespace, pod_name)
@@ -639,6 +641,9 @@ class ControlledCacheWarmer(StoppableThread):
                                self.__count_blacklisted(),
                                warm_attempts_info)
             self.__last_reported_warming_attempts = self.__warming_attempts.copy()
+
+            self.__loger.info('controlled_cache_warmer warming_times %s', self.__warming_times.summarize())
+            self.__warming_times.reset()
 
     def __count_blacklisted(self):
         """Counts and returns the total number of blacklisted containers.
@@ -812,6 +817,7 @@ class ControlledCacheWarmer(StoppableThread):
         @type traceback_report: str or None
         """
         current_time = self._get_current_time()
+        warm_time = None
         result_type = 'not_set'
         exception_to_report = None
         self.__lock.acquire()
@@ -819,6 +825,7 @@ class ControlledCacheWarmer(StoppableThread):
             if container_id in self.__active_pods:
                 entry = self.__active_pods[container_id]
                 if success:
+                    warm_time = current_time - entry.start_time
                     entry.set_warm()
                     result_type = 'success'
                 elif already_warm:
@@ -846,6 +853,9 @@ class ControlledCacheWarmer(StoppableThread):
         finally:
             self.__warming_attempts['total'] = self.__warming_attempts.get('total', 0) + 1
             self.__warming_attempts[result_type] = self.__warming_attempts.get(result_type, 0) + 1
+
+            if warm_time is not None:
+                self.__warming_times.add_sample(warm_time)
 
             self.__lock.release()
             if exception_to_report is not None and self.__logger is not None:
@@ -902,11 +912,13 @@ class ControlledCacheWarmer(StoppableThread):
     class WarmingEntry(object):
         """Used to represent an active container whose pod information should be warmed in the cache.
         """
-        def __init__(self, pod_namespace, pod_name):
+        def __init__(self, pod_namespace, pod_name, start_time):
             # The associated pod's namespace.
             self.pod_namespace = pod_namespace
             # The associated pod's name.
             self.pod_name = pod_name
+            # The time when this pod was first requested to be warmed
+            self.start_time = start_time
             # Whether or not it has been successfully warmed.
             self.is_warm = False
             # Used to indicate if it is been marked in the most recent marking run started by `begin_marking`.

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -542,11 +542,11 @@ class ControlledCacheWarmer(StoppableThread):
         self.__lock.acquire()
         try:
             if not container_id in self.__active_pods:
-                self.__active_pods[container_id] = ControlledCacheWarmer.WarmingEntry(pod_namespace, pod_name,
-                                                                                      start_time)
+                warming_entry = self.__active_pods[container_id] = ControlledCacheWarmer.WarmingEntry(
+                    pod_namespace, pod_name, start_time)
             else:
                 warming_entry = self.__active_pods[container_id]
-                was_warmed = self.__update_warming_state(warming_entry, start_time)
+            was_warmed = self.__update_warming_state(warming_entry, start_time)
             self.__active_pods[container_id].is_recently_marked = True
         finally:
             self.__lock.release()

--- a/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
@@ -222,6 +222,8 @@ class ControlledCacheWarmerTest(ScalyrTestCase):
         self.assertEqual(warmer.blacklisted_containers(), [])
         self.assertTrue(warmer.is_warm(self.NAMESPACE_1, self.POD_1))
 
+        # TODO: Add in second warming case once the test fix has been merged in.
+
     def test_remove_inactive(self):
         warmer = self.__warmer_test_instance
 

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -361,6 +361,9 @@ class _K8sCache( object ):
                 if hasattr(obj, 'access_time'):
                     if obj.access_time is None or obj.access_time < access_time:
                         stale.append((namespace, obj_name))
+                else:
+                    # never-accessed objects should also be considered stale
+                    stale.append((namespace, obj_name))
         return stale
 
     def mark_as_expired(self, access_time):

--- a/scalyr_agent/monitor_utils/tests/k8s_test.py
+++ b/scalyr_agent/monitor_utils/tests/k8s_test.py
@@ -618,3 +618,9 @@ class FakeCache(object):
         """
         obj = create_object_from_dict( { 'namespace': pod_namespace, 'name': pod_name } )
         self.__pod_cache._add_to_cache( obj )
+
+    def simulate_expire_all_pods_in_cache(self):
+        """
+        Simulates time-expiration of all pods in a cache
+        """
+        self.__pod_cache.mark_as_expired(time.time())

--- a/scalyr_agent/tests/util_test.py
+++ b/scalyr_agent/tests/util_test.py
@@ -25,7 +25,7 @@ import threading
 
 import scalyr_agent.util as scalyr_util
 
-from scalyr_agent.util import JsonReadFileException, RateLimiter, FakeRunState, ScriptEscalator
+from scalyr_agent.util import JsonReadFileException, RateLimiter, FakeRunState, ScriptEscalator, HistogramTracker
 from scalyr_agent.util import StoppableThread, RedirectorServer, RedirectorClient, RedirectorError
 from scalyr_agent.json_lib import JsonObject
 
@@ -618,3 +618,138 @@ class FakeSys(object):
             self._condition.acquire()
             self._condition.wait(timeout)
             self._condition.release()
+
+
+class TestHistogramTracker(ScalyrTestCase):
+    """Tests the HistogramTracker abstraction.
+    """
+    def setUp(self):
+        self._testing = HistogramTracker([10, 25, 50, 100])
+
+    def test_count(self):
+        self.assertEqual(self._testing.count(), 0)
+
+        self._testing.add_sample(1)
+        self._testing.add_sample(11)
+        self.assertEqual(self._testing.count(), 2)
+
+        self._testing.reset()
+        self.assertEqual(self._testing.count(), 0)
+
+    def test_average(self):
+        self._testing.add_sample(1)
+        self._testing.add_sample(11)
+        self.assertAlmostEqual(self._testing.average(), 6.0)
+
+        self._testing.reset()
+        self.assertIsNone(self._testing.average())
+
+        self._testing.add_sample(6)
+        self.assertAlmostEqual(self._testing.average(), 6.0)
+
+    def test_min(self):
+        self._testing.add_sample(1)
+        self._testing.add_sample(11)
+        self.assertAlmostEqual(self._testing.min(), 1.0)
+
+        self._testing.add_sample(15)
+        self.assertAlmostEqual(self._testing.min(), 1.0)
+
+        self._testing.add_sample(0.5)
+        self.assertAlmostEqual(self._testing.min(), 0.5)
+
+        self._testing.reset()
+        self.assertIsNone(self._testing.min())
+
+        self._testing.add_sample(15)
+        self.assertAlmostEqual(self._testing.min(), 15.0)
+
+    def test_max(self):
+        self._testing.add_sample(1)
+        self._testing.add_sample(11)
+        self.assertAlmostEqual(self._testing.max(), 11.0)
+
+        self._testing.add_sample(15)
+        self.assertAlmostEqual(self._testing.max(), 15.0)
+
+        self._testing.add_sample(0.5)
+        self.assertAlmostEqual(self._testing.max(), 15.0)
+
+        self._testing.reset()
+        self.assertIsNone(self._testing.max())
+
+        self._testing.add_sample(0)
+        self.assertAlmostEqual(self._testing.max(), 0)
+
+    def test_buckets(self):
+        buckets = self._buckets_to_list()
+        self.assertEqual(len(buckets), 0)
+
+        self._testing.add_sample(2)
+        buckets = self._buckets_to_list()
+        self.assertEqual(len(buckets), 1)
+        self.assertBucketEquals(buckets[0], (1, 2, 10))
+
+        self._testing.add_sample(50)
+        buckets = self._buckets_to_list()
+        self.assertEqual(len(buckets), 2)
+        self.assertBucketEquals(buckets[0], (1, 2, 10))
+        self.assertBucketEquals(buckets[1], (1, 50, 100))
+
+        self._testing.add_sample(5)
+        buckets = self._buckets_to_list()
+        self.assertEqual(len(buckets), 2)
+        self.assertBucketEquals(buckets[0], (2, 2, 10))
+        self.assertBucketEquals(buckets[1], (1, 50, 100))
+
+        self._testing.add_sample(200)
+        buckets = self._buckets_to_list()
+        self.assertEqual(len(buckets), 3)
+        self.assertBucketEquals(buckets[0], (2, 2, 10))
+        self.assertBucketEquals(buckets[1], (1, 50, 100))
+        self.assertBucketEquals(buckets[2], (1, 100, 200.01))
+
+    def test_estimate_percentile(self):
+        self.assertIsNone(self._testing.estimate_median())
+
+        self._testing.add_sample(0)
+        self._testing.add_sample(3)
+        self._testing.add_sample(4)
+        # Since all of the values fall into the first bucket, the estimate of the percentile will be the same for all
+        # percentiles.
+        self.assertAlmostEqual(self._testing.estimate_percentile(0.1), 5.0)
+        self.assertAlmostEqual(self._testing.estimate_percentile(0.5), 5.0)
+        self.assertAlmostEqual(self._testing.estimate_percentile(1.0), 5.0)
+
+        self._testing.add_sample(11)
+        self._testing.add_sample(12)
+        self._testing.add_sample(13)
+        self._testing.add_sample(55)
+
+        self.assertAlmostEqual(self._testing.estimate_percentile(0.1), 5.0)
+        self.assertAlmostEqual(self._testing.estimate_percentile(0.5), 17.5)
+        self.assertAlmostEqual(self._testing.estimate_percentile(1.0), 75.0)
+
+    def test_summarize(self):
+        self.assertEqual(self._testing.summarize(), "(count=0)")
+
+        self._testing.add_sample(2)
+        self._testing.add_sample(4)
+        self._testing.add_sample(45)
+        self._testing.add_sample(200)
+
+        self.assertEqual(self._testing.summarize(),
+                         "(count=4,avg=62.75,min=2.00,max=200.00,median=6.00)")
+
+    def assertBucketEquals(self, first, second):
+        self.assertEquals(first[0], second[0], "The counts do not equal")
+        self.assertAlmostEquals(first[1], second[1], "The lower bounds do not equal")
+        self.assertAlmostEquals(first[2], second[2], "The upper bounds do not equal")
+
+    def _buckets_to_list(self):
+        result = []
+        for count, lower, upper in self._testing.buckets():
+            result.append((count, lower, upper))
+        return result
+
+

--- a/scalyr_agent/tests/util_test.py
+++ b/scalyr_agent/tests/util_test.py
@@ -742,9 +742,9 @@ class TestHistogramTracker(ScalyrTestCase):
                          "(count=4,avg=62.75,min=2.00,max=200.00,median=6.00)")
 
     def assertBucketEquals(self, first, second):
-        self.assertEquals(first[0], second[0], "The counts do not equal")
-        self.assertAlmostEquals(first[1], second[1], "The lower bounds do not equal")
-        self.assertAlmostEquals(first[2], second[2], "The upper bounds do not equal")
+        self.assertEquals(first[0], second[0], msg="The counts do not equal")
+        self.assertAlmostEquals(first[1], second[1], msg="The lower bounds do not equal")
+        self.assertAlmostEquals(first[2], second[2], msg="The upper bounds do not equal")
 
     def _buckets_to_list(self):
         result = []


### PR DESCRIPTION
This PR fixes 2 bugs and add a unit test as follows:

# Bugs

1. Logic for stale entries should also return never-accessed objects
2. Recording of already-warmed entries should also be done for the case where a WarmingEntry does not exist.

# Unit test

Seems to me there are 2 `already-warmed` situations:
a) Another thread already-warms a container before `mark_to_warm` (the container will not be scheduled for warming). 
b) Another thread already-warms a container after `mark_to_warm` (the container is scheduled for warming)

The existing `test_already_warm` tests case (b).  Case (a) isn't tested.  I'm adding a test for case (a) and renaming `test_already_warm` for clarity.
