### PR TITLE
Fix six import in config_main.py

### DIFF
--- a/scalyr_agent/config_main.py
+++ b/scalyr_agent/config_main.py
@@ -37,7 +37,6 @@ import tempfile
 import traceback
 from io import open
 
-import six
 from distutils import spawn
 from optparse import OptionParser
 
@@ -59,6 +58,7 @@ scalyr_init()
 # [start of 2->TODO]
 # Check for suitability.
 # Important. Import six as any other dependency from "third_party" libraries after "__scalyr__.scalyr_init"
+import six
 from six.moves import input
 import six.moves.urllib.request
 import six.moves.urllib.parse


### PR DESCRIPTION
This pull request fixes an issue with system wide six library being used instead of the one we bundle with the package.

The reason for that was that we imported six before calling ``scalyr_init()`` which set ups ``PYTHONPATH`` and adds ``third_party/`` directory for it.

---

Catching such issues with tests is a bit hard since we would need to cover many different environments and it still wouldn't cover everything.

To avoid such issues in the future, I would recommend writing a lint / check script which checks all the Python files and fails with an error if any of the bundled library is imported anywhere before ``scalyr_init()`` is called.

I think it would be sufficient to just check the file header aka the top global part with imports.