### PR TITLE
Refactor and reduce use of json_lib

### DIFF
--- a/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
@@ -497,9 +497,9 @@ class ControlledCacheWarmerTest(ScalyrTestCase):
 
 class TestExtraServerAttributes(ScalyrTestCase):
     def _create_test_instance(self, configuration_logs_entry, monitors_log_configs):
-        logs_json_array = JsonArray()
+        logs_json_array = []
         for entry in configuration_logs_entry:
-            logs_json_array.add(JsonObject(content=entry))
+            logs_json_array.append(entry)
 
         config = ScalyrTestUtils.create_configuration(
             extra_toplevel_config={"logs": logs_json_array}

--- a/scalyr_agent/config_main.py
+++ b/scalyr_agent/config_main.py
@@ -60,7 +60,7 @@ from scalyr_agent.scalyr_client import ScalyrClientSession
 from scalyr_agent.configuration import Configuration
 from scalyr_agent.platform_controller import PlatformController
 
-import scalyr_agent.json_lib as json_lib
+import scalyr_agent.util as scalyr_util
 
 
 def set_api_key(config, config_file_path, new_api_key):
@@ -190,7 +190,7 @@ def write_config_fragment(config, file_name, field_description, config_json):
             if os.path.isfile(tmp_host_path):
                 os.unlink(tmp_host_path)
 
-            config_content = json_lib.serialize(config_json)
+            config_content = scalyr_util.json_encode(config_json)
 
             tmp_file = open(tmp_host_path, "w")
             print >> tmp_file, "// Sets the %s." % field_description
@@ -589,7 +589,7 @@ def upgrade_windows_install(
 
         # TODO:  We shouldn't have to reparse response on JSON, but for now that, that's what the client library
         # does.
-        data_payload = json_lib.parse(response)["data"]
+        data_payload = scalyr_util.json_decode(response)["data"]
 
         if not data_payload["update_required"]:
             print "The latest version is already installed."

--- a/scalyr_agent/config_util.py
+++ b/scalyr_agent/config_util.py
@@ -21,7 +21,8 @@ __author__ = "echee@scalyr.com"
 import os
 import re
 
-from scalyr_agent import json_lib
+import scalyr_agent.util as scalyr_util
+
 from scalyr_agent.json_lib.objects import (
     JsonArray,
     JsonObject,
@@ -177,7 +178,8 @@ def convert_config_param(field_name, value, convert_to, is_environment_variable=
 
         elif convert_to in (JsonArray, JsonObject):
             try:
-                return json_lib.parse(value)
+                # Needs to be json_lib.parse since it is parsing configuration.
+                return scalyr_util.json_scalyr_config_decode(value)
             except JsonParseException:
                 raise BadConfiguration(
                     'Could not parse value %s for field "%s" as %s'

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -103,7 +103,7 @@ class Configuration(object):
         try:
             try:
                 # First read the file.  This makes sure it exists and can be parsed.
-                self.__config = scalyr_util.read_file_as_json(self.__file_path)
+                self.__config = scalyr_util.read_config_file_as_json(self.__file_path)
 
                 # What implicit entries do we need to add?  metric monitor, agent.log, and then logs from all monitors.
             except JsonReadFileException, e:
@@ -142,7 +142,7 @@ class Configuration(object):
             # Now, look for any additional configuration in the config fragment directory.
             for fp in self.__list_files(self.config_directory):
                 self.__additional_paths.append(fp)
-                content = scalyr_util.read_file_as_json(fp)
+                content = scalyr_util.read_config_file_as_json(fp)
                 for k in content.keys():
                     if k not in allowed_multiple_keys:
                         if k in already_seen:

--- a/scalyr_agent/copying_manager.py
+++ b/scalyr_agent/copying_manager.py
@@ -1058,7 +1058,7 @@ class CopyingManager(StoppableThread, LogWatcher):
         This must be done periodically to ensure that if the agent process stops and starts up again, we pick up
         from where we left off copying each file.
         """
-        # Create the format that is expected.  An overall JsonObject with the time when the file was written,
+        # Create the format that is expected.  An overall dict with the time when the file was written,
         # and then an entry for each file path.
         checkpoints = {}
         state = {

--- a/scalyr_agent/json_lib/exceptions.py
+++ b/scalyr_agent/json_lib/exceptions.py
@@ -42,10 +42,13 @@ class JsonMissingFieldException(Exception):
 class JsonParseException(Exception):
     """Raised when a parsing problem occurs."""
 
-    def __init__(self, message, position, line_number):
+    def __init__(self, message, position=-1, line_number=-1):
         self.position = position
         self.line_number = line_number
         self.raw_message = message
-        position_message = " (line %i, byte position %i)" % (line_number, position)
+        if position >= 0 and line_number >= 0:
+            position_message = " (line %i, byte position %i)" % (line_number, position)
+        else:
+            position_message = ""
 
         Exception.__init__(self, message + position_message)

--- a/scalyr_agent/json_lib/tests/encode_decode_test.py
+++ b/scalyr_agent/json_lib/tests/encode_decode_test.py
@@ -109,16 +109,20 @@ class EncodeDecodeTest(ScalyrTestCase):
 
     def __test_encode_decode(self, text, obj):
         def __runtest(library):
-            self._setlib(library)
+            original_lib = util.get_json_lib()
 
-            if library == FALLBACK or not isinstance(obj, (JsonArray, JsonObject)):
-                text2 = util.json_encode(obj)
-                self.assertEquals(text, text2)
-                obj2 = util.json_decode(text2)
-                text3 = util.json_encode(obj2)
-                self.assertEquals(text, text3)
-            else:
-                self.assertRaises(TypeError, lambda: util.json_encode(obj))
+            self._setlib(library)
+            try:
+                if library == FALLBACK or not isinstance(obj, (JsonArray, JsonObject)):
+                    text2 = util.json_encode(obj)
+                    self.assertEquals(text, text2)
+                    obj2 = util.json_decode(text2)
+                    text3 = util.json_encode(obj2)
+                    self.assertEquals(text, text3)
+                else:
+                    self.assertRaises(TypeError, lambda: util.json_encode(obj))
+            finally:
+                util._set_json_lib(original_lib)
 
         if sys.version_info[:2] > (2, 4):
             __runtest(UJSON)

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -1344,7 +1344,7 @@ class LogFileIterator(object):
                 LogFileIterator.
             @param file_handle: The open file handle.
 
-            @type state_json: json_lib.JsonObject
+            @type state_json: dict
             @type file_handle: FileIO
             """
             # True if this file is still a valid portion of the overall iterator.
@@ -2700,7 +2700,7 @@ class LogMatcher(object):
             point.
 
         @type existing_processors: dict of str to LogFileProcessor
-        @type previous_state: dict of str to json_lib.JsonObject
+        @type previous_state: dict of str to dict
         @type copy_at_index_zero: bool
 
         @return: A list of the processors to handle the newly matched files.

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -45,7 +45,6 @@ import threading
 import time
 import timeit
 
-import scalyr_agent.json_lib as json_lib
 import scalyr_agent.scalyr_logging as scalyr_logging
 import scalyr_agent.util as scalyr_util
 
@@ -54,6 +53,7 @@ import scalyr_agent.third_party.uuid_tp.uuid as uuid
 from scalyr_agent.agent_status import LogMatcherStatus
 from scalyr_agent.agent_status import LogProcessorStatus
 
+from scalyr_agent.json_lib import JsonObject
 from scalyr_agent.line_matcher import LineMatcher
 
 from scalyr_agent.scalyr_client import Event
@@ -1362,22 +1362,22 @@ class LogFileIterator(object):
         def to_json(self):
             """Creates and returns the state serialized to Json.
 
-            @return: The JsonObject containing the serialized state.
-            @rtype: json_lib.JsonObject
+            @return: The dict containing the serialized state.
+            @rtype: dict
             """
-            result = json_lib.JsonObject(
-                position_start=self.position_start,
-                position_end=self.position_end,
-                last_known_size=self.last_known_size,
-                is_log_file=self.is_log_file,
-            )
+            result = {
+                "position_start": self.position_start,
+                "position_end": self.position_end,
+                "last_known_size": self.last_known_size,
+                "is_log_file": self.is_log_file,
+            }
             if self.inode is not None:
                 result["inode"] = self.inode
             return result
 
         @staticmethod
         def create_json(position_start, initial_offset, file_size, inode, is_log_file):
-            """Creates a JsonObject that represents the specified state.
+            """Creates a dict that represents the specified state.
 
             @param position_start: The start position relative to mark for this file.
             @param initial_offset: The initial offset in the file from where bytes should be read.
@@ -1392,14 +1392,14 @@ class LogFileIterator(object):
             @type is_log_file: bool
 
             @return:  The serialized state.
-            @rtype: json_lib.JsonObject
+            @rtype: dict
             """
-            result = json_lib.JsonObject(
-                position_start=position_start - initial_offset,
-                position_end=position_start + file_size - initial_offset,
-                last_known_size=file_size,
-                is_log_file=is_log_file,
-            )
+            result = {
+                "position_start": position_start - initial_offset,
+                "position_end": position_start + file_size - initial_offset,
+                "last_known_size": file_size,
+                "is_log_file": is_log_file,
+            }
             if inode is not None:
                 result["inode"] = inode
             return result
@@ -2877,7 +2877,7 @@ class LogMatcher(object):
                     log.warn(
                         "Invalid substition pattern in 'rename_logfile'. %s" % str(e)
                     )
-            elif isinstance(rename, json_lib.JsonObject):
+            elif isinstance(rename, JsonObject):
                 if "match" in rename and "replacement" in rename:
                     try:
                         pattern = re.compile(rename["match"])

--- a/scalyr_agent/run_monitor.py
+++ b/scalyr_agent/run_monitor.py
@@ -51,14 +51,14 @@ from __scalyr__ import scalyr_init
 scalyr_init()
 
 import scalyr_agent.scalyr_logging as scalyr_logging
-import scalyr_agent.json_lib as json_lib
-from scalyr_agent.log_watcher import LogWatcher
+import scalyr_agent.util as scalyr_util
 
 from scalyr_agent.monitors_manager import MonitorsManager
 from scalyr_agent.scalyr_monitor import BadMonitorConfiguration
 
 from scalyr_agent.configuration import Configuration
 from scalyr_agent.platform_controller import PlatformController, DefaultPaths
+from scalyr_agent.json_lib import JsonParseException
 
 log = scalyr_logging.getLogger("scalyr_agent.run_monitor")
 
@@ -87,9 +87,10 @@ def run_standalone_monitor(
     log.log(scalyr_logging.DEBUG_LEVEL_1, "Attempting to run module %s", monitor_module)
 
     try:
-        parsed_config = json_lib.parse(monitor_config)
+        # Needs to be json_lib.parse because it is parsing configuration
+        parsed_config = scalyr_util.json_scalyr_config_decode(monitor_config)
         log.log(scalyr_logging.DEBUG_LEVEL_1, "Parsed configuration successfully")
-    except json_lib.JsonParseException, e:
+    except JsonParseException, e:
         print >>sys.stderr, "Failed to parse the monitor configuration as valid JSON: %s", str(
             e
         )

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -37,7 +37,6 @@ except Exception:
     ssl = None
 
 
-import scalyr_agent.json_lib as json_lib
 import scalyr_agent.scalyr_logging as scalyr_logging
 import scalyr_agent.util as scalyr_util
 from scalyr_agent.connection import ConnectionFactory
@@ -447,7 +446,7 @@ class ScalyrClientSession(object):
             # Try to parse the response
             # noinspection PyBroadException
             try:
-                response_as_json = json_lib.parse(response)
+                response_as_json = scalyr_util.json_decode(response)
             except Exception:
                 # TODO: Do not just catch Exception.  Do narrower scope.  Also, log error here.
                 log.error(
@@ -808,7 +807,7 @@ class AddEventsRequest(object):
         # add in the 'events: [ ... ]' ourselves.  This way we can watch the size of the buffer as
         # we build up events.
         string_buffer = StringIO()
-        json_lib.serialize(base_body, output=string_buffer, use_fast_encoding=True)
+        scalyr_util.json_scalyr_request_encode(base_body, output=string_buffer)
 
         # Now go back and find the last '}' and delete it so that we can open up the JSON again.
         _rewind_past_close_curly(string_buffer)
@@ -1697,7 +1696,9 @@ class Event(object):
         output_buffer.write(self.__serialization_base)
         # Use a special serialization format for message so that we don't have to send CPU time escaping it.  This
         # is just a length prefixed format understood by Scalyr servers.
-        json_lib.serialize_as_length_prefixed_string(self.__message, output_buffer)
+        scalyr_util.json_scalyr_encode_length_prefixed_string(
+            self.__message, output_buffer
+        )
 
         # We fast path the very common case of just a timestamp and sequence delta fields.
         if not self.__has_non_optimal_fields and self.__num_optimal_fields == 3:

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -39,8 +39,6 @@ import scalyr_agent.util as util
 from cStringIO import StringIO
 from scalyr_agent.util import RateLimiter
 
-import scalyr_agent.json_lib as json_lib
-
 # The debugging levels supported on the debugger logger.  The higher the debug level, the
 # more verbose the output.
 DEBUG_LEVEL_0 = logging.INFO

--- a/scalyr_agent/test_util.py
+++ b/scalyr_agent/test_util.py
@@ -15,6 +15,8 @@
 #
 #
 # author: Edward Chee <echee@scalyr.com>
+import re
+import struct
 
 __author__ = "echee@scalyr.com"
 
@@ -28,7 +30,6 @@ import threading
 
 import scalyr_agent.util as scalyr_util
 
-from scalyr_agent import json_lib
 from scalyr_agent.configuration import Configuration
 from scalyr_agent.platform_controller import DefaultPaths
 from scalyr_agent.json_lib import JsonArray, JsonObject
@@ -56,7 +57,7 @@ class ScalyrTestUtils(object):
             toplevel_config.update(extra_toplevel_config)
 
         fp = open(config_file, "w")
-        fp.write(json_lib.serialize(JsonObject(**toplevel_config)))
+        fp.write(scalyr_util.json_encode(toplevel_config))
         fp.close()
 
         default_paths = DefaultPaths(
@@ -89,10 +90,10 @@ class ScalyrTestUtils(object):
         @param null_logger: If True, set all monitors to log to Nullhandler
         @param fake_clock: If non-null, the manager and all it's monitors' _run_state's will use the provided fake_clock
         """
-        monitors_json_array = JsonArray()
+        monitors_json_array = []
         if config_monitors:
             for entry in config_monitors:
-                monitors_json_array.add(JsonObject(content=entry))
+                monitors_json_array.append(entry)
 
         extras = {"monitors": monitors_json_array}
         if extra_toplevel_config:
@@ -147,3 +148,51 @@ class FakePlatform(object):
 
     def get_default_monitors(self, _):
         return self.__monitors
+
+
+def parse_scalyr_request(payload):
+    """Parses a payload encoded with the Scalyr-specific JSON optimizations. The only place these optimizations
+    are used are creating `AddEvent` requests.
+
+    NOTE:  This method is very fragile and just does enough conversion to support the tests.  It could lead to
+    erroneous results if patterns like "`s" and colons are used in strings content.  It is also not optimized
+    for performance.
+
+    :param payload: The request payload
+    :type payload: bytes
+    :return: The parsed request body
+    :rtype: dict
+    """
+    # Our general strategy is to rewrite the payload to be standard JSON and then use the
+    # standard JSON libraries to parse it.  There are two main optimizations we need to undo
+    # here: length-prefixed strings and not using quotes around key names in JSON objects.
+
+    # First, look for the length-prefixed strings.  These are marked by "`sXXXX" where XXXX is a four
+    # byte integer holding the number of bytes in the string.  This precedes the string.  So we find
+    # all of those and replace them with quotes.  We also have to escape the string.
+    # NOTE: It is very important all of our regex work against byte strings because our input is in bytes.
+    length_prefix_re = re.compile(b"`s(....)", re.DOTALL)
+
+    # Accumulate the rewrite of `payload` here.  We will eventually parse this as standard JSON.
+    rewritten_payload = b""
+    # The index of `payload` up to which we have processed (copied into `rewritten_payload`).
+    last_processed_index = -1
+
+    for x in length_prefix_re.finditer(payload):
+        # First add in the bytes between the last processed and the start of this match.
+        rewritten_payload += payload[last_processed_index + 1 : x.start(0)]
+        # Read the 4 bytes that describe the length, which is stored in regex group 1.
+        length = struct.unpack(">i", x.group(1))[0]
+        # Grab the string content as raw bytes.
+        raw_string = payload[x.end(1) : x.end(1) + length]
+        rewritten_payload += scalyr_util.json_encode(raw_string.decode("utf-8"))
+        last_processed_index = x.end(1) + length - 1
+    rewritten_payload += payload[last_processed_index + 1 : len(payload)]
+
+    # Now convert all places where we do not have quotes around key names to have quotes.
+    # This is pretty fragile.. we look for anything like
+    #      foo:
+    #  and convert it to
+    #      "foo":
+    rewritten_payload = re.sub(b"([\\w\\-]+):", b'"\\1":', rewritten_payload)
+    return scalyr_util.json_decode(rewritten_payload.decode("utf-8"))

--- a/scalyr_agent/tests/annotation_config_test.py
+++ b/scalyr_agent/tests/annotation_config_test.py
@@ -18,9 +18,6 @@
 __author__ = "imron@scalyr.com"
 
 from scalyr_agent.monitor_utils.annotation_config import process_annotations
-from scalyr_agent import json_lib
-from scalyr_agent.json_lib import JsonObject
-from scalyr_agent.json_lib import JsonArray
 
 from scalyr_agent.test_base import ScalyrTestCase
 

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -14,7 +14,6 @@
 # ------------------------------------------------------------------------
 #
 # author: Steven Czerwinski <czerwin@scalyr.com>
-import scalyr_agent.json_lib.objects
 
 __author__ = "czerwin@scalyr.com"
 
@@ -29,7 +28,6 @@ from scalyr_agent.config_util import (
     get_config_from_env,
 )
 from scalyr_agent.json_lib import JsonObject, JsonArray
-from scalyr_agent.json_lib import parse as parse_json, serialize as serialize_json
 from scalyr_agent.json_lib.objects import (
     ArrayOfStrings,
     SpaceAndCommaSeparatedArrayOfStrings,
@@ -37,6 +35,8 @@ from scalyr_agent.json_lib.objects import (
 from scalyr_agent.platform_controller import DefaultPaths
 
 from scalyr_agent.test_base import ScalyrTestCase
+
+import scalyr_agent.util as scalyr_util
 
 
 class TestConfigurationBase(ScalyrTestCase):
@@ -80,7 +80,13 @@ class TestConfigurationBase(ScalyrTestCase):
         return contents
 
     def _write_file_with_separator_conversion(self, contents):
-        contents = serialize_json(self.__convert_separators(parse_json(contents)))
+        contents = scalyr_util.json_encode(
+            self._convert_json_to_dict(
+                self.__convert_separators(
+                    scalyr_util.json_scalyr_config_decode(contents)
+                )
+            )
+        )
 
         fp = open(self._config_file, "w")
         fp.write(contents)
@@ -89,12 +95,41 @@ class TestConfigurationBase(ScalyrTestCase):
     def _write_config_fragment_file_with_separator_conversion(
         self, file_path, contents
     ):
-        contents = serialize_json(self.__convert_separators(parse_json(contents)))
+        contents = scalyr_util.json_encode(
+            self._convert_json_to_dict(
+                self.__convert_separators(
+                    scalyr_util.json_scalyr_config_decode(contents)
+                )
+            )
+        )
 
         full_path = os.path.join(self._config_fragments_dir, file_path)
         fp = open(full_path, "w")
         fp.write(contents)
         fp.close()
+
+    # TODO: This method may be generally useful in other parts of the code.  If we find we need it, maybe
+    # we should move it to test_util.  It is recursive code, so may not be performant.
+    def _convert_json_to_dict(self, value):
+        """Converts a `JsonObject` or `JsonArray` value to its dict/list equivalent, replacing
+        all uses of `JsonObject` with a `dict` and `JsonArray` with a `list`, recursively.
+
+        :param value: The value to convert
+        :type value: JsonArray|JsonObject|str|number|bool
+        :return: The converted value
+        :rtype: dict|list|str|number|bool
+        """
+        if type(value) is JsonObject:
+            result = dict()
+            for k, v in value.iteritems():
+                result[k] = self._convert_json_to_dict(v)
+            return result
+        elif type(value) is JsonArray:
+            result = []
+            for v in value:
+                result.append(self._convert_json_to_dict(v))
+            return result
+        return value
 
     class LogObject(object):
         def __init__(self, config):
@@ -1184,7 +1219,7 @@ class TestConfiguration(TestConfigurationBase):
             "use_unsafe_debugging": False,
         }
         self._write_file_with_separator_conversion(
-            serialize_json(JsonObject(config_file_dict))
+            scalyr_util.json_encode(config_file_dict)
         )
 
         config = self._create_test_configuration_instance()

--- a/scalyr_agent/tests/log_processing_test.py
+++ b/scalyr_agent/tests/log_processing_test.py
@@ -2544,7 +2544,8 @@ def _create_configuration(extra=None):
     os.makedirs(config_fragments_dir)
 
     payload = {"api_key": "fake"}
-    payload.update(extra)
+    if extra is not None:
+        payload.update(extra)
 
     fp = open(config_file, "w")
     fp.write(scalyr_util.json_encode(payload))

--- a/scalyr_agent/tests/scalyr_client_test.py
+++ b/scalyr_agent/tests/scalyr_client_test.py
@@ -29,9 +29,11 @@ from scalyr_agent.scalyr_client import (
     Event,
     ScalyrClientSession,
 )
-from scalyr_agent import json_lib
+
 from scalyr_agent.test_base import ScalyrTestCase
-import unittest
+
+
+import scalyr_agent.test_util as test_util
 
 
 class AddEventsRequestTest(ScalyrTestCase):
@@ -214,7 +216,7 @@ class AddEventsRequestTest(ScalyrTestCase):
         )
         self.assertEquals(request.total_events, 1)
 
-        json = json_lib.parse(request.get_payload())
+        json = test_util.parse_scalyr_request(request.get_payload())
         event = json["events"][0]
 
         self.assertFalse("si" in event)
@@ -232,7 +234,7 @@ class AddEventsRequestTest(ScalyrTestCase):
         )
         self.assertEquals(request.total_events, 1)
 
-        json = json_lib.parse(request.get_payload())
+        json = test_util.parse_scalyr_request(request.get_payload())
         event = json["events"][0]
 
         self.assertFalse("si" in event)
@@ -255,7 +257,7 @@ class AddEventsRequestTest(ScalyrTestCase):
         )
         self.assertEquals(request.total_events, 1)
 
-        json = json_lib.parse(request.get_payload())
+        json = test_util.parse_scalyr_request(request.get_payload())
         event = json["events"][0]
 
         self.assertEquals(expected_id, event["si"])
@@ -287,7 +289,7 @@ class AddEventsRequestTest(ScalyrTestCase):
         )
         self.assertEquals(request.total_events, 2)
 
-        json = json_lib.parse(request.get_payload())
+        json = test_util.parse_scalyr_request(request.get_payload())
         event = json["events"][1]
 
         self.assertFalse("si" in event)
@@ -328,7 +330,7 @@ class AddEventsRequestTest(ScalyrTestCase):
         )
         self.assertEquals(request.total_events, 3)
 
-        json = json_lib.parse(request.get_payload())
+        json = test_util.parse_scalyr_request(request.get_payload())
         event = json["events"][2]
 
         self.assertEquals(second_id, event["si"])
@@ -372,7 +374,7 @@ class AddEventsRequestTest(ScalyrTestCase):
         )
         self.assertEquals(request.total_events, 2)
 
-        json = json_lib.parse(request.get_payload())
+        json = test_util.parse_scalyr_request(request.get_payload())
         event = json["events"][1]
 
         self.assertFalse("si" in event)
@@ -416,7 +418,7 @@ class AddEventsRequestTest(ScalyrTestCase):
         )
         self.assertEquals(request.total_events, 2)
 
-        json = json_lib.parse(request.get_payload())
+        json = test_util.parse_scalyr_request(request.get_payload())
         event = json["events"][1]
 
         self.assertEquals(second_number, event["sn"])
@@ -448,17 +450,18 @@ class EventTest(ScalyrTestCase):
             '{thread:"foo", log:"foo", attrs:{message:`s\x00\x00\x00\nmy_message,sample_rate:0.5},ts:"42",si:"1",sn:2,sd:3}',
             output_buffer.getvalue(),
         )
+
         self.assertEquals(
-            json_lib.JsonObject(
-                log="foo",
-                thread="foo",
-                ts="42",
-                si="1",
-                sn=2,
-                sd=3,
-                attrs=json_lib.JsonObject(message="my_message", sample_rate=0.5),
-            ),
-            json_lib.parse(output_buffer.getvalue()),
+            {
+                "log": u"foo",
+                "thread": u"foo",
+                "ts": u"42",
+                "si": u"1",
+                "sn": 2,
+                "sd": 3,
+                "attrs": {"message": "my_message", "sample_rate": 0.5},
+            },
+            test_util.parse_scalyr_request(output_buffer.getvalue()),
         )
 
     def test_fast_path_fields(self):

--- a/scalyr_agent/tests/scalyr_monitor_test.py
+++ b/scalyr_agent/tests/scalyr_monitor_test.py
@@ -18,8 +18,6 @@
 __author__ = "czerwin@scalyr.com"
 
 
-from scalyr_agent.json_lib import serialize
-from scalyr_agent.json_lib import parse as json_lib_parse
 from scalyr_agent.json_lib.objects import JsonArray, JsonObject, ArrayOfStrings
 from scalyr_agent.scalyr_monitor import (
     MonitorConfig,
@@ -27,6 +25,8 @@ from scalyr_agent.scalyr_monitor import (
     define_config_option,
 )
 from scalyr_agent.test_base import ScalyrTestCase
+
+import scalyr_agent.util as scalyr_util
 
 
 class MonitorConfigTest(ScalyrTestCase):
@@ -94,7 +94,7 @@ class MonitorConfigTest(ScalyrTestCase):
 
         # str -> JsonArray
         self.assertEquals(
-            self.get(serialize(test_array), convert_to=JsonArray),
+            self.get(scalyr_util.json_encode(test_array), convert_to=JsonArray),
             JsonArray(*test_array),
         )
         self.assertRaises(
@@ -108,8 +108,8 @@ class MonitorConfigTest(ScalyrTestCase):
         # str -> JsonObject
         test_obj = {"a": 1, "b": "two", "c": [1, 2, 3]}
         self.assertEquals(
-            self.get(serialize(test_obj), convert_to=JsonObject),
-            json_lib_parse(serialize(test_obj)),
+            self.get(scalyr_util.json_encode(test_obj), convert_to=JsonObject),
+            scalyr_util.json_scalyr_config_decode(scalyr_util.json_encode(test_obj)),
         )
 
     def test_unicode_conversion(self):

--- a/scalyr_agent/tests/util_test.py
+++ b/scalyr_agent/tests/util_test.py
@@ -108,9 +108,15 @@ class TestUtil(ScalyrTestCase):
         self.__path = os.path.join(self.__tempdir, "testing.json")
 
     def test_read_file_as_json(self):
-        self.__create_file(self.__path, '{ a: "hi"}')
+        self.__create_file(self.__path, '{ "a": "hi"}')
 
-        json_object = scalyr_util.read_file_as_json(self.__path)
+        value = scalyr_util.read_file_as_json(self.__path)
+        self.assertEquals(value, {"a": "hi"})
+
+    def test_read_config_file_as_json(self):
+        self.__create_file(self.__path, '{ a: "hi"} // Test')
+
+        json_object = scalyr_util.read_config_file_as_json(self.__path)
         self.assertEquals(json_object, JsonObject(a="hi"))
 
     def test_read_file_as_json_no_file(self):
@@ -128,7 +134,7 @@ class TestUtil(ScalyrTestCase):
         scalyr_util.atomic_write_dict_as_json_file(self.__path, self.__path + "~", info)
 
         json_object = scalyr_util.read_file_as_json(self.__path)
-        self.assertEquals(json_object, JsonObject(a="hi"))
+        self.assertEquals(json_object, info)
 
     def __create_file(self, path, contents):
         fp = open(path, "w")


### PR DESCRIPTION
We will be deprecating the use key parts of json_lib such
as its own serialization to help reduce the amount of tricky
string Python 2 to 3 work we must do.

To help with this, this changes:

1.  Moves all references to the json_lib parsing and serialization
    code to a few central methods in `util.py` so that we can
    very easily see what is using the serialization.  Also added
    more meaningful function names to capture why the parsing or
    serialization is being used.

2.  Eliminates places where json_lib is used to parse or serialization
    JSON objects when it is not really needed.  It really is only
    need for parsing config files (which might have comments) and
    serializing JSON for requests to Scalyr.  All other uses
    have been eliminated.

Note:  Some "risky" changes are that the checkpoint files are now
being parsed using the standard JSON parsers.  So, when users
upgrade, they theorectically could see issues in that the previous
checkpoint was written by json_lib and is being parsed by the standard.
This shouldn't really be an issue since the serialization happened
without any of the Scalyr optimizations turned on.  The only potential
worry I have is if there were weird UTF-8 characters in file names
that were not properly encoded by json_lib.

Other potential areas are:
- Windows upgrade path (API response now parsed using standard JSON)
- K8s event monitor (event objects parsed using standard JSON)