### PR TITLE
Add memory profiler

### DIFF
--- a/lint-configs/python/mypy.ini
+++ b/lint-configs/python/mypy.ini
@@ -48,6 +48,9 @@ ignore_missing_imports = True
 [mypy-yappi]
 ignore_missing_imports = True
 
+[mypy-pympler]
+ignore_missing_imports = True
+
 [mypy-sha]
 ignore_missing_imports = True
 

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -72,7 +72,7 @@ scalyr_logging.set_log_destination(use_stdout=True)
 
 from optparse import OptionParser
 
-from scalyr_agent.profiler import Profiler
+from scalyr_agent.profiler import ScalyrProfiler
 from scalyr_agent.scalyr_client import ScalyrClientSession
 from scalyr_agent.copying_manager import CopyingManager
 from scalyr_agent.configuration import Configuration
@@ -961,7 +961,7 @@ class ScalyrAgent(object):
 
                 prev_server = scalyr_server
 
-                profiler = Profiler(self.__config)
+                profiler = ScalyrProfiler(self.__config)
 
                 while not self.__run_state.sleep_but_awaken_if_stopped(
                     config_change_check_interval

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -244,7 +244,7 @@ class Configuration(object):
                     parser="scalyrAgentProfiling",
                 )
                 self.__verify_log_entry_and_set_defaults(
-                    profile_config, description="profile log config"
+                    profile_config, description="CPU profile log config"
                 )
                 self.__log_configs.append(profile_config)
 
@@ -489,6 +489,10 @@ class Configuration(object):
     @property
     def profile_log_name(self):
         return self.__get_config().get_string("profile_log_name")
+
+    @property
+    def memory_profile_log_name(self):
+        return self.__get_config().get_string("memory_profile_log_name")
 
     @property
     def disable_logfile_addevents_format(self):
@@ -1926,6 +1930,14 @@ class Configuration(object):
             config,
             "profile_log_name",
             "agent.callgrind",
+            description,
+            apply_defaults,
+            env_aware=True,
+        )
+        self.__verify_or_set_optional_string(
+            config,
+            "memory_profile_log_name",
+            "agent.meminfo",
             description,
             apply_defaults,
             env_aware=True,

--- a/scalyr_agent/profiler.py
+++ b/scalyr_agent/profiler.py
@@ -324,6 +324,7 @@ class PeriodicMemorySummaryCaptureThread(StoppableThread):
 
         # 1. Capture aggregate values
         all_objects = muppy.get_objects()
+        all_objects = self._filter_muppy_objects(all_objects)
         sum1 = summary.summarize(all_objects)
         data = summary.format_(sum1, limit=50)
 
@@ -342,6 +343,22 @@ class PeriodicMemorySummaryCaptureThread(StoppableThread):
             "type": "diff",
         }
         self._profiling_data.append(item)
+
+    def _filter_muppy_objects(self, all_objects):
+        """
+        Remove and filter out objects from the muppy all objects list which we don't want to include
+        in the memory profiling data.
+
+        Currently we exclude ourselves to reduce the "observer effect".
+        """
+        result = []
+        for item in all_objects:
+            if isinstance(item, dict) and "_profiling_data" in item:
+                continue
+            elif isinstance(item, PeriodicMemorySummaryCaptureThread):
+                continue
+            result.append(item)
+        return result
 
 
 class MemoryProfiler(BaseProfiler):

--- a/scalyr_agent/tests/test_memory_leaks.py
+++ b/scalyr_agent/tests/test_memory_leaks.py
@@ -66,7 +66,7 @@ class MemoryLeaksTestCase(unittest.TestCase):
         )
 
         # New config object is created
-        for index in range(0, 100):
+        for index in range(0, 50):
             config = Configuration(
                 file_path=config_path, default_paths=default_paths, logger=None
             )
@@ -77,13 +77,13 @@ class MemoryLeaksTestCase(unittest.TestCase):
         config = Configuration(
             file_path=config_path, default_paths=default_paths, logger=None
         )
-        for index in range(0, 100):
+        for index in range(0, 50):
             config.parse()
             self.assertNoNewGarbage()
 
     def test_stopptable_thread_init_memory_leak(self):
         # There was a bug with StoppableThread constructor having a cycle
-        for index in range(0, 100):
+        for index in range(0, 50):
             thread = StoppableThread(name="test1")
             self.assertTrue(thread)
             self.assertNoNewGarbage()
@@ -92,7 +92,7 @@ class MemoryLeaksTestCase(unittest.TestCase):
         content = {"foo": "bar", "a": 2, "b": [1, 2, 3]}
 
         # New object
-        for index in range(0, 100):
+        for index in range(0, 50):
             json_object = JsonObject(content=content)
             dict_value = json_object.to_dict()
             self.assertEqual(content, dict_value)
@@ -102,7 +102,7 @@ class MemoryLeaksTestCase(unittest.TestCase):
         # Existing object
         json_object = JsonObject(content=content)
 
-        for index in range(0, 100):
+        for index in range(0, 50):
             dict_value = json_object.to_dict()
             self.assertEqual(content, dict_value)
             self.assertNoNewGarbage()

--- a/scalyr_agent/third_party/tcollector/tcollector.py
+++ b/scalyr_agent/third_party/tcollector/tcollector.py
@@ -232,7 +232,10 @@ class Collector(object):
           cut_off: A UNIX timestamp.  Any value that's older than this will be
             removed from the cache.
         """
-        for key in self.values.keys():
+        # NOTE: It's important we create copy of keys because otherwise we will be changing
+        # dictionary during iteration which throws under Python 3
+        keys = list(self.values.keys())
+        for key in keys:
             time = self.values[key][3]
             if time < cut_off:
                 del self.values[key]
@@ -323,7 +326,11 @@ class ReaderThread(threading.Thread):
             if now - lastevict_time > self.evictinterval:
                 lastevict_time = now
                 now -= self.evictinterval
-                for col in all_collectors():
+
+                # NOTE: It's important we create copy of keys because otherwise we will be changing
+                # dictionary during iteration which throws under Python 3
+                all_collectors_ = list(all_collectors())
+                for col in all_collectors_:
                     col.evict_old_keys(now)
 
             # and here is the loop that we really should get rid of, this

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -1096,6 +1096,13 @@ class StoppableThread(threading.Thread):
         """
         pass
 
+    def is_running(self):
+        # type: () -> bool
+        """
+        Return True if this thread is running.
+        """
+        return self._run_state.is_running()
+
     def stop(self, wait_on_join=True, join_timeout=5):
         """Stops the thread from running.
 


### PR DESCRIPTION
This pull request adds memory profiler which is based on the pympler library (https://pythonhosted.org/Pympler/).

I followed the existing Profiler abstraction and made it "pluggable" so we now have two types of profilers - CPU profiler and Memory profiler.

To avoid introducing more configuration options (we already have many), I decided to use existing configuration options which are already used for the CPU profiler (enable_profiling, profile_duration_minutes, max_profile_interval_minutes, etc.).

In the future, if we want more flexibility (e.g. different profiling duration and interval for CPU and memory profiler) we can introduce additional configuration options for the memory profiler.

Memory profiling data is written to ``<data dir>/agent.meminfo`` file. Here is the example output - https://gist.github.com/Kami/f746f7fdad98842e3c721f9493e142ca.

 Right now that file is just written to disk and it's not yet consumed by the agent. Initially we can probably just consume it raw / as is without writing a custom parser for it since the output is mostly line oriented anyway.