### PR TITLE
Imron/refactor

### DIFF
--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -2305,7 +2305,9 @@ class LogMatcher(object):
         removed from the list of processors.  These processors will be recreated
         the next time the file matcher is matched.
 
-        @return: A dict of paths -> checkpoints for any closed processors
+        @return: A dict of paths -> checkpoints for any closed processors.  The caller should
+            retain a copy of these checkpoints and be sure they are used when next running
+            the matcher.
         """
 
         self.__log_entry_config = log_entry_config

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -2321,6 +2321,7 @@ class LogMatcher(object):
             for p in self.__processors:
                 result.append( p.log_path )
 
+            self.__processors = []
         finally:
             self.__lock.release()
 
@@ -2360,11 +2361,14 @@ class LogMatcher(object):
         Returns true if the log matcher is finished and all of its processors are closed, and the matcher has
         been processed at least once
         """
+        finished = False
         self.__lock.acquire()
         try:
+            finished = self.__is_finished
+
             # we are only finished if `is_finished` is set and we have tried to check for a match
             # on the matcher at least once
-            if self.__is_finished and self.__last_check is None:
+            if finished and self.__last_check is None:
                 return False
 
             # check if all the processors are closed
@@ -2375,7 +2379,7 @@ class LogMatcher(object):
         finally:
             self.__lock.release()
 
-        return True
+        return finished
 
     def generate_status(self):
         """

--- a/scalyr_agent/tests/copying_manager_test.py
+++ b/scalyr_agent/tests/copying_manager_test.py
@@ -241,6 +241,7 @@ class DynamicLogPathTest(ScalyrTestCase):
 
         self._manager.schedule_log_path_for_removal( 'unittest', path )
         self.fake_scan()
+        self.fake_scan()
         matchers = self._manager.log_matchers
         self.assertEquals( 0, len(matchers) )
 
@@ -288,6 +289,37 @@ class DynamicLogPathTest(ScalyrTestCase):
         self._manager.remove_log_path( 'unittest', path )
         matchers = self._manager.log_matchers
         self.assertEquals( 0, len(matchers) )
+
+    def test_add_after_remove(self):
+        config = {}
+        self.create_copying_manager( config )
+        self.fake_scan()
+
+        path = os.path.join( self._log_dir, "newlog.log" )
+        self.append_log_lines( path, "line1\n" )
+
+        log_config = {
+            "path": path
+        }
+
+        self._manager.add_log_config( 'unittest', log_config )
+        self.fake_scan()
+        matchers = self._manager.log_matchers
+        self.assertEquals( 1, len(matchers) )
+        self.assertEquals( path, matchers[0].log_path )
+
+        self._manager.remove_log_path( 'unittest', path )
+        self.fake_scan()
+        self.fake_scan()
+        matchers = self._manager.log_matchers
+        self.assertEquals( 0, len(matchers) )
+        self.assertEquals( 0, self._manager.dynamic_matchers_count() )
+
+        self._manager.add_log_config( 'otherunittest', log_config )
+        self.fake_scan()
+        self.assertEquals( 1, self._manager.dynamic_matchers_count() )
+        self.assertEquals( path, matchers[0].log_path )
+
 
     def test_remove_log_path_different_monitor(self):
         config = {}

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -1860,7 +1860,7 @@ class TestLogFileProcessor(ScalyrTestCase):
         first_sid, _, _ = events.get_sequence(0)
         self.assertTrue(isinstance(first_sid, basestring))
 
-    def test_is_finished_not_finished( self ):
+    def test_closed_not_closed( self ):
         log_processor = self.log_processor
         self.append_file(self.__path, "First line\n" )
         events = TestLogFileProcessor.TestAddEventsRequest()
@@ -1869,11 +1869,11 @@ class TestLogFileProcessor(ScalyrTestCase):
         completion_callback(LogFileProcessor.SUCCESS)
         status = log_processor.generate_status()
 
-        self.assertFalse( log_processor.is_finished() )
+        self.assertFalse( log_processor.is_closed() )
 
-    def test_is_finished_bytes_pending( self ):
+    def test_is_closed_bytes_pending( self ):
         log_processor = self.log_processor
-        log_processor.finish()
+        log_processor.close_at_eof()
         self.append_file(self.__path, "First line\n" )
         events = TestLogFileProcessor.TestAddEventsRequest()
         (completion_callback, buffer_full) = log_processor.perform_processing(
@@ -1886,11 +1886,11 @@ class TestLogFileProcessor(ScalyrTestCase):
         completion_callback(LogFileProcessor.SUCCESS)
         status = log_processor.generate_status()
 
-        self.assertFalse( log_processor.is_finished() )
+        self.assertFalse( log_processor.is_closed() )
 
-    def test_is_finished_bytes_read_non_zero( self ):
+    def test_is_closed_bytes_read_non_zero( self ):
         log_processor = self.log_processor
-        log_processor.finish()
+        log_processor.close_at_eof()
         self.append_file(self.__path, "First line\n" )
         events = TestLogFileProcessor.TestAddEventsRequest()
         (completion_callback, buffer_full) = log_processor.perform_processing(
@@ -1898,11 +1898,11 @@ class TestLogFileProcessor(ScalyrTestCase):
         completion_callback(LogFileProcessor.SUCCESS)
         status = log_processor.generate_status()
 
-        self.assertFalse( log_processor.is_finished() )
+        self.assertFalse( log_processor.is_closed() )
 
-    def test_is_finished_yes( self ):
+    def test_is_closed_yes( self ):
         log_processor = self.log_processor
-        log_processor.finish()
+        log_processor.close_at_eof()
         self.append_file(self.__path, "First line\n" )
         events = TestLogFileProcessor.TestAddEventsRequest()
         (completion_callback, buffer_full) = log_processor.perform_processing(
@@ -1913,7 +1913,7 @@ class TestLogFileProcessor(ScalyrTestCase):
         completion_callback(LogFileProcessor.SUCCESS)
         status = log_processor.generate_status()
 
-        self.assertTrue( log_processor.is_finished() )
+        self.assertTrue( log_processor.is_closed() )
 
     def write_file(self, path, *lines):
         contents = ''.join(lines)

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -1857,6 +1857,61 @@ class TestLogFileProcessor(ScalyrTestCase):
         first_sid, _, _ = events.get_sequence(0)
         self.assertTrue(isinstance(first_sid, basestring))
 
+    def test_is_finished_not_finished( self ):
+        log_processor = self.log_processor
+        self.append_file(self.__path, "First line\n" )
+        events = TestLogFileProcessor.TestAddEventsRequest()
+        (completion_callback, buffer_full) = log_processor.perform_processing(
+            events, current_time=self.__fake_time)
+        completion_callback(LogFileProcessor.SUCCESS)
+        status = log_processor.generate_status()
+
+        self.assertFalse( log_processor.is_finished() )
+
+    def test_is_finished_bytes_pending( self ):
+        log_processor = self.log_processor
+        log_processor.finish()
+        self.append_file(self.__path, "First line\n" )
+        events = TestLogFileProcessor.TestAddEventsRequest()
+        (completion_callback, buffer_full) = log_processor.perform_processing(
+            events, current_time=self.__fake_time)
+        completion_callback(LogFileProcessor.SUCCESS)
+        (completion_callback, buffer_full) = log_processor.perform_processing(
+            events, current_time=self.__fake_time)
+        self.append_file(self.__path, "Second line\n" )
+        log_processor.scan_for_new_bytes()
+        completion_callback(LogFileProcessor.SUCCESS)
+        status = log_processor.generate_status()
+
+        self.assertFalse( log_processor.is_finished() )
+
+    def test_is_finished_bytes_read_non_zero( self ):
+        log_processor = self.log_processor
+        log_processor.finish()
+        self.append_file(self.__path, "First line\n" )
+        events = TestLogFileProcessor.TestAddEventsRequest()
+        (completion_callback, buffer_full) = log_processor.perform_processing(
+            events, current_time=self.__fake_time)
+        completion_callback(LogFileProcessor.SUCCESS)
+        status = log_processor.generate_status()
+
+        self.assertFalse( log_processor.is_finished() )
+
+    def test_is_finished_yes( self ):
+        log_processor = self.log_processor
+        log_processor.finish()
+        self.append_file(self.__path, "First line\n" )
+        events = TestLogFileProcessor.TestAddEventsRequest()
+        (completion_callback, buffer_full) = log_processor.perform_processing(
+            events, current_time=self.__fake_time)
+        completion_callback(LogFileProcessor.SUCCESS)
+        (completion_callback, buffer_full) = log_processor.perform_processing(
+            events, current_time=self.__fake_time)
+        completion_callback(LogFileProcessor.SUCCESS)
+        status = log_processor.generate_status()
+
+        self.assertTrue( log_processor.is_finished() )
+
     def write_file(self, path, *lines):
         contents = ''.join(lines)
         file_handle = open(path, 'wb')


### PR DESCRIPTION
This is the start of the refactoring for the logmatchers, log processors and the copying manager.

This PR only has the changes to the log matchers and log file processors, adding the concept of a `finished` matcher/processor (I opted for `finished` over `scheduled_to_close` for naming).

Calling `finish` on a log processor marks the processor as preparing to finish.  A processor will consider itself fully finished if it is marked as finished, and there are no bytes pending, and there were no bytes read last time the file was processed.

Calling `finish` on a log matcher marks it as preparing to finish.  A log matcher will consider itself fully finished if it is marked as finished, and it has been processed at least once, and all of its open processors are also fully finished.