### PR TITLE
pylint plugin for checking / enforcing ordering of bundled third party module imports

### DIFF
--- a/lint-configs/python/mypy.ini
+++ b/lint-configs/python/mypy.ini
@@ -104,3 +104,6 @@ ignore_missing_imports = True
 
 [mypy-pylint.*]
 ignore_missing_imports = True
+
+[mypy-astroid.*]
+ignore_missing_imports = True

--- a/lint-configs/python/mypy.ini
+++ b/lint-configs/python/mypy.ini
@@ -101,3 +101,6 @@ ignore_missing_imports = True
 
 [mypy-lib2to3.*]
 ignore_missing_imports = True
+
+[mypy-pylint.*]
+ignore_missing_imports = True

--- a/pylint_plugins/bundled_imports_checker.py
+++ b/pylint_plugins/bundled_imports_checker.py
@@ -194,7 +194,7 @@ def get_third_party_package_module_names():
     def is_python_module(directory_path, file_path):
         # type: (str, str) -> Tuple[bool, Optional[str]]
         """
-        Return package name if the provided file path is a Python package, None otherwise.
+        Return module name if the provided file path is a Python module, None otherwise.
         """
         if (
             os.path.isfile(file_path)

--- a/pylint_plugins/bundled_imports_checker.py
+++ b/pylint_plugins/bundled_imports_checker.py
@@ -1,0 +1,182 @@
+# Copyright 2019 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+pylint checker plugin which verifies that any import for a 3rd party bundled module (modules in
+scalyr_agent/third_party* directory) comes after "scalyr_init()" function call.
+
+This is important, because if module is imported before "scalyr_init()" function call it means it
+may use system version of that module instead of bundled version.
+
+NOTE: Currently this plugin is limited to only checking main entry point files since it doesn't
+implement cross file tracking (e.g. file A calls scalyr_init() and imports file B which then imports
+some bundled module).
+"""
+
+from __future__ import absolute_import
+
+if False:
+    from typing import List
+
+import os
+
+from collections import defaultdict
+
+from pylint.checkers import BaseChecker
+from pylint.interfaces import IAstroidChecker
+
+BASE_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.abspath(os.path.join(BASE_DIR, "../"))
+
+THIRD_PARTY_DIRECTORIES = [
+    os.path.join(BASE_DIR, "scalyr_agent/third_party"),
+    os.path.join(BASE_DIR, "scalyr_agent/third_party_tls"),
+    os.path.join(BASE_DIR, "scalyr_agent/third_party_python2"),
+]
+
+
+class ThirdPartyBundledImportOrderChecker(BaseChecker):
+    __implements__ = IAstroidChecker
+
+    name = "scalyr-bundled-imports-checker"
+
+    SCALYR_INIT_CALL_NOT_FOUND = "scalyr-init-call-not-found"
+    INVALID_BUNDLED_IMPORT_ORDER = "bundled-import-after-scalyr-init"
+
+    msgs = {
+        "E8001": (
+            'Found import "%s" on line %d, but no scalyr_init() line found.',
+            SCALYR_INIT_CALL_NOT_FOUND,
+            "",
+        ),
+        "E8002": (
+            'Import "%s" is on line %s, but it should come after scalyr_init() function call which is on line %s.',
+            INVALID_BUNDLED_IMPORT_ORDER,
+            "",
+        ),
+    }
+
+    options = ()
+    priority = -1
+
+    def __init__(self, linter):
+        super(ThirdPartyBundledImportOrderChecker, self).__init__(linter)
+
+        self._third_party_module_names = get_third_party_package_module_names()
+
+        # Stores reference to the node where scalyr_init is called
+        # Maps file_path -> node
+        self._scalyr_init_nodes = {}
+
+        # Stores references to imoort nodes which refer to 3rd party modules
+        # Maps file_path -> nodes
+        self._third_party_import_nodes = defaultdict(set)
+
+    def visit_call(self, node):
+        if getattr(node.func, "name", None) == "scalyr_init":
+            # TODO: Handle case where there are multiple scalyr_init calls - just store reference
+            # to the earliest one (aka one with lowest line number)
+            node_file_path = self._get_file_path_for_node(node=node)
+            node.file_path = node_file_path
+            self._scalyr_init_nodes[node_file_path] = node
+
+    def visit_import(self, node):
+        name = node.names[0][0]
+
+        if name in self._third_party_module_names:
+            node.name = name
+            node_file_path = self._get_file_path_for_node(node=node)
+            self._third_party_import_nodes[node_file_path].add(node)
+
+    def visit_importfrom(self, node):
+        if node.modname in self._third_party_module_names:
+            node.name = node.modname
+            node_file_path = self._get_file_path_for_node(node=node)
+            self._third_party_import_nodes[node_file_path].add(node)
+
+    def leave_module(self, node):
+        """
+        We perform the actual check just before we leave the module since that's when the file has
+        been fully processed.
+        """
+        node_file_path = self._get_file_path_for_node(node=node)
+
+        third_party_nodes = self._third_party_import_nodes.get(node_file_path, [])
+        scalyr_init_node = self._scalyr_init_nodes.get(node_file_path, None)
+
+        for import_node in third_party_nodes:
+            self._verify_import_node_comes_after_scalyr_init(
+                scalyr_init_node=scalyr_init_node, import_node=import_node
+            )
+
+    def _verify_import_node_comes_after_scalyr_init(
+        self, scalyr_init_node, import_node
+    ):
+        """
+        Verify any import which references a bundled third party module comes after scalyr_init()
+        call.
+        """
+        if not scalyr_init_node:
+            # TODO: Implement support for indirect imports. Currently we only check files which
+            # contain "scalyr_init()" call aka main entry points.
+            return
+            args = (import_node.name, import_node.lineno)
+            self.add_message(
+                self.SCALYR_INIT_CALL_NOT_FOUND, node=import_node, args=args
+            )
+
+        if import_node.lineno < scalyr_init_node.lineno:
+            args = (import_node.name, import_node.lineno, scalyr_init_node.lineno)
+            self.add_message(
+                self.INVALID_BUNDLED_IMPORT_ORDER, node=import_node, args=args
+            )
+            return
+
+    def _get_file_path_for_node(self, node):
+        # Recursievly walk up to the top most parent to find the file original node comes from
+        if getattr(node, "file", None):
+            return node.file
+        elif node.parent:
+            return self._get_file_path_for_node(node=node.parent)
+
+        return None
+
+
+def get_third_party_package_module_names():
+    # type: () -> List[str]
+    """
+    Return a list of bundled 3rd party package and module names.
+    """
+    result = []
+    for directory_path in THIRD_PARTY_DIRECTORIES:
+        file_names = os.listdir(directory_path)
+
+        for file_name in file_names:
+            file_path = os.path.join(directory_path, file_name)
+            init_file_path = os.path.join(file_path, "__init__.py")
+
+            if os.path.isdir(file_path) and os.path.isfile(init_file_path):
+                result.append(file_name)
+            elif (
+                os.path.isfile(file_path)
+                and file_path.endswith(".py")
+                and file_name != "__init__.py"
+            ):
+                result.append(file_name.replace(".py", ""))
+
+    return result
+
+
+def register(linter):
+    linter.register_checker(ThirdPartyBundledImportOrderChecker(linter))

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ setenv =
   LINT_FILES_TO_CHECK=*.py scripts/*.py benchmarks/scripts/*.py .circleci/*.py .circleci/modernize/ scalyr_agent/
   # Which Python binary to use for various lint targets
   LINT_PYTHON_BINARY={env:LINT_PYTHON_BINARY:python3.6}
+  PYTHONPATH={toxinidir}
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps =
     -r dev-requirements.txt
@@ -52,7 +53,7 @@ commands =
     bash -c 'black --check --config pyproject.toml {env:LINT_FILES_TO_CHECK}'
     python .circleci/modernize/modernize.py -j 2
     bash -c 'flake8 --config lint-configs/python/.flake8 {env:LINT_FILES_TO_CHECK}'
-    bash -c 'pylint -E --rcfile=./lint-configs/python/.pylintrc {env:LINT_FILES_TO_CHECK}'
+    bash -c 'pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins pylint_plugins.bundled_imports_checker {env:LINT_FILES_TO_CHECK}'
     bash -c 'mypy --pretty --no-incremental --config-file ./lint-configs/python/mypy.ini {env:LINT_FILES_TO_CHECK}'
 
 [testenv:black]
@@ -89,7 +90,7 @@ deps =
     -r lint-requirements.txt
     -r benchmarks/scripts/requirements.txt
 commands =
-    bash -c 'pylint -E --rcfile=./lint-configs/python/.pylintrc {env:LINT_FILES_TO_CHECK}'
+    bash -c 'pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins pylint_plugins.bundled_imports_checker {env:LINT_FILES_TO_CHECK}'
 
 [testenv:mypy]
 basepython = {env:LINT_PYTHON_BINARY}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py{2.7}-unit-tests,coverage
+envlist = lint,py{2.7}-unit-tests
 skipsdist = true
 # NOTE: We pass the TERM env to preserve colors
 passenv = TERM XDG_CACHE_HOME

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ basepython =
     {py3.7-unit-tests}: python3.7
     {py3.8-unit-tests}: python3.8
 setenv =
-  LINT_FILES_TO_CHECK=*.py scripts/*.py benchmarks/scripts/*.py .circleci/*.py .circleci/modernize/ scalyr_agent/
+  LINT_FILES_TO_CHECK=*.py scripts/*.py benchmarks/scripts/*.py pylint_plugins/*.py .circleci/*.py .circleci/modernize/ scalyr_agent/
   # Which Python binary to use for various lint targets
   LINT_PYTHON_BINARY={env:LINT_PYTHON_BINARY:python3.6}
   PYTHONPATH={toxinidir}


### PR DESCRIPTION
This pull request adds a pylint plugin which checks for the issues like the one fixed in #429.

It works by inspecting any file which calls ``scalyr_init()`` and ensures any import of a bundled module comes after that line.

Right now it's limited to the modules which call ``scalyr_init()`` directly and doesn't support indirect imports (e.g. module A calls scalyr_init() and imports module B and module B imports a bundled import).

This means it won't catch 100% of the edge cases, but it's better than nothing (implementing indirect import tracking would be much more involved).

Here is the error message pylint / build would fail with if we ran it on commit before #429 was merged:

```bash
************* Module scalyr_agent.config_main
scalyr_agent/config_main.py:40:0: E8002: Import "six" is on line 40, but it should come after scalyr_init() function call which is on line 57. (bundled-import-after-scalyr-init)
```