### PR TITLE
fix struct.pack|unpack wrapper for python < 2.7.7

### DIFF
--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -318,7 +318,7 @@ def _get_default_gateway():
             fields = line.strip().split()
             if fields[1] != "00000000" or not int(fields[3], 16) & 2:
                 continue
-            # 2->TODO struct.pack|unpack in python2.6 does not allow unicode format string.
+            # 2->TODO struct.pack|unpack in python < 2.7.7 does not allow unicode format string.
             result = socket.inet_ntoa(
                 compat.struct_pack_unicode("<L", int(fields[2], 16))
             )

--- a/scalyr_agent/compat.py
+++ b/scalyr_agent/compat.py
@@ -122,9 +122,9 @@ else:
 # 2->TODO struct.pack|unpack, does not accept unicode as format string.
 # see more: https://python-future.org/stdlib_incompatibilities.html#struct-pack
 # to avoid conversion of format string on every struct.pack call, we can monkey patch it here.
-if sys.version_info[:2] == (2, 6):
+if sys.version_info[:3] < (2, 7, 7):
 
-    def python2_6_unicode_pack_unpack_wrapper(f):
+    def python_unicode_pack_unpack_wrapper(f):
         def _pack_unpack(format_str, *args):
             """wrapper for struct.pack function that converts unicode format string to 'str'"""
             binary_format_str = six.ensure_binary(format_str)
@@ -132,8 +132,8 @@ if sys.version_info[:2] == (2, 6):
 
         return _pack_unpack
 
-    struct_pack_unicode = python2_6_unicode_pack_unpack_wrapper(struct.pack)
-    struct_unpack_unicode = python2_6_unicode_pack_unpack_wrapper(struct.unpack)
+    struct_pack_unicode = python_unicode_pack_unpack_wrapper(struct.pack)
+    struct_unpack_unicode = python_unicode_pack_unpack_wrapper(struct.unpack)
 else:
     struct_pack_unicode = struct.pack
     struct_unpack_unicode = struct.unpack

--- a/scalyr_agent/json_lib/serializer.py
+++ b/scalyr_agent/json_lib/serializer.py
@@ -39,6 +39,6 @@ def serialize_as_length_prefixed_string(value, output_buffer):
         to_serialize = value.encode("utf-8")
     else:
         to_serialize = value
-    # 2->TODO struct.pack|unpack in python2.6 does not allow unicode format string.
+    # 2->TODO struct.pack|unpack in python < 2.7.7 does not allow unicode format string.
     output_buffer.write(compat.struct_pack_unicode(">i", len(to_serialize)))
     output_buffer.write(to_serialize)

--- a/scalyr_agent/monitor_utils/server_processors.py
+++ b/scalyr_agent/monitor_utils/server_processors.py
@@ -254,7 +254,7 @@ class Int32RequestParser(object):
             # Make sure we have 4 bytes so that we can at least read the length prefix, and then try to read
             # the complete data payload.
             if num_bytes > self.__prefix_length:
-                # 2->TODO struct.pack|unpack in python2.6 does not allow unicode format string.
+                # 2->TODO struct.pack|unpack in python < 2.7.7 does not allow unicode format string.
                 (length,) = compat.struct_unpack_unicode(
                     six.ensure_str(self.__format),
                     input_buffer.read(self.__prefix_length),

--- a/scalyr_agent/monitor_utils/tests/server_processors_test.py
+++ b/scalyr_agent/monitor_utils/tests/server_processors_test.py
@@ -62,7 +62,7 @@ class TestInt32RequestParser(ScalyrTestCase):
 
     def run_test_case(self, input_string, length_to_send, truncate_size=None):
         input_buffer = io.BytesIO()
-        # 2->TODO struct.pack|unpack in python2.6 does not allow unicode format string.
+        # 2->TODO struct.pack|unpack in python < 2.7.7 does not allow unicode format string.
         input_buffer.write(compat.struct_pack_unicode("!I", length_to_send))
         input_buffer.write(input_string)
         if truncate_size is not None:

--- a/scalyr_agent/platform_windows.py
+++ b/scalyr_agent/platform_windows.py
@@ -784,7 +784,7 @@ class PipeRedirectorServer(RedirectorServer):
             """Closes the channel to the client.
             """
             try:
-                # 2->TODO struct.pack|unpack in python2.6 does not allow unicode format string.
+                # 2->TODO struct.pack|unpack in python < 2.7.7 does not allow unicode format string.
                 win32file.WriteFile(
                     self.__pipe_handle, compat.struct_pack_unicode("I", 0)
                 )

--- a/scalyr_agent/test_util.py
+++ b/scalyr_agent/test_util.py
@@ -183,7 +183,7 @@ def parse_scalyr_request(payload):
         # First add in the bytes between the last processed and the start of this match.
         rewritten_payload += payload[last_processed_index + 1 : x.start(0)]
         # Read the 4 bytes that describe the length, which is stored in regex group 1.
-        # 2->TODO struct.pack|unpack in python2.6 does not allow unicode format string.
+        # 2->TODO struct.pack|unpack in python < 2.7.7 does not allow unicode format string.
         length = compat.struct_unpack_unicode(">i", x.group(1))[0]
         # Grab the string content as raw bytes.
         raw_string = payload[x.end(1) : x.end(1) + length]

--- a/scalyr_agent/tests/util/util_test.py
+++ b/scalyr_agent/tests/util/util_test.py
@@ -684,7 +684,7 @@ class TestRedirectorServer(ScalyrTestCase):
         @rtype: (int,six.text_type)
         """
         prefix_code = content[0:4]
-        # 2->TODO struct.pack|unpack in python2.6 does not allow unicode format string.
+        # 2->TODO struct.pack|unpack in python < 2.7.7 does not allow unicode format string.
         code = compat.struct_unpack_unicode("i", prefix_code)[0]
         stream_id = code % 2
         num_bytes = code >> 1
@@ -780,7 +780,7 @@ class TestRedirectorClient(ScalyrTestCase):
         else:
             encoded_content = content
         code = len(encoded_content) * 2 + stream_id
-        # 2->TODO struct.pack|unpack in python2.6 does not allow unicode format string.
+        # 2->TODO struct.pack|unpack in python < 2.7.7 does not allow unicode format string.
         self._client_channel.simulate_server_write(
             compat.struct_pack_unicode("i", code) + encoded_content
         )

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -1407,7 +1407,7 @@ class RedirectorServer(object):
         self.__channel_lock.acquire()
         try:
             if self.__channel_lock is not None:
-                # 2->TODO struct.pack|unpack in python2.6 does not allow unicode format string.
+                # 2->TODO struct.pack|unpack in python < 2.7.7 does not allow unicode format string.
                 self.__channel.write(
                     compat.struct_pack_unicode("i", code) + encoded_content
                 )
@@ -1567,7 +1567,7 @@ class RedirectorClient(StoppableThread):
                 # Read one integer which should contain both the number of bytes of content that are being sent
                 # and which stream it should be written to.  The stream id is in the lower bit, and the number of
                 # bytes is shifted over by one.
-                # 2->TODO struct.pack|unpack in python2.6 does not allow unicode format string.
+                # 2->TODO struct.pack|unpack in python < 2.7.7 does not allow unicode format string.
                 code = compat.struct_unpack_unicode("i", self.__channel.read(4))[
                     0
                 ]  # Read str length


### PR DESCRIPTION
Fix struct wrapper in `compat` module, because the problem with unicode incompatible strung remains until python2.7.7.