### PR TITLE
Fix memory leak in the Configuration.parse() method (aka Configuration object)

### DIFF
--- a/lint-configs/python/mypy.ini
+++ b/lint-configs/python/mypy.ini
@@ -101,3 +101,6 @@ ignore_missing_imports = True
 
 [mypy-lib2to3.*]
 ignore_missing_imports = True
+
+[mypy-pytest.*]
+ignore_missing_imports = True

--- a/scalyr_agent/json_lib/objects.py
+++ b/scalyr_agent/json_lib/objects.py
@@ -171,23 +171,7 @@ class JsonObject(object):
         :return: The dict version of this JSON object.
         :rtype: dict
         """
-
-        def _convert_to_builtin_type(value):
-            value_type = type(value)
-            if value_type == JsonObject or value_type == dict:
-                result = dict()
-                for key, value in six.iteritems(value):
-                    result[key] = _convert_to_builtin_type(value)
-                return result
-            elif value_type == JsonArray or value_type == list:
-                result = []
-                for x in value:
-                    result.append(_convert_to_builtin_type(x))
-                return result
-            else:
-                return value
-
-        return _convert_to_builtin_type(self)
+        return convert_to_builtin_type(self)
 
     def get(self, field, default_value=None, none_if_missing=False):
         """Returns the specified field without any conversion.
@@ -700,3 +684,22 @@ class ArrayOfStrings(JsonArray):
 
 class SpaceAndCommaSeparatedArrayOfStrings(ArrayOfStrings):
     separators = [None, ","]  # type: List[Any]
+
+
+def convert_to_builtin_type(value):
+    """
+    Convert the provided JSON value for the native / builtin Python type.
+    """
+    value_type = type(value)
+    if value_type == JsonObject or value_type == dict:
+        result = dict()
+        for key, value in six.iteritems(value):
+            result[key] = convert_to_builtin_type(value)
+        return result
+    elif value_type == JsonArray or value_type == list:
+        result = []
+        for x in value:
+            result.append(convert_to_builtin_type(x))
+        return result
+    else:
+        return value

--- a/scalyr_agent/tests/fixtures/configs/agent2.json
+++ b/scalyr_agent/tests/fixtures/configs/agent2.json
@@ -1,0 +1,12 @@
+{
+  api_key: "foobar"
+  scalyr_server: "agent.scalyr.com",
+  debug_level: "5",
+
+  server_attributes: {
+     serverHost: "test",
+     tier: "test"
+  },
+
+  import_vars: [ "TEST_VAR" ],
+}

--- a/scalyr_agent/tests/test_memory_leaks.py
+++ b/scalyr_agent/tests/test_memory_leaks.py
@@ -1,0 +1,97 @@
+# Copyright 2014-2020 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module which adds tests for previous known memory leaks and makes sure they
+are not present anymore.
+"""
+
+from __future__ import unicode_literals
+
+from __future__ import absolute_import
+import os
+import gc
+import unittest
+
+from scalyr_agent.configuration import Configuration
+from scalyr_agent.platform_controller import DefaultPaths
+from scalyr_agent.util import StoppableThread
+from six.moves import range
+
+BASE_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
+
+__all__ = ["MemoryLeaksTestCase"]
+
+
+class MemoryLeaksTestCase(unittest.TestCase):
+    def setUp(self):
+        super(MemoryLeaksTestCase, self).setUp()
+        gc.set_debug(gc.DEBUG_SAVEALL)
+
+        os.environ["TEST_VAR"] = "foobar"
+
+        # There are always some uncollectable objects which are part of the runners which we
+        # are not interested in.
+        gc.collect()
+        self.base_gargage = self._garbage_to_set(gc.garbage)
+
+    def test_config_parse_memory_leak(self):
+        # There was a memory leak with config.parse() and underlying __perform_substitutions method
+        config_path = os.path.join(BASE_DIR, "fixtures/configs/agent2.json")
+        default_paths = DefaultPaths(
+            "/var/log/scalyr-agent-2",
+            "/etc/scalyr-agent-2/agent.json",
+            "/var/lib/scalyr-agent-2",
+        )
+
+        # New config object is created
+        for index in range(0, 100):
+            config = Configuration(
+                file_path=config_path, default_paths=default_paths, logger=None
+            )
+            config.parse()
+
+            gc.collect()
+            garbage = self._garbage_to_set(gc.garbage)
+            new_garbage = garbage.difference(self.base_gargage)
+            self.assertEqual(len(new_garbage), 0)
+
+        # Existing config object is reused
+        config = Configuration(
+            file_path=config_path, default_paths=default_paths, logger=None
+        )
+        for index in range(0, 100):
+            config.parse()
+
+            gc.collect()
+            garbage = self._garbage_to_set(gc.garbage)
+            new_garbage = garbage.difference(self.base_gargage)
+            self.assertEqual(len(new_garbage), 0)
+
+    def test_stopptable_thread_init_memory_leaks(self):
+        # There was a bug with StoppableThread constructor having a cycle
+        for index in range(0, 100):
+            thread = StoppableThread(name="test1")
+            self.assertTrue(thread)
+
+            gc.collect()
+            garbage = self._garbage_to_set(gc.garbage)
+            new_garbage = garbage.difference(self.base_gargage)
+            self.assertEqual(len(new_garbage), 0)
+
+    def _garbage_to_set(self, garbage):
+        """
+        Return set with serializable gargage data.
+        """
+        return set([str(obj) for obj in garbage])

--- a/scalyr_agent/tests/test_memory_leaks.py
+++ b/scalyr_agent/tests/test_memory_leaks.py
@@ -24,7 +24,6 @@ import os
 import gc
 import unittest
 
-import six
 import pytest
 
 from scalyr_agent.configuration import Configuration
@@ -39,8 +38,7 @@ __all__ = ["MemoryLeaksTestCase"]
 
 # By default all the tests run inside a single process so we mark this test and run it separately
 # since we don't want other tests to affect behavior of this test.
-@pytest.mark.memory_leak_test
-@unittest.skipIf(six.PY2, "Skipping tests under Python 2")
+@pytest.mark.memory_leak
 class MemoryLeaksTestCase(unittest.TestCase):
     def setUp(self):
         super(MemoryLeaksTestCase, self).setUp()

--- a/scalyr_agent/tests/test_memory_leaks.py
+++ b/scalyr_agent/tests/test_memory_leaks.py
@@ -18,11 +18,14 @@ are not present anymore.
 """
 
 from __future__ import unicode_literals
-
 from __future__ import absolute_import
+
 import os
 import gc
 import unittest
+
+import six
+import pytest
 
 from scalyr_agent.configuration import Configuration
 from scalyr_agent.platform_controller import DefaultPaths
@@ -34,6 +37,10 @@ BASE_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
 __all__ = ["MemoryLeaksTestCase"]
 
 
+# By default all the tests run inside a single process so we mark this test and run it separately
+# since we don't want other tests to affect behavior of this test.
+@pytest.mark.memory_leak_test
+@unittest.skipIf(six.PY2, "Skipping tests under Python 2")
 class MemoryLeaksTestCase(unittest.TestCase):
     def setUp(self):
         super(MemoryLeaksTestCase, self).setUp()

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -1042,6 +1042,7 @@ class StoppableThread(threading.Thread):
         # NOTE: We explicitly don't pass target= argument to the parent constructor since this
         # creates a cycle and a memory leak
         threading.Thread.__init__(self, name=name)
+
         if is_daemon:
             self.setDaemon(True)
         self.__target = target
@@ -1073,6 +1074,15 @@ class StoppableThread(threading.Thread):
             return StoppableThread.__name_prefix
         finally:
             StoppableThread.__name_lock.release()
+
+    def run(self):
+        """
+        NOTE: This is a workaround for using threading.Thread constructor target argument which
+        results in a cycle and a memory leak.
+
+        See https://bugs.python.org/issue704180 for details.
+        """
+        return self.__run_impl()
 
     def __run_impl(self):
         """Internal run implementation.

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -1039,7 +1039,9 @@ class StoppableThread(threading.Thread):
                 name = "%s%s" % (name_prefix, name)
             else:
                 name = name_prefix
-        threading.Thread.__init__(self, name=name, target=self.__run_impl)
+        # NOTE: We explicitly don't pass target= argument to the parent constructor since this
+        # creates a cycle and a memory leak
+        threading.Thread.__init__(self, name=name)
         if is_daemon:
             self.setDaemon(True)
         self.__target = target

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,5 @@ filterwarnings =
     # Ignore varios warnings about assertion methods being deprecated
     ignore:.*use.*instead.*:DeprecationWarning
     ignore:.*use.*instead.*:PendingDeprecationWarning
+markers =
+    memory_leak: marks tests which test memory leaks and should be run in isolation

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,10 @@ whitelist_externals =
     rm
     bash
 commands =
-    py.test -vv --durations=5
+    py.test -vv --durations=5 -m "not memory_leak_test"
+    # NOTE: We run memory leak tests separately so they run in a separate
+    # process and are isolated from other tests
+    py.test -vv --durations=5 -m "memory_leak_test"
 
 # NOTE: Older version of tox which still supports Python 2.6 doesn't support installing
 # requirements from a file so we need to declare them inline
@@ -35,7 +38,7 @@ basepython = python2.6
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps = -rpy26-unit-tests-requirements.txt
 commands =
-    py.test -vv --durations=5
+    py.test -vv --durations=5 -m "not memory_leak_test"
 
 # Lint target which runs all the linting tools such as black, modernize, pylint, flake8, mypy, etc.
 # NOTE: We use bash -c since we don't want tox to quote all the arguments, we want globs to

--- a/tox.ini
+++ b/tox.ini
@@ -107,4 +107,4 @@ commands =
 [testenv:coverage]
 commands =
     rm -f .coverage
-    py.test --cov=scalyr_agent/ --cov=tests/
+    py.test  -m "not memory_leak" --cov=scalyr_agent/ --cov=tests/

--- a/tox.ini
+++ b/tox.ini
@@ -23,10 +23,10 @@ whitelist_externals =
     rm
     bash
 commands =
-    py.test -vv --durations=5 -m "not memory_leak_test"
     # NOTE: We run memory leak tests separately so they run in a separate
     # process and are isolated from other tests
-    py.test -vv --durations=5 -m "memory_leak_test"
+    py.test -vv --durations=5 -m "not memory_leak"
+    py.test -vv --durations=5 scalyr_agent/tests/test_memory_leaks.py
 
 # NOTE: Older version of tox which still supports Python 2.6 doesn't support installing
 # requirements from a file so we need to declare them inline
@@ -38,7 +38,7 @@ basepython = python2.6
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps = -rpy26-unit-tests-requirements.txt
 commands =
-    py.test -vv --durations=5 -m "not memory_leak_test"
+    py.test -vv --durations=5 -m "not memory_leak"
 
 # Lint target which runs all the linting tools such as black, modernize, pylint, flake8, mypy, etc.
 # NOTE: We use bash -c since we don't want tox to quote all the arguments, we want globs to


### PR DESCRIPTION
This pull request fixes memory leak in the ``Configuration.parse()`` method.

---

I was tracking down memory leak in the agent and with various memory and GC instrumentation I got pointers to the agent main loop.

Each time the agent main loop ran and config was reloaded / re-read from disk, number of unreachable objects which can't be collected increased.

I confirmed that's indeed the root cause by adding ``continue`` statement to the main loop before ``self.__verify_config`` method call. With that continue statement in place, number of uncollectable objects stayed constant and didn't increase after each agent main loop run.

After diving in further, I found a memory leak inside ``Configuration.parse()`` method, more specifically, ``__perform_substitutions`` method which is called by ``parse()``.

Those inner functions defined inside ``__perform_substitution`` closure hold reference to the JsonObject config variable and vice versa so they were never released and garage collected.

Here is a simple script I used to verify verify the memory leak and then verify the fix - https://gist.github.com/Kami/bc3c89c4d5d866bfc4d64dd8835d7212

Before the fix:

```bash
$ SCALYR_AGEN_KEY=a python test_memory_leak.py 
Iteration: 1
Unreachable objects: 26

Iteration: 2
Unreachable objects: 52

Iteration: 3
Unreachable objects: 78

Iteration: 4
Unreachable objects: 104

Iteration: 5
Unreachable objects: 130

Iteration: 6
Unreachable objects: 156

Iteration: 7
Unreachable objects: 182

Iteration: 8
Unreachable objects: 208

Iteration: 9
Unreachable objects: 234

Iteration: 10
Unreachable objects: 260
```

To avoid the very large code block, here is the whole output with listed unreachable objects - https://gist.github.com/Kami/6fa4cb07f19a21ff7fde79a5e1d0e06b

After the fix:

```bash
$ SCALYR_AGEN_KEY=a python test_memory_leak.py 
Iteration: 1
Unreachable objects: 0
Unreachable objects:

[]

Iteration: 2
Unreachable objects: 0
Unreachable objects:

[]

Iteration: 3
Unreachable objects: 0
Unreachable objects:

[]

Iteration: 4
Unreachable objects: 0
Unreachable objects:

[]

Iteration: 5
Unreachable objects: 0
Unreachable objects:

[]

Iteration: 6
Unreachable objects: 0
Unreachable objects:

[]

Iteration: 7
Unreachable objects: 0
Unreachable objects:

[]

Iteration: 8
Unreachable objects: 0
Unreachable objects:

[]

Iteration: 9
Unreachable objects: 0
Unreachable objects:

[]

Iteration: 10
Unreachable objects: 0
Unreachable objects:

[]
```

---

The fix I implemented is to define those functions outside the closure inside the module level scope. This way they don't need to be re-defined on each ``__perform_substitution`` method call so we 
avoid the memory leak.