### PR TITLE
Fix increased memory usage under Python 2.7 when debug log level 5 is set

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,8 @@ master_only: &master_only
     branches:
       only:
         - master
-        - performance_tracking
         - release_performance_tracking
+        - fix_py27_debug_level_memory_leak
 
 version: 2.1
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,6 @@ master_only: &master_only
     branches:
       only:
         - master
-        - release_performance_tracking
-        - fix_py27_debug_level_memory_leak
 
 version: 2.1
 commands:

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -54,6 +54,11 @@ import scalyr_agent.scalyr_logging as scalyr_logging
 import scalyr_agent.util as scalyr_util
 from scalyr_agent.connection import ConnectionFactory
 
+# Maximum request body size (in characters / bytes) we log under DEBUG 5 log level. If the body is
+# larger than this value, we truncate it. This way we prevent debug log file from growing too large
+# and we avoid memory leak under Python 2.7 when logging very large bodies with unicode data.
+MAX_REQUEST_BODY_SIZE_LOG_MSG_LIMIT = 2048
+
 log = scalyr_logging.getLogger(__name__)
 
 
@@ -312,9 +317,9 @@ class ScalyrClientSession(object):
             else:
                 body_str = b""
 
-            # Workaround to fix issue with logging non utf-8 characters. We simply ignore
-            # non utf-8 characters
-            body_str_raw = body_str.decode("utf-8", "ignore")
+            # Store reference to the raw uncompressed body string since we will need it later for
+            # logging purposes
+            body_str_raw = body_str
 
             self.total_request_bytes_sent += len(body_str) + len(request_path)
 
@@ -337,12 +342,31 @@ class ScalyrClientSession(object):
                     )
                 else:
                     if is_post:
-                        log.log(
-                            scalyr_logging.DEBUG_LEVEL_5,
-                            'Sending POST %s with body "%s"',
-                            request_path,
-                            body_str_raw,
-                        )
+                        if log.getEffectiveLevel() == scalyr_logging.DEBUG_LEVEL_5:
+                            # NOTE: We only perform this string formatting if debug level is enabled
+                            # to save some CPU cycles when it's not.
+
+                            # Workaround to fix issue with logging non utf-8 characters. We simply
+                            # ignore non utf-8 characters.
+                            body_str_raw = body_str_raw.decode("utf-8", "ignore")
+
+                            if len(body_str_raw) > MAX_REQUEST_BODY_SIZE_LOG_MSG_LIMIT:
+                                # We truncate long messages to avoid filling up the debug log too
+                                # fast and to avoid increased memory usage under Python 2.7.
+                                body_str_raw = body_str_raw[
+                                    :MAX_REQUEST_BODY_SIZE_LOG_MSG_LIMIT
+                                ]
+                                body_str_raw += (
+                                    " ... [body truncated to %s chars] ..."
+                                    % (MAX_REQUEST_BODY_SIZE_LOG_MSG_LIMIT)
+                                )
+
+                            log.log(
+                                scalyr_logging.DEBUG_LEVEL_5,
+                                'Sending POST %s with body "%s"',
+                                request_path,
+                                body_str_raw,
+                            )
                         self.__connection.post(request_path, body=body_str)
                     else:
                         log.log(


### PR DESCRIPTION
This pull request fixes increased memory usage under Python 2.7 we observed recently on our CodeSpeed instance.

## Background

A week or so ago after setting up CodeSpeed instance, we observed increased memory usage of the agent benchmark which runs loaded agent under Python 2.7. The issue didn't appear when running the agent under Python 3 or when running idle configuration (aka agent doesn't monitor any log files).

![Screenshot from 2020-02-23 20-35-58](https://user-images.githubusercontent.com/125088/75118644-24b50d00-567c-11ea-95d7-de162b2ad9ba.png)

To put things into context - benchmarks which run under Python 3 show a couple of MB more memory usage compared to Python 2.7 pre-Python 3 changes, but that's expected and nothing to worry about. The problematic one was Python 2.7 where memory usage almost doubled (from around 30 MB to around 60 MB).

We originally thought it may be something related to unicode changes (under Python 2.7 unicode values take more memory even if they don't contain any unicode values), but after a lot of digging in, it turned out the problem lies elsewhere.

The PR which introduced this issue / regression is #393.

It turns out that for some (to me still unknown) reason, logging messages which contain very large unicode values result in increased memory usage.

I confirmed this is indeed the issue by testing various changes / combinations:

1) I decreased log level verbosity from 5 to lower level so that request body message is not logged
2) I commented out that log line
3) I tested the change from this PR

Here is now one of the builds in question:

* Python 2.7 - https://app.circleci.com/jobs/github/scalyr/scalyr-agent-2/19584/parallel-runs/0/steps/0-104
* Python 3.5 - https://app.circleci.com/jobs/github/scalyr/scalyr-agent-2/19579/parallel-runs/0/steps/0-104

As you can see, the memory usage is now more or less the same in both versions.

Things now also finally add up - there was no memory usage increase observed when running agent in the idle configuration because we don't log any large messages there and the issue didn't show up in the "release" branch because that branch doesn't contain change from #393.

## Proposed Implementation / Fix

This change updates the logging code so we truncate the message if the request body is longer than 1024 characters.

In addition to that, I also updated the code so we only manipulate raw body string and truncate it if debug log level is set.

In theory, this is not necessary since truncating the string itself and calling ``log.log`` has very small performance overhead when that log level is not enabled (strings are interpolated lazily when log message is formatted), but just in case.

In future / if needed, we could perhaps add another setting where large messages are preserved as is. This may come handy under some debugging / troubleshooting scenarios where increased memory usage is not a big deal.

## Conclusion

Even though it took quite a lot of digging in, CodeSpeed changes were well worth it since they uncovered first real world issue / regression (in addition to many other things they uncovered while I was hooking it up).

---

This issue does bring up another question though - right now we (intentionally) run all the agent benchmarks with debug log level 5 enabled (so we get access to more information which may help with troubleshooting during those runs).

This configuration doesn't represent real-world production deployment where debug level is disabled by default though.

Ideally, we would also run all the existing benchmarks with debug log level disabled as well. The problem is that this would add another 4 Circle CI builders and ~10 minutes to each build run (and now with benchmarking and packaging Circle CI changes we already have many builders).

This may or may not be an issue depending on how often we run them (right now we run benchmarks with debug configuration on every merge / push to master and we could perhaps configure it to run benchmarks with debug log level disabled every week on master branch / similar).

In theory, enabling debug log level should result in additional log messages being logged, etc. so if we don't see any increased resource consumption under debug level, we shouldn't see that under production configuration either, but that's not always 100% correct.

## TODO

- [x] Tests