### PR TITLE
AGENT-183:  Productize saving of k8s json responses. Version-check hourly.

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -2756,13 +2756,11 @@ class KubernetesMonitor( ScalyrMonitor ):
         return {'_k8s_ver': 'star'}
 
     def get_user_agent_fragment(self):
-        """This method is periodically invoked by a separate (MonitorsManager) thread and must be thread safe.
-        """
+        """This method is periodically invoked by a separate (MonitorsManager) thread and must be thread safe."""
         k8s_cache = self.__get_k8s_cache()
         ver = None
         runtime = None
         if k8s_cache:
-            # TODO-163: Re-enable version checks
             ver = k8s_cache.get_api_server_version()
             runtime = k8s_cache.get_container_runtime()
         ver = 'k8s=%s' % (ver if ver else 'true')

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -301,8 +301,24 @@ class Configuration(object):
         return self.__get_config().get_int('k8s_cache_purge_secs')
 
     @property
-    def k8s_log_api_responses_to_disk(self):
-        return self.__get_config().get_bool('k8s_log_api_responses_to_disk')
+    def k8s_log_api_responses(self):
+        return self.__get_config().get_bool('k8s_log_api_responses')
+
+    @property
+    def k8s_log_api_exclude_200s(self):
+        return self.__get_config().get_bool('k8s_log_api_exclude_200s')
+
+    @property
+    def k8s_log_api_min_response_len(self):
+        return self.__get_config().get_int('k8s_log_api_min_response_len')
+
+    @property
+    def k8s_log_api_min_latency(self):
+        return self.__get_config().get_float('k8s_log_api_min_latency')
+
+    @property
+    def k8s_log_api_ratelimit_interval(self):
+        return self.__get_config().get_float('k8s_log_api_ratelimit_interval')
 
     @property
     def k8s_controlled_warmer_max_attempts(self):
@@ -1109,13 +1125,30 @@ class Configuration(object):
         self.__verify_or_set_optional_int(config, 'k8s_cache_start_fuzz_secs', 0, description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_int(config, 'k8s_cache_purge_secs', 300, description, apply_defaults, env_aware=True)
 
-        # Whether to log api responses to disk (warning: this should be turned on only for debugging as it will
-        # fill up local disk over time
+        # Whether to log api responses to agent_debug.log
         self.__verify_or_set_optional_bool(
-            config, 'k8s_log_api_responses_to_disk', False, description, apply_defaults, env_aware=True
+            config, 'k8s_log_api_responses', False, description, apply_defaults, env_aware=True
         )
 
-        # TODO-163 : make controlled cache warmer settings more aggressive
+        # If set to True, do not log successes (response code 2xx)
+        self.__verify_or_set_optional_bool(
+            config, 'k8s_log_api_exclude_200s', False, description, apply_defaults, env_aware=True
+        )
+        # Minimum response length of api responses to be logged.  Responses smaller than this limit are not logged.
+        self.__verify_or_set_optional_int(
+            config, 'k8s_log_api_min_response_len', 0, description, apply_defaults, env_aware=True
+        )
+        # Minimum latency of responses to be logged.  Responses faster than this limit are not logged.
+        self.__verify_or_set_optional_float(
+            config, 'k8s_log_api_min_latency', 0.0, description, apply_defaults, env_aware=True
+        )
+        # If positive, api calls with the same path will be rate-limited to a message every interval seconds
+        self.__verify_or_set_optional_int(
+            config, 'k8s_log_api_ratelimit_interval', 0, description, apply_defaults, env_aware=True
+        )
+
+        # TODO-163 : make other settings more aggressive
+
         # Optional (defaults to 5). The maximum number of temporary errors that may occur when warming a pod\'s entry,
         # before the warmer blacklists it
         self.__verify_or_set_optional_int(


### PR DESCRIPTION
This is part of the option-b -> master integration effort.

In this PR, I do the following:

Productize the saving of JSON responses, including various configuration settings as discussed
Restrict k8s /version check to every hour

Note: This PR/branch replaces the [original PR which was approved, but became difficult to merge when I rebased `option-b/master`](https://github.com/scalyr/scalyr-agent-2/pull/257). Please see that original PR for the review discussion.