### PR TITLE
json_lib.parse converts byte strings to unicode before parsing.

### DIFF
--- a/scalyr_agent/json_lib/parser.py
+++ b/scalyr_agent/json_lib/parser.py
@@ -202,6 +202,14 @@ class JsonParser(object):
 
     @staticmethod
     def parse(input_text, check_duplicate_keys=False):
+        """
+        Parse json string (unicode or valid UTF-8 bytes)
+        :param input_text:
+        :param check_duplicate_keys:
+        :type input_text: six.text_type | six.binary_type
+        :type check_duplicate_keys: bool
+        """
+        input_text = six.ensure_text(input_text)
         return JsonParser(
             TextScanner(input_text), True, check_duplicate_keys
         ).parse_value()

--- a/scalyr_agent/json_lib/tests/parser_test.py
+++ b/scalyr_agent/json_lib/tests/parser_test.py
@@ -250,6 +250,27 @@ class JsonParserTests(ScalyrTestCase):
         self.assertEquals(x.get("a"), 5)
         self.assertEquals(x.get("b"), 7)
 
+    def test_parse_from_bytes(self):
+        self.assertEqual(JsonParser.parse(b"123"), 123)
+        self.assertEqual(JsonParser.parse(b"-10.5"), -10.5)
+        self.assertEqual(JsonParser.parse(b'"""Howdy\n"folks"!"""'), """Howdy\n"folks"!""")
+        self.assertEqual(JsonParser.parse(b"true"), True)
+        self.assertEqual(JsonParser.parse(b"null"), None)
+        self.assertEqual(JsonParser.parse(b" // Hi there\n  45"), 45)
+
+        x = JsonParser.parse(b"[1, 2, 3]")
+        self.assertEquals(len(x), 3)
+        self.assertEquals(x[0], 1)
+        self.assertEquals(x[1], 2)
+        self.assertEquals(x[2], 3)
+
+        x = JsonParser.parse(b"{ a: 5, b:3, c:true, d: \"Hello\"}")
+        self.assertEquals(len(x), 4)
+        self.assertEquals(x.get("a"), 5)
+        self.assertEquals(x.get("b"), 3)
+        self.assertEquals(x.get("c"), True)
+        self.assertEquals(x.get("d"), "Hello")
+
 
 def main():
     unittest.main()


### PR DESCRIPTION
Return back the ability to pass bytes string to `json_lib.parse` where then it will be converted to unicode.
