### PR TITLE
Improve error handling in Circle CI usage data script

### DIFF
--- a/scripts/circleci_usage_data.py
+++ b/scripts/circleci_usage_data.py
@@ -33,6 +33,7 @@ if False:
 import sys
 import argparse
 import datetime
+import json
 
 from io import StringIO
 
@@ -128,7 +129,17 @@ def get_usage_data_for_branch(
     if response.status_code == 404:
         raise ValueError("Invalid CIRCLE_CI_API_TOKEN or project_slug")
 
-    items = response.json().get("items", [])
+    try:
+        data = response.json()
+    except json.decoder.JSONDecodeError as e:
+        # This likely indicates issue with Circle CI returning invalid response
+        print(
+            "Failed to parse Circle CI response as json: %s. Got response: %s"
+            % (str(e), str(response.text))
+        )
+        sys.exit(1)
+
+    items = data.get("items", [])
     items = [item for item in items if (status == "all" or item["status"] == status)]
 
     if not items:


### PR DESCRIPTION
I noticed that usage cron job failed during the weekend (https://app.circleci.com/jobs/github/scalyr/scalyr-agent-2/19507/parallel-runs/0/steps/0-102) so I decided to add a bit more logging to the script.

I'm almost positive that the failure is related to a (temporary) issue with the Circle CI API, but it still doesn't hurt to have better logging in such scenarios.