### PR TITLE
Another Python 3.5 dict order related test fix.

### DIFF
--- a/scalyr_agent/tests/url_monitor_test.py
+++ b/scalyr_agent/tests/url_monitor_test.py
@@ -76,8 +76,8 @@ class UrlMonitorTestRequest(unittest.TestCase):
         self.assertEqual(actual_request.get_method(), "GET")
         self.assertFalse(actual_request.data is not None)
         self.assertEqual(
-            actual_request.header_items(),
-            [("Header_foo", "foo"), ("Header_bar", "bar")],
+            sorted(actual_request.header_items()),
+            sorted([("Header_foo", "foo"), ("Header_bar", "bar")]),
         )
 
     def test_post_request_with_data(self):


### PR DESCRIPTION
Unfortunately, I missed another similar test that does not pass on python3.5 because of `dict` order..