### PR TITLE
Bug: Fix non-deterministic glob2 test

### DIFF
--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -2828,6 +2828,7 @@ class LogMatcher(object):
                     new_processor.close_at_eof()
             self.__lock.release()
 
+            result.sort() # Sort the result so it is deterministic
             reached_return = True
             return result
 

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -2741,7 +2741,8 @@ class LogMatcher(object):
 
         # See if the file path matches.. even if it is not a glob, this will return the single file represented by it.
         try:
-            for matched_file in glob.glob(self.__log_entry_config["path"]):
+            # glob.glob is sorted here because otherwise it returns non-deterministic results
+            for matched_file in sorted(glob.glob(self.__log_entry_config["path"])):
                 skip = False
                 # check to see if this file matches any of the exclude globs
                 for exclude_glob in self.__log_entry_config["exclude"]:
@@ -2828,7 +2829,6 @@ class LogMatcher(object):
                     new_processor.close_at_eof()
             self.__lock.release()
 
-            result.sort() # Sort the result so it is deterministic
             reached_return = True
             return result
 

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -2156,9 +2156,10 @@ class TestLogMatcher(ScalyrTestCase):
                 self.__config, self._create_log_config(self.__glob_recursive)
             )
             processors = matcher.find_matches(dict(), dict())
+            processors.sort() # required to make this test deterministic.
             self.assertEquals(len(processors), 2)
-            self.assertEquals(processors[0].log_path, self.__path_three)
-            self.assertEquals(processors[1].log_path, self.__path_four)
+            self.assertEquals(processors[1].log_path, self.__path_three)
+            self.assertEquals(processors[0].log_path, self.__path_four)
 
             self._close_processors(processors)
 

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -2156,10 +2156,9 @@ class TestLogMatcher(ScalyrTestCase):
                 self.__config, self._create_log_config(self.__glob_recursive)
             )
             processors = matcher.find_matches(dict(), dict())
-            processors.sort() # required to make this test deterministic.
             self.assertEquals(len(processors), 2)
-            self.assertEquals(processors[1].log_path, self.__path_three)
-            self.assertEquals(processors[0].log_path, self.__path_four)
+            self.assertEquals(processors[0].log_path, self.__path_three)
+            self.assertEquals(processors[1].log_path, self.__path_four)
 
             self._close_processors(processors)
 


### PR DESCRIPTION
The test `test_matches_recursive_glob` in tests/log_processing_test.py was non-deterministic. 

This sorts the returned list of log processors to fix that. I've run it multiple times and seems to always pass now.