### PR TITLE
Exclude third_party_python2 from black refactor.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ exclude = '''
     | __pycache__
     | third_party
     | third_party_tls
+    | third_party_python2
   )/
 )
 '''


### PR DESCRIPTION
Exclude third_party_python2, very small change.