### PR TITLE
Use production server for agent benchmark runs, make "server_attributes" config option environment aware

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ master_only: &master_only
     branches:
       only:
         - master
-        - benchmarks_use_prod
 
 version: 2.1
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,10 @@ commands:
         description: "Optional bash command / script to run after starting the agent and the metrics capture script."
         type: string
         default: ""
+      agent_server_host:
+        description: "Value for the server_attributes.serverHost agent configuration option."
+        type: string
+        default: "ci-codespeed-benchmarks"
       capture_line_counts:
         description: "True to submit log line counts for each log level to CodeSpeed."
         type: boolean
@@ -131,6 +135,7 @@ commands:
             RUN_TIME: << parameters.run_time >>
             CAPTURE_INTERVAL: << parameters.capture_interval >>
             AGENT_CONFIG_FILE: "<< parameters.agent_config >>"
+            SCALYR_SERVER_ATTRIBUTES="{\"serverHost\": \"<< parameters.agent_server_host>>\"}"
           command: |
             # Create directories which are needed by the agent process
             mkdir -p ~/scalyr-agent-dev/{log,config,data}
@@ -566,6 +571,7 @@ jobs:
           codespeed_executable: "Python 2.7.17 - idle conf 1"
           codespeed_environment: "Circle CI Docker Executor Medium Size"
           agent_config: "benchmarks/configs/agent_no_monitored_logs.json"
+          agent_server_host: "ci-codespeed-benchmarks-py27-idle-conf-1"
           capture_line_counts: true
           cache_key_name: "benchmarks-idle-27"
 
@@ -578,6 +584,7 @@ jobs:
           codespeed_executable: "Python 3.5.9 - idle conf 1"
           codespeed_environment: "Circle CI Docker Executor Medium Size"
           agent_config: "benchmarks/configs/agent_no_monitored_logs.json"
+          agent_server_host: "ci-codespeed-benchmarks-py35-idle-conf-1"
           capture_line_counts: true
           cache_key_name: "benchmarks-idle-35"
 
@@ -590,6 +597,7 @@ jobs:
           codespeed_executable: "Python 2.7.17 - idle conf 2"
           codespeed_environment: "Circle CI Docker Executor Medium Size"
           agent_config: "benchmarks/configs/agent_no_monitored_logs_no_monitors.json"
+          agent_server_host: "ci-codespeed-benchmarks-py27-idle-conf-2"
           capture_line_counts: true
           cache_key_name: "benchmarks-idle-agent-no-monitors-py-27"
 
@@ -602,6 +610,7 @@ jobs:
           codespeed_executable: "Python 3.5.9 - idle conf 2"
           codespeed_environment: "Circle CI Docker Executor Medium Size"
           agent_config: "benchmarks/configs/agent_no_monitored_logs_no_monitors.json"
+          agent_server_host: "ci-codespeed-benchmarks-py35-idle-conf-2"
           capture_line_counts: true
           cache_key_name: "benchmarks-idle-agent-no-monitors-py-35"
 
@@ -615,6 +624,7 @@ jobs:
           codespeed_environment: "Circle CI Docker Executor Medium Size"
           agent_config: "benchmarks/configs/agent_single_50mb_access_log_file.json"
           agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/access_log_50_mb.log"
+          agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-1"
           run_time: 140
           capture_line_counts: true
           cache_key_name: "benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27"
@@ -629,6 +639,7 @@ jobs:
           codespeed_environment: "Circle CI Docker Executor Medium Size"
           agent_config: "benchmarks/configs/agent_single_50mb_access_log_file.json"
           agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/access_log_50_mb.log"
+          agent_server_host: "ci-codespeed-benchmarks-py35-loaded-conf-1"
           run_time: 140
           capture_line_counts: true
           cache_key_name: "benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35"
@@ -648,6 +659,7 @@ jobs:
           run_time: 140
           agent_pre_run_command: "touch /tmp/random.log"
           agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 2M 10 100 1"
+          agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-2"
           capture_line_counts: true
           cache_key_name: "benchmarks-loaded-agent-growing-log-file-py-27"
 
@@ -663,6 +675,7 @@ jobs:
           run_time: 140
           agent_pre_run_command: "touch /tmp/random.log"
           agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 2M 10 100 1"
+          agent_server_host: "ci-codespeed-benchmarks-py35-loaded-conf-2"
           capture_line_counts: true
           cache_key_name: "benchmarks-loaded-agent-growing-log-file-py-35"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ master_only: &master_only
     branches:
       only:
         - master
+        - benchmarks_use_prod
 
 version: 2.1
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ commands:
             RUN_TIME: << parameters.run_time >>
             CAPTURE_INTERVAL: << parameters.capture_interval >>
             AGENT_CONFIG_FILE: "<< parameters.agent_config >>"
-            SCALYR_SERVER_ATTRIBUTES="{\"serverHost\": \"<< parameters.agent_server_host>>\"}"
+            SCALYR_SERVER_ATTRIBUTES: "{\"serverHost\": \"<< parameters.agent_server_host>>\"}"
           command: |
             # Create directories which are needed by the agent process
             mkdir -p ~/scalyr-agent-dev/{log,config,data}

--- a/benchmarks/configs/agent.d/server.json
+++ b/benchmarks/configs/agent.d/server.json
@@ -1,13 +1,8 @@
 {
   // api_key: "",  // specified via environment variable
   // NOTE: The key defined as Circle CI env variable is available in qatesting
-  scalyr_server: "app-qatesting.scalyr.com",
+  scalyr_server: "agent.scalyr.com",
   // Circle CI doesn't have access to CA bundle file so we disable certificate verification
   verify_server_certificate: false,
   debug_level: "5",
-
-  server_attributes: {
-     serverHost: "ci-codespeed-benchmarks",
-     tier: "benchmarks"
-  }
 }

--- a/benchmarks/scripts/start-agent-and-capture-metrics.sh
+++ b/benchmarks/scripts/start-agent-and-capture-metrics.sh
@@ -61,7 +61,7 @@ echo "Using COMMIT_DATE=${COMMIT_DATE} and COMMIT_ID=${COMMIT_HASH}"
 echo "Starting agent process..."
 echo "Using command line options: ${AGENT_START_COMMAND}"
 
-${AGENT_START_COMMAND} &>/dev/null &
+${AGENT_START_COMMAND} 2>&1 &
 AGENT_PROCESS_PID=$!
 
 # NOTE: We use a trap to ensure this function is always executed, even if some command in this

--- a/scalyr_agent/config_util.py
+++ b/scalyr_agent/config_util.py
@@ -196,6 +196,9 @@ def convert_config_param(field_name, value, convert_to, is_environment_variable=
 
         elif convert_to in (JsonArray, JsonObject):
             try:
+                # Special case for empty objects
+                if convert_to == JsonObject and not value:
+                    return JsonObject()
                 # Needs to be json_lib.parse since it is parsing configuration.
                 return scalyr_util.json_scalyr_config_decode(value)
             except JsonParseException:

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1195,7 +1195,7 @@ class Configuration(object):
             config, "compression_level", 9, description, apply_defaults, env_aware=True
         )
         self.__verify_or_set_optional_attributes(
-            config, "server_attributes", description, apply_defaults
+            config, "server_attributes", description, apply_defaults, env_aware=True,
         )
         self.__verify_or_set_optional_string(
             config,

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -1680,6 +1680,29 @@ class TestGetConfigFromEnv(TestConfigurationBase):
         del os.environ["SCALYR_K8S_API_URL"]
         self.assertIsNone(get_config_from_env("k8s_api_url", convert_to=six.text_type))
 
+    def test_get_empty_json_object(self):
+        os.environ["SCALYR_SERVER_ATTRIBUTES"] = ""
+        self.assertEqual(
+            JsonObject(content={}),
+            get_config_from_env("server_attributes", convert_to=JsonObject),
+        )
+
+        os.environ["SCALYR_SERVER_ATTRIBUTES"] = '{"serverHost": "foo1.example.com"}'
+        self.assertEqual(
+            JsonObject(content={"serverHost": "foo1.example.com"}),
+            get_config_from_env("server_attributes", convert_to=JsonObject),
+        )
+
+        os.environ[
+            "SCALYR_SERVER_ATTRIBUTES"
+        ] = '{"serverHost": "foo1.example.com", "tier": "foo"}'
+        self.assertEqual(
+            JsonObject(content={"serverHost": "foo1.example.com", "tier": "foo"}),
+            get_config_from_env("server_attributes", convert_to=JsonObject),
+        )
+
+        del os.environ["SCALYR_SERVER_ATTRIBUTES"]
+
 
 class FakeLogWatcher:
     def add_log_config(self, a, b):

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -1691,6 +1691,10 @@ class TestGetConfigFromEnv(TestConfigurationBase):
             get_config_from_env("server_attributes", convert_to=JsonObject),
         )
 
+        del os.environ["SCALYR_SERVER_ATTRIBUTES"]
+        self.assertEqual(
+            None, get_config_from_env("server_attributes", convert_to=JsonObject),
+        )
         os.environ["SCALYR_SERVER_ATTRIBUTES"] = '{"serverHost": "foo1.example.com"}'
         self.assertEqual(
             JsonObject(content={"serverHost": "foo1.example.com"}),
@@ -1705,7 +1709,15 @@ class TestGetConfigFromEnv(TestConfigurationBase):
             get_config_from_env("server_attributes", convert_to=JsonObject),
         )
 
-        del os.environ["SCALYR_SERVER_ATTRIBUTES"]
+        os.environ[
+            "SCALYR_SERVER_ATTRIBUTES"
+        ] = '{"serverHost": "foo1.example.com", "tier": "foo", "bar": "baz"}'
+        self.assertEqual(
+            JsonObject(
+                content={"serverHost": "foo1.example.com", "tier": "foo", "bar": "baz"}
+            ),
+            get_config_from_env("server_attributes", convert_to=JsonObject),
+        )
 
 
 class FakeLogWatcher:

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -1257,13 +1257,17 @@ class TestConfiguration(TestConfigurationBase):
         original_verify_or_set_optional_array_of_strings = (
             config._Configuration__verify_or_set_optional_array_of_strings
         )
+        original_verify_or_set_optional_attributes = (
+            config._Configuration__verify_or_set_optional_attributes
+        )
 
         @patch.object(config, "_Configuration__verify_or_set_optional_bool")
         @patch.object(config, "_Configuration__verify_or_set_optional_int")
         @patch.object(config, "_Configuration__verify_or_set_optional_float")
         @patch.object(config, "_Configuration__verify_or_set_optional_string")
         @patch.object(config, "_Configuration__verify_or_set_optional_array_of_strings")
-        def patch_and_start_test(p4, p3, p2, p1, p0):
+        @patch.object(config, "_Configuration__verify_or_set_optional_attributes")
+        def patch_and_start_test(p5, p4, p3, p2, p1, p0):
             # Decorate the Configuration.__verify_or_set_optional_xxx methods as follows:
             # 1) capture fields that are environment-aware
             # 2) allow setting of the corresponding environment variable
@@ -1294,6 +1298,10 @@ class TestConfiguration(TestConfigurationBase):
                         return original_verify_or_set_optional_array_of_strings(
                             *args, **kwargs
                         )
+                    elif field_type == JsonObject:
+                        return original_verify_or_set_optional_attributes(
+                            *args, **kwargs
+                        )
 
                 return wrapper
 
@@ -1302,6 +1310,7 @@ class TestConfiguration(TestConfigurationBase):
             p2.side_effect = capture_aware_field(float)
             p3.side_effect = capture_aware_field(six.text_type)
             p4.side_effect = capture_aware_field(ArrayOfStrings)
+            p5.side_effect = capture_aware_field(JsonObject)
 
             # Build the Configuration object tree, also populating the field_types lookup in the process
             # This first iteration does not set any environment variables
@@ -1323,6 +1332,7 @@ class TestConfiguration(TestConfigurationBase):
             FAKE_FLOAT = 1234567.89
             FAKE_STRING = six.text_type(FAKE_INT)
             FAKE_ARRAY_OF_STRINGS = ArrayOfStrings(["s1", "s2", "s3"])
+            FAKE_OBJECT = JsonObject(**{"serverHost": "foo-bar-baz.com"})
 
             for field in expected_aware_fields:
                 field_type = field_types[field]
@@ -1362,6 +1372,12 @@ class TestConfiguration(TestConfigurationBase):
                         config_obj.get_json_array(field, none_if_missing=True),
                     )
                     fake_env[field] = FAKE_ARRAY_OF_STRINGS
+                elif field_type == JsonObject:
+                    self.assertNotEquals(
+                        FAKE_OBJECT,
+                        config_obj.get_json_object(field, none_if_missing=True),
+                    )
+                    fake_env[field] = FAKE_OBJECT
 
             def fake_environment_value(field):
                 if field not in fake_env:
@@ -1375,6 +1391,8 @@ class TestConfiguration(TestConfigurationBase):
                     result = six.text_type(
                         separator.join([x for x in fake_field_val])
                     ).lower()
+                elif isinstance(fake_field_val, JsonObject):
+                    result = six.text_type(fake_field_val).replace("'", '"')
                 else:
                     result = six.text_type(fake_field_val).lower()
                 return result
@@ -1395,6 +1413,8 @@ class TestConfiguration(TestConfigurationBase):
                     value = config._Configuration__get_config().get_string(field)
                 elif field_type == ArrayOfStrings:
                     value = config._Configuration__get_config().get_json_array(field)
+                elif field_type == JsonObject:
+                    value = config._Configuration__get_config().get_json_object(field)
 
                 config_file_value = config_file_dict.get(field)
                 if field in config_file_dict:

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -1392,7 +1392,11 @@ class TestConfiguration(TestConfigurationBase):
                         separator.join([x for x in fake_field_val])
                     ).lower()
                 elif isinstance(fake_field_val, JsonObject):
-                    result = six.text_type(fake_field_val).replace("'", '"')
+                    result = (
+                        six.text_type(fake_field_val)
+                        .replace("'", '"')
+                        .replace('u"', '"')
+                    )
                 else:
                     result = six.text_type(fake_field_val).lower()
                 return result


### PR DESCRIPTION
This pull request includes a couple of related changes:

1. Update agent config which is used with benchmarks to utilize production server instead of the qa testing one.
2. Make ``server_attributes`` config option environment aware. This allows us to dynamically set this value instead of relying on config rewrites (which is what smoketests currently do)
3. Update benchmark Circle CI jobs to use unique ``server_attributes.serverHost`` for each run to make troubleshooting / debugging easier.

## TODO

- [x] ~~Update secret Circle CI environment variable so it uses prod key for account cloudtech-builds~~ - it appears that was already done by @czerwingithub 
- [x] Verify server change + scalyr_key work correctly