### PR TITLE
AGENT-323: Missing `stream` event attribute in Docker and K8s

### DIFF
--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -2162,7 +2162,7 @@ class LogFileProcessor(object):
         """
         result = Event(base=self.__base_event)
         if line_object.attrs:
-            result.add_missing_attributes(line_object.attrs)
+            result.add_missing_attributes(line_object.attrs, log_line_attributes=True)
         result.set_message(line_object.line)
         if sampling_rate != 1.0:
             result.set_sampling_rate(sampling_rate)

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -1652,7 +1652,7 @@ class LogFileProcessor(object):
         """ Adds items attributes to the base_event's attributes if the base_event doesn't
         already have those attributes set
         """
-        self.__base_event.add_missing_attributes(attributes)
+        self.__base_event.add_attributes(attributes)
 
     def set_max_log_offset_size(self, max_log_offset_size):
         """Sets the max_log_offset_size.
@@ -2162,7 +2162,7 @@ class LogFileProcessor(object):
         """
         result = Event(base=self.__base_event)
         if line_object.attrs:
-            result.add_missing_attributes(line_object.attrs, log_line_attributes=True)
+            result.add_attributes(line_object.attrs, overwrite_existing=True)
         result.set_message(line_object.line)
         if sampling_rate != 1.0:
             result.set_sampling_rate(sampling_rate)

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -1572,17 +1572,13 @@ class Event(object):
         if attributes:
             attributes = dict(attributes)
 
-        if self.__parent_event:
-            changed = False
-            for key, value in six.iteritems(attributes):
-                if key not in self.__attrs or overwrite_existing:
-                    changed = True
-                    self.__attrs[key] = value
+        changed = False
+        for key, value in six.iteritems(attributes):
+            if key not in self.__attrs or overwrite_existing:
+                changed = True
+                self.__attrs[key] = value
 
-            if changed:
-                self.__set_attributes(self.__thread_id, self.__attrs)
-        else:
-            self.__attrs.update(attributes)
+        if changed:
             self.__set_attributes(self.__thread_id, self.__attrs)
 
     @property

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -1503,6 +1503,12 @@ class Event(object):
         self.__num_optimal_fields = 0
 
     def __set_attributes(self, thread_id, attributes, log_line_attributes=False):
+        """ Set the attributes and thread id of an Event.
+
+        In the default case of `log_line_attributes` being False this will not add the attributes to the serialization
+        base because those attributes should be included in the attributes of the log. If `log_line_attributes` is True
+        they will be serialized but not set to `__attrs`, so any events based off this one will not inherit them.
+        """
         self.__thread_id = thread_id
         if self.__disable_logfile_addevents_format or not log_line_attributes:
             self.__attrs = attributes
@@ -1536,7 +1542,10 @@ class Event(object):
 
     def add_missing_attributes(self, attributes, log_line_attributes=False):
         """ Adds items attributes to the base_event's attributes if the base_event doesn't
-        already have those attributes set
+        already have those attributes set.
+
+        If log_line_attributes is True the attributes will be added to the serialized form of the Event, but not
+        to its `__attrs` field, so they won't be inherited by any events created with this as a base.
         """
         if self.__attrs:
             changed = False
@@ -1544,7 +1553,7 @@ class Event(object):
             if not log_line_attributes:
                 new_attrs = dict(self.__attrs)
             for key, value in six.iteritems(attributes):
-                if not key in self.__attrs:
+                if log_line_attributes or not key in self.__attrs:
                     changed = True
                     new_attrs[key] = value
 

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -1474,6 +1474,9 @@ class Event(object):
         if (attrs is not None or thread_id is not None) and base is not None:
             raise Exception("Cannot use both attrs/thread_id and base")
 
+        if self.__attrs is None:
+            self.__attrs = dict()
+
         self.__thread_id = None
         self.__parent_event = None
         if base is not None:
@@ -1542,7 +1545,7 @@ class Event(object):
     def __get_attributes_to_serialize(self):
         if self.__disable_logfile_addevents_format:
             result = dict()
-            if self.__parent_event and self.__parent_event.__attrs:
+            if self.__parent_event:
                 result = dict(self.__parent_event.__attrs)
             if self.__attrs:
                 result.update(self.__attrs)
@@ -1557,22 +1560,22 @@ class Event(object):
         If overwrite_existing is True an attribute will be added even if the __parent_event has the same key defined,
         unless the value also matched to avoid wasting bytes.
         """
+        if attributes:
+            attributes = dict(attributes)
+
         if self.__parent_event:
             changed = False
-            new_attrs = dict()
-            if self.__attrs:
-                new_attrs = dict(self.__attrs)
             for key, value in six.iteritems(attributes):
                 if key not in self.__parent_event.__attrs or (
                     overwrite_existing and self.__parent_event.__attrs[key] != value
                 ):
                     changed = True
-                    new_attrs[key] = value
+                    self.__attrs[key] = value
 
             if changed:
-                self.__set_attributes(self.__thread_id, new_attrs)
+                self.__set_attributes(self.__thread_id, self.__attrs)
         else:
-            self.__set_attributes(self.__thread_id, dict(attributes))
+            self.__set_attributes(self.__thread_id, attributes)
 
     @property
     def attrs(self):

--- a/scalyr_agent/tests/scalyr_client_test.py
+++ b/scalyr_agent/tests/scalyr_client_test.py
@@ -167,7 +167,7 @@ class AddEventsRequestTest(ScalyrTestCase):
         request.add_log_and_thread("log2", "Log two", {})
 
         event_one = Event().set_message("eventOne")
-        event_one.add_missing_attributes({"source": "stdout"}, log_line_attributes=True)
+        event_one.add_attributes({"source": "stdout"}, overwrite_existing=True)
 
         self.assertTrue(request.add_event(event_one, timestamp=1))
 
@@ -185,14 +185,14 @@ class AddEventsRequestTest(ScalyrTestCase):
         request.add_log_and_thread("log2", "Log two", {})
 
         event_base = Event()
-        event_base.add_missing_attributes(
-            {"source": "stdout", "base": "base"}, log_line_attributes=False
+        event_base.add_attributes(
+            {"source": "stdout", "base": "base"}, overwrite_existing=False
         )
 
         event_one = Event(base=event_base)
         event_one.set_message("eventOne")
-        event_one.add_missing_attributes(
-            {"source": "stdin", "event": "event"}, log_line_attributes=True
+        event_one.add_attributes(
+            {"source": "stdin", "event": "event"}, overwrite_existing=True
         )
 
         self.assertTrue(request.add_event(event_one, timestamp=1))
@@ -466,7 +466,7 @@ class EventTest(ScalyrTestCase):
         x.serialize(output_buffer)
 
         self.assertEquals(
-            '{thread:"foo", log:"foo", attrs:{message:`s\x00\x00\x00\nmy_message,sample_rate:0.5},ts:"42",si:"1",sn:2,sd:3}',
+            '{thread:"foo", log:"foo", attrs:{"parser":"bar",message:`s\x00\x00\x00\nmy_message,sample_rate:0.5},ts:"42",si:"1",sn:2,sd:3}',
             output_buffer.getvalue(),
         )
 
@@ -478,7 +478,7 @@ class EventTest(ScalyrTestCase):
                 "si": u"1",
                 "sn": 2,
                 "sd": 3,
-                "attrs": {"message": "my_message", "sample_rate": 0.5},
+                "attrs": {"parser": "bar", "message": "my_message", "sample_rate": 0.5},
             },
             test_util.parse_scalyr_request(output_buffer.getvalue()),
         )
@@ -493,7 +493,7 @@ class EventTest(ScalyrTestCase):
         x.serialize(output_buffer)
 
         self.assertEquals(
-            '{thread:"foo", log:"foo", attrs:{message:`s\x00\x00\x00\nmy_message},sd:3,ts:"42"}',
+            '{thread:"foo", log:"foo", attrs:{"parser":"bar",message:`s\x00\x00\x00\nmy_message},sd:3,ts:"42"}',
             output_buffer.getvalue(),
         )
 
@@ -507,7 +507,7 @@ class EventTest(ScalyrTestCase):
         x.serialize(output_buffer)
 
         self.assertEquals(
-            '{thread:"foo", log:"foo", attrs:{message:`s\x00\x00\x00\nmy_message},sd:3}',
+            '{thread:"foo", log:"foo", attrs:{"parser":"bar",message:`s\x00\x00\x00\nmy_message},sd:3}',
             output_buffer.getvalue(),
         )
 
@@ -520,7 +520,7 @@ class EventTest(ScalyrTestCase):
         x.serialize(output_buffer)
 
         self.assertEquals(
-            '{thread:"foo", log:"foo", attrs:{message:`s\x00\x00\x00\nmy_message},ts:"42"}',
+            '{thread:"foo", log:"foo", attrs:{"parser":"bar",message:`s\x00\x00\x00\nmy_message},ts:"42"}',
             output_buffer.getvalue(),
         )
 
@@ -533,7 +533,7 @@ class EventTest(ScalyrTestCase):
         x.serialize(output_buffer)
 
         self.assertEquals(
-            '{thread:"foo", log:"foo", attrs:{message:`s\x00\x00\x00\nmy_message,sample_rate:0.5}}',
+            '{thread:"foo", log:"foo", attrs:{"parser":"bar",message:`s\x00\x00\x00\nmy_message,sample_rate:0.5}}',
             output_buffer.getvalue(),
         )
 
@@ -546,7 +546,7 @@ class EventTest(ScalyrTestCase):
         x.serialize(output_buffer)
 
         self.assertEquals(
-            '{thread:"foo", log:"foo", attrs:{message:`s\x00\x00\x00\nmy_message},si:"hi"}',
+            '{thread:"foo", log:"foo", attrs:{"parser":"bar",message:`s\x00\x00\x00\nmy_message},si:"hi"}',
             output_buffer.getvalue(),
         )
 
@@ -559,7 +559,7 @@ class EventTest(ScalyrTestCase):
         x.serialize(output_buffer)
 
         self.assertEquals(
-            '{thread:"foo", log:"foo", attrs:{message:`s\x00\x00\x00\nmy_message},sn:5}',
+            '{thread:"foo", log:"foo", attrs:{"parser":"bar",message:`s\x00\x00\x00\nmy_message},sn:5}',
             output_buffer.getvalue(),
         )
 
@@ -587,7 +587,7 @@ class EventTest(ScalyrTestCase):
         x.serialize(output_buffer)
 
         self.assertEquals(
-            '{attrs:{message:`s\x00\x00\x00\nmy_message,sample_rate:0.5},ts:"42",si:"1",sn:2,sd:3}',
+            '{attrs:{"parser":"bar",message:`s\x00\x00\x00\nmy_message,sample_rate:0.5},ts:"42",si:"1",sn:2,sd:3}',
             output_buffer.getvalue(),
         )
 
@@ -622,7 +622,7 @@ class EventTest(ScalyrTestCase):
         x.serialize(output_buffer)
 
         self.assertEquals(
-            '{thread:"foo", log:"foo", attrs:{message:`s\x00\x00\x00\nmy_message,sample_rate:0.5},ts:"42",si:"1",sn:2,sd:3}',
+            '{thread:"foo", log:"foo", attrs:{"parser":"bar",message:`s\x00\x00\x00\nmy_message,sample_rate:0.5},ts:"42",si:"1",sn:2,sd:3}',
             output_buffer.getvalue(),
         )
 
@@ -636,13 +636,13 @@ class EventTest(ScalyrTestCase):
         x.set_sequence_number_delta(3)
         x.set_timestamp(42)
 
-        x.add_missing_attributes({"trigger_update": "yes"})
+        x.add_attributes({"trigger_update": "yes"})
 
         output_buffer = StringIO()
         x.serialize(output_buffer)
 
         self.assertEquals(
-            '{thread:"foo", log:"foo", attrs:{message:`s\x00\x00\x00\nmy_message,sample_rate:0.5},ts:"42",si:"1",sn:2,sd:3}',
+            '{thread:"foo", log:"foo", attrs:{"trigger_update":"yes",message:`s\x00\x00\x00\nmy_message,sample_rate:0.5},ts:"42",si:"1",sn:2,sd:3}',
             output_buffer.getvalue(),
         )
 

--- a/scalyr_agent/tests/scalyr_client_test.py
+++ b/scalyr_agent/tests/scalyr_client_test.py
@@ -161,6 +161,26 @@ class AddEventsRequestTest(ScalyrTestCase):
 
         request.close()
 
+    def test_set_log_line_attributes(self):
+        request = AddEventsRequest(self.__body)
+        request.set_client_time(1)
+        request.add_log_and_thread("log1", "Hi there", {})
+
+        self.assertTrue(request.add_log_and_thread("log2", "Log two", {}))
+
+        event_one = Event().set_message("eventOne")
+        event_one.add_missing_attributes({"source": "stdout"}, log_line_attributes=True)
+
+        self.assertTrue(request.add_event(event_one, timestamp=1))
+
+        self.assertEquals(
+            request.get_payload(),
+            """{"token":"fakeToken", events: [{attrs:{"source":"stdout",message:`s\x00\x00\x00\neventOne},ts:"1"}], """
+            """logs: [{"attrs":{},"id":"log2"}], threads: [{"id":"log2","name":"Log two"}], client_time: 1 }""",
+        )
+
+        request.close()
+
     def test_set_client_time(self):
         request = AddEventsRequest(self.__body)
         request.set_client_time(100)

--- a/scalyr_agent/tests/scalyr_client_test.py
+++ b/scalyr_agent/tests/scalyr_client_test.py
@@ -164,9 +164,7 @@ class AddEventsRequestTest(ScalyrTestCase):
     def test_set_log_line_attributes(self):
         request = AddEventsRequest(self.__body)
         request.set_client_time(1)
-        request.add_log_and_thread("log1", "Hi there", {})
-
-        self.assertTrue(request.add_log_and_thread("log2", "Log two", {}))
+        request.add_log_and_thread("log2", "Log two", {})
 
         event_one = Event().set_message("eventOne")
         event_one.add_missing_attributes({"source": "stdout"}, log_line_attributes=True)
@@ -175,7 +173,7 @@ class AddEventsRequestTest(ScalyrTestCase):
 
         self.assertEquals(
             request.get_payload(),
-            """{"token":"fakeToken", events: [{attrs:{"source":"stdout",message:`s\x00\x00\x00\neventOne},ts:"1"}], """
+            """{"token":"fakeToken", events: [{attrs:{"source":"stdout",message:`s\x00\x00\x00\x08eventOne},ts:"1"}], """
             """logs: [{"attrs":{},"id":"log2"}], threads: [{"id":"log2","name":"Log two"}], client_time: 1 }""",
         )
 

--- a/scalyr_agent/tests/scalyr_client_test.py
+++ b/scalyr_agent/tests/scalyr_client_test.py
@@ -179,6 +179,31 @@ class AddEventsRequestTest(ScalyrTestCase):
 
         request.close()
 
+    def test_set_log_line_attributes_with_base_attributes(self):
+        request = AddEventsRequest(self.__body)
+        request.set_client_time(1)
+        request.add_log_and_thread("log2", "Log two", {})
+
+        event_base = Event()
+        event_base.add_missing_attributes(
+            {"source": "stdout", "base": "base"}, log_line_attributes=False
+        )
+
+        event_one = Event(base=event_base)
+        event_one.set_message("eventOne")
+        event_one.add_missing_attributes(
+            {"source": "stdin", "event": "event"}, log_line_attributes=True
+        )
+
+        self.assertTrue(request.add_event(event_one, timestamp=1))
+
+        self.assertEquals(
+            request.get_payload(),
+            """{"token":"fakeToken", events: [{attrs:{"event":"event","source":"stdin",message:`s\x00\x00\x00\x08eventOne},ts:"1"}], """
+            """logs: [{"attrs":{},"id":"log2"}], threads: [{"id":"log2","name":"Log two"}], client_time: 1 }""",
+        )
+        request.close()
+
     def test_set_client_time(self):
         request = AddEventsRequest(self.__body)
         request.set_client_time(100)


### PR DESCRIPTION
The result of a missed case (log line specific attributes) during the changes to the addEvents format. This PR changes `add_missing_attributes` to act differently depending on if the attributes being added are log line specific or general to the log file overall.