### PR TITLE
Add warning for Python 2.4 and 2.5

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -450,6 +450,9 @@ class ScalyrAgent(object):
             print >> sys.stderr, 'Terminating agent, please fix the error and restart the agent.'
             return 1
 
+        if sys.version_info[:2] < (2, 6):
+            print >> sys.stderr, 'Warning, the Scalyr Agent will not support running on Python 2.4, 2.5 after Oct 2019'
+
         if not no_fork:
             # Do one last check to just cut down on the window of race conditions.
             self.__fail_if_already_running()


### PR DESCRIPTION
We've already alerted existing customers impacted by this, but
added a warning that the agent will no longer run under
Python 2.4 or Python 2.5 starting Nov 2019.