### PR TITLE
Improve response debug logging in the copying manager

### DIFF
--- a/scalyr_agent/copying_manager.py
+++ b/scalyr_agent/copying_manager.py
@@ -802,6 +802,17 @@ class CopyingManager(StoppableThread, LogWatcher):
                                 result,
                             )
 
+                            if result != "success":
+                                # Log the whole response body in case server returns non-success
+                                # response so we can troubleshoot the error (aka is it bug in the
+                                # agent code or similar)
+                                log.log(
+                                    scalyr_logging.DEBUG_LEVEL_5,
+                                    'Received server response with status="%s" and body: %s',
+                                    result,
+                                    full_response,
+                                )
+
                             if (
                                 result == "success"
                                 or "discardBuffer" in result


### PR DESCRIPTION
This pull request updates copying manager to log the whole server response body in case server returns a non-successful response (aka ``status != 'success'``).

This now makes it possible to troubleshoot and track down issues when server returns a non-successful response or we fail to parse the response (previously it wasn't possible to track down some issues since we didn't have enough information in the logs and the only option would be to look up actual response in the API logs, but even then this wouldn't be enough in cases where the bug lies in the agent code).

See https://github.com/scalyr/scalyr-agent-2/commit/13ee02e4039a016660185c122411d2a3803fbb62 for some more context.

## TODO

- [x] Tests