### PR TITLE
AGENT-189: Make ratelimiter defaults more aggressive

### DIFF
--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1115,16 +1115,15 @@ class Configuration(object):
             config, 'k8s_log_api_responses_to_disk', False, description, apply_defaults, env_aware=True
         )
 
-        # TODO-163 : make controlled cache warmer settings more aggressive
-        # Optional (defaults to 5). The maximum number of temporary errors that may occur when warming a pod\'s entry,
-        # before the warmer blacklists it
-        self.__verify_or_set_optional_int(
-            config, 'k8s_controlled_warmer_max_attempts', 5, description, apply_defaults, env_aware=True
-        )
-        # Optional (defaults to 3). The number of times the warmer will retry a query to warm a pod if it fails due to
-        # a temporary error.
+        # Optional (defaults to 3). The number of times the warmer will retry a query to warm a pod before giving up and
+        # classifying it as a Temporary Error
         self.__verify_or_set_optional_int(
             config, 'k8s_controlled_warmer_max_query_retries', 3, description, apply_defaults, env_aware=True
+        )
+        # Optional (defaults to 5). The maximum number of Temporary Errors that may occur when warming a pod's entry,
+        # before the warmer blacklists it.
+        self.__verify_or_set_optional_int(
+            config, 'k8s_controlled_warmer_max_attempts', 5, description, apply_defaults, env_aware=True
         )
         # Optional (defaults to 300). When a pod is blacklisted, how many secs it must wait until it is
         # tried again for warming.
@@ -1139,13 +1138,13 @@ class Configuration(object):
             config, 'k8s_ratelimit_cluster_num_agents', 1, description, apply_defaults, env_aware=True
         )
         self.__verify_or_set_optional_float(
-            config, 'k8s_ratelimit_cluster_rps_init', 40.0, description, apply_defaults, env_aware=True
+            config, 'k8s_ratelimit_cluster_rps_init', 1000.0, description, apply_defaults, env_aware=True
         )
         self.__verify_or_set_optional_float(
             config, 'k8s_ratelimit_cluster_rps_min', 1.0, description, apply_defaults, env_aware=True
         )
         self.__verify_or_set_optional_float(
-            config, 'k8s_ratelimit_cluster_rps_max', 20000.0, description, apply_defaults, env_aware=True
+            config, 'k8s_ratelimit_cluster_rps_max', 1E9, description, apply_defaults, env_aware=True
         )
         self.__verify_or_set_optional_int(
             config, 'k8s_ratelimit_consecutive_increase_threshold', 5, description, apply_defaults, env_aware=True


### PR DESCRIPTION
Now that we've concluded the main problem was likely big JSON requests and removed those, we can push the k8s api masters much more aggressively.

The ratelimiter was recently changed to consider existing rate in calculating the new rate.  As such, it will not simply double until reaching the configured max-rate.  Therefore, the more important rate to configure is the _initial_ rate.  In this PR I'm setting it to 1000 (Starting at 200 in a recent 1000-node cluster was just fine, so 1000 for less constrained clusters should be good).

The max rate is set to 1E9, which, is effectively infinity (in a 5K cluster, it'll be 200K rps, which is in the order of what we saw attained in the setting of a 1000-node cluster)

I am leaving the cacherwarmer retry settings unchanged as these pertain to failure scenarios.  Failure would indicate something is wrong, in which case we _do_ want to switch from aggressive -> conservative mode.

Finally, I also include `SCALYR_K8S_RATELIMIT_CLUSTER_NUM_AGENTS` as a commented-out example in the sample configmap.  For the aggressive case customer should not have to configure any ratelimiter settings since the coded defaults suffice.  However, this placeholder may be good for customers with large clusters, as well as to advertize the fact that we have a built-in ratelimiter, which can then become a starting point for more detailed ratelimiter settings.