### PR TITLE
AGENT-330  Add defensive code to investigate K8s initialization issues

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -2619,11 +2619,12 @@ class ContainerChecker(object):
             self.__thread.start()
 
         except K8sInitException as e:
+            e_as_text = six.text_type(e)
             global_log.warn(
                 "Failed to start container checker - %s. Aborting kubernetes_monitor"
-                % (six.text_type(e))
+                % e_as_text
             )
-            k8s_utils.terminate_agent_process(e.message)
+            k8s_utils.terminate_agent_process(getattr(e, "message", e_as_text))
             raise
         except Exception as e:
             global_log.warn(

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -292,10 +292,10 @@ define_config_option(
 define_config_option(
     __monitor__,
     "k8s_cache_init_abort_delay",
-    "Optional (defaults to 20). The number of seconds to wait for initialization of the kubernetes cache before aborting "
+    "Optional (defaults to 120). The number of seconds to wait for initialization of the kubernetes cache before aborting "
     "the kubernetes_monitor.",
     convert_to=int,
-    default=20,
+    default=120,
 )
 
 define_config_option(
@@ -2500,6 +2500,10 @@ class ContainerChecker(object):
             # create the k8s cache
             self.k8s_cache = k8s_utils.cache(self._global_config)
 
+            # TODO: Uncomment after the v59 release.  This is a bit of a risky change that needs more testing
+            # to ensure we do not hurt some class of customers.
+            # self.__verify_service_account()
+
             if self.__controlled_warmer is not None:
                 self.__controlled_warmer.set_k8s_cache(self.k8s_cache)
                 self.__controlled_warmer.start()
@@ -2508,29 +2512,27 @@ class ContainerChecker(object):
             message_delay = 5
             start_time = time.time()
             message_time = start_time
-            abort = False
 
             # wait until the k8s_cache is initialized before aborting
             while not self.k8s_cache.is_initialized():
                 time.sleep(delay)
                 current_time = time.time()
-                # see if we need to print a message
-                elapsed = current_time - message_time
-                if elapsed > message_delay:
-                    self._logger.log(
-                        scalyr_logging.DEBUG_LEVEL_0,
-                        "start() - waiting for Kubernetes cache to be initialized",
-                    )
-                    message_time = current_time
+                last_initialization_error = self.k8s_cache.last_initialization_error()
+                if last_initialization_error is not None:
+                    # see if we need to abort the monitor because we've been waiting too long for init
+                    if current_time - start_time > self.__k8s_cache_init_abort_delay:
+                        raise K8sInitException(
+                            "Kubernetes monitor failed to start due to cache initialization error: %s"
+                            % last_initialization_error
+                        )
 
-                # see if we need to abort the monitor because we've been waiting too long for init
-                elapsed = current_time - start_time
-                if elapsed > self.__k8s_cache_init_abort_delay:
-                    abort = True
-                    break
-
-            if abort:
-                raise K8sInitException("Unable to initialize kubernetes cache")
+                    # see if we need to print a message
+                    if current_time - message_time > message_delay:
+                        self._logger.warning(
+                            "Kubernetes monitor not started yet (will retry) due to error in cache initialization %s",
+                            last_initialization_error,
+                        )
+                        message_time = current_time
 
             # check to see if the user has manually specified a cluster name, and if so then
             # force enable 'Starbuck' features
@@ -2621,6 +2623,7 @@ class ContainerChecker(object):
                 "Failed to start container checker - %s. Aborting kubernetes_monitor"
                 % (six.text_type(e))
             )
+            k8s_utils.terminate_agent_process(e.message)
             raise
         except Exception as e:
             global_log.warn(
@@ -3169,6 +3172,20 @@ class ContainerChecker(object):
                 result.append({"cid": cid, "stream": "raw", "log_config": log_config})
 
         return result
+
+    def __verify_service_account(self):
+        """
+        Verifies that the appropriate service account information can be read from the pod, otherwise raises
+        a `K8sInitException`.  This is meant to catch common configuration issues.
+        """
+        if self._global_config.k8s_verify_api_queries and not (
+            os.path.isfile(self._global_config.k8s_service_account_cert)
+            and os.access(self._global_config.k8s_service_account_cert, os.R_OK)
+        ):
+            raise K8sInitException(
+                "Service account certificate not found at '%s'.  Be sure "
+                "'automountServiceAccountToken' is set to True"
+            )
 
 
 class KubernetesMonitor(ScalyrMonitor):

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -368,6 +368,18 @@ class Configuration(object):
         return self.__get_config().get_int("k8s_cache_purge_secs")
 
     @property
+    def k8s_service_account_cert(self):
+        return self.__get_config().get_string("k8s_service_account_cert")
+
+    @property
+    def k8s_service_account_token(self):
+        return self.__get_config().get_string("k8s_service_account_token")
+
+    @property
+    def k8s_service_account_namespace(self):
+        return self.__get_config().get_string("k8s_service_account_namespace")
+
+    @property
     def k8s_log_api_responses(self):
         # UNDOCUMENTED_CONFIG
         return self.__get_config().get_bool("k8s_log_api_responses")
@@ -1654,6 +1666,30 @@ class Configuration(object):
             config,
             "k8s_cache_purge_secs",
             300,
+            description,
+            apply_defaults,
+            env_aware=True,
+        )
+        self.__verify_or_set_optional_string(
+            config,
+            "k8s_service_account_cert",
+            "/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+            description,
+            apply_defaults,
+            env_aware=True,
+        )
+        self.__verify_or_set_optional_string(
+            config,
+            "k8s_service_account_token",
+            "/var/run/secrets/kubernetes.io/serviceaccount/token",
+            description,
+            apply_defaults,
+            env_aware=True,
+        )
+        self.__verify_or_set_optional_string(
+            config,
+            "k8s_service_account_namespace",
+            "/var/run/secrets/kubernetes.io/serviceaccount/namespace",
             description,
             apply_defaults,
             env_aware=True,

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -261,6 +261,19 @@ class TestConfiguration(TestConfigurationBase):
 
         self.assertEquals(config.pipeline_threshold, 1.1)
 
+        self.assertEquals(
+            config.k8s_service_account_cert,
+            "/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+        )
+        self.assertEquals(
+            config.k8s_service_account_token,
+            "/var/run/secrets/kubernetes.io/serviceaccount/token",
+        )
+        self.assertEquals(
+            config.k8s_service_account_namespace,
+            "/var/run/secrets/kubernetes.io/serviceaccount/namespace",
+        )
+
         self.assertEquals(len(config.log_configs), 2)
         self.assertPathEquals(
             config.log_configs[0].get_string("path"), "/var/log/tomcat6/access.log"
@@ -354,6 +367,10 @@ class TestConfiguration(TestConfigurationBase):
             http_proxy: "http://foo.com",
             https_proxy: "https://bar.com",
 
+            k8s_service_account_cert: "foo_cert",
+            k8s_service_account_token: "foo_token",
+            k8s_service_account_namespace: "foo_namespace",
+
             logs: [ { path: "/var/log/tomcat6/access.log", ignore_stale_files: true} ],
             journald_logs: [ { journald_unit: ".*", parser: "journald_catchall" } ]
           }
@@ -415,6 +432,10 @@ class TestConfiguration(TestConfigurationBase):
         self.assertFalse(config.verify_server_certificate)
         self.assertTrue(config.debug_init)
         self.assertTrue(config.pidfile_advanced_reuse_guard)
+
+        self.assertEquals(config.k8s_service_account_cert, "foo_cert")
+        self.assertEquals(config.k8s_service_account_token, "foo_token")
+        self.assertEquals(config.k8s_service_account_namespace, "foo_namespace")
 
         self.assertTrue(config.log_configs[0].get_bool("ignore_stale_files"))
         self.assertEqual(


### PR DESCRIPTION
This adds in more diagnostic information describing why the K8s
cache fails to initialize.  This also changes the agent to
restart if it is not initialized within 2 minutes.  (Customers
reporting this issue say that restarting the agent usually solves
the problem)