### PR TITLE
AGENT-248 - put percpu metrics behind an option

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -2545,8 +2545,7 @@ class KubernetesMonitor( ScalyrMonitor ):
                 count = 1
                 if percpu:
                     for usage in percpu:
-                        # Use dev for the CPU number since it is a known tag for Scalyr to use in delta computation.
-                        extra = { 'dev' : count }
+                        extra = { 'cpu' : count }
                         if k8s_extra is not None:
                             extra.update(k8s_extra)
                         self._logger.emit_value( 'docker.cpu.usage', usage, extra, monitor_id_override=container )

--- a/scalyr_agent/tests/configuration_docker_test.py
+++ b/scalyr_agent/tests/configuration_docker_test.py
@@ -51,6 +51,7 @@ class TestConfigurationDocker(TestConfiguration):
             "docker_log_prefix": (STANDARD_PREFIX, TEST_STRING, str),
             "log_mode": ('SCALYR_DOCKER_LOG_MODE', TEST_STRING, str),
             "docker_raw_logs": (STANDARD_PREFIX, False, bool),  # test config file is set to True
+            "docker_percpu_metrics": (STANDARD_PREFIX, True, bool),  # test config file is set to False
             "metrics_only": ('SCALYR_DOCKER_METRICS_ONLY', True, bool),
             "container_globs": (STANDARD_PREFIX, TEST_ARRAY_OF_STRINGS, ArrayOfStrings),
             "container_globs_exclude": (STANDARD_PREFIX, TEST_ARRAY_OF_STRINGS, ArrayOfStrings),

--- a/scalyr_agent/tests/configuration_k8s_test.py
+++ b/scalyr_agent/tests/configuration_k8s_test.py
@@ -58,6 +58,7 @@ class TestConfigurationK8s(TestConfigurationBase):
         k8s_testmap = {
             "container_check_interval": (STANDARD_PREFIX, TEST_INT, int),
             "docker_max_parallel_stats": (STANDARD_PREFIX, TEST_INT, int),
+            "docker_percpu_metrics": (STANDARD_PREFIX, True, bool),
             "container_globs": (STANDARD_PREFIX, TEST_ARRAY_OF_STRINGS, ArrayOfStrings),
             "report_container_metrics": (STANDARD_PREFIX, False, bool),
             "report_k8s_metrics": (STANDARD_PREFIX, True, bool),


### PR DESCRIPTION
Testing for this has been done manually, both for the kubernetes and docker monitors.

One interesting thing when listing the individual cpus is that the kubernetes monitor specified an extra field of `dev`, while the docker monitor specifies `cpu`.

There was a bug with the docker monitor that prevented it from actually outputting that extra field, which I've now fixed, but perhaps we want to standardize on a single key for this field?

Also, it turns out the other cpu metrics *were* getting logged, just in a separate place (which is why I didn't notice previously).

# Notes

Here's a snapshot of relevant entries in `kubernetes_monitor.log`:

# k8s monitor: SCALYR_DOCKER_PERCPU_METRICS=True

![image](https://user-images.githubusercontent.com/48775713/65003729-90fe3a00-d8ae-11e9-96d3-c83711a339a7.png)

# k8s monitor: SCALYR_DOCKER_PERCPU_METRICS=False

![image](https://user-images.githubusercontent.com/48775713/65002701-fb60ab80-d8a9-11e9-8a2b-ef0faea1ad26.png)


# Docker monitor: SCALYR_DOCKER_PERCPU_METRICS=True

![image](https://user-images.githubusercontent.com/48775713/65003509-a888f300-d8ad-11e9-91d7-b9717102f627.png)

# Docker monitor: SCALYR_DOCKER_PERCPU_METRICS=False

![image](https://user-images.githubusercontent.com/48775713/65003577-f271d900-d8ad-11e9-8d83-c4e28d9efd36.png)

