### PR TITLE
AGENT-186: Check for _tunnel_host

### DIFF
--- a/scalyr_agent/connection.py
+++ b/scalyr_agent/connection.py
@@ -258,7 +258,7 @@ class HTTPConnectionWithTimeout(httplib.HTTPConnection):
             self.sock = socket.create_connection((self.host, self.port), self.__timeout)
         else:
             self.sock = create_connection_helper(self.host, self.port, timeout=self.__timeout)
-        if self._tunnel_host:
+        if hasattr(self, '_tunnel_host') and self._tunnel_host:
             self._tunnel()
 
 
@@ -315,7 +315,7 @@ class HTTPSConnectionWithTimeoutAndVerification(httplib.HTTPSConnection):
         else:
             self.sock = create_connection_helper(self.host, self.port, timeout=self.__timeout)
 
-        if self._tunnel_host:
+        if hasattr(self, '_tunnel_host') and self._tunnel_host:
             self._tunnel()
 
         # Now ask the ssl library to wrap the socket and verify the server certificate if we have a ca_file.


### PR DESCRIPTION
I don't fully understand why it didn't manifest in the existing smoketest image (most likely due to the pre-built python 2.5 binary that is used in that image was compiled such that the bug did not manifest).  

I think what I've done in this PR is the correct thing to do though as it codes defensively against missing `_tunnel_host` (which we already do in other areas of the code but apparently miss 2 spots)