### PR TITLE
Update the `envfrom` yaml to use `apps/v1` apiVersion

### DIFF
--- a/k8s/scalyr-agent-2-envfrom.yaml
+++ b/k8s/scalyr-agent-2-envfrom.yaml
@@ -1,77 +1,104 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  annotations:
+    deprecated.daemonset.template.generation: "0"
+  creationTimestamp: null
+  labels:
+    app: scalyr-agent-2
   name: scalyr-agent-2
 spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: scalyr-agent-2
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: scalyr-agent-2
     spec:
-      serviceAccountName: scalyr-service-account
       containers:
-      - name: scalyr-agent
+      - env:
+        - name: SCALYR_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: scalyr-api-key
+              name: scalyr-api-key
+        - name: SCALYR_K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: SCALYR_K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: SCALYR_K8S_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: SCALYR_K8S_POD_UID
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.uid
+        - name: SCALYR_K8S_KUBELET_HOST_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        envFrom:
+        - configMapRef:
+            name: scalyr-config
         image: scalyr/scalyr-k8s-agent:2.0.59
         imagePullPolicy: Always
-        env:
-          - name: SCALYR_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: scalyr-api-key
-                key: scalyr-api-key
-          - name: SCALYR_K8S_NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: SCALYR_K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: SCALYR_K8S_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: SCALYR_K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: SCALYR_K8S_KUBELET_HOST_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.hostIP
-        envFrom:
-          - configMapRef:
-              name: scalyr-config
+        name: scalyr-agent
         resources:
           limits:
             memory: 500Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
         volumeMounts:
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
+        - mountPath: /var/lib/docker/containers
+          name: varlibdockercontainers
           readOnly: true
-        - name: varlogpods
-          mountPath: /var/log/pods
+        - mountPath: /var/log/pods
+          name: varlogpods
           readOnly: true
-        - name: varlogcontainers
-          mountPath: /var/log/containers
+        - mountPath: /var/log/containers
+          name: varlogcontainers
           readOnly: true
-        - name: dockersock
-          mountPath: /var/scalyr/docker.sock
+        - mountPath: /var/scalyr/docker.sock
+          name: dockersock
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: scalyr-service-account
+      serviceAccountName: scalyr-service-account
+      terminationGracePeriodSeconds: 30
       volumes:
-      - name: varlibdockercontainers
-        hostPath:
+      - hostPath:
           path: /var/lib/docker/containers
-      - name: varlogpods
-        hostPath:
+          type: ""
+        name: varlibdockercontainers
+      - hostPath:
           path: /var/log/pods
-      - name: varlogcontainers
-        hostPath:
+          type: ""
+        name: varlogpods
+      - hostPath:
           path: /var/log/containers
-      - name: dockersock
-        hostPath:
+          type: ""
+        name: varlogcontainers
+      - hostPath:
           path: /var/run/docker.sock
+          type: ""
+        name: dockersock
       # comment this section if you do not want to run on the master
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists


### PR DESCRIPTION
Mostly done through running `kubectl convert -f k8s/scalyr-agent-2-envfrom.yaml`, with some minor manual reordering.

From my testing this change should work just fine for Kubernetes versions 1.9 and higher, and our stats show no one using versions older than that.