### PR TITLE
Fix intermediately failing logging rate limit test

### DIFF
--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -924,11 +924,17 @@ class RateLimiterLogFilter(object):
     def filter(self, record):
         if hasattr(record, "rate_limited_set"):
             return record.rate_limited_result
+
         record.rate_limited_set = True
         # Note, it is important we set rate_limited_droppped_records before we invoke the formatter since the
         # formatting is dependent on that value and our formatters cache the result.
         record.rate_limited_dropped_records = self.__dropped_records
         record_str = self.__formatter.format(record)
+
+        # Store size of the original and formatted records on the record object itself. Right now
+        # this is mostly used in the tests, but could also be useful in other contexts.
+        record.original_size = len(record.message)
+        record.formatted_size = len(record_str)
         record.rate_limited_result = self.__rate_limiter.charge_if_available(
             len(record_str)
         )

--- a/scalyr_agent/tests/scalyr_logging_test.py
+++ b/scalyr_agent/tests/scalyr_logging_test.py
@@ -38,6 +38,7 @@ class ScalyrLoggingTest(ScalyrTestCase):
             agent_log_file_path=self.__log_path,
         )
         self.__logger = scalyr_logging.getLogger("scalyr_agent.agent_main")
+        self.__logger.set_keep_last_record(False)
 
     def test_output_to_file(self):
         self.__logger.info("Hello world")
@@ -235,45 +236,59 @@ class ScalyrLoggingTest(ScalyrTestCase):
         Drop log messages with log size > max_write_burst but do not drop
         following small log messages
         """
+        max_write_burst = 500
+        log_write_rate = 20000
+
         self.__log_path = tempfile.mktemp(".log")
         scalyr_logging.set_log_destination(
             use_disk=True,
             logs_directory=os.path.dirname(self.__log_path),
             agent_log_file_path=self.__log_path,
-            max_write_burst=500,
-            log_write_rate=20000,
+            max_write_burst=max_write_burst,
+            log_write_rate=log_write_rate,
         )
         self.__logger = scalyr_logging.getLogger("scalyr_agent.agent_main")
 
         self.__logger.set_keep_last_record(True)
-        try:
-            # NOTE: Actual value which is being used for the rate limitting is the formatted value
-            # and that value contains much more information than the string we generate here.
-            # This means that 450 + common formatted string data will aways be > 500 and we need to
-            # make sure that "max_write_burst" value we use is large enough so formatted "First
-            # message" and "Second message" (with a warning) fit in that value, otherwise depending
-            # on the timing and fill rate, the test may fail.
-            string_300 = "a" * 450
+        # NOTE: Actual value which is being used for the rate limitting is the formatted value
+        # and that value contains much more information than the string we generate here.
+        # This means that 450 + common formatted string data will aways be > 500 and we need to
+        # make sure that "max_write_burst" value we use is large enough so formatted "First
+        # message" and "Second message" (with a warning) fit in that value, otherwise depending
+        # on the timing and fill rate, the test may fail.
+        string_450 = "a" * 450
 
-            self.__logger.info("First message")
-            self.assertTrue(self.__log_contains("First message"))
+        self.__logger.info("First message")
+        self.assertTrue(self.__log_contains("First message"))
 
-            self.__logger.info("Dropped message %s", string_300)
-            self.assertFalse(self.__log_contains("Dropped message"))
+        first_message_record = self.__logger.last_record
+        self.assertEqual(first_message_record.message, 'First message')
 
-            self.__logger.info("Second message")
-            has_second_message = self.__log_contains("Second message")
-            last_record = self.__logger.last_record
-            # TODO: Remove these extra asserts once we have determined the cause of this test case
-            # being flaky: https://scalyr.myjetbrains.com/youtrack/issue/AGENT-313
-            self.assertEqual("Second message", last_record.message)
-            self.assertEqual(1, last_record.rate_limited_dropped_records)
-            self.assertTrue(last_record.rate_limited_result)
-            self.assertTrue(last_record.rate_limited_set)
-            self.assertTrue(has_second_message)
-            self.assertTrue(self.__log_contains("Warning, skipped writing 1 log lines"))
-        finally:
-            self.__logger.set_keep_last_record(False)
+        self.__logger.info("Dropped message %s", string_450)
+        self.assertFalse(self.__log_contains("Dropped message"))
+
+        self.__logger.info("Second message")
+        has_second_message = self.__log_contains("Second message")
+        second_message_record = self.__logger.last_record
+
+        second_message_record = self.__logger.last_record
+        self.assertEqual(second_message_record.message, 'Second message')
+
+        # Verify that formatted first mesage + second message length is not larger then 500
+        # (max_write_burst) which would indicate invalid test which may intermediatly fail
+        # depending on the test timing
+        self.assertEqual(1, second_message_record.rate_limited_dropped_records)
+
+        if ((first_message_record.formatted_size + second_message_record.formatted_size) >=
+                max_write_burst):
+            self.fail('Length of the formatted first and second mesage string is longer than '
+                      '%s bytes (max_write_burst). Increase max_write_burst used or update the '
+                      'strings otherwise tests may occasionally fail.' % (max_write_burst))
+
+        self.assertTrue(second_message_record.rate_limited_result)
+        self.assertTrue(second_message_record.rate_limited_set)
+        self.assertTrue(has_second_message)
+        self.assertTrue(self.__log_contains("Warning, skipped writing 1 log lines"))
 
     def test_limit_once_per_x_secs(self):
         log = scalyr_logging.getLogger("scalyr_agent.foo")

--- a/scalyr_agent/tests/util_test.py
+++ b/scalyr_agent/tests/util_test.py
@@ -414,6 +414,25 @@ class TestRateLimiter(ScalyrTestCase):
         self.assertTrue(self.charge_if_available(80))
         self.assertFalse(self.charge_if_available(1))
 
+    def test_custom_bucket_size_and_rate(self):
+        self.__test_rate = RateLimiter(10, 1, current_time=0)
+        self.assertTrue(self.charge_if_available(10))
+        self.assertFalse(self.charge_if_available(10))
+        self.advance_time(1)
+        self.assertFalse(self.charge_if_available(10))
+        self.advance_time(5)
+        self.assertFalse(self.charge_if_available(10))
+
+    def test_zero_bucket_fill_rate(self):
+        self.__test_rate = RateLimiter(100, 0, current_time=0)
+        self.assertTrue(self.charge_if_available(20))
+        self.assertTrue(self.charge_if_available(80))
+        self.assertFalse(self.charge_if_available(1))
+        self.advance_time(1)
+        self.assertFalse(self.charge_if_available(20))
+        self.advance_time(5)
+        self.assertFalse(self.charge_if_available(20))
+
     def test_refill(self):
         self.assertTrue(self.charge_if_available(60))
         self.assertFalse(self.charge_if_available(60))


### PR DESCRIPTION
While working on #377, I noticed ``ScalyrLoggingTest.test_rate_limit_no_write_rate`` tests fails very often.

After digging in, I believe I found an issue in the test itself and a potential fix / workaround.

## Context, Background

Right now we set ``max_write_burst`` aka ``bucket_size`` to 250 bytes.

The problem is that the actual message string value we use when determining the message size is the fully formatted string and that string is much longer than the original string we pass to the logger method in the tests. 

Formatted string value also contains module name, timestamp and for the first successfully logged message after the rate limit being hit, it's also prefixed with a warning that a previous message has been rate limited.

For example:

```bash
.... Warning, skipped writing 1 log lines due to limit set by `monitor_log_write_rate` option...
2020-01-28 14:43:34.401Z INFO [core] [scalyr_logging_test.py:269] Second message
```

This means that depending on the test timing and bucket fill rate the actual length of the first and last formatted message which should be written successfully may exceed this 250 bytes limit we originally used and the last message ("second message") will be rate limited instead of being successfully logged and the test will fail.

## Proposed Solution

There are a couple of possible solutions.

I went with the simplest one which simply increases ``max_write_burst`` value so it will always be greater than ``len(formatted first message) + len(formatted last message with rate limited previous message warning)``.

---

On some somewhat related note - part of a problem also is that we prefix first successfully logged message after rate limit being hit with a warning that we skipped writing x log lines and this affects the actual message length we use when determining if there is still space left in the bucket.

A perhaps better approach would be to not take that warning string into account when determining message size for rate limit purposes (but that's out of scope here and to be discussed).