### PR TITLE
Submit code coverage reports to codecov

### DIFF
--- a/.circleci/.coveragerc_ci
+++ b/.circleci/.coveragerc_ci
@@ -2,10 +2,10 @@
 source =
     /home/circleci/scalyr-agent-2/
     /usr/share/scalyr-agent-2/py/
-    
+
 [report]
 skip_covered=True
 omit =
+    */.virtualenvs/*
     */venv/*
     */third_party*/*
-    */scalyr-agent/tests/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,7 @@ jobs:
           command: |
             virtualenv venv
             source venv/bin/activate
-            pip install coverage
+            pip install coverage "codecov==2.0.15"
             mkdir -p cov
             cp .circleci/.coveragerc_ci cov/.coveragerc
 
@@ -322,6 +322,7 @@ jobs:
           command: |
             source ../venv/bin/activate
             coverage report
+            codecov
 
   modernize-check:
     working_directory: ~/scalyr-agent-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,12 +322,19 @@ jobs:
           path: cov
 
       - run:
-          name: report
+          name: Print coverage report
           working_directory: cov
           command: |
             source ../venv/bin/activate
             coverage report
-            codecov
+
+      - run:
+          name: Upload coverage data to codecov.io
+          working_directory: cov
+          command: |
+            source ../venv/bin/activate
+            coverage xml --rcfile=.coveragerc -i -o coverage.xml
+            codecov --file coverage.xml
 
   modernize-check:
     working_directory: ~/scalyr-agent-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ jobs:
           command: |
             source ../venv/bin/activate
             coverage xml --rcfile=.coveragerc -i -o coverage.xml
-            codecov --file coverage.xml
+            codecov --root=/home/circleci/scalyr-agent-2/ --file coverage.xml
 
   modernize-check:
     working_directory: ~/scalyr-agent-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ jobs:
           command: |
             source ../venv/bin/activate
             coverage xml --rcfile=.coveragerc -i -o coverage.xml
-            codecov --root=/home/circleci/scalyr-agent-2/ --file coverage.xml
+            codecov --root=/home/circleci/scalyr-agent-2/ --disable gcov --file coverage.xml
 
   modernize-check:
     working_directory: ~/scalyr-agent-2
@@ -381,6 +381,6 @@ workflows:
       - coverage:
           requires:
             - unittest-27
-          # - smoke-docker-json
-          # - smoke-docker-syslog
-          # - smoke-k8s
+            - smoke-docker-json
+            - smoke-docker-syslog
+            - smoke-k8s

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,6 +381,6 @@ workflows:
       - coverage:
           requires:
             - unittest-27
-            - smoke-docker-json
-            - smoke-docker-syslog
-            - smoke-k8s
+          # - smoke-docker-json
+          # - smoke-docker-syslog
+          # - smoke-k8s

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,6 +297,7 @@ jobs:
       - restore_cache:
           key: deps1-{{ .Branch }}-{{ checksum "dev-requirements.txt" }}
       - run:
+          name: Install dependencies
           command: |
             # Small safety check to make sure the build fails if codecov.yml file is invalid.
             # By default codecov doesn't fail on invalid config and simply falls back to
@@ -313,6 +314,7 @@ jobs:
           at: cov
 
       - run:
+          name: Combine coverage
           working_directory: cov
           command: |
             source ../venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,6 +298,11 @@ jobs:
           key: deps1-{{ .Branch }}-{{ checksum "dev-requirements.txt" }}
       - run:
           command: |
+            # Small safety check to make sure the build fails if codecov.yml file is invalid.
+            # By default codecov doesn't fail on invalid config and simply falls back to
+            # system wide default config in case repo local config is invalid. This usually results
+            # in confused and undesired behavior.
+            curl --max-time 10 --data-binary @codecov.yml https://codecov.io/validate | grep -i 'Valid!'
             virtualenv venv
             source venv/bin/activate
             pip install coverage "codecov==2.0.15"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 scalyr-agent-2
 ==============
-[![CircleCI](https://circleci.com/gh/scalyr/scalyr-agent-2.svg?style=svg)](https://circleci.com/gh/scalyr/scalyr-agent-2)
+
+[![CircleCI](https://circleci.com/gh/scalyr/scalyr-agent-2.svg?style=svg)](https://circleci.com/gh/scalyr/scalyr-agent-2) 
+[![codecov](https://codecov.io/gh/scalyr/scalyr-agent-2/branch/master/graph/badge.svg)](https://codecov.io/gh/scalyr/scalyr-agent-2)
 
 This repository holds the source code for the Scalyr Agent, a daemon that collects logs and metrics from
 customer machines and transmits them to Scalyr.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ For more information on the Scalyr Agent, please visit https://www.scalyr.com/he
 
 To learn more about Scalyr, visit https://www.scalyr.com.
 
-
 Features
 ========
 
@@ -23,7 +22,6 @@ Key features:
   * Easy-to-use troubleshooting features
   * Modular configuration files
   * Extensibility using monitor plugins
-
 
 Developing
 ==========

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,4 @@
 codecov:
-  bot: ""
   notify:
     require_ci_to_pass: yes
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,11 +16,11 @@ coverage:
         #threshold: 2%
         #patch: yes
 
-# Code coverage data is relative to scalyr_agent/ directory so we need to
-# prepend it for codecov.io web reports to work correctly since those rely
-# on paths relative to the repo root
+# Code coverage data needs to be relative to the repo root, but in out reports it's
+# relative to /home/circleci/scalyr-agent-2/ so we need to fix the paths so it works
+# correctly on codecov.io
 fixes:
-    - "::scalyr_agent/"
+    - "/home/circleci/scalyr-agent-2/::
 
 comment:
   layout: "reach, diff, flags, files"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2         # decimal places to display: 0 <= value <= 4
+  round: nearest
+  range: 50...90      # custom range of coverage colors from red -> yellow -> green
+
+  status:
+    project:
+      default:
+        default: false
+        # TODO: Define threshold once we agree on them
+        #target: auto
+        #threshold: 2%
+        #patch: yes
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: yes
+  require_head: yes

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,5 +26,5 @@ comment:
   layout: "reach, diff, flags, files"
   behavior: default
   require_changes: false
-  require_base: no
-  require_head: no
+  require_base: false
+  require_head: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,6 +16,12 @@ coverage:
         #threshold: 2%
         #patch: yes
 
+# Code coverage data is relative to scalyr_agent/ directory so we need to
+# prepend it for codecov.io web reports to work correctly since those rely
+# on paths relative to the repo root
+fixes:
+    - "::scalyr_agent/"
+
 comment:
   layout: "reach, diff, flags, files"
   behavior: default

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 codecov:
+  bot: ""
   notify:
     require_ci_to_pass: yes
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,7 +20,7 @@ coverage:
 # relative to /home/circleci/scalyr-agent-2/ so we need to fix the paths so it works
 # correctly on codecov.io
 fixes:
-    - "/home/circleci/scalyr-agent-2/::
+    - "/home/circleci/scalyr-agent-2/::"
 
 comment:
   layout: "reach, diff, flags, files"

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,5 +26,5 @@ comment:
   layout: "reach, diff, flags, files"
   behavior: default
   require_changes: false
-  require_base: false
-  require_head: false
+  require_base: yes
+  require_head: yes

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,5 +26,5 @@ comment:
   layout: "reach, diff, flags, files"
   behavior: default
   require_changes: false
-  require_base: yes
-  require_head: yes
+  require_base: no
+  require_head: no


### PR DESCRIPTION
Small change which updates existing ``coverage`` Circle CI job to submit combined / aggregated coverage data to codecov.io service.

This means that in addition to the raw plain text code coverage output which is currently displayed in the Circle CI job output we now also get nicer visualization such as this one - https://codecov.io/gh/scalyr/scalyr-agent-2/branch/submit_code_coverage_to_codecov.

In addition to the nice web based visualization, we also get two other things:

1. Pull request comments with information about coverage for a specific PR
2. Ability to define a coverage threshold (either absolute or relative) and fail a PR via Github status check if that threshold is not reached