### PR TITLE
Small pre-commit config fixes and improvements

### DIFF
--- a/.circleci/modernize/modernize.py
+++ b/.circleci/modernize/modernize.py
@@ -387,7 +387,7 @@ if __name__ == "__main__":
         "files",
         metavar="FILES",
         type=str,
-        nargs="+",
+        nargs="?",
         help="File paths to run the script on. If not specified it runs on all the files.",
     )
     parser.add_argument(

--- a/.circleci/modernize/modernize.py
+++ b/.circleci/modernize/modernize.py
@@ -24,6 +24,11 @@
 # Note: This is only python3 script.
 
 if False:
+    # NOTE: This is a workaround for old Python versions where typing module is not available
+    # We should eventually improve that once we start producing distributions with Python
+    # interpreter and dependencies bundled in.
+    # Adding conditional "typing" dependency would require too much boiler plate code at this point
+
     from typing import Dict
     from typing import Any
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,10 +23,11 @@ repos:
       name: pylint
       entry: .tox/lint/bin/pylint -E --rcfile=./lint-configs/python/.pylintrc
       language: script
+      types: [file, python]
   - repo: local
     hooks:
     - id: mypy
       name: mypy
-      entry: .tox/lint/bin/mypy --pretty --no-incremental --config-file ./lint-configs/python/mypy.ini
+      entry: .tox/lint/bin/mypy --pretty --config-file ./lint-configs/python/mypy.ini
       language: script
       types: [file, python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,9 @@ repos:
     hooks:
     - id: mypy
       name: mypy
+      # NOTE: We intentionally want to run in incremental mode to speed this check up
+      # (which is not the case for tox -elint target and CI where we want to avoid using
+      # MyPy cache)>
       entry: .tox/lint/bin/mypy --pretty --config-file ./lint-configs/python/mypy.ini
       language: script
       types: [file, python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,9 @@ repos:
     hooks:
     - id: black
       name: black
-      entry: .tox/lint/bin/black --check --config pyproject.toml
+      # NOTE: We don't use --check flag because we want pre-commit hook to auto format the files
+      # and not just performed the check like we do on the CI
+      entry: .tox/lint/bin/black --config pyproject.toml
       language: script
       types: [file, python]
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,13 @@ repos:
       types: [file, python]
   - repo: local
     hooks:
+    - id: modernize
+      name: modernize
+      entry: .tox/lint/bin/python .circleci/modernize/modernize.py -j 2 --write
+      language: script
+      types: [file, python]
+  - repo: local
+    hooks:
     - id: flake8
       name: flake8
       entry: .tox/lint/bin/flake8 --config lint-configs/python/.flake8

--- a/lint-configs/python/mypy.ini
+++ b/lint-configs/python/mypy.ini
@@ -92,3 +92,6 @@ ignore_missing_imports = True
 
 [mypy-win32con]
 ignore_missing_imports = True
+
+[mypy-libmodernize.*]
+ignore_missing_imports = True

--- a/tox.ini
+++ b/tox.ini
@@ -40,18 +40,18 @@ deps =
     -r dev-requirements.txt
     -r lint-requirements.txt
 commands =
-    bash -c 'black --check --config pyproject.toml *.py scripts/*.py scalyr_agent/'
+    bash -c 'black --check --config pyproject.toml *.py scripts/*.py .circleci/modernize/*.py scalyr_agent/'
     python .circleci/modernize/modernize.py -j 2
-    bash -c 'flake8 --config lint-configs/python/.flake8 *.py scripts/*.py  scalyr_agent/'
-    bash -c 'pylint -E --rcfile=./lint-configs/python/.pylintrc *.py scripts/*.py scalyr_agent/'
-    bash -c 'mypy --pretty --no-incremental --config-file ./lint-configs/python/mypy.ini *.py scripts/*.py scalyr_agent/'
+    bash -c 'flake8 --config lint-configs/python/.flake8 *.py scripts/*.py .circleci/modernize/*.py scalyr_agent/'
+    bash -c 'pylint -E --rcfile=./lint-configs/python/.pylintrc *.py scripts/*.py .circleci/modernize/*.py scalyr_agent/'
+    bash -c 'mypy --pretty --no-incremental --config-file ./lint-configs/python/mypy.ini *.py .circleci/modernize/*.py scripts/*.py scalyr_agent/'
 
 [testenv:black]
 deps =
     -r dev-requirements.txt
     -r lint-requirements.txt
 commands =
-    bash -c 'black --check --config pyproject.toml *.py scripts/*.py scalyr_agent/'
+    bash -c 'black --check --config pyproject.toml *.py scripts/*.py .circleci/modernize/*.py scalyr_agent/'
 
 [testenv:modernize]
 deps =
@@ -65,21 +65,21 @@ deps =
     -r dev-requirements.txt
     -r lint-requirements.txt
 commands =
-    bash -c 'flake8 --config lint-configs/python/.flake8 *.py scripts/*.py  scalyr_agent/'
+    bash -c 'flake8 --config lint-configs/python/.flake8 *.py scripts/*.py .circleci/modernize/*.py scalyr_agent/'
 
 [testenv:pylint]
 deps =
     -r dev-requirements.txt
     -r lint-requirements.txt
 commands =
-    bash -c 'pylint -E --rcfile=./lint-configs/python/.pylintrc *.py scripts/*.py scalyr_agent/'
+    bash -c 'pylint -E --rcfile=./lint-configs/python/.pylintrc *.py scripts/*.py .circleci/modernize/*.py scalyr_agent/'
 
 [testenv:mypy]
 deps =
     -r dev-requirements.txt
     -r lint-requirements.txt
 commands =
-    bash -c 'mypy --pretty --no-incremental --config-file ./lint-configs/python/mypy.ini *.py scripts/*.py scalyr_agent/'
+    bash -c 'mypy --pretty --no-incremental --config-file ./lint-configs/python/mypy.ini *.py .circleci/modernize/*.py scripts/*.py scalyr_agent/'
 
 # TODO: Once we make more progress, set coverage % threshold and fail a build if it's not reached
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,8 @@ commands =
 # Lint target which runs all the linting tools such as black, modernize, pylint, flake8, mypy, etc.
 # NOTE: We use bash -c since we don't want tox to quote all the arguments, we want globs to
 # be expaded
+# NOTE: If you update any of the lint targets or the lint target itself, make sure you also update
+# corresponding pre commit hook configuration in .pre-commit-config.yaml
 [testenv:lint]
 deps =
     -r dev-requirements.txt


### PR DESCRIPTION
This pull request contains three fixes / improvements to the pre-commit config:

1. Add missing ``types`` attribute to the pylint check. Without that, it will try to run pylint on all the files and not just Python ones.

2. Update ``black`` hook and make sure that also automatically formats the files and doesn't just perform a check.

Performing just a check is desired behavior for the CI, but pre-commit hook should also apply auto formatting fixes.

3. Make sure we run MyPy in incremental mode - this way it will use local cache and the runs will be faster.

Keep in mind that's it's desired that on the CI (such as ``tox -elint`` target) we don't use cache to avoid any stale cache related issues, but during local development where pre-commit runs, using cache is desired, otherwise MyPy check will be slow.

Results (with a single changed Python file).

Before:

```bash
$ time pre-commit run
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
mypy.....................................................................Passed

real	0m13.221s
user	0m6.796s
sys	0m1.568s
```

After:

```bash
$ time pre-commit run
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
mypy.....................................................................Passed

real	0m5.460s
user	0m4.440s
sys	0m0.612s
```

Keep in mind that a lot of those checks (pylint, MyPy) are "cross Python package" and need to process multiple files even if a single file has changed (to track the types, called functions, etc.).