### PR TITLE
Added test feature to help investigate hung threads

### DIFF
--- a/scalyr_agent/tests/util_test.py
+++ b/scalyr_agent/tests/util_test.py
@@ -231,7 +231,28 @@ class TestStoppableThread(ScalyrTestCase):
         self._run_counter = 0
 
     def test_basic_use(self):
+        # Since the ScalyrTestCase sets the name prefix, we need to set it back to None to get an unmolested name.
+        StoppableThread.set_name_prefix(None)
         test_thread = StoppableThread('Testing', self._run_method)
+        self.assertEqual(test_thread.getName(), 'Testing')
+        test_thread.start()
+        test_thread.stop()
+
+        self.assertTrue(self._run_counter > 0)
+
+    def test_name_prefix(self):
+        StoppableThread.set_name_prefix('test_name_prefix: ')
+        test_thread = StoppableThread('Testing', self._run_method)
+        self.assertEqual(test_thread.getName(), 'test_name_prefix: Testing')
+        test_thread.start()
+        test_thread.stop()
+
+        self.assertTrue(self._run_counter > 0)
+
+    def test_name_prefix_with_none(self):
+        StoppableThread.set_name_prefix('test_name_prefix: ')
+        test_thread = StoppableThread(target=self._run_method)
+        self.assertEqual(test_thread.getName(), 'test_name_prefix: ')
         test_thread.start()
         test_thread.stop()
 


### PR DESCRIPTION
This is meant to investigate the case where the test process does
not exit because it is waiting for some thread to stop that will
never stop.

To implement this, I added the ability to set a name prefix for
all StoppableThreads created.  The test framework uses this to set
a prefix including the test case, so that all threads can be tied
back to the test case that created it.

Also created a thread in the testing framework which will wait
60s for the tests to finish.  If they do not (and hence hung),
it will print out all active thread names.

Hopefully this will help give information about which test case
is creating threads that hang the tests.