### PR TITLE
Investigate K8s flaky test

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -2459,6 +2459,12 @@ class ContainerChecker(object):
 
     def _get_container_runtime(self):
         """ Gets the container runtime currently in use """
+        if not self.k8s_cache:
+            global_log.warning(
+                "Coud not determine K8s CRI because no k8 cache.",
+                limit_once_per_x_secs=300,
+                limit_key="k8s_cri_no_cache",
+            )
         return (self.k8s_cache and self.k8s_cache.get_container_runtime()) or "unknown"
 
     def start(self):


### PR DESCRIPTION
Added extra logging to help investigate flaky K8s smoke
test when run in CircleCI.  It appears as if the container
runtime environment cannot be determined.