### PR TITLE
Fix bug in smoketest_release_standalone.sh

### DIFF
--- a/.circleci/docker_unified_smoke_unit/Dockerfile.sanity.centos
+++ b/.circleci/docker_unified_smoke_unit/Dockerfile.sanity.centos
@@ -13,6 +13,7 @@ FROM centos
 RUN yum install -y epel-release && yum install -y python36 python36-pip
 RUN pip3 install requests
 RUN yum install -y perl
+RUN yum install -y sudo
 
 #------------------------------------------------------
 # Copy and run test scripts

--- a/.circleci/docker_unified_smoke_unit/Dockerfile.sanity.ubuntu
+++ b/.circleci/docker_unified_smoke_unit/Dockerfile.sanity.ubuntu
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y curl python python3
 RUN apt-get install -y python3-pip
 RUN apt-get install perl
 RUN pip3 install requests
+RUN apt-get install sudo
 
 #------------------------------------------------------
 # Copy and run test scripts

--- a/.circleci/smoketest_release_standalone.sh
+++ b/.circleci/smoketest_release_standalone.sh
@@ -60,8 +60,8 @@ elif [[ $ARTIFACT_FILE =~ .*deb ]]; then
   apt-get update
 elif [[ $ARTIFACT_FILE == "PUBLISHED" ]]; then
   echo "Installing via published script (https://www.scalyr.com/install-agent.sh)"
-  pushd /tmp && curl https://www.scalyr.com/install-agent.sh -o /tmp/install_agent.sh && chmod 755 /tmp/install_agent.sh && \
-   /tmp/install-agent.sh --set-api-key $SCALYR_API_KEY
+  pushd /tmp && curl https://www.scalyr.com/install-agent.sh -o /tmp/install-agent.sh && sleep 3 && chmod 755 /tmp/install-agent.sh && \
+  sudo /tmp/install-agent.sh --set-api-key $SCALYR_API_KEY
 elif [[ $ARTIFACT_FILE =~ .*gz ]]; then
   pushd /usr/share
   tar --no-same-owner -zxf $ARTIFACT_FILE
@@ -76,6 +76,8 @@ fi
 FILES=/tmp
 
 if [[ ! -f $SCALYR_AGENT_ETC_DIR/agent.json ]]; then
+    find / -name scalyr_install.log
+    cat $(find / -name scalyr_install.log)
     exit 1
 fi
 


### PR DESCRIPTION
This PR fixes a bug where the smoketest of the primary `install-agent.sh` script was broken.
Also runs the script under `sudo` which avoids errors in ubuntu.