### PR TITLE
Kops setup scripts

### DIFF
--- a/performance/kops_cluster_setup/agentscale.yaml
+++ b/performance/kops_cluster_setup/agentscale.yaml
@@ -1,0 +1,284 @@
+# Creates a five-zone cluster but only with a small number of workers nodes.
+# 
+# Small number of worker nodes is advisable as setting it to a large number (e.g. 1000) 
+# leads to situations where the cluster ultimately does not start but you'd find out after
+# 1.5-2 hours (on AWS).  Therefore, create the cluster with a small number of nodes, then 
+# go into the AWS EC2 console and increase the autoscaling group limits to expand the number
+# of nodes.
+#
+# Additional tweaks:
+# 1. Avoids gossip protocol as it could be source of ongoing high worker CPU/mem
+# 2. Master nodes must have local SSD (i3.4xlarge $1.2/hr each)
+# 3. private network
+# 4. Calico network provider
+# 5. arp hook must have space before multicmd semicolons
+# 6. Use lower k8s version (1.10) otherwise multi-master cluster creation fails!
+# 7. One master per AZ zone unfortunately
+#
+# Reference Notes:
+# https://github.com/kubernetes/kops/issues/6172
+#   hooks:
+#   - manifest: |
+#       Type=oneshot
+#       ExecStart=/sbin/sysctl net.ipv4.neigh.default.gc_thresh3=100000 ; /sbin/sysctl net.ipv4.neigh.default.gc_thresh2=90000 ; /sbin/sysctl -p
+#     name: increase-neigh-gc-thresh.service
+apiVersion: kops/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: null
+  name: agentscale.dev.scalyr.com
+spec:
+  api:
+    loadBalancer:
+      type: Public
+  authorization:
+    rbac: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: s3://agentscale-dev-scalyr-com-state-store/agentscale.dev.scalyr.com
+  etcdClusters:
+  - cpuRequest: 200m
+    etcdMembers:
+    - instanceGroup: master-us-east-1a
+      name: a
+    - instanceGroup: master-us-east-1b
+      name: b
+    - instanceGroup: master-us-east-1c
+      name: c
+    - instanceGroup: master-us-east-1d
+      name: d
+    - instanceGroup: master-us-east-1f
+      name: f
+    memoryRequest: 100Mi
+    name: main
+  - cpuRequest: 100m
+    etcdMembers:
+    - instanceGroup: master-us-east-1a
+      name: a
+    - instanceGroup: master-us-east-1b
+      name: b
+    - instanceGroup: master-us-east-1c
+      name: c
+    - instanceGroup: master-us-east-1d
+      name: d
+    - instanceGroup: master-us-east-1f
+      name: f
+    memoryRequest: 100Mi
+    name: events
+  hooks:
+  - manifest: |
+      Type=oneshot
+      ExecStart=/sbin/sysctl net.ipv4.neigh.default.gc_thresh3=100000 ; /sbin/sysctl net.ipv4.neigh.default.gc_thresh2=90000 ; /sbin/sysctl -p
+    name: increase-neigh-gc-thresh.service
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubelet:
+    anonymousAuth: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  kubernetesVersion: 1.10.13
+  masterPublicName: api.agentscale.dev.scalyr.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    kopeio: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-east-1a
+    type: Private
+    zone: us-east-1a
+  - cidr: 172.20.64.0/19
+    name: us-east-1b
+    type: Private
+    zone: us-east-1b
+  - cidr: 172.20.96.0/19
+    name: us-east-1c
+    type: Private
+    zone: us-east-1c
+  - cidr: 172.20.128.0/19
+    name: us-east-1d
+    type: Private
+    zone: us-east-1d
+  - cidr: 172.20.160.0/19
+    name: us-east-1f
+    type: Private
+    zone: us-east-1f
+  - cidr: 172.20.0.0/22
+    name: utility-us-east-1a
+    type: Utility
+    zone: us-east-1a
+  - cidr: 172.20.4.0/22
+    name: utility-us-east-1b
+    type: Utility
+    zone: us-east-1b
+  - cidr: 172.20.8.0/22
+    name: utility-us-east-1c
+    type: Utility
+    zone: us-east-1c
+  - cidr: 172.20.12.0/22
+    name: utility-us-east-1d
+    type: Utility
+    zone: us-east-1d
+  - cidr: 172.20.16.0/22
+    name: utility-us-east-1f
+    type: Utility
+    zone: us-east-1f
+  topology:
+    bastion:
+      bastionPublicName: bastion.agentscale.dev.scalyr.com
+      idleTimeoutSeconds: 3600
+    dns:
+      type: Public
+    masters: private
+    nodes: private
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+  name: master-us-east-1a
+spec:
+  image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13
+  machineType: i3.4xlarge
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-east-1a
+  role: Master
+  subnets:
+  - us-east-1a
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+  name: master-us-east-1b
+spec:
+  image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13
+  machineType: i3.4xlarge
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-east-1b
+  role: Master
+  subnets:
+  - us-east-1b
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+  name: master-us-east-1c
+spec:
+  image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13
+  machineType: i3.4xlarge
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-east-1c
+  role: Master
+  subnets:
+  - us-east-1c
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+  name: master-us-east-1d
+spec:
+  image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13
+  machineType: i3.4xlarge
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-east-1d
+  role: Master
+  subnets:
+  - us-east-1d
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+  name: master-us-east-1f
+spec:
+  image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13
+  machineType: i3.4xlarge
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-east-1f
+  role: Master
+  subnets:
+  - us-east-1f
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+  name: nodes
+spec:
+  image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13
+  machineType: t3.small
+  maxSize: 10
+  minSize: 10
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
+  role: Node
+  subnets:
+  - us-east-1a
+  - us-east-1b
+  - us-east-1c
+  - us-east-1d
+  - us-east-1f
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+  name: bastions
+spec:
+  image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13
+  machineType: t2.micro
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: bastions
+  role: Bastion
+  subnets:
+  - utility-us-east-1a
+  - utility-us-east-1b
+  - utility-us-east-1c
+  - utility-us-east-1d
+  - utility-us-east-1f

--- a/performance/kops_cluster_setup/create_agentscale_yaml.sh
+++ b/performance/kops_cluster_setup/create_agentscale_yaml.sh
@@ -1,0 +1,34 @@
+# This script generates the kops cluster definition file
+# For 5 masters, you'll need to create the cluster in us-east-1 as each master currently
+# requires its own availability zone.
+# Additionally, I encountered some problems in us-east-1e and had to use 1f instead)
+
+# Define variables
+export AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id)
+export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key)
+BUCKET=agentscale-dev-scalyr-com-state-store
+export KOPS_CLUSTER_NAME=agentscale.dev.scalyr.com
+export KOPS_STATE_STORE=s3://${BUCKET}
+
+# Create bucket for cluster state
+aws s3api create-bucket \
+    --bucket ${BUCKET} \
+    --region us-east-1
+
+# Version the bucket
+aws s3api put-bucket-versioning --bucket ${BUCKET}  --versioning-configuration Status=Enabled
+    
+kops create cluster \
+    --ssh-public-key ~/.ssh/agentscale_id_rsa.pub \
+    --master-count 5 \
+    --node-count 10 \
+    --zones us-east-1a,us-east-1b,us-east-1c,us-east-1d,us-east-1f \
+    --master-zones us-east-1a,us-east-1b,us-east-1c,us-east-1d,us-east-1f \
+    --node-size t3.small \
+    --master-size i3.4xlarge \
+    --topology private \
+    --networking kopeio-vxlan \
+    --bastion \
+    --name ${KOPS_CLUSTER_NAME} \
+    --dry-run -oyaml > fivezones.yaml
+

--- a/performance/kops_cluster_setup/fivezones.yaml
+++ b/performance/kops_cluster_setup/fivezones.yaml
@@ -1,0 +1,254 @@
+apiVersion: kops/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: null
+  name: agentscale.dev.scalyr.com
+spec:
+  api:
+    loadBalancer:
+      type: Public
+  authorization:
+    rbac: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: s3://agentscale-dev-scalyr-com-state-store/agentscale.dev.scalyr.com
+  etcdClusters:
+  - cpuRequest: 200m
+    etcdMembers:
+    - instanceGroup: master-us-east-1a
+      name: a
+    - instanceGroup: master-us-east-1b
+      name: b
+    - instanceGroup: master-us-east-1c
+      name: c
+    - instanceGroup: master-us-east-1d
+      name: d
+    - instanceGroup: master-us-east-1f
+      name: f
+    memoryRequest: 100Mi
+    name: main
+  - cpuRequest: 100m
+    etcdMembers:
+    - instanceGroup: master-us-east-1a
+      name: a
+    - instanceGroup: master-us-east-1b
+      name: b
+    - instanceGroup: master-us-east-1c
+      name: c
+    - instanceGroup: master-us-east-1d
+      name: d
+    - instanceGroup: master-us-east-1f
+      name: f
+    memoryRequest: 100Mi
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubelet:
+    anonymousAuth: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  kubernetesVersion: 1.12.10
+  masterPublicName: api.agentscale.dev.scalyr.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    kopeio: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-east-1a
+    type: Private
+    zone: us-east-1a
+  - cidr: 172.20.64.0/19
+    name: us-east-1b
+    type: Private
+    zone: us-east-1b
+  - cidr: 172.20.96.0/19
+    name: us-east-1c
+    type: Private
+    zone: us-east-1c
+  - cidr: 172.20.128.0/19
+    name: us-east-1d
+    type: Private
+    zone: us-east-1d
+  - cidr: 172.20.160.0/19
+    name: us-east-1f
+    type: Private
+    zone: us-east-1f
+  - cidr: 172.20.0.0/22
+    name: utility-us-east-1a
+    type: Utility
+    zone: us-east-1a
+  - cidr: 172.20.4.0/22
+    name: utility-us-east-1b
+    type: Utility
+    zone: us-east-1b
+  - cidr: 172.20.8.0/22
+    name: utility-us-east-1c
+    type: Utility
+    zone: us-east-1c
+  - cidr: 172.20.12.0/22
+    name: utility-us-east-1d
+    type: Utility
+    zone: us-east-1d
+  - cidr: 172.20.16.0/22
+    name: utility-us-east-1f
+    type: Utility
+    zone: us-east-1f
+  topology:
+    bastion:
+      bastionPublicName: bastion.agentscale.dev.scalyr.com
+    dns:
+      type: Public
+    masters: private
+    nodes: private
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+  name: master-us-east-1a
+spec:
+  image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
+  machineType: i3.4xlarge
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-east-1a
+  role: Master
+  subnets:
+  - us-east-1a
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+  name: master-us-east-1b
+spec:
+  image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
+  machineType: i3.4xlarge
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-east-1b
+  role: Master
+  subnets:
+  - us-east-1b
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+  name: master-us-east-1c
+spec:
+  image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
+  machineType: i3.4xlarge
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-east-1c
+  role: Master
+  subnets:
+  - us-east-1c
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+  name: master-us-east-1d
+spec:
+  image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
+  machineType: i3.4xlarge
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-east-1d
+  role: Master
+  subnets:
+  - us-east-1d
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+  name: master-us-east-1f
+spec:
+  image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
+  machineType: i3.4xlarge
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-east-1f
+  role: Master
+  subnets:
+  - us-east-1f
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+  name: nodes
+spec:
+  image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
+  machineType: t3.small
+  maxSize: 10
+  minSize: 10
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
+  role: Node
+  subnets:
+  - us-east-1a
+  - us-east-1b
+  - us-east-1c
+  - us-east-1d
+  - us-east-1f
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+  name: bastions
+spec:
+  image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
+  machineType: t2.micro
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: bastions
+  role: Bastion
+  subnets:
+  - utility-us-east-1a
+  - utility-us-east-1b
+  - utility-us-east-1c
+  - utility-us-east-1d
+  - utility-us-east-1f

--- a/performance/kops_cluster_setup/sample_commands.txt
+++ b/performance/kops_cluster_setup/sample_commands.txt
@@ -1,0 +1,52 @@
+###################################################################################################################
+# Author: echee@scalyr.com (Edward Chee)
+#
+# Prerequisites:
+# 1) Install kops
+# 2) Create and version an s3 bucket.  Create the agentscale.yaml cluster definition file 
+#    Run `create_agentscale_yaml.sh` to do this.  The cluster definition will be saved to `fivezones.yaml`.
+# 3) Save `fivezones.yaml` as `agentscale.yaml`.  Customize `agentscale.yaml`, e.g turning off Gossip protocol.
+#    (Diff `fivezones.yaml` and `agentscale.yaml` to view the customizations I used to 
+#    successfully bring up a 1000-node cluster.)
+###################################################################################################################
+
+###################################################################################################################
+# Necessary environment variables for connecting to AWS 
+# Note: you must be granted read/write access to the AWS cluster and have requested appropriate resource
+# limits (e.g. if you need 1000 t3.small worker nodes, submit a request from the AWS console.)
+###################################################################################################################
+export AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id)
+export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key)
+
+###################################################################################################################
+# kops environment variables. These must match the settings you used in step 2 to create the s3 bucket
+###################################################################################################################
+BUCKET=agentscale-dev-scalyr-com-state-store
+export KOPS_CLUSTER_NAME=agentscale.dev.scalyr.com
+export KOPS_STATE_STORE=s3://${BUCKET}
+
+###################################################################################################################
+# Load the cluster definition
+###################################################################################################################
+kops create -f agentscale.yaml
+
+###################################################################################################################
+# Grant your ssh public key access to the cluster
+###################################################################################################################
+kops create secret --name agentscale.dev.scalyr.com sshpublickey admin -i ~/.ssh/agentscale_id_rsa.pub
+
+###################################################################################################################
+# Create the cluster
+###################################################################################################################
+kops update cluster --name agentscale.dev.scalyr.com --yes
+
+###################################################################################################################
+# Wait a while then check cluster status
+###################################################################################################################
+kops validate cluster
+kubectl get nodes
+
+###################################################################################################################
+# When done, delete the cluster
+###################################################################################################################
+kops delete cluster --name agentscale.dev.scalyr.com --yes


### PR DESCRIPTION
This PR commits the kops script and customizations used to successfully create a kops-managed cluster (1000 nodes).   

The recent 2.0.51 agent release contains major code changes which were validated on this 1000-node cluster (primarily eliminate CPU and outbound network traffic due to 1000 agents accessing the api masters)