### PR TITLE
AGENT-64: Fix several skipped tests

### DIFF
--- a/scalyr_agent/tests/copying_manager_test.py
+++ b/scalyr_agent/tests/copying_manager_test.py
@@ -628,7 +628,7 @@ class TestableCopyingManager(CopyingManager):
             # This notifies any threads waiting in the `run_and_stop_at` method.  They would be blocking waiting for
             # the CopyingManager thread to stop at this point.
             self.__test_state_cv.notifyAll()
-            # We need to wait until some other state is set as the stop state.  The `notifyAll` in `run_and_stop_at_at`
+            # We need to wait until some other state is set as the stop state.  The `notifyAll` in `run_and_stop_at`
             # method will wake us up.
             self.__test_state_cv_wait_with_timeout(start_time)
 

--- a/scalyr_agent/tests/copying_manager_test.py
+++ b/scalyr_agent/tests/copying_manager_test.py
@@ -24,7 +24,7 @@ import tempfile
 
 import logging
 import sys
-import unittest
+import time
 
 root = logging.getLogger()
 root.setLevel(logging.DEBUG)
@@ -215,7 +215,6 @@ class CopyingManagerEnd2EndTest(ScalyrTestCase):
         if self._controller is not None:
             self._controller.stop()
 
-    @skip("@czerwin to investigate")
     def test_single_log_file(self):
         controller = self.__create_test_instance()
         self.__append_log_lines('First line', 'Second line')
@@ -228,7 +227,6 @@ class CopyingManagerEnd2EndTest(ScalyrTestCase):
 
         responder_callback('success')
 
-    @skip("@czerwin to investigate")
     def test_multiple_scans_of_log_file(self):
         controller = self.__create_test_instance()
         self.__append_log_lines('First line', 'Second line')
@@ -248,7 +246,6 @@ class CopyingManagerEnd2EndTest(ScalyrTestCase):
         self.assertEquals(1, len(lines))
         self.assertEquals('Third line', lines[0])
 
-    @skip("@czerwin to investigate")
     def test_normal_error(self):
         controller = self.__create_test_instance()
         self.__append_log_lines('First line', 'Second line')
@@ -269,7 +266,6 @@ class CopyingManagerEnd2EndTest(ScalyrTestCase):
         self.assertEquals('First line', lines[0])
         self.assertEquals('Second line', lines[1])
 
-    @skip("@czerwin to investigate")
     def test_drop_request_due_to_error(self):
         controller = self.__create_test_instance()
         self.__append_log_lines('First line', 'Second line')
@@ -289,7 +285,6 @@ class CopyingManagerEnd2EndTest(ScalyrTestCase):
         self.assertEquals(1, len(lines))
         self.assertEquals('Third line', lines[0])
 
-    @skip("@czerwin to investigate")
     def test_request_too_large_error(self):
         controller = self.__create_test_instance()
         self.__append_log_lines('First line', 'Second line')
@@ -311,7 +306,6 @@ class CopyingManagerEnd2EndTest(ScalyrTestCase):
         self.assertEquals('Second line', lines[1])
         self.assertEquals('Third line', lines[2])
 
-    @skip("@czerwin to investigate")
     def test_pipelined_requests(self):
         controller = self.__create_test_instance(use_pipelining=True)
         self.__append_log_lines('First line', 'Second line')
@@ -341,7 +335,6 @@ class CopyingManagerEnd2EndTest(ScalyrTestCase):
 
         responder_callback('success')
 
-    @skip("@czerwin to investigate")
     def test_pipelined_requests_with_normal_error(self):
         controller = self.__create_test_instance(use_pipelining=True)
         self.__append_log_lines('First line', 'Second line')
@@ -382,7 +375,6 @@ class CopyingManagerEnd2EndTest(ScalyrTestCase):
 
         responder_callback('success')
 
-    @skip("@czerwin to investigate")
     def test_pipelined_requests_with_retry_error(self):
         controller = self.__create_test_instance(use_pipelining=True)
         self.__append_log_lines('First line', 'Second line')
@@ -488,33 +480,42 @@ class TestableCopyingManager(CopyingManager):
 
     To actually control the copying manager, use the TestController object returned by ``controller``.
     """
+    # The different points at which the CopyingManager can be stopped.  See below.
+    SLEEPING = 'sleeping'
+    SENDING = 'sending'
+    RESPONDING = 'responding'
+
+    # To prevent tests from hanging indefinitely, wait a maximum amount of time before giving up on some test condition.
+    WAIT_TIMEOUT = 5.0
+
     def __init__(self, configuration, monitors):
         CopyingManager.__init__(self, configuration, monitors)
         # Approach:  We will override key methods of CopyingManager, blocking them from returning until the controller
         # tells it to proceed.  This allows us to then do things like write new log lines while the CopyingManager is
-        # blocked.   Coordinating the communication between the two threads is done using two condition variables.
+        # blocked.   Coordinating the communication between the two threads is done using one condition variable.
         # We changed the CopyingManager to block in three places: while it is sleeping before it starts a new loop,
-        # when it invokes ``_send_events`` to send a new request, and when it blocks to receive the response.
-        # These three states or referred to as "sleeping", "blocked_on_send", "blocked_on_receive".
+        # when it invokes `_send_events` to send a new request, and when it blocks to receive the response.
+        # These three states are referred to as 'sleeping', 'sending', 'responding'.
+        #
+        # The CopyingManager will have state to record where it should next block (i.e., if it should block at
+        # 'sleeping' when it attempts to sleep).  The test controller will manipulate this state, notifying changes on
+        # the condition variable. The CopyingManager will block in this state (and indicate it is blocked) until the
+        # test controller sets a new state to block at.
         #
         # This cv protects all of the variables written by the CopyingManager thread.
         self.__test_state_cv = threading.Condition()
-        # Which state the CopyingManager is currently blocked in -- "sleeping", "blocked_on_send", "blocked_on_receive"
-        self.__test_state = None
-        # The number of times the CopyingManager has blocked.
-        self.__test_state_changes = 0
-        # Whether or not the CopyingManager should stop.
-        self.__test_stopping = False
+        # Which state the CopyingManager should block in -- "sleeping", "sending", "responding"
+        # We initialize it to a special value "all" so that it stops as soon the CopyingManager starts up.
+        self.__test_stop_state = 'all'
+        # If not none, a state the test must pass through before it tries to stop at `__test_stop_state`.
+        # If this transition is not observed by the time it does get to the stop state, an assertion is thrown.
+        self.__test_required_transition = None
+        # Whether or not the CopyingManager is stopped at __test_stop_state.
+        self.__test_is_stopped = False
         # Written by CopyingManager.  The last AddEventsRequest request passed into ``_send_events``.
         self.__captured_request = None
         # Protected by __test_state_cv.  The status message to return for the next call to ``_send_events``.
         self.__pending_response = None
-
-        # This cv protects __advance_requests and is used mainly by the testing thread.
-        self.__advance_requests_cv = threading.Condition()
-        # This is incremented everytime the controller wants the CopyingManager to advance to the next blocking state,
-        # regardless of which state it is in.
-        self.__advance_requests = 0
 
         self.__controller = TestableCopyingManager.TestController(self)
 
@@ -526,8 +527,10 @@ class TestableCopyingManager(CopyingManager):
         """Blocks the CopyingManager thread until the controller tells it to proceed.
         """
         self.__test_state_cv.acquire()
-        self.__wait_until_advance_received('sleeping')
-        self.__test_state_cv.release()
+        try:
+            self.__block_if_should_stop_at(TestableCopyingManager.SLEEPING)
+        finally:
+            self.__test_state_cv.release()
 
     def _create_add_events_request(self, session_info=None, max_size=None):
         # Need to override this to return an AddEventsRequest even though we don't have a real scalyr client instance.
@@ -545,21 +548,25 @@ class TestableCopyingManager(CopyingManager):
         """
         # First, block even returning from this method until the controller advances us.
         self.__test_state_cv.acquire()
-        self.__wait_until_advance_received('blocked_on_send')
-        self.__captured_request = add_events_task.add_events_request
-        self.__test_state_cv.release()
+        try:
+            self.__block_if_should_stop_at(TestableCopyingManager.SENDING)
+            self.__captured_request = add_events_task.add_events_request
+        finally:
+            self.__test_state_cv.release()
 
         # Create a method that we can return that will (when invoked) return the response
         def emit_response():
             # Block on return the response until the state is advanced.
             self.__test_state_cv.acquire()
-            self.__wait_until_advance_received('blocked_on_receive')
+            try:
+                self.__block_if_should_stop_at(TestableCopyingManager.RESPONDING)
 
-            # Use the pending response if there is one.  Otherwise, we just say "success" which means all add event
-            # requests will just be processed.
-            result = self.__pending_response
-            self.__pending_response = None
-            self.__test_state_cv.release()
+                # Use the pending response if there is one.  Otherwise, we just say "success" which means all add event
+                # requests will just be processed.
+                result = self.__pending_response
+                self.__pending_response = None
+            finally:
+                self.__test_state_cv.release()
 
             if result is not None:
                 return result, 0, 'fake'
@@ -567,37 +574,6 @@ class TestableCopyingManager(CopyingManager):
                 return 'success', 0, 'fake'
 
         return emit_response
-
-    def __wait_until_advance_received(self, new_state):
-        """Helper method for blocking the thread until the controller thread has indicated this one should advance
-        to its next state.
-
-        You must be holding the self.__test_state_cv lock to invoke this method.
-
-        @param new_state: The name of the blocking state the CopyingManager is in until it is advanced.
-        @type new_state: str
-        """
-        if self.__test_stopping:
-            return
-        # We are about to block, so be sure to increment the count.  We make use of this to detect when state changes
-        # are made.  This is broadcasted to the controller thread.
-        self.__test_state_changes += 1
-        self.__test_state = new_state
-        self.__test_state_cv.notifyAll()
-        self.__test_state_cv.release()
-
-        # Now we have to wait until we see another advance request.  To do that, we just note when the number of
-        # advances has increased.  Of course, we need to get the __advance_requests_cv lock to look at that var.
-        self.__advance_requests_cv.acquire()
-        original_advance_requests = self.__advance_requests
-
-        while self.__advance_requests == original_advance_requests:
-            self.__advance_requests_cv.wait()
-        self.__advance_requests_cv.release()
-
-        # Get the lock again so that we have it when the method returns.
-        self.__test_state_cv.acquire()
-        self.__test_state = 'running'
 
     def captured_request(self):
         """Returns the last request that was passed into ``_send_events`` by the CopyingManager, or None if there
@@ -626,26 +602,94 @@ class TestableCopyingManager(CopyingManager):
         self.__pending_response = status_message
         self.__test_state_cv.release()
 
-    def advance_until(self, final_state):
-        """Instructs the CopyingManager thread to keep advancing through its blocking states until it reaches the
-        named one.
+    def __block_if_should_stop_at(self, current_point):
+        """Invoked by the CopyManager thread to report it has transitioned to the specified state and will block if
+        `run_and_stop_at` has been invoked with `current_point` as the stopping point.
 
-        @param final_state:  The name of the state to wait for (such as "sleeping", "blocked_on_receive", etc.
-        @type final_state: str
+        @param current_point: The point reached by the CopyingManager thread, only valid values are
+            `SLEEPING`, `SENDING`, and `RESPONDING`.
+        @type current_point: str
+        """
+        # If we are passing through the required_transition state, consume it to signal we have accomplished
+        # the transition.
+        if current_point == self.__test_required_transition:
+            self.__test_required_transition = None
+
+        # Block if it has been requested that we block here.  Note, __test_stop_state can only be:
+        # 'all'  -- indicating it should stop at the first state it sees.
+        # None -- indicating the test is shutting down and the CopyingManger thread should just run until it finishes
+        # One of `SLEEPING`, `SENDING`, and `RESPONDING` -- indicating where we should next block the CopyingManager.
+        start_time = time.time()
+        while self.__test_stop_state == 'all' or current_point == self.__test_stop_state:
+            self.__test_is_stopped = True
+            if self.__test_required_transition is not None:
+                raise AssertionError('Stopped at %s state but did not transition through %s' % (
+                    current_point, self.__test_required_transition))
+            # This notifies any threads waiting in the `run_and_stop_at` method.  They would be blocking waiting for
+            # the CopyingManager thread to stop at this point.
+            self.__test_state_cv.notifyAll()
+            # We need to wait until some other state is set as the stop state.  The `notifyAll` in `run_and_stop_at_at`
+            # method will wake us up.
+            self.__test_state_cv_wait_with_timeout(start_time)
+
+        self.__test_is_stopped = False
+
+    def run_and_stop_at(self, stopping_at, required_transition_state=None):
+        """Invoked by the testing thread to indicate the CopyingManager thread should run and keep running until
+        it enters the specified state.  If `required_transition_state` is specified, then the CopyingManager thread
+        must transition through the specified state before it stops, otherwise an AssertionError will be raised.
+
+        Note, if the CopyingManager thread is already stopping in the `stopping_at` thread, then this call will
+        immediately return.  It does not wait for the next occurrence of that state.
+
+        @param stopping_at: The state to stop at.  Only valid values are `SLEEPING`, `SENDING`, `RESPONDING`
+        @param required_transition_state: If not None, requires that the CopyingManager transitions through the
+            specified state before it gets to `stopping_at`.  Otherwise an AssertionError will be thrown.
+              Only valid values are `SLEEPING`, `SENDING`, `RESPONDING`
+
+        @type stopping_at: str
+        @type required_transition_state: str or None
         """
         self.__test_state_cv.acquire()
-        original_count = self.__test_state_changes
+        try:
+            # Just to avoid mistakes in testing, make sure we successfully consumed any require transitions before
+            # we tell it to stop anywhere else.
+            if self.__test_required_transition is not None:
+                raise AssertionError('Setting new stop state %s with pending required transition %s' % (
+                    stopping_at, self.__test_required_transition))
+            # If we are already in the required_transition_state, consume it.
+            if self.__test_is_stopped and self.__test_stop_state == required_transition_state:
+                self.__test_required_transition = None
+            else:
+                self.__test_required_transition = required_transition_state
 
-        # We have to keep incrementing the __advanced_requests count so that the copying manager thread keeps
-        # advancing.  We wait on the test_state_cv because everytime the CopyingManager blocks, it notifies that cv.
-        while self.__test_state_changes <= original_count or self.__test_state != final_state:
-            self.__advance_requests_cv.acquire()
-            self.__advance_requests += 1
-            self.__advance_requests_cv.notifyAll()
-            self.__advance_requests_cv.release()
-            self.__test_state_cv.wait()
+            if self.__test_is_stopped and self.__test_stop_state == stopping_at:
+                return
 
-        self.__test_state_cv.release()
+            self.__test_stop_state = stopping_at
+            self.__test_is_stopped = False
+            # This will wake up threads in `__block_if_should_stop_at` which are waiting for a new stopping point.
+            self.__test_state_cv.notifyAll()
+
+            start_time = time.time()
+            # Wait until we get to this point.
+            while not self.__test_is_stopped:
+                # This will be woken up by the notify in `__block_if_should_stop_at` method.
+                self.__test_state_cv_wait_with_timeout(start_time)
+        finally:
+            self.__test_state_cv.release()
+
+    def __test_state_cv_wait_with_timeout(self, start_time):
+        """Waits on the `__test_state_cv` condition variable, but will also throw an AssertionError if the wait
+        time exceeded the `start_time` plus `WAIT_TIMEOUT`.
+
+        @param start_time:  The start time when we first began waiting on this condition, in seconds past epoch.
+        @type start_time: Number
+        """
+        deadline = start_time + TestableCopyingManager.WAIT_TIMEOUT
+        self.__test_state_cv.wait(timeout=(deadline - time.time()) + 0.5)
+        if time.time() > deadline:
+            raise AssertionError('Deadline exceeded while waiting on condition variable')
 
     def stop_manager(self, wait_on_join=True, join_timeout=5):
         """Stops the manager's thread.
@@ -658,30 +702,13 @@ class TestableCopyingManager(CopyingManager):
         @rtype:
         """
         # We need to do some extra work here in case the CopyingManager thread is currently in a blocked state.
-        # We need to tell it to advance.
+        # We need to tell it to keep running.
         self.__test_state_cv.acquire()
-        self.__test_stopping = True
+        self.__test_stop_state = None
+        self.__test_state_cv.notifyAll()
         self.__test_state_cv.release()
 
-        self.__advance_requests_cv.acquire()
-        self.__advance_requests += 1
-        self.__advance_requests_cv.notifyAll()
-        self.__advance_requests_cv.release()
-
         CopyingManager.stop_manager(self, wait_on_join=wait_on_join, join_timeout=join_timeout)
-
-    @property
-    def test_state(self):
-        """
-        @return:  Returns the name of the state the CopyingManager thread is currently blocked in, such as
-            "sleeping", "blocked_on_send", "blocked_on_receive".
-        @rtype: str
-        """
-        self.__test_state_cv.acquire()
-        try:
-            return self.__test_state
-        finally:
-            self.__test_state_cv.release()
 
     class TestController(object):
         """Used to control the TestableCopyingManager.
@@ -691,10 +718,9 @@ class TestableCopyingManager(CopyingManager):
         def __init__(self, copying_manager):
             self.__copying_manager = copying_manager
             copying_manager.start_manager(dict(fake_client=True))
-
             # To do a proper initialization where the copying manager has scanned the current log file and is ready
             # for the next loop, we let it go all the way through the loop once and wait in the sleeping state.
-            self.__copying_manager.advance_until('sleeping')
+            copying_manager.run_and_stop_at(TestableCopyingManager.SLEEPING)
 
         def perform_scan(self):
             """Tells the CopyingManager thread to go through the process loop until far enough where it has performed
@@ -702,8 +728,9 @@ class TestableCopyingManager(CopyingManager):
 
             At this point, the CopyingManager should have a request ready to be sent.
             """
-            self.__copying_manager.captured_request()
-            self.__copying_manager.advance_until('blocked_on_send')
+            # We guarantee it has scanned by making sure it has gone from sleeping to sending.
+            self.__copying_manager.run_and_stop_at(TestableCopyingManager.SENDING,
+                                                   required_transition_state=TestableCopyingManager.SLEEPING)
 
         def perform_pipeline_scan(self):
             """Tells the CopyingManager thread to advance far enough where it has performed the file system scan
@@ -711,7 +738,9 @@ class TestableCopyingManager(CopyingManager):
 
             This is only valid to call immediately after a ``perform_scan``
             """
-            self.__copying_manager.advance_until('blocked_on_receive')
+            # We guarantee it has done the pipeline scan by making sure it has gone through responding to sending.
+            self.__copying_manager.run_and_stop_at(TestableCopyingManager.RESPONDING,
+                                                   required_transition_state=TestableCopyingManager.SENDING)
 
         def wait_for_rpc(self):
             """Tells the CopyingManager thread to advance to the point where it has emulated sending an RPC.
@@ -720,13 +749,12 @@ class TestableCopyingManager(CopyingManager):
                 when invoked will return the passed in status message as the response to the AddEventsRequest.
             @rtype: (AddEventsRequest, func)
             """
-            if self.__copying_manager.test_state != 'blocked_on_receive':
-                self.__copying_manager.advance_until('blocked_on_receive')
+            self.__copying_manager.run_and_stop_at(TestableCopyingManager.RESPONDING)
             request = self.__copying_manager.captured_request()
 
             def send_response(status_message):
                 self.__copying_manager.set_response(status_message)
-                self.__copying_manager.advance_until('sleeping')
+                self.__copying_manager.run_and_stop_at(TestableCopyingManager.SLEEPING)
 
             return request, send_response
 

--- a/scalyr_agent/tests/scalyr_client_test.py
+++ b/scalyr_agent/tests/scalyr_client_test.py
@@ -32,9 +32,9 @@ class AddEventsRequestTest(ScalyrTestCase):
 
     def setUp(self):
         self.__body = {'token': 'fakeToken'}
+        scalyr_client._set_last_timestamp(0)
 
     def test_basic_case(self):
-        scalyr_client._set_last_timestamp( 0 )
         request = AddEventsRequest(self.__body)
         request.set_client_time(1)
 
@@ -80,7 +80,6 @@ class AddEventsRequestTest(ScalyrTestCase):
         request.close()
 
     def test_maximum_bytes_exceeded(self):
-        scalyr_client._set_last_timestamp( 0 )
         request = AddEventsRequest(self.__body, max_size=103)
         request.set_client_time(1)
 
@@ -93,7 +92,6 @@ class AddEventsRequestTest(ScalyrTestCase):
         request.close()
 
     def test_maximum_bytes_exceeded_from_threads(self):
-        scalyr_client._set_last_timestamp( 0 )
         request = AddEventsRequest(self.__body, max_size=100)
         request.set_client_time(1)
 
@@ -107,7 +105,6 @@ class AddEventsRequestTest(ScalyrTestCase):
         request.close()
 
     def test_set_position(self):
-        scalyr_client._set_last_timestamp( 0 )
         request = AddEventsRequest(self.__body)
         request.set_client_time(1)
         position = request.position()
@@ -124,7 +121,6 @@ class AddEventsRequestTest(ScalyrTestCase):
         request.close()
 
     def test_set_position_with_thread(self):
-        scalyr_client._set_last_timestamp( 0 )
         request = AddEventsRequest(self.__body)
         request.set_client_time(1)
         position = request.position()
@@ -144,7 +140,6 @@ class AddEventsRequestTest(ScalyrTestCase):
         request.close()
 
     def test_set_client_time(self):
-        scalyr_client._set_last_timestamp( 0 )
         request = AddEventsRequest(self.__body)
         request.set_client_time(100)
 


### PR DESCRIPTION
1.  Fix issue with the scalyr_client where the testing code was
not properly clearing out some global state.

2.  Fix the CopyingManager end-to-end tests.  The testing code has
several issues in its use of two condition variables.  Simplified
code so that there were no longer any race conditions.  Also
added in deadlines for waiting on the condition variable to
prevent the tests hanging indefinitely.