### PR TITLE
Change the default configuration value of `check_remote_if_no_tty` to…

### DIFF
--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1032,7 +1032,7 @@ class Configuration(object):
 
         self.__verify_or_set_optional_string(config, 'api_key', '', description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_bool(config, 'allow_http', False, description, apply_defaults, env_aware=True)
-        self.__verify_or_set_optional_bool(config, 'check_remote_if_no_tty', True, description, apply_defaults, env_aware=True)
+        self.__verify_or_set_optional_bool(config, 'check_remote_if_no_tty', False, description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_string(config, 'compression_type', 'deflate', description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_int(config, 'compression_level', 9, description, apply_defaults, env_aware=True)
         self.__verify_or_set_optional_attributes(config, 'server_attributes', description, apply_defaults)


### PR DESCRIPTION
… `False`.

Mentioned in a comment here:
[https://scalyr.myjetbrains.com/youtrack/issue/AGENT-271](https://scalyr.myjetbrains.com/youtrack/issue/AGENT-271)
The comment says true but it was already that, the intent was false.