### PR TITLE
Fix Python 3 related errors in the tcollectors

### DIFF
--- a/scalyr_agent/third_party/tcollector/tcollector.py
+++ b/scalyr_agent/third_party/tcollector/tcollector.py
@@ -232,10 +232,15 @@ class Collector(object):
           cut_off: A UNIX timestamp.  Any value that's older than this will be
             removed from the cache.
         """
-        for key in self.values.keys():
+        # NOTE: It's important we create copy of keys because otherwise we will be changing
+        # dictionary during iteration which throws under Python 3
+        keys = list(self.values.keys())
+        for key in keys:
             time = self.values[key][3]
             if time < cut_off:
                 del self.values[key]
+
+        del keys
 
 
 class StdinCollector(Collector):
@@ -323,7 +328,11 @@ class ReaderThread(threading.Thread):
             if now - lastevict_time > self.evictinterval:
                 lastevict_time = now
                 now -= self.evictinterval
-                for col in all_collectors():
+
+                # NOTE: It's important we create copy of keys because otherwise we will be changing
+                # dictionary during iteration which throws under Python 3
+                all_collectors_ = list(all_collectors())
+                for col in all_collectors_:
                     col.evict_old_keys(now)
 
             # and here is the loop that we really should get rid of, this


### PR DESCRIPTION
I noticed that under Python 3, tcollector throws an exception when keys are to be evicted from the cache:

```bash
  File "/home/kami/.pythonz/pythons/CPython-3.6.9/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/home/kami/w/scalyr/scalyr-agent-2/scalyr_agent/third_party/tcollector/tcollector.py", line 327, in run
    col.evict_old_keys(now)
  File "/home/kami/w/scalyr/scalyr-agent-2/scalyr_agent/third_party/tcollector/tcollector.py", line 235, in evict_old_keys
    for key in self.values.keys():
RuntimeError: dictionary changed size during iteration
```

The issue is related to ``dict.keys()`` method in Python 3 returning a dictionary view object and not a simple list, which shouldn't be changed during the iterator.

To work around that, we create a simple list version of the ``keys()`` return value.