### PR TITLE
Make k8s_ignore_namespaces an ArrayOfStrings

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
@@ -248,7 +248,7 @@ class KubernetesEventsMonitor( ScalyrMonitor ):
 
         # The namespace whose logs we should not collect.
         self.__k8s_namespaces_to_ignore = []
-        for x in self._global_config.k8s_ignore_namespaces.split():
+        for x in self._global_config.k8s_ignore_namespaces:
             self.__k8s_namespaces_to_ignore.append(x.strip())
 
         default_rotation_count, default_max_bytes = self._get_log_rotation_configuration()

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -1531,13 +1531,13 @@ class KubernetesMonitor( ScalyrMonitor ):
         # The namespace whose logs we should not collect.
         global_namespaces_to_ignore = self._global_config.k8s_ignore_namespaces
         default_val = Configuration.DEFAULT_K8S_IGNORE_NAMESPACES
-        if global_namespaces_to_ignore and [g for g in global_namespaces_to_ignore] != default_val:
+        if global_namespaces_to_ignore is not None and [g for g in global_namespaces_to_ignore] != default_val:
             # use global value
             result = global_namespaces_to_ignore
         else:
             # use local value
             local_namespaces_to_ignore = self._config.get('k8s_ignore_namespaces')
-            if local_namespaces_to_ignore and [l for l in local_namespaces_to_ignore] != default_val:
+            if local_namespaces_to_ignore is not None and [l for l in local_namespaces_to_ignore] != default_val:
                 result = local_namespaces_to_ignore
             else:
                 result = default_val

--- a/scalyr_agent/json_lib/__init__.py
+++ b/scalyr_agent/json_lib/__init__.py
@@ -36,7 +36,7 @@ __author__ = 'Steven Czerwinski <czerwin@scalyr.com>'
 
 from scalyr_agent.json_lib.exceptions import JsonConversionException
 from scalyr_agent.json_lib.exceptions import JsonMissingFieldException, JsonParseException
-from scalyr_agent.json_lib.objects import JsonObject, JsonArray, ArrayOfStrings
+from scalyr_agent.json_lib.objects import JsonObject, JsonArray, ArrayOfStrings, SpaceAndCommaSeparatedArrayOfStrings
 from scalyr_agent.json_lib.parser import parse
 from scalyr_agent.json_lib.serializer import serialize
 from scalyr_agent.json_lib.serializer import serialize_as_length_prefixed_string

--- a/scalyr_agent/json_lib/objects.py
+++ b/scalyr_agent/json_lib/objects.py
@@ -623,12 +623,20 @@ class JsonArray(object):
 
 class ArrayOfStrings(JsonArray):
 
-    def __init__(self, *args):
+    separators = [',']
+
+    def __init__(self, values=None):
         """Imposes additional constraint that each element must be a string
         @raise TypeError if an element is not a string
         """
         self._items = []
-        for arg in args:
-            if type(arg) not in (str, unicode):
-                raise TypeError('A non-string element was found: %s' % str(arg))
-            self._items.append(arg)
+        if values:
+            for val in values:
+                if type(val) not in (str, unicode):
+                    raise TypeError('A non-string element was found: %s' % str(val))
+                self._items.append(val)
+
+
+class SpaceAndCommaSeparatedArrayOfStrings(ArrayOfStrings):
+    separators = [None, ',']
+

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -96,7 +96,7 @@ def cache( config ):
     # split comma delimited string of namespaces to ignore in to a list
     # of strings
     namespaces_to_ignore = []
-    for x in config.k8s_ignore_namespaces.split():
+    for x in config.k8s_ignore_namespaces:
         namespaces_to_ignore.append(x.strip())
 
     # create a new cache config

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -809,8 +809,8 @@ class MonitorConfig(object):
 
             # Perform conversion again in case both config-file and environment values were absent and the default
             # value requires conversion.
-            if convert_to is not None and type(result) != convert_to:
-                result = convert_config_param(field, result, convert_to)
+            if convert_to is not None and not issubclass(convert_to, type(result)):
+                    result = convert_config_param(field, result, convert_to)
 
             if max_value is not None and result > max_value:
                 raise BadMonitorConfiguration('Value of %s in field "%s" is invalid; maximum is %s' % (

--- a/scalyr_agent/tests/configuration_k8s_test.py
+++ b/scalyr_agent/tests/configuration_k8s_test.py
@@ -3,6 +3,8 @@ from mock import patch, Mock
 
 from scalyr_agent import scalyr_monitor
 from scalyr_agent.builtin_monitors.kubernetes_monitor import KubernetesMonitor
+from scalyr_agent.config_util import BadConfiguration
+from scalyr_agent.configuration import Configuration
 from scalyr_agent.copying_manager import CopyingManager
 from scalyr_agent.monitors_manager import MonitorsManager
 from scalyr_agent.json_lib.objects import ArrayOfStrings
@@ -12,6 +14,32 @@ from scalyr_agent.tests.configuration_test import TestConfigurationBase
 
 class TestConfigurationK8s(TestConfigurationBase):
     """This test subclasses from TestConfiguration for easier exclusion in python 2.5 and below"""
+
+    def _create_test_objects(self):
+        config = self._create_test_configuration_instance()
+        config.parse()
+
+        # echee TODO: once AGENT-40 docker PR merges in, some of the test-setup code below can be eliminated and
+        # reused from that PR (I moved common code into scalyr_agent/test_util
+        def fake_init(self):
+            # Initialize some requisite variables so that the k8s monitor loop can run
+            self._KubernetesMonitor__container_checker = None
+            self._KubernetesMonitor__namespaces_to_ignore = []
+            self._KubernetesMonitor__include_controller_info = None
+            self._KubernetesMonitor__report_container_metrics = None
+            self._KubernetesMonitor__metric_fetcher = None
+            self._set_ignore_namespaces()
+
+        mock_logger = Mock()
+
+        @patch.object(KubernetesMonitor, '_initialize', new=fake_init)
+        def create_manager():
+            scalyr_monitor.log = mock_logger
+            return MonitorsManager(config, FakePlatform([]))
+
+        monitors_manager = create_manager()
+        return monitors_manager, config, mock_logger
+
 
     @patch('scalyr_agent.builtin_monitors.kubernetes_monitor.docker')
     def test_environment_aware_module_params(self, mock_docker):
@@ -88,27 +116,7 @@ class TestConfigurationK8s(TestConfigurationBase):
         }
         """)
 
-        config = self._create_test_configuration_instance()
-        config.parse()
-
-        # echee TODO: once AGENT-40 docker PR merges in, some of the test-setup code below can be eliminated and
-        # reused from that PR (I moved common code into scalyr_agent/test_util
-        def fake_init(self):
-            # Initialize some requisite variables so that the k8s monitor loop can run
-            self._KubernetesMonitor__container_checker = None
-            self._KubernetesMonitor__namespaces_to_ignore = []
-            self._KubernetesMonitor__include_controller_info = None
-            self._KubernetesMonitor__report_container_metrics = None
-            self._KubernetesMonitor__metric_fetcher = None
-
-        mock_logger = Mock()
-
-        @patch.object(KubernetesMonitor, '_initialize', new=fake_init)
-        def create_manager():
-            scalyr_monitor.log = mock_logger
-            return MonitorsManager(config, FakePlatform([]))
-
-        monitors_manager = create_manager()
+        monitors_manager, config, mock_logger = self._create_test_objects()
         k8s_monitor = monitors_manager.monitors[0]
         k8s_events_monitor = monitors_manager.monitors[1]
 
@@ -246,3 +254,95 @@ class TestConfigurationK8s(TestConfigurationBase):
         _assert_environment_variable('SCALYR_K8S_EVENTS_DISABLE', 'false', False)
         _assert_environment_variable('SCALYR_K8S_EVENTS_DISABLE', 'False', False)
         _assert_environment_variable('SCALYR_K8S_EVENTS_DISABLE', 'F', False)
+
+    def test_k8s_ignore_namespaces(self):
+
+        def _verify(expected):
+            monitors_manager, config, mock_logger = self._create_test_objects()
+            k8s_monitor = monitors_manager.monitors[0]
+            result = k8s_monitor._get_ignore_namespaces()
+            if result is None:
+                self.assertIsNone(expected)
+            else:
+                self.assertEquals(expected, result)
+
+        def _test_k8s_ignore_namespaces_local(test_str, expected):
+            self._write_file_with_separator_conversion(""" { 
+                api_key: "hi there",
+                logs: [ { path:"/var/log/tomcat6/access.log" }],
+                monitors: [
+                    {
+                        module: "scalyr_agent.builtin_monitors.kubernetes_monitor",
+                        k8s_ignore_namespaces: %s
+                    }
+                ]
+              }
+            """ % test_str)
+            _verify(expected)
+
+        def _test_k8s_ignore_namespaces_global(test_str, expected):
+            self._write_file_with_separator_conversion(""" { 
+                api_key: "hi there",
+                k8s_ignore_namespaces: %s,
+                logs: [ { path:"/var/log/tomcat6/access.log" }],
+                monitors: [
+                    {
+                        module: "scalyr_agent.builtin_monitors.kubernetes_monitor"
+                    }
+                ]
+              }
+            """ % test_str)
+            _verify(expected)
+
+        def _test_k8s_ignore_namespaces_environ(test_str, expected):
+            os.environ['SCALYR_K8S_IGNORE_NAMESPACES'] = test_str
+            self._write_file_with_separator_conversion(""" { 
+                api_key: "hi there",
+                logs: [ { path:"/var/log/tomcat6/access.log" }],
+                monitors: [
+                    {
+                        module: "scalyr_agent.builtin_monitors.kubernetes_monitor"
+                    }
+                ]
+              }
+            """)
+            _verify(expected)
+
+        def _test_k8s_ignore_namespaces_supersedes(env_str, local_str, expected):
+            os.environ['SCALYR_K8S_IGNORE_NAMESPACES'] = env_str
+            self._write_file_with_separator_conversion(""" { 
+                api_key: "hi there",
+                logs: [ { path:"/var/log/tomcat6/access.log" }],
+                monitors: [
+                    {
+                        module: "scalyr_agent.builtin_monitors.kubernetes_monitor",
+                        k8s_ignore_namespaces: %s
+                    }
+                ]
+              }
+            """ % local_str)
+            _verify(expected)
+
+        expected = ['a', 'b', 'c', 'd']
+        kube_system = Configuration.DEFAULT_K8S_IGNORE_NAMESPACES
+
+        # define locally in agent.json
+        _test_k8s_ignore_namespaces_local(r'"a, b  c, d"', expected)
+        _test_k8s_ignore_namespaces_local(r'["a", "b", "c", "d"]', expected)
+        _test_k8s_ignore_namespaces_local(r'""', kube_system)
+
+        # defined globally in agent.json
+        _test_k8s_ignore_namespaces_global(r'["a", "b", "c", "d"]', expected)
+        self.assertRaises(BadConfiguration, lambda: _test_k8s_ignore_namespaces_global(r'"a, b  c, d"', expected))
+
+        # defined in environment
+        _test_k8s_ignore_namespaces_environ(r'a, b  c, d', expected)
+        _test_k8s_ignore_namespaces_environ(r'["a", "b", "c", "d"]', expected)
+        _test_k8s_ignore_namespaces_environ(r'', kube_system)
+
+        # environment supersedes local
+        _test_k8s_ignore_namespaces_supersedes("a b c d", r'"1 2 3"', expected)
+        _test_k8s_ignore_namespaces_supersedes("a b, c d", r'"1, 2 3"', expected)
+        _test_k8s_ignore_namespaces_supersedes(r'["a", "b", "c", "d"]', r'["1", "2", "3"]', expected)
+        _test_k8s_ignore_namespaces_supersedes(r'', r'"1, 2, 3"', ["1", "2", "3"])
+        _test_k8s_ignore_namespaces_supersedes(r'', r'""', kube_system)

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -25,6 +25,7 @@ from mock import patch, Mock
 from scalyr_agent.configuration import Configuration, BadConfiguration
 from scalyr_agent.json_lib import JsonObject, JsonArray
 from scalyr_agent.json_lib import parse as parse_json, serialize as serialize_json
+from scalyr_agent.json_lib.objects import ArrayOfStrings
 from scalyr_agent.platform_controller import DefaultPaths
 
 from scalyr_agent.test_base import ScalyrTestCase
@@ -970,10 +971,10 @@ class TestConfiguration(TestConfigurationBase):
         config = self._create_test_configuration_instance()
         self.assertRaises(BadConfiguration, config.parse)
 
-    def test_environment_aware_global_params_true(self):
+    def test_environment_aware_global_params_uppercase(self):
         self._test_environment_aware_global_params(True)
 
-    def test_environment_aware_global_params_false(self):
+    def test_environment_aware_global_params_lowercase(self):
         self._test_environment_aware_global_params(True)
 
     def _test_environment_aware_global_params(self, uppercase):
@@ -1008,12 +1009,14 @@ class TestConfiguration(TestConfigurationBase):
         original_verify_or_set_optional_int = config._Configuration__verify_or_set_optional_int
         original_verify_or_set_optional_float = config._Configuration__verify_or_set_optional_float
         original_verify_or_set_optional_string = config._Configuration__verify_or_set_optional_string
+        original_verify_or_set_optional_array_of_strings = config._Configuration__verify_or_set_optional_array_of_strings
 
         @patch.object(config, '_Configuration__verify_or_set_optional_bool')
         @patch.object(config, '_Configuration__verify_or_set_optional_int')
         @patch.object(config, '_Configuration__verify_or_set_optional_float')
         @patch.object(config, '_Configuration__verify_or_set_optional_string')
-        def patch_and_start_test(p3, p2, p1, p0):
+        @patch.object(config, '_Configuration__verify_or_set_optional_array_of_strings')
+        def patch_and_start_test(p4, p3, p2, p1, p0):
             # Decorate the Configuration.__verify_or_set_optional_xxx methods as follows:
             # 1) capture fields that are environment-aware
             # 2) allow setting of the corresponding environment variable
@@ -1040,12 +1043,15 @@ class TestConfiguration(TestConfigurationBase):
                         return original_verify_or_set_optional_float(*args, **kwargs)
                     elif field_type == str:
                         return original_verify_or_set_optional_string(*args, **kwargs)
+                    elif field_type == ArrayOfStrings:
+                        return original_verify_or_set_optional_array_of_strings(*args, **kwargs)
                 return wrapper
 
             p0.side_effect = capture_aware_field(bool)
             p1.side_effect = capture_aware_field(int)
             p2.side_effect = capture_aware_field(float)
             p3.side_effect = capture_aware_field(str)
+            p4.side_effect = capture_aware_field(ArrayOfStrings)
 
             # Build the Configuration object tree, also populating the field_types lookup in the process
             # This first iteration does not set any environment variables
@@ -1065,6 +1071,7 @@ class TestConfiguration(TestConfigurationBase):
             FAKE_INT = 1234567890
             FAKE_FLOAT = 1234567.89
             FAKE_STRING = str(FAKE_INT)
+            FAKE_ARRAY_OF_STRINGS = ArrayOfStrings(['s1', 's2', 's3'])
 
             for field in expected_aware_fields:
                 field_type = field_types[field]
@@ -1090,10 +1097,23 @@ class TestConfiguration(TestConfigurationBase):
                     self.assertNotEquals(FAKE_STRING, config_obj.get_string(field, none_if_missing=True))
                     fake_env[field] = FAKE_STRING
 
+                elif field_type == ArrayOfStrings:
+                    self.assertNotEquals(FAKE_ARRAY_OF_STRINGS, config_obj.get_json_array(field, none_if_missing=True))
+                    fake_env[field] = FAKE_ARRAY_OF_STRINGS
+
             def fake_environment_value(field):
                 if field not in fake_env:
                     return None
-                return str(fake_env[field]).lower()
+                fake_field_val = fake_env[field]
+                if isinstance(fake_field_val, ArrayOfStrings):
+                    separator = ','
+                    # legacy whitespace separator support for 'k8s_ignore_namespaces'
+                    if field == 'k8s_ignore_namespaces':
+                        separator = ' '
+                    result = str(separator.join([x for x in fake_field_val])).lower()
+                else:
+                    result = str(fake_field_val).lower()
+                return result
             function_lookup = {'get_environment': fake_environment_value}
 
             config.parse()
@@ -1108,6 +1128,8 @@ class TestConfiguration(TestConfigurationBase):
                     value = config._Configuration__get_config().get_float(field)
                 elif field_type == str:
                     value = config._Configuration__get_config().get_string(field)
+                elif field_type == ArrayOfStrings:
+                    value = config._Configuration__get_config().get_json_array(field)
 
                 config_file_value = config_file_dict.get(field)
                 if field in config_file_dict:

--- a/scalyr_agent/tests/scalyr_monitor_test.py
+++ b/scalyr_agent/tests/scalyr_monitor_test.py
@@ -80,7 +80,7 @@ class MonitorConfigTest(ScalyrTestCase):
         test_array = ["a", "b", "c"]
 
         # str -> ArrayOfStrings (must support different variations)
-        arr = ArrayOfStrings(*test_array)
+        arr = ArrayOfStrings(test_array)
         self.assertEquals(self.get('a,b,c', convert_to=ArrayOfStrings), arr)
         self.assertEquals(self.get('a,b,  c', convert_to=ArrayOfStrings), arr)
         self.assertEquals(self.get('"a", "b", "c"', convert_to=ArrayOfStrings), arr)
@@ -143,7 +143,7 @@ class MonitorConfigTest(ScalyrTestCase):
         test_array = ["a", "b", "c"]
         self.assertEquals(
             self.get(test_array, convert_to=ArrayOfStrings),
-            ArrayOfStrings(*test_array)
+            ArrayOfStrings(test_array)
         )
 
     def test_jsonarray_conversion(self):
@@ -155,7 +155,7 @@ class MonitorConfigTest(ScalyrTestCase):
         # JsonArray -> ArrayOfStrings supported
         test_array = ["a", "b", "c"]
         json_arr = JsonArray(*test_array)
-        self.assertEquals(self.get(json_arr, convert_to=ArrayOfStrings), ArrayOfStrings(*test_array))
+        self.assertEquals(self.get(json_arr, convert_to=ArrayOfStrings), ArrayOfStrings(test_array))
 
         # JsonArray -> invalid ArrayOfStrings
         test_array = ["a", "b", 3]
@@ -165,7 +165,7 @@ class MonitorConfigTest(ScalyrTestCase):
     def test_arrayofstrings_conversion(self):
         # JsonArray -> list not supported
         test_array = ["a", "b", "c"]
-        json_arr = ArrayOfStrings(*test_array)
+        json_arr = ArrayOfStrings(test_array)
         self.assertRaises(BadMonitorConfiguration, lambda: self.get(json_arr, convert_to=list))
 
         # ArrayOfStrings -> JsonArray supported


### PR DESCRIPTION
# Background

`k8s_ignore_namespaces` is inconsistently handled.  It should be typed as an `ArrayOfStrings`, which is comma-delimited.  This enables user to specify a single comma-separated string environment variable, consistent with some other parameters.

 However, to preserve legacy behavior (splittable by whitespace), I define a new type `SpaceAndCommaSeparatedArrayOfStrings` which is a subclass of `ArrayOfStrings`.  (And necessary plumbing to make it work).

# Changes

1. Make `k8s_ignore_namespaces` an SpaceAndCommaSeparatedArrayOfStrings.
2. Remove duplicate `k8s_ignore_namespaces` from `kubernetes_monitor.py`

# Testing
- Augmented `_test_environment_aware_global_params` to handle ArrayOfString types.
- manual testing: Entered the following configmap entry:
`SCALYR_K8S_IGNORE_NAMESPACES: "kube-system a , b , c"`
- verified agent.log shows correct ignored namespaces:
![image](https://user-images.githubusercontent.com/48775713/63406846-e0c90e80-c39f-11e9-8161-d01a894bb7e0.png)
