### PR TITLE
Replace scalyr-specific variables with placeholders

### DIFF
--- a/performance/kops_cluster_setup/README.md
+++ b/performance/kops_cluster_setup/README.md
@@ -1,0 +1,1 @@
+Please see `sample_commands.txt`.

--- a/performance/kops_cluster_setup/agentscale.yaml
+++ b/performance/kops_cluster_setup/agentscale.yaml
@@ -26,7 +26,7 @@ apiVersion: kops/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: null
-  name: agentscale.dev.scalyr.com
+  name: <YOUR_CUSTER_NAME>
 spec:
   api:
     loadBalancer:
@@ -35,7 +35,7 @@ spec:
     rbac: {}
   channel: stable
   cloudProvider: aws
-  configBase: s3://agentscale-dev-scalyr-com-state-store/agentscale.dev.scalyr.com
+  configBase: s3://<YOUR_BUCKET_STORE_NAME>/<YOUR_CUSTER_NAME>
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:
@@ -78,7 +78,7 @@ spec:
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.10.13
-  masterPublicName: api.agentscale.dev.scalyr.com
+  masterPublicName: api.<YOUR_CUSTER_NAME>
   networkCIDR: 172.20.0.0/16
   networking:
     kopeio: {}
@@ -128,7 +128,7 @@ spec:
     zone: us-east-1f
   topology:
     bastion:
-      bastionPublicName: bastion.agentscale.dev.scalyr.com
+      bastionPublicName: bastion.<YOUR_CUSTER_NAME>
       idleTimeoutSeconds: 3600
     dns:
       type: Public
@@ -142,7 +142,7 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+    kops.k8s.io/cluster: <YOUR_CUSTER_NAME>
   name: master-us-east-1a
 spec:
   image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13
@@ -162,7 +162,7 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+    kops.k8s.io/cluster: <YOUR_CUSTER_NAME>
   name: master-us-east-1b
 spec:
   image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13
@@ -182,7 +182,7 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+    kops.k8s.io/cluster: <YOUR_CUSTER_NAME>
   name: master-us-east-1c
 spec:
   image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13
@@ -202,7 +202,7 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+    kops.k8s.io/cluster: <YOUR_CUSTER_NAME>
   name: master-us-east-1d
 spec:
   image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13
@@ -222,7 +222,7 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+    kops.k8s.io/cluster: <YOUR_CUSTER_NAME>
   name: master-us-east-1f
 spec:
   image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13
@@ -242,7 +242,7 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+    kops.k8s.io/cluster: <YOUR_CUSTER_NAME>
   name: nodes
 spec:
   image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13
@@ -266,7 +266,7 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+    kops.k8s.io/cluster: <YOUR_CUSTER_NAME>
   name: bastions
 spec:
   image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13

--- a/performance/kops_cluster_setup/create_agentscale_yaml.sh
+++ b/performance/kops_cluster_setup/create_agentscale_yaml.sh
@@ -6,8 +6,8 @@
 # Define variables
 export AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id)
 export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key)
-BUCKET=agentscale-dev-scalyr-com-state-store
-export KOPS_CLUSTER_NAME=agentscale.dev.scalyr.com
+BUCKET=<YOUR_BUCKET_STORE_NAME>
+export KOPS_CLUSTER_NAME=<YOUR_CLUSTER_NAME>  # should be a valid DNS name, e.g. <YOUR_CUSTER_NAME>
 export KOPS_STATE_STORE=s3://${BUCKET}
 
 # Create bucket for cluster state

--- a/performance/kops_cluster_setup/create_agentscale_yaml.sh
+++ b/performance/kops_cluster_setup/create_agentscale_yaml.sh
@@ -7,7 +7,7 @@
 export AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id)
 export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key)
 BUCKET=<YOUR_BUCKET_STORE_NAME>
-export KOPS_CLUSTER_NAME=<YOUR_CLUSTER_NAME>  # should be a valid DNS name, e.g. <YOUR_CUSTER_NAME>
+export KOPS_CLUSTER_NAME=<YOUR_CLUSTER_NAME>  # should be a valid DNS name, e.g. agentscale.dev.scalyr.com
 export KOPS_STATE_STORE=s3://${BUCKET}
 
 # Create bucket for cluster state

--- a/performance/kops_cluster_setup/fivezones.yaml
+++ b/performance/kops_cluster_setup/fivezones.yaml
@@ -2,7 +2,7 @@ apiVersion: kops/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: null
-  name: agentscale.dev.scalyr.com
+  name: <YOUR_CUSTER_NAME>
 spec:
   api:
     loadBalancer:
@@ -11,7 +11,7 @@ spec:
     rbac: {}
   channel: stable
   cloudProvider: aws
-  configBase: s3://agentscale-dev-scalyr-com-state-store/agentscale.dev.scalyr.com
+  configBase: s3://<YOUR_BUCKET_STORE_NAME>/<YOUR_CUSTER_NAME>
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.12.10
-  masterPublicName: api.agentscale.dev.scalyr.com
+  masterPublicName: api.<YOUR_CUSTER_NAME>
   networkCIDR: 172.20.0.0/16
   networking:
     kopeio: {}
@@ -99,7 +99,7 @@ spec:
     zone: us-east-1f
   topology:
     bastion:
-      bastionPublicName: bastion.agentscale.dev.scalyr.com
+      bastionPublicName: bastion.<YOUR_CUSTER_NAME>
     dns:
       type: Public
     masters: private
@@ -112,7 +112,7 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+    kops.k8s.io/cluster: <YOUR_CUSTER_NAME>
   name: master-us-east-1a
 spec:
   image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
@@ -132,7 +132,7 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+    kops.k8s.io/cluster: <YOUR_CUSTER_NAME>
   name: master-us-east-1b
 spec:
   image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
@@ -152,7 +152,7 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+    kops.k8s.io/cluster: <YOUR_CUSTER_NAME>
   name: master-us-east-1c
 spec:
   image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
@@ -172,7 +172,7 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+    kops.k8s.io/cluster: <YOUR_CUSTER_NAME>
   name: master-us-east-1d
 spec:
   image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
@@ -192,7 +192,7 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+    kops.k8s.io/cluster: <YOUR_CUSTER_NAME>
   name: master-us-east-1f
 spec:
   image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
@@ -212,7 +212,7 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+    kops.k8s.io/cluster: <YOUR_CUSTER_NAME>
   name: nodes
 spec:
   image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21
@@ -236,7 +236,7 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: agentscale.dev.scalyr.com
+    kops.k8s.io/cluster: <YOUR_CUSTER_NAME>
   name: bastions
 spec:
   image: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-06-21

--- a/performance/kops_cluster_setup/sample_commands.txt
+++ b/performance/kops_cluster_setup/sample_commands.txt
@@ -2,12 +2,24 @@
 # Author: echee@scalyr.com (Edward Chee)
 #
 # Prerequisites:
+#
 # 1) Install kops
 # 2) Create and version an s3 bucket.  Create the agentscale.yaml cluster definition file 
 #    Run `create_agentscale_yaml.sh` to do this.  The cluster definition will be saved to `fivezones.yaml`.
 # 3) Save `fivezones.yaml` as `agentscale.yaml`.  Customize `agentscale.yaml`, e.g turning off Gossip protocol.
 #    (Diff `fivezones.yaml` and `agentscale.yaml` to view the customizations I used to 
 #    successfully bring up a 1000-node cluster.)
+#
+# Finally, note that all scripts and sample files have the following placeholders:
+#  <YOUR_CUSTER_NAME> : must be a valid DNS name, e.g. agentscale.dev.scalyr.com (pick something unique to your org)
+#  <YOUR_BUCKET_STORE_NAME> : s3 bucket name
+#
+# These placeholders were retroactively edited in the generated `fivezones.yaml` and `agentscale.yaml` to prevent
+# inadvertent reuse of the same s3 bucket by multiple parties.
+#
+# If you wish to use the `agentscale.yaml` directly, you must replace those placeholders with your custom values.
+# Otherwise, set them and run the sample commands in this script to generate `fivezones.yaml`, then `agentscale.yaml`.
+#
 ###################################################################################################################
 
 ###################################################################################################################
@@ -21,8 +33,8 @@ export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key)
 ###################################################################################################################
 # kops environment variables. These must match the settings you used in step 2 to create the s3 bucket
 ###################################################################################################################
-BUCKET=agentscale-dev-scalyr-com-state-store
-export KOPS_CLUSTER_NAME=agentscale.dev.scalyr.com
+BUCKET=<YOUR_BUCKET_STORE_NAME>
+export KOPS_CLUSTER_NAME=<YOUR_CUSTER_NAME>
 export KOPS_STATE_STORE=s3://${BUCKET}
 
 ###################################################################################################################
@@ -33,12 +45,12 @@ kops create -f agentscale.yaml
 ###################################################################################################################
 # Grant your ssh public key access to the cluster
 ###################################################################################################################
-kops create secret --name agentscale.dev.scalyr.com sshpublickey admin -i ~/.ssh/agentscale_id_rsa.pub
+kops create secret --name $KOPS_CLUSTER_NAME sshpublickey admin -i ~/.ssh/agentscale_id_rsa.pub
 
 ###################################################################################################################
 # Create the cluster
 ###################################################################################################################
-kops update cluster --name agentscale.dev.scalyr.com --yes
+kops update cluster --name $KOPS_CLUSTER_NAME --yes
 
 ###################################################################################################################
 # Wait a while then check cluster status
@@ -49,4 +61,4 @@ kubectl get nodes
 ###################################################################################################################
 # When done, delete the cluster
 ###################################################################################################################
-kops delete cluster --name agentscale.dev.scalyr.com --yes
+kops delete cluster --name $KOPS_CLUSTER_NAME --yes


### PR DESCRIPTION
This PR replaces scalyr-specific kops settings (bucketname, cluster name) with placeholders to emphasize the need for users to customize these.