### PR TITLE
Fix a couple of small Python 2 and 3 compatibility issues

### DIFF
--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -312,7 +312,9 @@ class ScalyrClientSession(object):
             else:
                 body_str = ""
 
-            body_str_raw = body_str
+            # Workaround to fix issue with logging non utf-8 characters. We simply ignore
+            # non utf-8 characters
+            body_str_raw = body_str.decode("utf-8", "ignore")
 
             self.total_request_bytes_sent += len(body_str) + len(request_path)
 

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -1774,15 +1774,21 @@ class TestJournaldLogConfigManager(TestConfigurationBase):
 
         lcm = LogConfigManager(config, None)
         matched_config = lcm.get_config("test")
-        self.assertEqual("TestParser", matched_config["parser"])
-        self.assertEqual(
-            six.text_type([{"match_expression": "a", "replacement": "yes"}]),
-            six.text_type(matched_config["redaction_rules"]),
-        )
-        self.assertEqual(
-            six.text_type([{"match_expression": "INFO", "sampling_rate": 0.1}]),
-            six.text_type(matched_config["sampling_rules"]),
-        )
+
+        # NOTE: We need to sort the values since we can't rely on dict ordering
+        expected = [{"match_expression": "a", "replacement": "yes"}]
+        expected[0] = sorted(expected[0].items())
+
+        actual = list(matched_config["redaction_rules"])
+        actual[0] = sorted(actual[0].items())
+        self.assertEqual(expected, actual)
+
+        expected = [{"match_expression": "INFO", "sampling_rate": 0.1}]
+        expected[0] = sorted(expected[0].items())
+
+        actual = list(matched_config["sampling_rules"])
+        actual[0] = sorted(actual[0].items())
+        self.assertEqual(expected, actual)
         self.assertEqual("true", matched_config["attributes"]["webServer"])
 
     def test_default_logger(self):

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -18,6 +18,10 @@ from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
+
+if False:
+    from typing import Union
+
 import codecs
 import sys
 import struct
@@ -391,6 +395,7 @@ def md5_hexdigest(data):
 
 
 def remove_newlines_and_truncate(input_string, char_limit):
+    # type (Union[str, bytes], int) -> str
     """Returns the input string but with all newlines removed and truncated.
 
     The newlines are replaced with spaces.  This is done both for carriage return and newline.
@@ -400,7 +405,7 @@ def remove_newlines_and_truncate(input_string, char_limit):
     @param input_string: The string to transform
     @param char_limit: The maximum number of characters the resulting string should be
 
-    @type input_string: str
+    @type input_string: str or bytes
     @type char_limit: int
 
     @return:  The string with all newlines replaced with spaces and truncated.

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -406,6 +406,7 @@ def remove_newlines_and_truncate(input_string, char_limit):
     @return:  The string with all newlines replaced with spaces and truncated.
     @rtype: str
     """
+    input_string = six.ensure_text(input_string)
     return input_string.replace("\n", " ").replace("\r", " ")[0:char_limit]
 
 


### PR DESCRIPTION
I tried to run latest version of master under Python 2 and Python 3 while testing the signals change and I encountered some exceptions in the log related to mixing bytes and unicode.

This pull request fixes two small issues I've encountered.

There are likely many more which will only be uncovered only while running the agent and that's where a more systematic approach + end to end tests come into play.

Ideally as part of end to end tests, we would spin up an agent process under Python 2 Python 3 with some real life configuration and DEBUG level set and then we would grep agent.log and agent_debug.log for exceptions / errors and work from there.