### PR TITLE
AGENT-187: Move standalone smoketest code into repo.  Unify unit/smoke tests into single image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e PYTHON_VERSION=2.6 scalyr/scalyr-agent-ci-unittest:1 /tmp/unittest.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e PYTHON_VERSION=2.6 scalyr/scalyr-agent-ci-unittest:2 /tmp/unittest.sh
 
   unittest-25:
     docker:
@@ -50,7 +50,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e PYTHON_VERSION=2.5 scalyr/scalyr-agent-ci-unittest:1 /tmp/unittest.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e PYTHON_VERSION=2.5 scalyr/scalyr-agent-ci-unittest:2 /tmp/unittest.sh
 
   unittest-24:
     docker:
@@ -59,44 +59,60 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e PYTHON_VERSION=2.4 scalyr/scalyr-agent-ci-unittest:1 /tmp/unittest.sh
+          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e PYTHON_VERSION=2.4 scalyr/scalyr-agent-ci-unittest:2 /tmp/unittest.sh
 
   smoke-standalone-27:
     docker:
       - image: circleci/python:2.7-jessie-browsers
     steps:
+      - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.7 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:9 /tmp/smoketest_standalone.sh
-
+          command: |
+            docker container create --name dummy -v shared_vol:/app alpine && \
+            docker cp $(pwd)/.circleci/smoketest_standalone.sh dummy:/app/ && \
+            docker run -it -v shared_vol:/app -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.7 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} -e CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM} scalyr/scalyr-agent-ci-unittest:2 /app/smoketest_standalone.sh && \
+            docker rm dummy;
   smoke-standalone-26:
     docker:
       - image: circleci/python:2.7-jessie-browsers
     steps:
+      - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.6 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:9 /tmp/smoketest_standalone.sh
-
+          command: |
+            docker container create --name dummy -v shared_vol:/app alpine && \
+            docker cp $(pwd)/.circleci/smoketest_standalone.sh dummy:/app/ && \
+            docker run -it -v shared_vol:/app -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.6 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} -e CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM} scalyr/scalyr-agent-ci-unittest:2 /tmp/smoketest_standalone.sh && \
+            docker rm dummy;
   smoke-standalone-25:
     docker:
       - image: circleci/python:2.7-jessie-browsers
     steps:
+      - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.5 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:9 /tmp/smoketest_standalone.sh
-
+          command: |
+            docker container create --name dummy -v shared_vol:/app alpine && \
+            docker cp $(pwd)/.circleci/smoketest_standalone.sh dummy:/app/ && \
+            docker run -it -v shared_vol:/app -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.5 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} -e CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM} scalyr/scalyr-agent-ci-unittest:2 /tmp/smoketest_standalone.sh && \
+            docker rm dummy
   smoke-standalone-24:
     docker:
       - image: circleci/python:2.7-jessie-browsers
     steps:
+      - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker run -it -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.4 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} scalyr/scalyr-agent-ci-smoketest:9 /tmp/smoketest_standalone.sh
-
+          command: |
+            docker container create --name dummy -v shared_vol:/app alpine && \
+            docker cp $(pwd)/.circleci/smoketest_standalone.sh dummy:/app/ && \
+            docker run -it -v shared_vol:/app -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.4 -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} -e CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM} scalyr/scalyr-agent-ci-unittest:2 /tmp/smoketest_standalone.sh && \
+            docker rm dummy
   smoke-docker-json:
     docker:
       - image: circleci/python:2.7-jessie-browsers
@@ -116,7 +132,7 @@ jobs:
           paths:
             - "venv"
       - run:
-          command: source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-smoketest:9 json 300
+          command: source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-unittest:2 json 300
 
   smoke-docker-syslog:
     docker:
@@ -137,7 +153,7 @@ jobs:
           paths:
             - "venv"
       - run:
-          command: source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-smoketest:9 syslog 300
+          command: source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-unittest:2 syslog 300
 
   smoke-k8s:
     machine:
@@ -186,7 +202,7 @@ jobs:
       - run:
           name: build k8s agent and run smoketest
           command: |
-            source ./.circleci/smoketest_k8s.sh scalyr/scalyr-agent-ci-smoketest:9 300
+            source ./.circleci/smoketest_k8s.sh scalyr/scalyr-agent-ci-unittest:2 300
 
   smoke-k8s-helm:
     machine:

--- a/.circleci/smoketest_docker.sh
+++ b/.circleci/smoketest_docker.sh
@@ -39,7 +39,7 @@ max_wait=$3
 #----------------------------------------------------------------------------------------
 
 # Smoketest code (built into smoketest image)
-smoketest_script="/usr/bin/python3 /tmp/smoketest.py"
+smoketest_script="source ~/.bashrc && pyenv shell 3.7.3 && python3 /tmp/smoketest.py"
 
 # Erase variables (to avoid subtle config bugs in development)
 syslog_driver_option=""
@@ -102,11 +102,11 @@ echo "Agent container ID == ${agent_hostname}"
 # You MUST provide scalyr server, api key and importantly, the agent_hostname container ID for the agent-liveness
 # query to work (uploader container waits for agent to be alive before uploading data)
 docker run ${syslog_driver_option}  -d --name ${contname_uploader} ${smoketest_image} \
-${smoketest_script} ${contname_uploader} ${max_wait} \
+bash -c "${smoketest_script} ${contname_uploader} ${max_wait} \
 --mode uploader \
 --scalyr_server ${SCALYR_SERVER} \
 --read_api_key ${READ_API_KEY} \
---agent_hostname ${agent_hostname}
+--agent_hostname ${agent_hostname}"
 
 # Capture uploader short container ID
 uploader_hostname=$(docker ps --format "{{.ID}}" --filter "name=$contname_uploader")
@@ -115,13 +115,13 @@ echo "Uploader container ID == ${uploader_hostname}"
 # Launch synchronous Verifier image (writes to stdout and also queries Scalyr)
 # Like the Uploader, the Verifier also waits for agent to be alive before uploading data
 docker run ${syslog_driver_option} -it --name ${contname_verifier} ${smoketest_image} \
-${smoketest_script} ${contname_verifier} ${max_wait} \
+bash -c "${smoketest_script} ${contname_verifier} ${max_wait} \
 --mode verifier \
 --scalyr_server ${SCALYR_SERVER} \
 --read_api_key ${READ_API_KEY} \
 --agent_hostname ${agent_hostname} \
 --uploader_hostname ${uploader_hostname} \
---debug true
+--debug true"
 
 kill_and_delete_docker_test_containers
 

--- a/.circleci/smoketest_standalone.sh
+++ b/.circleci/smoketest_standalone.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+##################################################################
+# Usage: <this_script>
+# Expects the following env vars
+#   TEST_BRANCH: git branch
+#   PYTHON_VERSION: python version to run test as (2.4-2.6)
+#   SCALYR_API_KEY: Write api key
+#   READ_API_KEY: Read api key for querying
+#   SCALYR_SERVER: scalyr server
+#   MAX_WAIT: max secs to verify upload
+#   CIRCLE_BUILD_NUM
+##################################################################
+
+alias ll='ls -la'
+PS1='\h:\w\$ '
+
+FILES=/tmp
+
+# Create work directory to checkout source code
+mkdir -p /tmp/src && pushd /tmp/src
+if [ ! -d "./scalyr-agent-2" ]; then
+    git clone https://github.com/scalyr/scalyr-agent-2.git
+fi
+cd scalyr-agent-2
+git checkout $TEST_BRANCH
+
+# Make sure /usr/local/bin/fpm is runnable
+export PATH=/usr/local/bin:$PATH
+
+# Build RPM with python 2.7
+source ~/.bashrc && pyenv shell 2.7.12 && pyenv version
+echo "Building agent RPM"
+python build_package.py rpm
+RPMFILE=`ls scalyr-agent*.rpm`
+sudo -E rpm -i $RPMFILE
+
+# Switch python version and set PATH.  Also symlink /usr/bin/python to Tcollector doesn't
+# inadvertently use preinstalled 2.7
+python_version_opt='--version'
+if [[ $PYTHON_VERSION == "2.4" ]]; then
+    PYENV_VERSION="2.4.1"
+    python_version_opt='-V'
+elif [[ $PYTHON_VERSION == "2.5" ]]; then
+    PYENV_VERSION="2.5.4"
+elif [[ $PYTHON_VERSION == "2.6" ]]; then
+    PYENV_VERSION="2.6.9"
+elif [[ $PYTHON_VERSION == "2.7" ]]; then
+    PYENV_VERSION="2.7.12"
+fi
+source ~/.bashrc && pyenv shell $PYENV_VERSION && pyenv version
+
+# Make sure system python is the same as test version (for tcollector)
+pythonbin=$(which python)
+echo "pythonbin == $pythonbin"
+sudo ln -sf ${pythonbin} /usr/bin/python
+ls -la /usr/bin/python
+
+# Setup the agent config (files must be owned by root as agent runs as root)
+sudo /bin/cp -f $FILES/override_files/agent.json /etc/scalyr-agent-2/agent.json
+sudo perl -pi.bak -e "s{CIRCLE_BUILD_NUM}{$CIRCLE_BUILD_NUM}" /etc/scalyr-agent-2/agent.json
+echo "Overriding contents of: /etc/scalyr-agent-2/agent.json"
+cat /etc/scalyr-agent-2/agent.json
+
+echo "{api_key: \"$SCALYR_API_KEY\"}" > /tmp/api_key.json
+sudo mv /tmp/api_key.json /etc/scalyr-agent-2/agent.d/api_key.json
+echo "{scalyr_server: \"qatesting.scalyr.com\", debug_init: true, debug_level: 5}" > /tmp/scalyr_server.json
+sudo mv /tmp/scalyr_server.json /etc/scalyr-agent-2/agent.d/scalyr_server.json
+
+# Start the agent.  Must use -E to inherit environment for proper python settings
+echo "Starting agent ..."
+sudo -E scalyr-agent-2 start
+
+if [[ ! -f /var/log/scalyr-agent-2/agent.pid ]]; then
+    exit 1
+fi
+
+function print_header() {
+    header="$1";
+    if [[ -n $header ]]; then
+        echo "";
+        echo "=======================================";
+        echo $header;
+        echo "=======================================";
+    fi
+}
+
+# Display python version that tcollector lib uses
+print_header 'Agent Python version:'
+python $python_version_opt
+
+print_header 'Python version used by tcollector (/usr/bin/python) is:'
+/usr/bin/python $python_version_opt
+
+print_header 'Python processes'
+ps -ef | fgrep python
+
+# Write to a test file after starting agent (otherwise logs are not included since considered too old)
+# This file must match the log stanza in the overridden agent.json config
+LOGFILE='/var/log/scalyr-agent-2/data.json'
+
+# Execute the test in Python3 (independent of the agent python version)
+# Fake the container name (i.e. don't actually need to run docker --name
+print_header 'Querying Scalyr server to verify log upload'
+
+# The smoketest python process requires python 3
+sudo -E bash -c "source ~/.bashrc && pyenv shell 3.7.3 && python $FILES/smoketest.py \
+ci-agent-standalone-${CIRCLE_BUILD_NUM} $MAX_WAIT \
+--scalyr_server $SCALYR_SERVER --read_api_key $READ_API_KEY \
+--python_version $PYTHON_VERSION --monitored_logfile $LOGFILE \
+--debug true"


### PR DESCRIPTION
This PR is the result of many iterations trying to unify unit/smoke tests.  Supporting older python versions is a real pain but I think this PR finally succeeds in doing so with a single docker image.  (Note the docker file for creating the test image will be in a separate repo). 

# Summary

- Modify circleCI yaml to use new unified image

- Checkin standalone smoketest code into this repo

