### PR TITLE
Fix metric types for "app.disk.requests" metrics

### DIFF
--- a/scalyr_agent/builtin_monitors/linux_process_metrics.py
+++ b/scalyr_agent/builtin_monitors/linux_process_metrics.py
@@ -156,7 +156,6 @@ define_metric(
     "app.disk.requests",
     "Total disk read requests.",
     extra_fields={"type": "read"},
-    unit="bytes",
     cumulative=True,
 )
 
@@ -174,7 +173,6 @@ define_metric(
     "app.disk.requests",
     "Total disk write requests.",
     extra_fields={"type": "write"},
-    unit="bytes",
     cumulative=True,
 )
 

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -732,6 +732,12 @@ class MonitorInformation(object):
         else:
             return None
 
+    def __repr__(self):
+        return "<MonitorInformation monitor_module=%s,metrics=%s>" % (
+            self.__monitor_module,
+            self.__metrics,
+        )
+
 
 class ConfigOption(object):
     """Simple object to hold the fields for a single configuration option.
@@ -781,6 +787,12 @@ class MetricDescription(object):
         # The category for this metric.  This needs only to be supplied if the metric list is long for a particular
         # monitor.
         self.category = None
+
+    def __repr__(self):
+        return (
+            "<MetricDescription metric_name=%s,unit=%s,cumulative=%s,extra_fields=%s>"
+            % (self.metric_name, self.unit, self.cumulative, str(self.extra_fields))
+        )
 
 
 class LogFieldDescription(object):

--- a/scalyr_agent/tests/linux_process_metrics_test.py
+++ b/scalyr_agent/tests/linux_process_metrics_test.py
@@ -28,8 +28,27 @@ from scalyr_agent.builtin_monitors.linux_process_metrics import (
 )
 from scalyr_agent.test_base import ScalyrTestCase
 import scalyr_agent.scalyr_logging as scalyr_logging
+from scalyr_agent.scalyr_monitor import MonitorInformation
 
 from six.moves import range
+
+
+class MetricInformationTestCase(ScalyrTestCase):
+    def test_define_metric_metric_units(self):
+        # Verify all the metrics have the correct type defined
+        monitor_info = MonitorInformation.get_monitor_info(
+            "scalyr_agent.builtin_monitors.linux_process_metrics"
+        )
+        metrics = monitor_info.metrics
+
+        self.assertEqual(len(metrics), 14)
+        disk_requests_metrics = [
+            m for m in metrics if m.metric_name == "app.disk.requests"
+        ]
+
+        self.assertEqual(len(disk_requests_metrics), 2)
+        self.assertEqual(disk_requests_metrics[0].unit, None)
+        self.assertEqual(disk_requests_metrics[1].unit, None)
 
 
 class TestMetricClass(ScalyrTestCase):


### PR DESCRIPTION
This pull request fixes ``app.disk.requests`` (``type={read,write}``) metric type.

Those two metrics represent a total number of read / write requests (counter) so bytes is not a correct unit.

## TODO

- [x] Tests