### PR TITLE
Bug: Fix Support for recursive ** globs by switching to glob2 library

### DIFF
--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -28,7 +28,14 @@ __author__ = 'czerwin@scalyr.com'
 import datetime
 import errno
 import fnmatch
-import glob2
+import sys
+# Glob2 requires a Python version >= 2.6. This check falls back to the built-in glob module when running under
+# old Python versions. This can be removed when we no longer support Python earlier than 2.6.
+# When support for Python earlier than 3.5 is deprecated, the built-in glob with a recursive option can be used.
+if sys.version_info >= (2, 6):
+    import glob2 as glob
+else:
+    import glob as glob
 import os
 import random
 import re
@@ -2477,7 +2484,7 @@ class LogMatcher(object):
 
         # See if the file path matches.. even if it is not a glob, this will return the single file represented by it.
         try:
-            for matched_file in glob2.glob(self.__log_entry_config['path']):
+            for matched_file in glob.glob(self.__log_entry_config['path']):
                 skip = False
                 # check to see if this file matches any of the exclude globs
                 for exclude_glob in self.__log_entry_config['exclude']:

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -28,7 +28,7 @@ __author__ = 'czerwin@scalyr.com'
 import datetime
 import errno
 import fnmatch
-import glob
+import glob2
 import os
 import random
 import re
@@ -2477,15 +2477,16 @@ class LogMatcher(object):
 
         # See if the file path matches.. even if it is not a glob, this will return the single file represented by it.
         try:
-            for matched_file in glob.glob(self.__log_entry_config['path']):
-
+            for matched_file in glob2.glob(self.__log_entry_config['path']):
                 skip = False
                 # check to see if this file matches any of the exclude globs
                 for exclude_glob in self.__log_entry_config['exclude']:
                     if fnmatch.fnmatch( matched_file, exclude_glob ):
                         skip = True
                         break
-
+                # Check if this is a directory
+                if os.path.isdir(matched_file):
+                    skip = True
                 # if so, skip it.
                 if skip:
                     continue

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -2019,13 +2019,15 @@ class TestLogMatcher(ScalyrTestCase):
         self._close_processors(processors)
 
     def test_matches_recursive_glob(self):
-        matcher = LogMatcher(self.__config, self._create_log_config(self.__glob_recursive))
-        processors = matcher.find_matches(dict(), dict())
-        self.assertEquals(len(processors), 2)
-        self.assertEquals(processors[0].log_path, self.__path_three)
-        self.assertEquals(processors[1].log_path, self.__path_four)
+        # Recursive "**" glob patterns are only supported on Python 2.6 and above.
+        if sys.version_info >= (2, 6):
+            matcher = LogMatcher(self.__config, self._create_log_config(self.__glob_recursive))
+            processors = matcher.find_matches(dict(), dict())
+            self.assertEquals(len(processors), 2)
+            self.assertEquals(processors[0].log_path, self.__path_three)
+            self.assertEquals(processors[1].log_path, self.__path_four)
 
-        self._close_processors(processors)
+            self._close_processors(processors)
 
     def test_ignores_stale_file(self):
         staleness_threshold = 300  # 5 mins

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -1977,14 +1977,27 @@ class TestLogMatcher(ScalyrTestCase):
         self.__config = _create_configuration()
 
         self.__tempdir = tempfile.mkdtemp()
+
+        # Create directories for recursive ** globbing
+        self.__directory_aa = os.path.join(self.__tempdir, "recursive", "a", "a")
+        self.__directory_ab = os.path.join(self.__tempdir, "recursive", "a", "b")
+        os.makedirs(self.__directory_aa)
+        os.makedirs(self.__directory_ab)
+
         self.__file_system = FileSystem()
         self.__path_one = os.path.join(self.__tempdir, 'text.txt')
         self.__path_two = os.path.join(self.__tempdir, 'text_two.txt')
+        self.__path_three = os.path.join(self.__directory_aa, "aa.txt")
+        self.__path_four = os.path.join(self.__directory_ab, "ab.txt")
+
         self.__glob_one = os.path.join(self.__tempdir, '*.txt')
         self.__glob_two = os.path.join(self.__tempdir, '*two.txt')
+        self.__glob_recursive = os.path.join(self.__tempdir, "recursive/**/*")
 
         self._create_file(self.__path_one)
         self._create_file(self.__path_two)
+        self._create_file(self.__path_three)
+        self._create_file(self.__path_four)
 
         self.__fake_time = 10
 
@@ -2002,6 +2015,15 @@ class TestLogMatcher(ScalyrTestCase):
         matcher = LogMatcher(self.__config, self._create_log_config(self.__glob_two))
         processors = matcher.find_matches(dict(), dict())
         self.assertEquals(len(processors), 1)
+
+        self._close_processors(processors)
+
+    def test_matches_recursive_glob(self):
+        matcher = LogMatcher(self.__config, self._create_log_config(self.__glob_recursive))
+        processors = matcher.find_matches(dict(), dict())
+        self.assertEquals(len(processors), 2)
+        self.assertEquals(processors[0].log_path, self.__path_three)
+        self.assertEquals(processors[1].log_path, self.__path_four)
 
         self._close_processors(processors)
 

--- a/scalyr_agent/third_party/README.md
+++ b/scalyr_agent/third_party/README.md
@@ -33,6 +33,7 @@ The following libraries are included:
   * [asn1crypto](#asn1crypto)
   * [cffi](#cffi)
   * [oscrypto](#oscrypto)
+  * [glob2](#glob2)
 
 ## tcollector<a name="tcollector">
 
@@ -104,7 +105,7 @@ A pure Python implementation of lex and yacc.
 
 Used by PySMI.
 
-## pg8000<a name="pg8000"
+## pg8000<a name="pg8000">
 
 A Pure-Python interface to the PostgreSQL database engine
 
@@ -169,3 +170,7 @@ C Foreign Function Interface for Python.  Allows you to interact with almost any
 `certvalidator` requires this library.
 
 An encryption library that `tlslite-ng` depends on.  See project home [here](https://github.com/wbond/oscrypto).
+
+## glob2<a name="glob2">
+
+An extended version of Python's builtin glob module which adds support for recursive '**' globbing syntax. See project home [here](https://github.com/miracle2k/python-glob2).

--- a/scalyr_agent/third_party/glob2/__init__.py
+++ b/scalyr_agent/third_party/glob2/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+from .impl import *
+
+
+__version__ = (0, 7)

--- a/scalyr_agent/third_party/glob2/compat.py
+++ b/scalyr_agent/third_party/glob2/compat.py
@@ -1,0 +1,167 @@
+# Back-port functools.lru_cache to Python 2 (and <= 3.2)
+# {{{ http://code.activestate.com/recipes/578078/ (r6)
+
+from collections import namedtuple
+from functools import update_wrapper
+from threading import RLock
+
+_CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "maxsize", "currsize"])
+
+class _HashedSeq(list):
+    __slots__ = 'hashvalue'
+
+    def __init__(self, tup, hash=hash):
+        self[:] = tup
+        self.hashvalue = hash(tup)
+
+    def __hash__(self):
+        return self.hashvalue
+
+def _make_key(args, kwds, typed,
+             kwd_mark = (object(),),
+             fasttypes = set((int, str, frozenset, type(None))),
+             sorted=sorted, tuple=tuple, type=type, len=len):
+    'Make a cache key from optionally typed positional and keyword arguments'
+    key = args
+    if kwds:
+        sorted_items = sorted(kwds.items())
+        key += kwd_mark
+        for item in sorted_items:
+            key += item
+    if typed:
+        key += tuple(type(v) for v in args)
+        if kwds:
+            key += tuple(type(v) for k, v in sorted_items)
+    elif len(key) == 1 and type(key[0]) in fasttypes:
+        return key[0]
+    return _HashedSeq(key)
+
+def lru_cache(maxsize=100, typed=False):
+    """Least-recently-used cache decorator.
+
+    If *maxsize* is set to None, the LRU features are disabled and the cache
+    can grow without bound.
+
+    If *typed* is True, arguments of different types will be cached separately.
+    For example, f(3.0) and f(3) will be treated as distinct calls with
+    distinct results.
+
+    Arguments to the cached function must be hashable.
+
+    View the cache statistics named tuple (hits, misses, maxsize, currsize) with
+    f.cache_info().  Clear the cache and statistics with f.cache_clear().
+    Access the underlying function with f.__wrapped__.
+
+    See:  http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used
+
+    """
+
+    # Users should only access the lru_cache through its public API:
+    #       cache_info, cache_clear, and f.__wrapped__
+    # The internals of the lru_cache are encapsulated for thread safety and
+    # to allow the implementation to change (including a possible C version).
+
+    def decorating_function(user_function):
+
+        cache = dict()
+        stats = [0, 0]                  # make statistics updateable non-locally
+        HITS, MISSES = 0, 1             # names for the stats fields
+        make_key = _make_key
+        cache_get = cache.get           # bound method to lookup key or return None
+        _len = len                      # localize the global len() function
+        lock = RLock()                  # because linkedlist updates aren't threadsafe
+        root = []                       # root of the circular doubly linked list
+        root[:] = [root, root, None, None]      # initialize by pointing to self
+        nonlocal_root = [root]                  # make updateable non-locally
+        PREV, NEXT, KEY, RESULT = 0, 1, 2, 3    # names for the link fields
+
+        if maxsize == 0:
+
+            def wrapper(*args, **kwds):
+                # no caching, just do a statistics update after a successful call
+                result = user_function(*args, **kwds)
+                stats[MISSES] += 1
+                return result
+
+        elif maxsize is None:
+
+            def wrapper(*args, **kwds):
+                # simple caching without ordering or size limit
+                key = make_key(args, kwds, typed)
+                result = cache_get(key, root)   # root used here as a unique not-found sentinel
+                if result is not root:
+                    stats[HITS] += 1
+                    return result
+                result = user_function(*args, **kwds)
+                cache[key] = result
+                stats[MISSES] += 1
+                return result
+
+        else:
+
+            def wrapper(*args, **kwds):
+                # size limited caching that tracks accesses by recency
+                key = make_key(args, kwds, typed) if kwds or typed else args
+                with lock:
+                    link = cache_get(key)
+                    if link is not None:
+                        # record recent use of the key by moving it to the front of the list
+                        root, = nonlocal_root
+                        link_prev, link_next, key, result = link
+                        link_prev[NEXT] = link_next
+                        link_next[PREV] = link_prev
+                        last = root[PREV]
+                        last[NEXT] = root[PREV] = link
+                        link[PREV] = last
+                        link[NEXT] = root
+                        stats[HITS] += 1
+                        return result
+                result = user_function(*args, **kwds)
+                with lock:
+                    root, = nonlocal_root
+                    if key in cache:
+                        # getting here means that this same key was added to the
+                        # cache while the lock was released.  since the link
+                        # update is already done, we need only return the
+                        # computed result and update the count of misses.
+                        pass
+                    elif _len(cache) >= maxsize:
+                        # use the old root to store the new key and result
+                        oldroot = root
+                        oldroot[KEY] = key
+                        oldroot[RESULT] = result
+                        # empty the oldest link and make it the new root
+                        root = nonlocal_root[0] = oldroot[NEXT]
+                        oldkey = root[KEY]
+                        oldvalue = root[RESULT]
+                        root[KEY] = root[RESULT] = None
+                        # now update the cache dictionary for the new links
+                        del cache[oldkey]
+                        cache[key] = oldroot
+                    else:
+                        # put result in a new link at the front of the list
+                        last = root[PREV]
+                        link = [last, root, key, result]
+                        last[NEXT] = root[PREV] = cache[key] = link
+                    stats[MISSES] += 1
+                return result
+
+        def cache_info():
+            """Report cache statistics"""
+            with lock:
+                return _CacheInfo(stats[HITS], stats[MISSES], maxsize, len(cache))
+
+        def cache_clear():
+            """Clear the cache and cache statistics"""
+            with lock:
+                cache.clear()
+                root = nonlocal_root[0]
+                root[:] = [root, root, None, None]
+                stats[:] = [0, 0]
+
+        wrapper.__wrapped__ = user_function
+        wrapper.cache_info = cache_info
+        wrapper.cache_clear = cache_clear
+        return update_wrapper(wrapper, user_function)
+
+    return decorating_function

--- a/scalyr_agent/third_party/glob2/fnmatch.py
+++ b/scalyr_agent/third_party/glob2/fnmatch.py
@@ -1,0 +1,141 @@
+"""Filename matching with shell patterns.
+
+fnmatch(FILENAME, PATTERN) matches according to the local convention.
+fnmatchcase(FILENAME, PATTERN) always takes case in account.
+
+The functions operate by translating the pattern into a regular
+expression.  They cache the compiled regular expressions for speed.
+
+The function translate(PATTERN) returns a regular expression
+corresponding to PATTERN.  (It does not compile it.)
+"""
+import os
+import re
+try:
+    from functools import lru_cache
+except ImportError:
+    from .compat import lru_cache
+
+__all__ = ["filter", "fnmatch", "fnmatchcase", "translate"]
+
+
+def _norm_paths(path, norm_paths, sep):
+    if norm_paths is None:
+        path = re.sub(r'\/', sep or os.sep, path)  # cached internally
+    elif norm_paths:
+        path = os.path.normcase(path)
+    return path
+
+
+def fnmatch(name, pat, norm_paths=True, case_sensitive=True, sep=None):
+    """Test whether FILENAME matches PATTERN.
+
+    Patterns are Unix shell style:
+
+    *       matches everything
+    ?       matches any single character
+    [seq]   matches any character in seq
+    [!seq]  matches any char not in seq
+
+    An initial period in FILENAME is not special.
+    Both FILENAME and PATTERN are first case-normalized
+    if the operating system requires it.
+    If you don't want this, use fnmatchcase(FILENAME, PATTERN).
+
+    :param slashes:
+    :param norm_paths:
+        A tri-state boolean:
+        when true, invokes `os.path,.normcase()` on both paths,
+        when `None`, just equalize slashes/backslashes to `os.sep`,
+        when false, does not touch paths at all.
+
+        Note that a side-effect of `normcase()` on *Windows* is that
+        it converts to lower-case all matches of `?glob()` functions.
+    :param case_sensitive:
+        defines the case-sensitiviness of regex doing the matches
+    :param sep:
+        in case only slahes replaced, what sep-char to substitute with;
+        if false, `os.sep` is used.
+
+    Notice that by default, `normcase()` causes insensitive matching
+    on *Windows*, regardless of `case_insensitive` param.
+    Set ``norm_paths=None, case_sensitive=False`` to preserve
+    verbatim mathces.
+    """
+    name, pat = [_norm_paths(p, norm_paths, sep)
+                 for p in (name, pat)]
+
+    return fnmatchcase(name, pat, case_sensitive=case_sensitive)
+
+
+@lru_cache(maxsize=256, typed=True)
+def _compile_pattern(pat, case_sensitive):
+    if isinstance(pat, bytes):
+        pat_str = pat.decode('ISO-8859-1')
+        res_str = translate(pat_str)
+        res = res_str.encode('ISO-8859-1')
+    else:
+        res = translate(pat)
+    flags = 0 if case_sensitive else re.IGNORECASE
+    return re.compile(res, flags).match
+
+
+def filter(names, pat, norm_paths=True, case_sensitive=True, sep=None):
+    """Return the subset of the list NAMES that match PAT."""
+    result = []
+    pat = _norm_paths(pat, norm_paths, sep)
+    match = _compile_pattern(pat, case_sensitive)
+    for name in names:
+        m = match(_norm_paths(name, norm_paths, sep))
+        if m:
+            result.append((name,
+                           tuple(_norm_paths(p, norm_paths, sep) for p in m.groups())))
+    return result
+
+
+def fnmatchcase(name, pat, case_sensitive=True):
+    """Test whether FILENAME matches PATTERN, including case.
+
+    This is a version of fnmatch() which doesn't case-normalize
+    its arguments.
+    """
+    match = _compile_pattern(pat, case_sensitive)
+    return match(name) is not None
+
+
+def translate(pat):
+    """Translate a shell PATTERN to a regular expression.
+
+    There is no way to quote meta-characters.
+    """
+
+    i, n = 0, len(pat)
+    res = ''
+    while i < n:
+        c = pat[i]
+        i = i+1
+        if c == '*':
+            res = res + '(.*)'
+        elif c == '?':
+            res = res + '(.)'
+        elif c == '[':
+            j = i
+            if j < n and pat[j] == '!':
+                j = j+1
+            if j < n and pat[j] == ']':
+                j = j+1
+            while j < n and pat[j] != ']':
+                j = j+1
+            if j >= n:
+                res = res + '\\['
+            else:
+                stuff = pat[i:j].replace('\\','\\\\')
+                i = j+1
+                if stuff[0] == '!':
+                    stuff = '^' + stuff[1:]
+                elif stuff[0] == '^':
+                    stuff = '\\' + stuff
+                res = '%s([%s])' % (res, stuff)
+        else:
+            res = res + re.escape(c)
+    return '(?ms)' + res + '\Z'

--- a/scalyr_agent/third_party/glob2/impl.py
+++ b/scalyr_agent/third_party/glob2/impl.py
@@ -1,0 +1,216 @@
+"""Filename globbing utility."""
+
+from __future__ import absolute_import
+
+import sys
+import os
+import re
+from os.path import join
+from . import fnmatch
+
+try:
+    from itertools import imap
+except ImportError:
+    imap = map
+
+
+class Globber(object):
+
+    listdir = staticmethod(os.listdir)
+    isdir = staticmethod(os.path.isdir)
+    islink = staticmethod(os.path.islink)
+    exists = staticmethod(os.path.lexists)
+
+    def walk(self, top, followlinks=False, sep=None):
+        """A simplified version of os.walk (code copied) that uses
+        ``self.listdir``, and the other local filesystem methods.
+
+        Because we don't care about file/directory distinctions, only
+        a single list is returned.
+        """
+        try:
+            names = self.listdir(top)
+        except os.error as err:
+            return
+
+        items = []
+        for name in names:
+            items.append(name)
+
+        yield top, items
+
+        for name in items:
+            new_path = _join_paths([top, name], sep=sep)
+            if followlinks or not self.islink(new_path):
+                for x in self.walk(new_path, followlinks):
+                    yield x
+
+    def glob(self, pathname, with_matches=False, include_hidden=False, recursive=True,
+             norm_paths=True, case_sensitive=True, sep=None):
+        """Return a list of paths matching a pathname pattern.
+
+        The pattern may contain simple shell-style wildcards a la
+        fnmatch. However, unlike fnmatch, filenames starting with a
+        dot are special cases that are not matched by '*' and '?'
+        patterns.
+
+        If ``include_hidden`` is True, then files and folders starting with
+        a dot are also returned.
+        """
+        return list(self.iglob(pathname, with_matches, include_hidden,
+                               norm_paths, case_sensitive, sep))
+
+    def iglob(self, pathname, with_matches=False, include_hidden=False, recursive=True,
+              norm_paths=True, case_sensitive=True, sep=None):
+        """Return an iterator which yields the paths matching a pathname
+        pattern.
+
+        The pattern may contain simple shell-style wildcards a la
+        fnmatch. However, unlike fnmatch, filenames starting with a
+        dot are special cases that are not matched by '*' and '?'
+        patterns.
+
+        If ``with_matches`` is True, then for each matching path
+        a 2-tuple will be returned; the second element if the tuple
+        will be a list of the parts of the path that matched the individual
+        wildcards.
+
+        If ``include_hidden`` is True, then files and folders starting with
+        a dot are also returned.
+        """
+        result = self._iglob(pathname, True, include_hidden,
+                             norm_paths, case_sensitive, sep)
+        if with_matches:
+            return result
+        return imap(lambda s: s[0], result)
+
+    def _iglob(self, pathname, rootcall, include_hidden,
+               norm_paths, case_sensitive, sep):
+        """Internal implementation that backs :meth:`iglob`.
+
+        ``rootcall`` is required to differentiate between the user's call to
+        iglob(), and subsequent recursive calls, for the purposes of resolving
+        certain special cases of ** wildcards. Specifically, "**" is supposed
+        to include the current directory for purposes of globbing, but the
+        directory itself should never be returned. So if ** is the lastmost
+        part of the ``pathname`` given the user to the root call, we want to
+        ignore the current directory. For this, we need to know which the root
+        call is.
+        """
+
+        # Short-circuit if no glob magic
+        if not has_magic(pathname):
+            if self.exists(pathname):
+                yield pathname, ()
+            return
+
+        # If no directory part is left, assume the working directory
+        dirname, basename = os.path.split(pathname)
+
+        # If the directory is globbed, recurse to resolve.
+        # If at this point there is no directory part left, we simply
+        # continue with dirname="", which will search the current dir.
+        # `os.path.split()` returns the argument itself as a dirname if it is a
+        # drive or UNC path.  Prevent an infinite recursion if a drive or UNC path
+        # contains magic characters (i.e. r'\\?\C:').
+        if dirname != pathname and has_magic(dirname):
+            # Note that this may return files, which will be ignored
+            # later when we try to use them as directories.
+            # Prefiltering them here would only require more IO ops.
+            dirs = self._iglob(dirname, False, include_hidden,
+                               norm_paths, case_sensitive, sep)
+        else:
+            dirs = [(dirname, ())]
+
+        # Resolve ``basename`` expr for every directory found
+        for dirname, dir_groups in dirs:
+            for name, groups in self.resolve_pattern(dirname, basename,
+                                                     not rootcall, include_hidden,
+                                                     norm_paths, case_sensitive, sep):
+                yield _join_paths([dirname, name], sep=sep), dir_groups + groups
+
+    def resolve_pattern(self, dirname, pattern, globstar_with_root, include_hidden,
+                        norm_paths, case_sensitive, sep):
+        """Apply ``pattern`` (contains no path elements) to the
+        literal directory in ``dirname``.
+
+        If pattern=='', this will filter for directories. This is
+        a special case that happens when the user's glob expression ends
+        with a slash (in which case we only want directories). It simpler
+        and faster to filter here than in :meth:`_iglob`.
+        """
+
+        if sys.version_info[0] == 3:
+            if isinstance(pattern, bytes):
+                dirname = bytes(os.curdir, 'ASCII')
+        else:
+            if isinstance(pattern, unicode) and not isinstance(dirname, unicode):
+                dirname = unicode(dirname, sys.getfilesystemencoding() or
+                                           sys.getdefaultencoding())
+
+        # If no magic, short-circuit, only check for existence
+        if not has_magic(pattern):
+            if pattern == '':
+                if self.isdir(dirname):
+                    return [(pattern, ())]
+            else:
+                if self.exists(_join_paths([dirname, pattern], sep=sep)):
+                    return [(pattern, ())]
+            return []
+
+        if not dirname:
+            dirname = os.curdir
+
+        try:
+            if pattern == '**':
+                # Include the current directory in **, if asked; by adding
+                # an empty string as opposed to '.', we spare ourselves
+                # having to deal with os.path.normpath() later.
+                names = [''] if globstar_with_root else []
+                for top, entries in self.walk(dirname, sep=sep):
+                    _mkabs = lambda s: _join_paths([top[len(dirname) + 1:], s], sep=sep)
+                    names.extend(map(_mkabs, entries))
+                # Reset pattern so that fnmatch(), which does not understand
+                # ** specifically, will only return a single group match.
+                pattern = '*'
+            else:
+                names = self.listdir(dirname)
+        except os.error:
+            return []
+
+        if not include_hidden and not _ishidden(pattern):
+            # Remove hidden files, but take care to ensure
+            # that the empty string we may have added earlier remains.
+            # Do not filter out the '' that we might have added earlier
+            names = filter(lambda x: not x or not _ishidden(x), names)
+        return fnmatch.filter(names, pattern, norm_paths, case_sensitive, sep)
+
+
+default_globber = Globber()
+glob = default_globber.glob
+iglob = default_globber.iglob
+del default_globber
+
+
+magic_check = re.compile('[*?[]')
+magic_check_bytes = re.compile(b'[*?[]')
+
+
+def has_magic(s):
+    if isinstance(s, bytes):
+        match = magic_check_bytes.search(s)
+    else:
+        match = magic_check.search(s)
+    return match is not None
+
+
+def _ishidden(path):
+    return path[0] in ('.', b'.'[0])
+
+
+def _join_paths(paths, sep=None):
+    path = join(*paths)
+    if sep:
+        path = re.sub(r'\/', sep, path)  # cached internally
+    return path
+

--- a/scalyr_agent/third_party/licenses/LICENSE_glob2.txt
+++ b/scalyr_agent/third_party/licenses/LICENSE_glob2.txt
@@ -1,0 +1,27 @@
+﻿Copyright (c) 2008, Michael Elsdörfer <http://elsdoerfer.name>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials
+       provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Python's builtin glob module does not support recursive globbing with ** until Python 3.5.

As we presently support Python 2.7, this change moves to using the third-party library glob2 which supports **

(Resubmitting to fix CircleCI)