### PR TITLE
Send Circle CI usage reports to the new mailing list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,7 +454,7 @@ jobs:
             export PYTHONPATH=.
             python scripts/circleci_usage_data.py --project_slug=gh/scalyr/scalyr-agent-2 \
                 --workflow=unittest --status=success --branch=all --limit=5 \
-                --email=tomaz@scalyr.com
+                --email=cloudtech-builds@scalyr.com
 
 workflows:
   version: 2


### PR DESCRIPTION
This pull request updates Circle CI usage report job to send email to the new mailing list used for build notifications.