### PR TITLE
AGENT-252: Replace alpine with slim image for performance reasons

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,15 @@
 # base image that creates all necessary dependencies for
 # the scalyr-agent
 # NOTE: multi-stage builds require Docker 17.05 or greater
-FROM python:2.7-alpine3.9 as scalyr-dependencies
+FROM python:2.7-slim as scalyr-dependencies
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
-RUN apk --update add build-base python-dev gcc
+RUN apt-get update && apt-get install -y build-essential
 RUN pip --no-cache-dir install --root /tmp/dependencies ujson yappi
 
 # main image - copies dependencies from scalyr-dependencies and extracts
 # the tar-zipped file containing the scalyr-agent code
-FROM python:2.7-alpine3.9 as scalyr
+FROM python:2.7-slim as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 COPY --from=scalyr-dependencies  /tmp/dependencies/ /

--- a/docker/Dockerfile.build_from_source
+++ b/docker/Dockerfile.build_from_source
@@ -2,11 +2,11 @@
 # the scalyr-agent, and builds a tarball of the scalyr-agent
 # from the source code of the main scalyr-agent-2 repository
 # NOTE: multi-stage builds require Docker 17.05 or greater
-FROM python:2.7-alpine3.9 as scalyr-dependencies
+FROM python:2.7-slim as scalyr-dependencies
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 # install dev dependencies.
-RUN apk --update add build-base python-dev gcc git bash
+RUN apt-get update && apt-get install -y build-essential git bash
 RUN mkdir -p /tmp/scalyr/src
 
 # install python dependencies
@@ -28,7 +28,7 @@ RUN mkdir -p /tmp/scalyr/install
 RUN tar --no-same-owner -C /tmp/scalyr/install -zxf /tmp/scalyr/src/scalyr-k8s-agent.tar.gz
 
 # main image - copies dependencies and the scalyr-agent from scalyr-dependencies
-FROM python:2.7-alpine3.9 as scalyr
+FROM python:2.7-slim as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 COPY --from=scalyr-dependencies  /tmp/dependencies/ /

--- a/docker/Dockerfile.k8s
+++ b/docker/Dockerfile.k8s
@@ -1,15 +1,15 @@
 # base image that creates all necessary dependencies for
 # the scalyr-agent
 # NOTE: multi-stage builds require Docker 17.05 or greater
-FROM python:2.7-alpine3.9 as scalyr-dependencies
+FROM python:2.7-slim as scalyr-dependencies
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
-RUN apk --update add build-base python-dev gcc
+RUN apt-get update && apt-get install -y build-essential
 RUN pip --no-cache-dir install --root /tmp/dependencies ujson yappi
 
 # main image - copies dependencies from scalyr-dependencies and extracts
 # the tar-zipped file containing the scalyr-agent code
-FROM python:2.7-alpine3.9 as scalyr
+FROM python:2.7-slim as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 COPY --from=scalyr-dependencies  /tmp/dependencies/ /

--- a/docker/Dockerfile.syslog
+++ b/docker/Dockerfile.syslog
@@ -1,15 +1,15 @@
 # base image that creates all necessary dependencies for
 # the scalyr-agent
 # NOTE: multi-stage builds require Docker 17.05 or greater
-FROM python:2.7-alpine3.9 as scalyr-dependencies
+FROM python:2.7-slim as scalyr-dependencies
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
-RUN apk --update add build-base python-dev gcc
-RUN pip --no-cache-dir install --root /tmp/dependencies ujson
+RUN apt-get update && apt-get install -y build-essential
+RUN pip --no-cache-dir install --root /tmp/dependencies ujson yappi
 
 # main image - copies dependencies from scalyr-dependencies and extracts
 # the tar-zipped file containing the scalyr-agent code
-FROM python:2.7-alpine3.9 as scalyr
+FROM python:2.7-slim as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 COPY --from=scalyr-dependencies  /tmp/dependencies/ /


### PR DESCRIPTION
There are some performance concerns for alpine image which uses musl instead of glibc
https://superuser.com/questions/1219609/why-is-the-alpine-docker-image-over-50-slower-than-the-ubuntu-image

We are changing to use `slim` image.

# How was this tested

I ran `python build_package.py k8s_builder|docker_syslog_builder|docker_json_builder` and tested each docker image manually.  Also, the smoketests do these as well.