### PR TITLE
AGENT-241: allow empty config params

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -1531,13 +1531,13 @@ class KubernetesMonitor( ScalyrMonitor ):
         # The namespace whose logs we should not collect.
         global_namespaces_to_ignore = self._global_config.k8s_ignore_namespaces
         default_val = Configuration.DEFAULT_K8S_IGNORE_NAMESPACES
-        if global_namespaces_to_ignore and [g for g in global_namespaces_to_ignore] != default_val:
+        if global_namespaces_to_ignore is not None and [g for g in global_namespaces_to_ignore] != default_val:
             # use global value
             result = global_namespaces_to_ignore
         else:
             # use local value
             local_namespaces_to_ignore = self._config.get('k8s_ignore_namespaces')
-            if local_namespaces_to_ignore and [l for l in local_namespaces_to_ignore] != default_val:
+            if local_namespaces_to_ignore is not None and [l for l in local_namespaces_to_ignore] != default_val:
                 result = local_namespaces_to_ignore
             else:
                 result = default_val


### PR DESCRIPTION
Empty string config params are currently treated identically as if they were not defined at all. 

This fails to allow customers to override config params that have default values (e.g. `k8s_ignore_namespaces` is currently set to `kube-system`). 

For example, a customer may want to include `kube-system` namespace and should be able to define `SCALYR_K8S_IGNORE_NAMESPACES`: ""` (empty string), thus allowing `kube-system` namespaced pods to be logged.

# CHANGES

This PR changes the config param framework code to allow empty strings to be converted where it makes sense (for example if a config param is a `str` or `ArrayOfStrings` or `bool`).

Please see the new unit tests for clarity

# NOTE

This PR is based off [AGENT-236-k8s-ignore-namespaces](https://github.com/scalyr/scalyr-agent-2/pull/286) branch because it is closely related, and in fact, fixes some bugs for the `k8s_ignore_namespaces` config param introduced by this PR.

# TESTS

- Add unit tests to assert behavior of util functions.
- Fixes unit tests from the [AGENT-236-k8s-ignore-namespaces](https://github.com/scalyr/scalyr-agent-2/pull/286) branch.