### PR TITLE
AGENT-249: Turn on k8s_ver

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -2757,8 +2757,7 @@ class KubernetesMonitor( ScalyrMonitor ):
 
     def get_extra_server_attributes(self):
         # Immutable, hence thread safe
-        return None
-        # return {'_k8s_ver': 'star'}
+        return {'_k8s_ver': 'star'}
 
     def get_user_agent_fragment(self):
         """This method is periodically invoked by a separate (MonitorsManager) thread and must be thread safe."""

--- a/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
@@ -498,6 +498,6 @@ class TestExtraServerAttributes(ScalyrTestCase):
                 fake_clock=fake_clock,
             )
             copying_manager = CopyingManager(config, monitors_manager.monitors)
-            # self.assertEquals(copying_manager._CopyingManager__expanded_server_attributes.get('_k8s_ver'), 'star')
+            self.assertEquals(copying_manager._CopyingManager__expanded_server_attributes.get('_k8s_ver'), 'star')
         run_test()
 


### PR DESCRIPTION
# Background

The Scalyr UI "Log Sources" overview page has always listed out individual entries of  `serverHosts` of a k8s cluster.  For large clusters, this page becomes super long.  The fix is to attach a `_k8s_ver` attribute to events coming from k8s serverHosts.  This allows the UI to no longer display these serverHosts as individual items in the "Log Sources" overview.

Note: A side effect is from now on, you can no longer enter a k8s serverHost into the serverHost search box and expect the logFile search popdown to be populated with all logfiles from this serverHost.  
![image](https://user-images.githubusercontent.com/48775713/64899109-abca7780-d63e-11e9-9889-55d2d36d8d01.png)


However, the `logfile` facet will still list out all logfiles, include agent.log
![image](https://user-images.githubusercontent.com/48775713/64899093-93f2f380-d63e-11e9-8b31-559fdba5dcb7.png)

# Code change
The k8s_ver attribute code change was committed previously but commented out because backend/api layer changes were not ready.  These dependencies are now in production so we can safely uncomment the code. 

Done by reverting commit 2869c3d028774315adb78b458be1b76af426575c.


