### PR TITLE
Fix unittest to capture output generated by loggers

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -22,8 +22,10 @@
 __author__ = 'czerwin@scalyr.com'
 
 from scalyr_agent.__scalyr__ import scalyr_init
-scalyr_init()
+import scalyr_agent.scalyr_logging as scalyr_logging
 
+scalyr_init()
+scalyr_logging.set_log_destination(use_stdout=True)
 
 from scalyr_agent.all_tests import run_all_tests
 

--- a/scalyr_agent/all_tests.py
+++ b/scalyr_agent/all_tests.py
@@ -94,7 +94,11 @@ def run_all_tests():
             print( "Error loading test_case '%s'.  %s, %s" % (test_case, str(e), traceback.format_exc()) )
 
     test_suite = unittest.TestSuite(suites)
-    text_runner = unittest.TextTestRunner(buffer=True).run(test_suite)
+    if sys.version_info[:2] < (2, 7):
+        # 2.6 and below to do not support capturing test output
+        text_runner = unittest.TextTestRunner().run(test_suite)
+    else:
+        text_runner = unittest.TextTestRunner(buffer=True).run(test_suite)
     if not text_runner.wasSuccessful():
         error = True
     sys.exit(error)

--- a/scalyr_agent/all_tests.py
+++ b/scalyr_agent/all_tests.py
@@ -94,7 +94,7 @@ def run_all_tests():
             print( "Error loading test_case '%s'.  %s, %s" % (test_case, str(e), traceback.format_exc()) )
 
     test_suite = unittest.TestSuite(suites)
-    text_runner = unittest.TextTestRunner().run(test_suite)
+    text_runner = unittest.TextTestRunner(buffer=True).run(test_suite)
     if not text_runner.wasSuccessful():
         error = True
     sys.exit(error)

--- a/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
@@ -148,6 +148,7 @@ class ControlledCacheWarmerTest(ScalyrTestCase):
     POD_2 = 'pod_2'
 
     def setUp(self):
+        super(ControlledCacheWarmerTest, self).setUp()
         self.__fake_cache = FakeCache()
         self.__warmer_test_instance = ControlledCacheWarmer(max_failure_count=5, blacklist_time_secs=300)
         self.assertFalse(self.__warmer_test_instance.is_running())

--- a/scalyr_agent/monitor_utils/tests/annotation_config_test.py
+++ b/scalyr_agent/monitor_utils/tests/annotation_config_test.py
@@ -24,9 +24,6 @@ from scalyr_agent.test_base import ScalyrTestCase
 
 
 class TestAnnotationConfig(ScalyrTestCase):
-    def setUp(self):
-        pass
-
     def test_plain_values(self):
         annotations = {
             "log.config.scalyr.com/someKey": "someValue",

--- a/scalyr_agent/monitor_utils/tests/blocking_rate_limiter_test.py
+++ b/scalyr_agent/monitor_utils/tests/blocking_rate_limiter_test.py
@@ -59,6 +59,7 @@ def rate_maintainer(consecutive_success_threshold, backoff_rate, increase_rate):
 class BlockingRateLimiterTest(ScalyrTestCase):
 
     def setUp(self):
+        super(BlockingRateLimiterTest, self).setUp()
         self._fake_clock = FakeClock()
         self._test_state = {
             'count': 0,

--- a/scalyr_agent/monitor_utils/tests/k8s_test.py
+++ b/scalyr_agent/monitor_utils/tests/k8s_test.py
@@ -43,6 +43,7 @@ class Test_K8sCache( ScalyrTestCase ):
             self.access_time = access_time
 
     def setUp(self):
+        super(Test_K8sCache, self).setUp()
         self.k8s = FakeK8s()
         self.clock = FakeClock()
         self.processor = FakeProcessor()
@@ -124,6 +125,7 @@ class TestKubernetesApi(ScalyrTestCase):
     Tests the Kubernetes API
     """
     def setUp(self):
+        super(TestKubernetesApi, self).setUp()
         self._path = '/foo'
 
     def _get_expected_log_mesg(self, path, stack_trace_lines, response_content):
@@ -322,6 +324,7 @@ class TestDockerMetricFetcher(ScalyrTestCase):
     """Tests the DockerMetricFetch abstraction.
     """
     def setUp(self):
+        super(TestDockerMetricFetcher, self).setUp()
         self._faker = DockerClientFaker()
         self._fetcher = DockerMetricFetcher(self._faker, 5)
 

--- a/scalyr_agent/monitor_utils/tests/server_processors_test.py
+++ b/scalyr_agent/monitor_utils/tests/server_processors_test.py
@@ -30,6 +30,7 @@ from scalyr_agent.test_base import ScalyrTestCase
 
 class TestInt32RequestParser(ScalyrTestCase):
     def setUp(self):
+        super(TestInt32RequestParser, self).setUp()
         self.__buffer = cStringIO.StringIO()
 
     def test_basic_case(self):
@@ -120,6 +121,7 @@ class FakeSocket(object):
 
 class TestRequestStream(ScalyrTestCase):
     def setUp(self):
+        super(TestRequestStream, self).setUp()
         self.__fake_socket = FakeSocket()
         self.__fake_run_state = FakeRunState()
 
@@ -202,6 +204,7 @@ class TestRequestStream(ScalyrTestCase):
 
 class TestLineRequestEOF( ScalyrTestCase ):
     def setUp(self):
+        super(TestLineRequestEOF, self).setUp()
         self.__fake_socket = FakeSocket()
         self.__fake_run_state = FakeRunState()
 
@@ -219,6 +222,7 @@ class TestLineRequestEOF( ScalyrTestCase ):
 
 class TestConnectionHandler(ScalyrTestCase):
     def setUp(self):
+        super(TestConnectionHandler, self).setUp()
         self.__fake_socket = FakeSocket()
         self.__fake_run_state = FakeRunState()
         self.__last_request = None

--- a/scalyr_agent/test_base.py
+++ b/scalyr_agent/test_base.py
@@ -115,6 +115,8 @@ class BaseScalyrTestCase(unittest.TestCase):
     # noinspection PyPep8Naming
     def __init__(self, methodName='runTest'):
         unittest.TestCase.__init__(self, methodName=methodName)
+        # Add in some code to check to make sure that derived classed invoked this classes `setUp` method if
+        # they overrode it.
         self.__setup_invoked = False
         self.addCleanup(self.verify_setup_invoked)
 
@@ -138,7 +140,9 @@ if sys.version_info[:2] < (2, 7):
         """The base class for Scalyr tests.
 
         This is used mainly to hide differences between the test fixtures available in the various Python
-        versions
+        versions.
+
+        WARNING:  Derived classes that override setUp, must be sure to invoke the inherited setUp method.
         """
         def assertIs(self, obj1, obj2, msg=None):
             """Just like self.assertTrue(a is b), but with a nicer default message."""
@@ -178,7 +182,9 @@ else:
         """The base class for Scalyr tests.
 
         This is used mainly to hide differences between the test fixtures available in the various Python
-        versions
+        versions.
+
+        WARNING:  Derived classes that override setUp, must be sure to invoke the inherited setUp method.
         """
         def assertIs(self, obj1, obj2, msg=None):
             unittest.TestCase.assertIs(self, obj1, obj2, msg=msg)

--- a/scalyr_agent/test_base.py
+++ b/scalyr_agent/test_base.py
@@ -113,12 +113,13 @@ class BaseScalyrTestCase(unittest.TestCase):
     adds protection to help detect hung test threads.
     """
     # noinspection PyPep8Naming
-    def __init__(self, methodName='runTest'):
+    def __init__(self, methodName='runTest', verify_setup_invoked=False):
         unittest.TestCase.__init__(self, methodName=methodName)
         # Add in some code to check to make sure that derived classed invoked this classes `setUp` method if
         # they overrode it.
-        self.__setup_invoked = False
-        self.addCleanup(self.verify_setup_invoked)
+        if verify_setup_invoked:
+            self.__setup_invoked = False
+            self.addCleanup(self.verify_setup_invoked)
 
     def setUp(self):
         # We need to reset the log destinations here because it is only at this point is stdout replaced with
@@ -144,6 +145,11 @@ if sys.version_info[:2] < (2, 7):
 
         WARNING:  Derived classes that override setUp, must be sure to invoke the inherited setUp method.
         """
+        # noinspection PyPep8Naming
+        def __init__(self, methodName='runTest'):
+            # Do not verify the setup was invoked since it relies on addCleanup which is only available in 2.7
+            BaseScalyrTestCase.__init__(self, methodName=methodName, verify_setup_invoked=False)
+
         def assertIs(self, obj1, obj2, msg=None):
             """Just like self.assertTrue(a is b), but with a nicer default message."""
             if obj1 is not obj2:
@@ -186,6 +192,10 @@ else:
 
         WARNING:  Derived classes that override setUp, must be sure to invoke the inherited setUp method.
         """
+        # noinspection PyPep8Naming
+        def __init__(self, methodName='runTest'):
+            BaseScalyrTestCase.__init__(self, methodName=methodName, verify_setup_invoked=True)
+
         def assertIs(self, obj1, obj2, msg=None):
             unittest.TestCase.assertIs(self, obj1, obj2, msg=msg)
 

--- a/scalyr_agent/tests/agent_status_test.py
+++ b/scalyr_agent/tests/agent_status_test.py
@@ -91,6 +91,7 @@ class TestReportStatus(ScalyrTestCase):
         os.environ.update(self.saved_env)
 
     def setUp(self):
+        super(TestReportStatus, self).setUp()
         self.saved_env = dict(os.environ)
         os.environ.clear()
         self.time = 1409958853

--- a/scalyr_agent/tests/auto_flushing_rotating_file_test.py
+++ b/scalyr_agent/tests/auto_flushing_rotating_file_test.py
@@ -27,6 +27,7 @@ from scalyr_agent.monitor_utils.auto_flushing_rotating_file import AutoFlushingR
 class AutoFlushingRotatingFileTestCase( unittest.TestCase ):
 
     def setUp(self):
+        super(AutoFlushingRotatingFileTestCase, self).setUp()
         self._tempdir = tempfile.mkdtemp()
         self._path = os.path.join(self._tempdir, 'out.log')
 

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -35,6 +35,7 @@ from scalyr_agent.test_base import ScalyrTestCase
 class TestConfigurationBase(ScalyrTestCase):
 
     def setUp(self):
+        super(TestConfigurationBase, self).setUp()
         self.original_os_env = dict([(k, v) for k, v in os.environ.iteritems()])
         self._config_dir = tempfile.mkdtemp()
         self._config_file = os.path.join(self._config_dir, 'agent.json')

--- a/scalyr_agent/tests/copying_manager_test.py
+++ b/scalyr_agent/tests/copying_manager_test.py
@@ -52,6 +52,7 @@ ONE_MB = 1024 * 1024
 class DynamicLogPathTest(ScalyrTestCase):
 
     def setUp(self):
+        super(DynamicLogPathTest, self).setUp()
         self._temp_dir = tempfile.mkdtemp()
         self._data_dir = os.path.join(self._temp_dir, 'data')
         self._log_dir = os.path.join(self._temp_dir, 'log')
@@ -137,6 +138,7 @@ class DynamicLogPathTest(ScalyrTestCase):
 
 class CopyingParamsTest(ScalyrTestCase):
     def setUp(self):
+        super(CopyingParamsTest, self).setUp()
         self.__config_dir = tempfile.mkdtemp()
         self.__config_file = os.path.join(self.__config_dir, 'agentConfig.json')
         self.__config_fragments_dir = os.path.join(self.__config_dir, 'configs.d')
@@ -328,6 +330,7 @@ class CopyingManagerInitializationTest(ScalyrTestCase):
 class CopyingManagerEnd2EndTest(ScalyrTestCase):
 
     def setUp(self):
+        super(CopyingManagerEnd2EndTest, self).setUp()
         self._controller = None
 
     def tearDown(self):

--- a/scalyr_agent/tests/linux_process_metrics_test.py
+++ b/scalyr_agent/tests/linux_process_metrics_test.py
@@ -77,6 +77,7 @@ class TestMetricClass(ScalyrTestCase):
 
 class TestProcessMonitorInitialize(ScalyrTestCase):
     def setUp(self):
+        super(TestProcessMonitorInitialize, self).setUp()
         self.config_commandline = {
             "module": "scalyr_agent.builtin_monitors.linux_process_metrics",
             "id": "myapp",
@@ -95,6 +96,7 @@ class TestProcessMonitorRecordMetrics(ScalyrTestCase):
     """
 
     def setUp(self):
+        super(TestProcessMonitorRecordMetrics, self).setUp()
         self.config_commandline = {
             "module": "scalyr_agent.builtin_monitors.linux_process_metrics",
             "id": "myapp",
@@ -178,6 +180,7 @@ class TestProcessMonitorRecordMetrics(ScalyrTestCase):
 
 class TestProcessListUtility(ScalyrTestCase):
     def setUp(self):
+        super(TestProcessListUtility, self).setUp()
         self.ps = ProcessList()
 
     def test_no_process(self):
@@ -260,6 +263,7 @@ class TestProcessMonitorRunningTotal(ScalyrTestCase):
     """
 
     def setUp(self):
+        super(TestProcessMonitorRunningTotal, self).setUp()
         self.config_commandline = {
             "module": "scalyr_agent.builtin_monitors.linux_process_metrics",
             "id": "myapp",

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -132,6 +132,7 @@ class TestCRILogParsing(ScalyrTestCase):
 
 class TestLogFileIterator(ScalyrTestCase):
     def setUp(self):
+        super(TestLogFileIterator, self).setUp()
         self.__tempdir = tempfile.mkdtemp()
         self.__file_system = FileSystem()
         self.__path = os.path.join(self.__tempdir, 'text.txt')
@@ -1118,6 +1119,7 @@ class TestLogLineSampler(ScalyrTestCase):
             self.__pending_numbers.append(random_number)
 
     def setUp(self):
+        super(TestLogLineSampler, self).setUp()
         self.sampler = TestLogLineSampler.TestableLogLineSampler()
 
     def test_no_sampling_rules(self):
@@ -1159,6 +1161,7 @@ class TestLogLineSampler(ScalyrTestCase):
 
 class TestLogFileProcessor(ScalyrTestCase):
     def setUp(self):
+        super(TestLogFileProcessor, self).setUp()
         self.__tempdir = tempfile.mkdtemp()
         self.__file_system = FileSystem()
         self.__path = os.path.join(self.__tempdir, 'text.txt')
@@ -1912,6 +1915,7 @@ class TestLogFileProcessor(ScalyrTestCase):
 
 class TestLogMatcher(ScalyrTestCase):
     def setUp(self):
+        super(TestLogMatcher, self).setUp()
         self.__config = _create_configuration()
 
         self.__tempdir = tempfile.mkdtemp()

--- a/scalyr_agent/tests/platform_posix_test.py
+++ b/scalyr_agent/tests/platform_posix_test.py
@@ -29,6 +29,7 @@ from scalyr_agent.test_base import ScalyrTestCase
 
 class TestStatusReporter(ScalyrTestCase):
     def setUp(self):
+        super(TestStatusReporter, self).setUp()
         self.receiver = StatusReporter()
         self.sender = StatusReporter(duplicate_reporter=self.receiver)
 
@@ -54,6 +55,7 @@ class TestStatusReporter(ScalyrTestCase):
 
 class TestPidfileManager(ScalyrTestCase):
     def setUp(self):
+        super(TestPidfileManager, self).setUp()
         self.__pidfile_name = self._create_tempfile_name()
 
         self.__test_manager = PidfileManager(self.__pidfile_name)

--- a/scalyr_agent/tests/scalyr_client_test.py
+++ b/scalyr_agent/tests/scalyr_client_test.py
@@ -31,6 +31,7 @@ import unittest
 class AddEventsRequestTest(ScalyrTestCase):
 
     def setUp(self):
+        super(AddEventsRequestTest, self).setUp()
         self.__body = {'token': 'fakeToken'}
         scalyr_client._set_last_timestamp(0)
 
@@ -292,9 +293,6 @@ class AddEventsRequestTest(ScalyrTestCase):
 
 
 class EventTest(ScalyrTestCase):
-    def setUp(self):
-        pass
-
     def test_all_fields(self):
         x = Event(thread_id='foo', attrs={"parser": "bar"})
         x.set_message("my_message")
@@ -452,7 +450,8 @@ class EventTest(ScalyrTestCase):
 
 
 class EventSequencerTest(ScalyrTestCase):
-    def setUp( self ):
+    def setUp(self):
+        super(EventSequencerTest, self).setUp()
         self.event_sequencer = EventSequencer()
 
     def test_sequence_id_but_no_number( self ):
@@ -560,6 +559,7 @@ class EventSequencerTest(ScalyrTestCase):
 class PostFixBufferTest(ScalyrTestCase):
 
     def setUp(self):
+        super(PostFixBufferTest, self).setUp()
         self.__format = '], threads: THREADS, client_time: TIMESTAMP }'
 
     def test_basic_case(self):

--- a/scalyr_agent/tests/scalyr_logging_test.py
+++ b/scalyr_agent/tests/scalyr_logging_test.py
@@ -27,6 +27,7 @@ from scalyr_agent.test_base import ScalyrTestCase
 
 class ScalyrLoggingTest(ScalyrTestCase):
     def setUp(self):
+        super(ScalyrLoggingTest, self).setUp()
         self.__log_path = tempfile.mktemp('.log')
         scalyr_logging.set_log_destination(use_disk=True, logs_directory=os.path.dirname(self.__log_path),
                                            agent_log_file_path=self.__log_path)

--- a/scalyr_agent/tests/syslog_monitor_test.py
+++ b/scalyr_agent/tests/syslog_monitor_test.py
@@ -214,6 +214,7 @@ class SyslogMonitorConnectTest(SyslogMonitorTestCase):
             pass
 
     def setUp(self):
+        super(SyslogMonitorConnectTest, self).setUp()
         self.monitor = None
         self.sockets = []
 

--- a/scalyr_agent/tests/url_monitor_test.py
+++ b/scalyr_agent/tests/url_monitor_test.py
@@ -30,6 +30,7 @@ class UrlMonitorTestRequest(unittest.TestCase):
     """
 
     def setUp(self):
+        super(UrlMonitorTestRequest, self).setUp()
         self.legit_headers = JsonArray()
         self.legit_headers.add(JsonObject({'header': 'header_foo', 'value': 'foo'}))
         self.legit_headers.add(JsonObject({'header': 'header_bar', 'value': 'bar'}))

--- a/scalyr_agent/tests/util_test.py
+++ b/scalyr_agent/tests/util_test.py
@@ -37,6 +37,7 @@ from scalyr_agent.test_base import ScalyrTestCase
 
 class TestUtilCompression(ScalyrTestCase):
     def setUp(self):
+        super(TestUtilCompression, self).setUp()
         self._data = 'The rain in spain. ' * 1000
 
     def test_zlib(self):
@@ -91,6 +92,7 @@ class TestUtilCompression(ScalyrTestCase):
 class TestUtil(ScalyrTestCase):
 
     def setUp(self):
+        super(TestUtil, self).setUp()
         self.__tempdir = tempfile.mkdtemp()
         self.__path = os.path.join(self.__tempdir, 'testing.json')
 
@@ -222,6 +224,7 @@ class TestUtil(ScalyrTestCase):
 
 class TestRateLimiter(ScalyrTestCase):
     def setUp(self):
+        super(TestRateLimiter, self).setUp()
         self.__test_rate = RateLimiter(100, 10, current_time=0)
         self.__current_time = 0
 
@@ -284,6 +287,7 @@ class TestRunState(ScalyrTestCase):
 
 class TestStoppableThread(ScalyrTestCase):
     def setUp(self):
+        super(TestStoppableThread, self).setUp()
         self._run_counter = 0
 
     def test_basic_use(self):
@@ -412,6 +416,7 @@ class TestRedirectorServer(ScalyrTestCase):
     """Tests the RedirectorServer code using fakes for stdout, stderr and the channel.
     """
     def setUp(self):
+        super(TestRedirectorServer, self).setUp()
         # Allows us to watch what bytes are being sent to the client.
         self._channel = FakeServerChannel()
         # Allows us to write bytes to stdout, stderr without them going to the terminal.
@@ -486,6 +491,7 @@ class TestRedirectorClient(ScalyrTestCase):
     """Test the RedirectorClient by faking out the client channel and also the clock.
     """
     def setUp(self):
+        super(TestRedirectorClient, self).setUp()
         self._fake_sys = FakeSys()
         # Since the client is an actual other thread that blocks waiting for input from the server, we have to
         # simulate the time using a fake clock.  That will allow us to wait up the client thread from time to time.
@@ -567,6 +573,7 @@ class TestRedirectionService(ScalyrTestCase):
     """Tests both the RedirectorServer and the RedirectorClient communicating together.
     """
     def setUp(self):
+        super(TestRedirectionService, self).setUp()
         self._client_sys = FakeSys()
         self._server_sys = FakeSys()
         self._fake_clock = scalyr_util.FakeClock()
@@ -706,6 +713,7 @@ class TestHistogramTracker(ScalyrTestCase):
     """Tests the HistogramTracker abstraction.
     """
     def setUp(self):
+        super(TestHistogramTracker, self).setUp()
         self._testing = HistogramTracker([10, 25, 50, 100])
 
     def test_count(self):

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -23,6 +23,7 @@ import thread
 
 __author__ = 'czerwin@scalyr.com'
 
+import logging
 import base64
 import calendar
 import datetime
@@ -892,7 +893,7 @@ class StoppableThread(threading.Thread):
                 self.run_and_propagate()
         except Exception, e:
             self.__exception_info = sys.exc_info()
-            print >> sys.stderr, 'Received exception from run method in StoppableThread %s' % str(e)
+            logging.getLogger().warn('Received exception from run method in StoppableThread %s' % str(e))
             return None
 
     def run_and_propagate(self):


### PR DESCRIPTION
This fixes the tests so that all output generated by our use
of the Python loggers will be captured during unittest execution.

To do this, needed to set the use of stdout for our logging whenever
we are about to run a test case.

Suggest review path:  Look at test_base.py first.  Almost all other changes are just to added in calling the inherited setUp method.