### PR TITLE
Fix string issue when building Windows package

### DIFF
--- a/build_package.py
+++ b/build_package.py
@@ -51,6 +51,8 @@ from scalyr_agent.__scalyr__ import get_install_root, SCALYR_VERSION, scalyr_ini
 
 scalyr_init()
 
+import scalyr_agent.util as scalyr_util
+
 # [start of 2->TODO]
 # Check for suitability.
 # Important. Import six as any other dependency from "third_party" libraries after "__scalyr__.scalyr_init"
@@ -317,10 +319,10 @@ def build_win32_installer_package(variant, version):
         variant = "main"
 
     # Generate a unique identifier used to identify this version of the Scalyr Agent to windows.
-    product_code = uuid.uuid3(_scalyr_guid_, "ProductID:%s:%s" % (variant, version))
+    product_code = create_scalyr_uuid3("ProductID:%s:%s" % (variant, version))
     # The upgrade code identifies all families of versions that can be upgraded from one to the other.  So, this
     # should be a single number for all Scalyr produced ones.
-    upgrade_code = uuid.uuid3(_scalyr_guid_, "UpgradeCode:%s" % variant)
+    upgrade_code = create_scalyr_uuid3("UpgradeCode:%s" % variant)
 
     # For prereleases, we use weird version numbers like 4.0.4.pre5.1 .  That does not work for Windows which
     # requires X.X.X.X.  So, we convert if necessary.
@@ -385,7 +387,7 @@ def create_wxs_file(template_path, dist_path, destination_path):
         entry = {
             "BASE": base_file,
             "FILE_ID": file_id,
-            "COMPONENT_GUID": str(uuid.uuid3(_scalyr_guid_, "DistComp%s" % base_file)),
+            "COMPONENT_GUID": str(create_scalyr_uuid3("DistComp%s" % base_file)),
             "COMPONENT_ID": "%s_comp" % file_id,
             "FILE_SOURCE": dist_file_path,
         }
@@ -416,6 +418,18 @@ def create_wxs_file(template_path, dist_path, destination_path):
             f.write(line)
     finally:
         f.close()
+
+
+def create_scalyr_uuid3(name):
+    """
+    Create a UUID based on the Scalyr UUID namespace and a hash of `name`.
+
+    :param name: The name
+    :type name: six.text
+    :return: The UUID
+    :rtype: uuid.UUID
+    """
+    return scalyr_util.create_uuid3(_scalyr_guid_, name)
 
 
 def expand_template(input_lines, dist_files):

--- a/scalyr_agent/tests/util/util_test.py
+++ b/scalyr_agent/tests/util/util_test.py
@@ -31,6 +31,7 @@ import datetime
 import os
 import tempfile
 import threading
+import uuid
 from mock import patch, MagicMock
 import six
 
@@ -308,6 +309,13 @@ class TestUtil(ScalyrTestCase):
         self.assertTrue(len(first) > 0)
         self.assertTrue(len(second) > 0)
         self.assertNotEqual(first, second)
+
+    def test_create_uuid3(self):
+        namespace = uuid.UUID("{aaaaffff-22c7-4d50-92c1-123456781234}")
+        self.assertEqual(
+            scalyr_util.create_uuid3(namespace, "test-string"),
+            uuid.UUID("{72a49a0a-d92e-383c-a88b-2060e372e1af}"),
+        )
 
     def test_remove_newlines_and_truncate(self):
         self.assertEquals(scalyr_util.remove_newlines_and_truncate("hi", 1000), "hi")

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -390,11 +390,7 @@ def create_uuid3(namespace, name):
     :return:
     :rtype: uuid.UUID
     """
-    if six.PY2:
-        return uuid.uuid3(namespace, six.ensure_binary(name))
-    else:
-        # noinspection PyTypeChecker
-        return uuid.uuid3(namespace, six.ensure_text(name))
+    return uuid.uuid3(namespace, six.ensure_str(name))
 
 
 def md5_hexdigest(data):

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -386,11 +386,15 @@ def create_uuid3(namespace, name):
     :param namespace: The namespace
     :param name: The string
     :type namespace: uuid.UUID
-    :type name: six.text | six.binary
+    :type name: six.text
     :return:
     :rtype: uuid.UUID
     """
-    return uuid.uuid3(namespace, six.ensure_binary(name))
+    if six.PY2:
+        return uuid.uuid3(namespace, six.ensure_binary(name))
+    else:
+        # noinspection PyTypeChecker
+        return uuid.uuid3(namespace, six.ensure_text(name))
 
 
 def md5_hexdigest(data):

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -380,6 +380,19 @@ def create_unique_id():
     return base64_id.decode("utf-8")
 
 
+def create_uuid3(namespace, name):
+    """
+    Return new UUID based on a hash of a UUID namespace and a string.
+    :param namespace: The namespace
+    :param name: The string
+    :type namespace: uuid.UUID
+    :type name: six.text | six.binary
+    :return:
+    :rtype: uuid.UUID
+    """
+    return uuid.uuid3(namespace, six.ensure_binary(name))
+
+
 def md5_hexdigest(data):
     """
     Returns the md5 digest of the input data


### PR DESCRIPTION
Fixed issue related to 2->3 strings and unicode.  We were not
properly using a binary string when concat'ing it with a UUID.