### PR TITLE
Restore report_k8s_metrics default to True

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -109,7 +109,7 @@ define_config_option( __monitor__, 'report_container_metrics',
 
 define_config_option( __monitor__, 'report_k8s_metrics',
                       'Optional (defaults to True). If true and report_container_metrics is true, metrics will be '
-                      'collected from the k8s and reported to Scalyr.  ', convert_to=bool, default=False, env_aware=True)
+                      'collected from the k8s and reported to Scalyr.  ', convert_to=bool, default=True, env_aware=True)
 
 define_config_option( __monitor__, 'k8s_ignore_namespaces',
                       'Optional (defaults to "kube-system"). A comma-delimited list of the namespaces whose pods\'s '


### PR DESCRIPTION
In a previous PR, this setting was inadvertently defaulted to False.

This PR restores it (and also harmonizes it with the documentation) 