### PR TITLE
Update pre-commit configuration so it matches tox lint configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,32 @@
-#default_language_version:
-#  python: python3.7
+default_language_version:
+  python: python3.6
+
 exclude: '(third_party.*|third_party_tls.*)'
 repos:
-  - repo: https://github.com/psf/black
-    rev: 19.10b0
+  - repo: local
     hooks:
-      - id: black
-#        language_version: python3.7
-
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    - id: black
+      name: black
+      entry: .tox/lint/bin/black --check --config pyproject.toml
+      language: script
+      types: [file, python]
+  - repo: local
     hooks:
-    - id: end-of-file-fixer
-    - id: trailing-whitespace
-#    - id: check-yaml # Disabled: Fails on some files in this repo.
-
-# MyPy for use later
-#- repo: https://github.com/pre-commit/mirrors-mypy
-#  rev: v0.740
-#  hooks:
-#  - id: mypy
-
-# pylint for use later after resolving the warnings
-#  - repo: https://github.com/pre-commit/mirrors-pylint
-#    rev: v2.4.4
-#    hooks:
-#    - id: pylint
+    - id: flake8
+      name: flake8
+      entry: .tox/lint/bin/flake8 --config lint-configs/python/.flake8
+      language: script
+      types: [file, python]
+  - repo: local
+    hooks:
+    - id: pylint
+      name: pylint
+      entry: .tox/lint/bin/pylint -E --rcfile=./lint-configs/python/.pylintrc
+      language: script
+  - repo: local
+    hooks:
+    - id: mypy
+      name: mypy
+      entry: .tox/lint/bin/mypy --pretty --no-incremental --config-file ./lint-configs/python/mypy.ini
+      language: script
+      types: [file, python]

--- a/README.md
+++ b/README.md
@@ -106,25 +106,34 @@ To build the Debian package, execute the following command in the root directory
 
     python build_package.py deb
 
-### Code Formatting
+### Pre-Commit Hooks
 
-This project uses the [Black](http://black.readthedocs.io) code autoformatting tool with default settings.
+This project uses the [Black](http://black.readthedocs.io) code autoformatting tool with default
+settings.
 
 [Pre-commit](https://pre-commit.com) is used to automatically run checks including Black formatting
 prior to a git commit.
 
 To use pre-commit:
-- Use one of the [Installation Methods](https://pre-commit.com/#install) from the documentation
-- Install the hooks with `pre-commit install`
-- To manually execute the pre-commit hooks (including black), run `pre-commit run --all-files`
 
-### Pre-commit and Black Configuration
+- Use one of the [Installation Methods](https://pre-commit.com/#install) from the documentation.
+- Install the hooks with `pre-commit install`.
+- To manually execute the pre-commit hooks (including black), run `pre-commit run --all-files` (
+  run it on all the files) or ``pre-commit run`` (run it only on staged files).
+
+All the pre-commit targets rely on binaries from tox virtual environment so you need to make sure
+tox virtual environment for ``lint`` target exists:
+
+```bash
+tox -elint --notest --recreate
+```
+
+#### Pre-commit Configuration
 
 - `.pre-commit-config.yaml` configures the scripts run by pre-commit
-- `pyproject.toml` configures the Black settings including folder exclusions for `third_party`
 
-To update the Pre-commit hooks including black, run `pre-commit autoupdate`.
-This will update `.pre-commit-config.yaml` and will need to be committed to the repository.
+To update the Pre-commit hooks , run `pre-commit autoupdate`. This will update
+`.pre-commit-config.yaml` and will need to be committed to the repository.
 
 ## Contributing
 


### PR DESCRIPTION
This pull request updates pre-commit config file so it matches our lint configuration from ``tox`` config.

This means pre-commit now runs the same checks (with the same configuration) as running ``tox -e lint`` does.

By default, ``pre-commit`` creates virtual environment for each check / hook, but I wanted to avoid that since we already have a virtual environment with all the dependencies for out tox targets (not to mention that there are also dependency version and configuration issues there).