### PR TITLE
Replace alpine with slim image for performance reasons

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,15 @@
 # base image that creates all necessary dependencies for
 # the scalyr-agent
 # NOTE: multi-stage builds require Docker 17.05 or greater
-FROM python:2.7-alpine3.9 as scalyr-dependencies
+FROM python:2.7-slim as scalyr-dependencies
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
-RUN apk --update add build-base python-dev gcc
+RUN apt-get update && apt-get install -y build-essential
 RUN pip --no-cache-dir install --root /tmp/dependencies ujson yappi
 
 # main image - copies dependencies from scalyr-dependencies and extracts
 # the tar-zipped file containing the scalyr-agent code
-FROM python:2.7-alpine3.9 as scalyr
+FROM python:2.7-slim as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 COPY --from=scalyr-dependencies  /tmp/dependencies/ /

--- a/docker/Dockerfile.build_from_source
+++ b/docker/Dockerfile.build_from_source
@@ -2,11 +2,11 @@
 # the scalyr-agent, and builds a tarball of the scalyr-agent
 # from the source code of the main scalyr-agent-2 repository
 # NOTE: multi-stage builds require Docker 17.05 or greater
-FROM python:2.7-alpine3.9 as scalyr-dependencies
+FROM python:2.7-slim as scalyr-dependencies
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 # install dev dependencies.
-RUN apk --update add build-base python-dev gcc git bash
+RUN apt-get update && apt-get install -y build-essential git bash
 RUN mkdir -p /tmp/scalyr/src
 
 # install python dependencies
@@ -28,7 +28,7 @@ RUN mkdir -p /tmp/scalyr/install
 RUN tar --no-same-owner -C /tmp/scalyr/install -zxf /tmp/scalyr/src/scalyr-k8s-agent.tar.gz
 
 # main image - copies dependencies and the scalyr-agent from scalyr-dependencies
-FROM python:2.7-alpine3.9 as scalyr
+FROM python:2.7-slim as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 COPY --from=scalyr-dependencies  /tmp/dependencies/ /

--- a/docker/Dockerfile.syslog
+++ b/docker/Dockerfile.syslog
@@ -1,15 +1,15 @@
 # base image that creates all necessary dependencies for
 # the scalyr-agent
 # NOTE: multi-stage builds require Docker 17.05 or greater
-FROM python:2.7-alpine3.9 as scalyr-dependencies
+FROM python:2.7-slim as scalyr-dependencies
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
-RUN apk --update add build-base python-dev gcc
-RUN pip --no-cache-dir install --root /tmp/dependencies ujson
+RUN apt-get update && apt-get install -y build-essential
+RUN pip --no-cache-dir install --root /tmp/dependencies ujson yappi
 
 # main image - copies dependencies from scalyr-dependencies and extracts
 # the tar-zipped file containing the scalyr-agent code
-FROM python:2.7-alpine3.9 as scalyr
+FROM python:2.7-slim as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 COPY --from=scalyr-dependencies  /tmp/dependencies/ /


### PR DESCRIPTION
Due to an unfortunate merge sequence another branch that included a revert of this PR was merged to master after the original PR for this was made, thereby undoing this feature.

This is a cherry pick of the original commit, to replace alpine with slim.