### PR TITLE
AGENT-182: Umask 0022 for posix systems

### DIFF
--- a/scalyr_agent/platform_posix.py
+++ b/scalyr_agent/platform_posix.py
@@ -273,7 +273,10 @@ class PosixPlatformController(PlatformController):
             os.chdir("/")
             # noinspection PyArgumentList
             os.setsid()
-            os.umask(0)
+            # set umask to be consistent with common settings on linux systems.  This makes the standalone agent
+            # created-file permissions consistent with that of docker/k8s agents (no write permissions for group and
+            # others)
+            os.umask(0022)
 
             # do second fork
             pid = os.fork()


### PR DESCRIPTION
Standalone agent creates files that are other and group writable (logfiles, temp status file, checkpoint files).

platform_posix.py:__daemonize() explicitly resets umask(0), thus causing agent python process to not inherit/honor environment umask settings.

k8s and docker agents do not daemonize(), hence are not subject to this code path. Therefore, they inherit default linux umask of 0022 and thus produce tighter permissions.

Solution is to simply set umask(0022) instead of umask(0), given that there was no intentional motivation behind setting umask(0) aside from copying the UNIX double-fork recipe.

# How was this tested:

Ran agent and verified files were correct permissions.