### PR TITLE
Smoketest and dockerfiles for Release automation

### DIFF
--- a/.circleci/docker_unified_smoke_unit/Dockerfile.sanity.centos
+++ b/.circleci/docker_unified_smoke_unit/Dockerfile.sanity.centos
@@ -1,0 +1,20 @@
+#--------------------------------------------------------------------------------------------------
+# This dockerfile builds a minimal centos-based image for running a sanity smoketest during the
+# automated release process.
+#
+# It requires the same files/assets as the unified smoke/unit Dockerfile
+#
+# Example build command:
+#   docker build -f <thisfile> -t scalyr/scalyr-agent-ci-sanity:centos.1 .
+#--------------------------------------------------------------------------------------------------
+
+FROM centos
+
+RUN yum install -y epel-release && yum install -y python36 python36-pip
+RUN pip3 install requests
+RUN yum install -y perl
+
+#------------------------------------------------------
+# Copy and run test scripts
+#------------------------------------------------------
+COPY unittest smoketest /tmp/

--- a/.circleci/docker_unified_smoke_unit/Dockerfile.sanity.ubuntu
+++ b/.circleci/docker_unified_smoke_unit/Dockerfile.sanity.ubuntu
@@ -1,0 +1,21 @@
+#--------------------------------------------------------------------------------------------------
+# This dockerfile builds a minimal ubuntu-based image for running a sanity smoketest during the
+# automated release process.
+#
+# It requires the same files/assets as the unified smoke/unit Dockerfile
+#
+# Example build command:
+#   docker build -f <thisfile> -t scalyr/scalyr-agent-ci-sanity:ubuntu.1 .
+#--------------------------------------------------------------------------------------------------
+
+FROM ubuntu
+
+RUN apt-get update && apt-get install -y curl python python3
+RUN apt-get install -y python3-pip
+RUN apt-get install perl
+RUN pip3 install requests
+
+#------------------------------------------------------
+# Copy and run test scripts
+#------------------------------------------------------
+COPY unittest smoketest /tmp/

--- a/.circleci/docker_unified_smoke_unit/Dockerfile.unittest
+++ b/.circleci/docker_unified_smoke_unit/Dockerfile.unittest
@@ -1,3 +1,16 @@
+#--------------------------------------------------------------------------------------------------
+# This dockerfile builds the unified image for running Scalyr agent unit & smoke tests
+#
+# It requires the following files:
+#
+# smoketest
+#   override_files
+#     agent.json (agent config file with placeholder serverHost token)
+#   smoketest.py (main smoketest python script)
+# unittest
+#   unittest.sh (unittest script)
+#--------------------------------------------------------------------------------------------------
+
 FROM centos
 
 RUN yum install -y sudo gcc gcc-c++ make git patch openssl-devel zlib-devel readline-devel sqlite-devel bzip2-devel which wget

--- a/.circleci/docker_unified_smoke_unit/smoketest/smoketest.py
+++ b/.circleci/docker_unified_smoke_unit/smoketest/smoketest.py
@@ -81,6 +81,7 @@ import socket
 import sys
 import threading
 import urllib
+from copy import deepcopy
 
 
 NAME_SUFFIX_UPLOADER = 'uploader'
@@ -844,6 +845,10 @@ if __name__ == '__main__':
             CONTAINER_PREFIX_2_VERIFIER_CLASS.keys())
         )
 
+    args_copy = deepcopy(vars(args))
+    if 'read_api_key' in args_copy:
+        args_copy['read_api_key'] = args_copy['read_api_key'][:4] + "xxxxxxxxx"
+    _pretty_print('smoketest.py command line args', str(args_copy))
     actor = klass(**vars(args))
 
     # Optionally start upload in a separate thread.  Verifiers should not upload.

--- a/.circleci/smoketest_release_standalone.sh
+++ b/.circleci/smoketest_release_standalone.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+##################################################################
+# Scalyr Agent standalone release smoketest
+#
+#   Simulates customer install of a provided release artifact (rpm, deb, tarball)
+#   Artifact may be locally built file or public/published version.
+#
+# Behavior:
+#   Runs a standalone smoketest
+#   Starts the agent, configured to watch a designated local file.
+#   Runs the standalone-agent smoketest, a python process that comprises:
+#     uploader: writes text into the designated local file
+#     verifier: queries scalyr backend to verify that the agent has
+#               correctly uploaded the designated local file.
+#
+# Expects /tmp to contain smoketest.py and the override agent config files
+#
+# Usage: <this_script>
+# Expects the following env vars
+#   ARTIFACT_FILE: Full path to artifact file to install locally (or if eq "PUBLISHED", will install the
+#     latest published version via https://www.scalyr.com/install-agent.sh script.)
+#   PYTHON_VERSION: python version to run test with
+#   SCALYR_API_KEY: Write api key
+#   READ_API_KEY: Read api key for querying
+#   SCALYR_SERVER: scalyr server
+#   MAX_WAIT: max secs to verify upload
+#   CIRCLE_BUILD_NUM: arbitrary unique build number
+#   AGENT_VERSION: agent release version (e.g. 2.0.51)
+##################################################################
+
+alias ll='ls -la'
+PS1='\h:\w\$ '
+
+# Validate inputs
+function validate_envar() {
+  envar="$1";
+  if [[ -z ${!envar} ]]; then
+    echo "Environment variable ${envar} must not be empty";
+    exit 1;
+  fi
+}
+for envar in ARTIFACT_FILE PYTHON_VERSION SCALYR_API_KEY READ_API_KEY SCALYR_SERVER MAX_WAIT CIRCLE_BUILD_NUM AGENT_VERSION; do
+  validate_envar "$envar"
+done
+
+
+# Simulate customer install of artifact
+echo "Artifact_file = \"$ARTIFACT_FILE\""
+export SCALYR_AGENT_ETC_DIR=/etc/scalyr-agent-2
+export SCALYR_AGENT_LOG_DIR=/var/log/scalyr-agent-2
+if [[ $ARTIFACT_FILE =~ .*rpm ]]; then
+  echo "Installing local yum artifact"
+  yum install -y --nogpgcheck $ARTIFACT_FILE
+  yum install -y scalyr-repo
+  yum install -y scalyr-agent-2
+elif [[ $ARTIFACT_FILE =~ .*deb ]]; then
+  echo "Installing local debian artifact"
+  apt-get install -y $ARTIFACT_FILE
+  apt-get update
+elif [[ $ARTIFACT_FILE == "PUBLISHED" ]]; then
+  echo "Installing via published script (https://www.scalyr.com/install-agent.sh)"
+  pushd /tmp && curl https://www.scalyr.com/install-agent.sh -o /tmp/install_agent.sh && chmod 755 /tmp/install_agent.sh && \
+   /tmp/install-agent.sh --set-api-key $SCALYR_API_KEY
+elif [[ $ARTIFACT_FILE =~ .*gz ]]; then
+  pushd /usr/share
+  tar --no-same-owner -zxf $ARTIFACT_FILE
+  mv scalyr-agent-${AGENT_VERSION} scalyr-agent-2
+  export PATH=/usr/share/scalyr-agent-2/bin:$PATH
+  popd
+  SCALYR_AGENT_ETC_DIR=/usr/share/scalyr-agent-2/config
+  SCALYR_AGENT_LOG_DIR=/usr/share/scalyr-agent-2/log
+fi
+
+# Directory where smoketest.py is stored
+FILES=/tmp
+
+if [[ ! -f $SCALYR_AGENT_ETC_DIR/agent.json ]]; then
+    exit 1
+fi
+
+# Setup the agent config (files must be owned by root as agent runs as root)
+/bin/cp -f $FILES/override_files/agent.json $SCALYR_AGENT_ETC_DIR/agent.json
+perl -pi.bak -e "s{CIRCLE_BUILD_NUM}{$CIRCLE_BUILD_NUM}" $SCALYR_AGENT_ETC_DIR/agent.json
+echo "Overriding contents of agent.json"
+cat $SCALYR_AGENT_ETC_DIR/agent.json
+
+echo "{api_key: \"$SCALYR_API_KEY\"}" > /tmp/api_key.json
+mv /tmp/api_key.json $SCALYR_AGENT_ETC_DIR/agent.d/api_key.json
+echo "{scalyr_server: \"${SCALYR_SERVER}\", debug_init: true, debug_level: 5}" > /tmp/scalyr_server.json
+mv /tmp/scalyr_server.json $SCALYR_AGENT_ETC_DIR/agent.d/scalyr_server.json
+
+echo "Starting agent ..."
+scalyr-agent-2 start
+
+if [[ ! -f $SCALYR_AGENT_LOG_DIR/agent.pid ]]; then
+    exit 1
+fi
+
+function print_header() {
+    header="$1";
+    if [[ -n $header ]]; then
+        echo "";
+        echo "=======================================";
+        echo $header;
+        echo "=======================================";
+    fi
+}
+
+# Display python version that tcollector lib uses
+print_header 'Agent Python version:'
+python --version
+
+print_header 'Python version used by tcollector (/usr/bin/python) is:'
+/usr/bin/python --version
+
+print_header 'Python processes'
+ps -ef | fgrep python
+
+# Write to a test file after starting agent (otherwise logs are not included since considered too old)
+# This file must match the log stanza in the overridden agent.json config
+LOGFILE='/var/log/scalyr-agent-2/data.json'
+
+# Execute the test in Python3 (independent of the agent python version)
+# Fake the container name (i.e. don't actually need to run docker --name
+print_header 'Querying Scalyr server to verify log upload'
+
+# The smoketest python process requires python 3
+python3 $FILES/smoketest.py \
+ci-agent-standalone-${CIRCLE_BUILD_NUM} $MAX_WAIT \
+--scalyr_server $SCALYR_SERVER --read_api_key $READ_API_KEY \
+--python_version $PYTHON_VERSION --monitored_logfile $LOGFILE \
+--debug true
+

--- a/.circleci/smoketest_standalone.sh
+++ b/.circleci/smoketest_standalone.sh
@@ -10,6 +10,8 @@
 #     verifier: queries scalyr backend to verify that the agent has
 #               correctly uploaded the designated local file.
 #
+# Expects /tmp to contain smoketest.py and the override agent config files
+#
 # Usage: <this_script>
 # Expects the following env vars
 #   TEST_BRANCH: git branch


### PR DESCRIPTION
This PR adds a smoketest script and dockerfiles to run a release-related "sanity check" (smoketest).  Basically, instead of getting code from the agent git repo, it takes a provided artifact (rpm, debian, tarball etc), mimics the user installation procedure and runs the smoketest on the installed agent. 
