### PR TITLE
Add (opt-in) Garbage Collection related metrics to the agent status output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ master_only: &master_only
     branches:
       only:
         - master
+        - agent_status_gc_metrics
 
 version: 2.1
 commands:
@@ -141,6 +142,7 @@ commands:
             AGENT_CONFIG_FILE: "<< parameters.agent_config >>"
             SCALYR_SERVER_ATTRIBUTES: "{\"serverHost\": \"<< parameters.agent_server_host>>\"}"
             CAPTURE_AGENT_STATUS_METRICS: << parameters.capture_agent_status_metrics >>
+            DRY_RUN: "true"
           command: |
             # Create directories which are needed by the agent process
             mkdir -p ~/scalyr-agent-dev/{log,config,data}
@@ -742,23 +744,7 @@ workflows:
             - smoke-k8s
   benchmarks:
     jobs:
-      - benchmarks-idle-agent-py-27:
-          <<: *master_only
-      - benchmarks-idle-agent-py-35:
-          <<: *master_only
-      - benchmarks-idle-agent-no-monitors-py-27:
-          <<: *master_only
-      - benchmarks-idle-agent-no-monitors-py-35:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
-          <<: *master_only
       - benchmarks-loaded-agent-single-50mb-log-file-with-parser-gc-stats-py-27:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
           <<: *master_only
 
   weekly-circle-ci-usage-report:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ master_only: &master_only
     branches:
       only:
         - master
+        - agent_status_gc_metrics
 
 version: 2.1
 commands:
@@ -750,22 +751,6 @@ workflows:
             - smoke-k8s
   benchmarks:
     jobs:
-      - benchmarks-idle-agent-py-27:
-          <<: *master_only
-      - benchmarks-idle-agent-py-35:
-          <<: *master_only
-      - benchmarks-idle-agent-no-monitors-py-27:
-          <<: *master_only
-      - benchmarks-idle-agent-no-monitors-py-35:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
-          <<: *master_only
       - benchmarks-loaded-agent-single-50mb-log-file-with-parser-gc-stats-py-27:
           <<: *master_only
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,8 @@ commands:
             # Workaround for issue with cffi library on the system using
             # different version than the one which is bundled with the agent
             pip install --user "cffi==1.12.3"
-            pip install --user "ujson==1.35"
+            # TODO: Add another benchmark with ujson
+            # pip install --user "ujson==1.35"
       - run:
           name: Run Agent And Capture Resource Utilization
           # NOTE: The following variables are specified in the Circle CI WebUI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,7 @@ commands:
             # Workaround for issue with cffi library on the system using
             # different version than the one which is bundled with the agent
             pip install --user "cffi==1.12.3"
+            pip install --user "ujson==1.35"
       - run:
           name: Run Agent And Capture Resource Utilization
           # NOTE: The following variables are specified in the Circle CI WebUI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ commands:
             CAPTURE_INTERVAL: << parameters.capture_interval >>
             AGENT_CONFIG_FILE: "<< parameters.agent_config >>"
             SCALYR_SERVER_ATTRIBUTES: "{\"serverHost\": \"<< parameters.agent_server_host>>\"}"
-            CAPTURE_AGENT_STATUS_METRICS: << parameters.capture_agent_status_metrics >>
+            CAPTURE_AGENT_STATUS_METRICS: "<< parameters.capture_agent_status_metrics >>"
             DRY_RUN: "true"
           command: |
             # Create directories which are needed by the agent process

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,10 @@ commands:
         description: "True to submit log line counts for each log level to CodeSpeed."
         type: boolean
         default: false
+      dry_run:
+        description: "True to enable dry run which runs the benchmarks without submitting data to CodeSpeed."
+        type: boolean
+        default: false
       cache_key_name:
         description: "Circle CI cache key name"
         type: string
@@ -123,6 +127,7 @@ commands:
             # Workaround for issue with cffi library on the system using
             # different version than the one which is bundled with the agent
             pip install --user "cffi==1.12.3"
+            pip install --user "ujson==1.35"
             # TODO: Add another benchmark with ujson
             # pip install --user "ujson==1.35"
       - run:
@@ -142,8 +147,8 @@ commands:
             CAPTURE_INTERVAL: << parameters.capture_interval >>
             AGENT_CONFIG_FILE: "<< parameters.agent_config >>"
             SCALYR_SERVER_ATTRIBUTES: "{\"serverHost\": \"<< parameters.agent_server_host>>\"}"
-            CAPTURE_AGENT_STATUS_METRICS: "true"
-            DRY_RUN: "true"
+            CAPTURE_AGENT_STATUS_METRICS: "<< parameters.capture_agent_status_metrics >>"
+            DRY_RUN: "<< parameters.dry_run >>"
           command: |
             # Create directories which are needed by the agent process
             mkdir -p ~/scalyr-agent-dev/{log,config,data}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,10 @@ commands:
         description: "Value for the server_attributes.serverHost agent configuration option."
         type: string
         default: "ci-codespeed-benchmarks"
+      capture_agent_status_metrics:
+        description: "True to capture additional metrics exposed via agent status command."
+        type: boolean
+        default: false
       capture_line_counts:
         description: "True to submit log line counts for each log level to CodeSpeed."
         type: boolean
@@ -136,6 +140,7 @@ commands:
             CAPTURE_INTERVAL: << parameters.capture_interval >>
             AGENT_CONFIG_FILE: "<< parameters.agent_config >>"
             SCALYR_SERVER_ATTRIBUTES: "{\"serverHost\": \"<< parameters.agent_server_host>>\"}"
+            CAPTURE_AGENT_STATUS_METRICS: << parameters.capture_agent_status_metrics >>
           command: |
             # Create directories which are needed by the agent process
             mkdir -p ~/scalyr-agent-dev/{log,config,data}
@@ -644,6 +649,22 @@ jobs:
           capture_line_counts: true
           cache_key_name: "benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35"
 
+  benchmarks-loaded-agent-single-50mb-log-file-with-parser-gc-stats-py-27:
+    working_directory: ~/scalyr-agent-2
+    docker:
+      - image: circleci/python:2.7.17
+    steps:
+      - codespeed_agent_process_benchmark:
+          codespeed_executable: "Python 2.7.17 - loaded conf gc"
+          codespeed_environment: "Circle CI Docker Executor Medium Size"
+          agent_config: "benchmarks/configs/agent_single_50mb_access_log_file_gc_metrics.json"
+          agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/access_log_50_mb.log"
+          agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-1-gc-stats"
+          run_time: 140
+          capture_agent_status_metrics: true
+          capture_line_counts: true
+          cache_key_name: "benchmarks-loaded-agent-single-50mb-log-file-with-parser-gc-stats-py-27"
+
   # NOTE: For the benchmarks below to work correctly "/tmp/random.log" file
   # which is being written to during the benchmark must existing before the
   # agent process is started.
@@ -732,6 +753,8 @@ workflows:
       - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
           <<: *master_only
       - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-gc-stats-py-27:
           <<: *master_only
       - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
           <<: *master_only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ commands:
             CAPTURE_INTERVAL: << parameters.capture_interval >>
             AGENT_CONFIG_FILE: "<< parameters.agent_config >>"
             SCALYR_SERVER_ATTRIBUTES: "{\"serverHost\": \"<< parameters.agent_server_host>>\"}"
-            CAPTURE_AGENT_STATUS_METRICS: "<< parameters.capture_agent_status_metrics >>"
+            CAPTURE_AGENT_STATUS_METRICS: "true"
             DRY_RUN: "true"
           command: |
             # Create directories which are needed by the agent process

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ master_only: &master_only
     branches:
       only:
         - master
-        - agent_status_gc_metrics
 
 version: 2.1
 commands:
@@ -745,6 +744,22 @@ workflows:
             - smoke-k8s
   benchmarks:
     jobs:
+      - benchmarks-idle-agent-py-27:
+          <<: *master_only
+      - benchmarks-idle-agent-py-35:
+          <<: *master_only
+      - benchmarks-idle-agent-no-monitors-py-27:
+          <<: *master_only
+      - benchmarks-idle-agent-no-monitors-py-35:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
+          <<: *master_only
       - benchmarks-loaded-agent-single-50mb-log-file-with-parser-gc-stats-py-27:
           <<: *master_only
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ master_only: &master_only
     branches:
       only:
         - master
-        - agent_status_gc_metrics
 
 version: 2.1
 commands:
@@ -751,6 +750,22 @@ workflows:
             - smoke-k8s
   benchmarks:
     jobs:
+      - benchmarks-idle-agent-py-27:
+          <<: *master_only
+      - benchmarks-idle-agent-py-35:
+          <<: *master_only
+      - benchmarks-idle-agent-no-monitors-py-27:
+          <<: *master_only
+      - benchmarks-idle-agent-no-monitors-py-35:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
+          <<: *master_only
       - benchmarks-loaded-agent-single-50mb-log-file-with-parser-gc-stats-py-27:
           <<: *master_only
 

--- a/benchmarks/configs/agent.d/server.json
+++ b/benchmarks/configs/agent.d/server.json
@@ -1,8 +1,8 @@
 {
   // api_key: "",  // specified via environment variable
   // NOTE: The key defined as Circle CI env variable is available in qatesting
-  scalyr_server: "agent.scalyr.com",
+  // scalyr_server: "",  // specified via environment variable
   // Circle CI doesn't have access to CA bundle file so we disable certificate verification
   verify_server_certificate: false,
-  debug_level: "5",
+  debug_level: "5"
 }

--- a/benchmarks/configs/agent_single_50mb_access_log_file_gc_metrics.json
+++ b/benchmarks/configs/agent_single_50mb_access_log_file_gc_metrics.json
@@ -1,0 +1,21 @@
+{
+  // We want to consume whole file from the beginning so we set max offset to 100 MB
+  max_log_offset_size: 104857600,
+
+  // Enable GC stats capture and decrease main loop interval to better capture any potential
+  // object leaks
+  config_change_check_interval: 5,
+  enable_gc_stats: true,
+  garbage_collect_interval: 5
+
+  logs: [
+     {
+         path: "/tmp/access_log_50_mb.log",
+         attributes: { parser: "accessLog" },
+         copy_from_start: true
+     }
+  ],
+
+  monitors: [
+  ]
+}

--- a/benchmarks/scripts/common.sh
+++ b/benchmarks/scripts/common.sh
@@ -30,3 +30,25 @@ function verify_mandatory_common_env_variables_are_set() {
         fi
     done
 }
+
+# Function which prints common configuration environment variables making
+# sure we don't print private ones
+function print_common_env_variables() {
+    print_environment_variables CODESPEED_URL CODESPEED_PROJECT \
+        CODESPEED_EXECUTABLE CODESPEED_ENVIRONMENT CODESPEED_BRANCH \
+        COMMIT_DATE COMMIT_HASH DRY_RUN CAPTURE_AGENT_STATUS_METRICS
+}
+
+# Function which prints values of the provided environment variables
+function print_environment_variables() {
+    env_variables=("$@")
+
+    echo "Using environment settings:"
+    echo ""
+
+    for var_name in "${env_variables[@]}"; do
+        echo "${var_name}=${!var_name}"
+    done
+
+    echo ""
+}

--- a/benchmarks/scripts/send-log-level-counts-to-codespeed.sh
+++ b/benchmarks/scripts/send-log-level-counts-to-codespeed.sh
@@ -46,6 +46,7 @@ COMMON_COMMAND_LINE_ARGS="--codespeed-url=\"${CODESPEED_URL}\" \
     --commit-id=\"${COMMIT_HASH}\""
 
 echo "Using COMMIT_DATE=${COMMIT_DATE} and COMMIT_ID=${COMMIT_HASH}"
+print_common_env_variables
 
 eval python ${SEND_VALUE_SCRPT_PATH} ${COMMON_COMMAND_LINE_ARGS} \
     --codespeed-benchmark="log_lines_info" \

--- a/benchmarks/scripts/send_usage_data_to_codespeed.py
+++ b/benchmarks/scripts/send_usage_data_to_codespeed.py
@@ -64,6 +64,7 @@ import argparse
 from datetime import datetime
 from collections import defaultdict
 
+import six
 import numpy as np
 import psutil
 
@@ -246,7 +247,7 @@ def get_agent_status_metrics(process):
     agent_data_path = os.path.expanduser("~/scalyr-agent-dev/data")
     status_format_file = os.path.join(agent_data_path, "status_format")
     with open(status_format_file, "w") as fp:
-        fp.write("json")
+        fp.write(six.text_type("json"))
 
     # Ask agent to dump metrics
     os.kill(process.pid, signal.SIGUSR1)

--- a/benchmarks/scripts/send_usage_data_to_codespeed.py
+++ b/benchmarks/scripts/send_usage_data_to_codespeed.py
@@ -323,6 +323,9 @@ def main(
 
     # Calculate derivatives for gauge metrics
     for metric_name in METRICS_GAUGES.keys():
+        if metric_name not in captured_values:
+            continue
+
         values = captured_values[metric_name]
 
         percentile_999 = np.percentile(values, 99.9)

--- a/benchmarks/scripts/send_usage_data_to_codespeed.py
+++ b/benchmarks/scripts/send_usage_data_to_codespeed.py
@@ -37,6 +37,8 @@ Dependencies:
 """
 
 from __future__ import absolute_import
+from __future__ import print_function
+from io import open
 
 if False:
     # NOTE: This is a workaround for old Python versions where typing module is not available
@@ -52,10 +54,11 @@ if False:
     T_metric_value = Union[int, float]
 
 import os
-
 import sys
 import time
 import logging
+import signal
+import json
 import argparse
 
 from datetime import datetime
@@ -89,6 +92,8 @@ METRICS_GAUGES = {
     "memory_usage_vms": Metric(name="app.mem.bytes", _type="vmsize"),
     # IO related metrics
     "io_open_fds": Metric(name="app.io.fds", _type="open"),
+    # GC related metrics
+    "gc_garbage": Metric(name="app.gc.garbage", _type=None),
 }  # type: Dict[str, Metric]
 
 METRICS_COUNTERS = {
@@ -168,8 +173,10 @@ def send_data_to_codespeed(
     )
 
 
-def capture_metrics(tracker, process, metrics, values):
-    # type: (ProcessTracker, psutil.Process, Dict[str, Metric], dict) -> dict
+def capture_metrics(
+    tracker, process, metrics, values, capture_agent_status_metrics=False
+):
+    # type: (ProcessTracker, psutil.Process, Dict[str, Metric], dict, bool) -> dict
     """
     Capture gauge metric types and store them in the provided dictionary.
     """
@@ -185,8 +192,15 @@ def capture_metrics(tracker, process, metrics, values):
     psutil_metrics = get_additional_psutil_metrics(process=process)
     process_metrics.update(psutil_metrics)
 
+    # Add in agent_status metrics (if enabled)
+    if capture_agent_status_metrics:
+        agent_status_metrics = get_agent_status_metrics(process=process)
+        process_metrics.update(agent_status_metrics)
+
     metric_values = {}
     for metric_name, metric_obj in metrics.items():
+        if metric_obj not in process_metrics:
+            continue
         value = process_metrics[metric_obj]
         format_func = METRIC_FORMAT_FUNCTIONS.get(metric_name, lambda val: val)
         value = format_func(value)
@@ -221,6 +235,39 @@ def get_additional_psutil_metrics(process):
     return result
 
 
+def get_agent_status_metrics(process):
+    # type: (psutil.Process) -> dict
+    """
+    Retrieve additional agent related metrics utilizing agent status functionality.
+    """
+    result = {}
+
+    # Request json format
+    agent_data_path = os.path.expanduser("~/scalyr-agent-dev/data")
+    status_format_file = os.path.join(agent_data_path, "status_format")
+    with open(status_format_file, "w") as fp:
+        fp.write("json")
+
+    # Ask agent to dump metrics
+    os.kill(process.pid, signal.SIGUSR1)
+
+    # Wait a bit for agent to write the metrics and parse the metrics
+    time.sleep(2)
+
+    status_file = os.path.join(agent_data_path, "last_status")
+
+    with open(status_file, "r") as fp:
+        content = fp.read()
+
+    content = json.loads(content)
+
+    # NOTE: Currently we only capture gc metrics
+    metric_gc_garbage = Metric(name="app.gc.garbage", _type=None)
+    result[metric_gc_garbage] = content.get("gc_stats", {}).get("garbage", 0)
+
+    return result
+
+
 def main(
     pid,
     codespeed_url,
@@ -231,9 +278,10 @@ def main(
     branch,
     commit_id,
     commit_date=None,
+    capture_agent_status_metrics=False,
     dry_run=False,
 ):
-    # type: (int, str, Optional[Tuple[str, str]], str, str, str, str, str, Optional[datetime], bool) -> None
+    # type: (int, str, Optional[Tuple[str, str]], str, str, str, str, str, Optional[datetime], bool, bool) -> None
     """
     Main entry point / run loop for the script.
     """
@@ -247,6 +295,9 @@ def main(
     # It maps metric name to a dictionary with the results
     captured_values = defaultdict(list)  # type: Dict[str, List[T_metric_value]]
 
+    # Give it some time for the process to start and initialize before first capture
+    time.sleep(5)
+
     while time.time() <= end_time:
         logger.debug("Capturing gauge metrics...")
         capture_metrics(
@@ -254,6 +305,7 @@ def main(
             process=process,
             metrics=METRICS_GAUGES,
             values=captured_values,
+            capture_agent_status_metrics=capture_agent_status_metrics,
         )
         time.sleep(args.capture_interval)
 
@@ -344,6 +396,12 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
+        "--capture-agent-status-metrics",
+        action="store_true",
+        default=False,
+        help=("True to also capture additional metrics using agent status file."),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         default=False,
@@ -366,5 +424,6 @@ if __name__ == "__main__":
         branch=args.branch,
         commit_id=args.commit_id,
         commit_date=commit_date,
+        capture_agent_status_metrics=args.capture_agent_status_metrics,
         dry_run=args.dry_run,
     )

--- a/benchmarks/scripts/start-agent-and-capture-metrics.sh
+++ b/benchmarks/scripts/start-agent-and-capture-metrics.sh
@@ -107,5 +107,5 @@ CAPTURE_SCRIPT_COMMAND="${CAPTURE_METRICS_SCRIPT_PATH} \
     ${ADDITIONAL_CAPTURE_SCRIPT_FLAGS} \
     --debug"
 
-echo "Starting the metrics capture script..."
+echo "Starting the metrics capture script (ADDITIONAL_CAPTURE_SCRIPT_FLAGS=${ADDITIONAL_CAPTURE_SCRIPT_FLAGS})..."
 eval ${CAPTURE_SCRIPT_COMMAND}

--- a/benchmarks/scripts/start-agent-and-capture-metrics.sh
+++ b/benchmarks/scripts/start-agent-and-capture-metrics.sh
@@ -58,13 +58,13 @@ DRY_RUN=${DRY_RUN:-"0"}
 
 CAPTURE_AGENT_STATUS_METRICS=${CAPTURE_AGENT_STATUS_METRICS:-"0"}
 
-if [ "${CAPTURE_AGENT_STATUS_METRICS}" = "true" ]; then
+if [ "${CAPTURE_AGENT_STATUS_METRICS}" = "true" ] || [ "${CAPTURE_AGENT_STATUS_METRICS}" = "1" ]; then
     ADDITIONAL_CAPTURE_SCRIPT_FLAGS="--capture-agent-status-metrics "
 else
     ADDITIONAL_CAPTURE_SCRIPT_FLAGS=""
 fi
 
-if [ "${DRY_RUN}" = "true" ]; then
+if [ "${DRY_RUN}" = "true" ] || [ "${DRY_RUN}" = "1" ]; then
     ADDITIONAL_CAPTURE_SCRIPT_FLAGS+="--dry-run "
 fi
 

--- a/benchmarks/scripts/start-agent-and-capture-metrics.sh
+++ b/benchmarks/scripts/start-agent-and-capture-metrics.sh
@@ -54,6 +54,14 @@ RUN_TIME=${RUN_TIME-"60"}
 # How often to capture metrics during the capture run time (in seconds)
 CAPTURE_INTERVAL=${CAPTURE_INTERVAL-"10"}
 
+CAPTURE_AGENT_STATUS_METRICS=${CAPTURE_AGENT_STATUS_METRICS:-"0"}
+
+if [ "${CAPTURE_AGENT_STATUS_METRICS}" -eq "true" ]; then
+    ADDITIONAL_SCRIPT_FLAGS="--capture-agent-status-metrics"
+else
+    ADDITIONAL_SCRIPT_FLAGS=""
+fi
+
 echo "Starting the agent process and metrics capture for ${RUN_TIME} seconds"
 echo "Using COMMIT_DATE=${COMMIT_DATE} and COMMIT_ID=${COMMIT_HASH}"
 
@@ -90,6 +98,7 @@ CAPTURE_SCRIPT_COMMAND="${CAPTURE_METRICS_SCRIPT_PATH} \
     --branch=\"${CODESPEED_BRANCH}\" \
     --commit-date=\"${COMMIT_DATE}\" \
     --commit-id=\"${COMMIT_HASH}\" \
+    ${ADDITIONAL_SCRIPT_FLAGS} \
     --debug"
 
 echo "Starting the metrics capture script..."

--- a/benchmarks/scripts/start-agent-and-capture-metrics.sh
+++ b/benchmarks/scripts/start-agent-and-capture-metrics.sh
@@ -69,7 +69,7 @@ if [ "${DRY_RUN}" = "true" ]; then
 fi
 
 echo "Starting the agent process and metrics capture for ${RUN_TIME} seconds"
-echo "Using COMMIT_DATE=${COMMIT_DATE} and COMMIT_ID=${COMMIT_HASH}"
+print_common_env_variables
 
 # 1. Start the agent
 echo "Starting agent process..."

--- a/benchmarks/scripts/start-agent-and-capture-metrics.sh
+++ b/benchmarks/scripts/start-agent-and-capture-metrics.sh
@@ -54,12 +54,18 @@ RUN_TIME=${RUN_TIME-"60"}
 # How often to capture metrics during the capture run time (in seconds)
 CAPTURE_INTERVAL=${CAPTURE_INTERVAL-"10"}
 
+DRY_RUN=${DRY_RUN:-"0"}
+
 CAPTURE_AGENT_STATUS_METRICS=${CAPTURE_AGENT_STATUS_METRICS:-"0"}
 
-if [ "${CAPTURE_AGENT_STATUS_METRICS}" -eq "true" ]; then
-    ADDITIONAL_SCRIPT_FLAGS="--capture-agent-status-metrics"
+if [ "${CAPTURE_AGENT_STATUS_METRICS}" = "true" ]; then
+    ADDITIONAL_CAPTURE_SCRIPT_FLAGS="--capture-agent-status-metrics "
 else
-    ADDITIONAL_SCRIPT_FLAGS=""
+    ADDITIONAL_CAPTURE_SCRIPT_FLAGS=""
+fi
+
+if [ "${DRY_RUN}" = "true" ]; then
+    ADDITIONAL_CAPTURE_SCRIPT_FLAGS+="--dry-run "
 fi
 
 echo "Starting the agent process and metrics capture for ${RUN_TIME} seconds"
@@ -98,7 +104,7 @@ CAPTURE_SCRIPT_COMMAND="${CAPTURE_METRICS_SCRIPT_PATH} \
     --branch=\"${CODESPEED_BRANCH}\" \
     --commit-date=\"${COMMIT_DATE}\" \
     --commit-id=\"${COMMIT_HASH}\" \
-    ${ADDITIONAL_SCRIPT_FLAGS} \
+    ${ADDITIONAL_CAPTURE_SCRIPT_FLAGS} \
     --debug"
 
 echo "Starting the metrics capture script..."

--- a/scalyr_agent/agent_status.py
+++ b/scalyr_agent/agent_status.py
@@ -101,6 +101,22 @@ class AgentStatus(BaseAgentStatus):
         self.monitor_manager_status = None
 
 
+class GCStatus(BaseAgentStatus):
+    """
+    Class which holds garbage collection statistics.
+
+    Those stats are disabled by default because they have an impact on memory usage so they must
+    be explicitly enabled.
+    """
+
+    def __init__(self):
+        # This metric indicates number of objects which are unreachable but can't be freed.
+        self.garbage = 0
+
+    def to_dict(self):
+        return self.__dict__
+
+
 class OverallStats(AgentStatus):
     """Used to track stats that are calculated over the lifetime of the agent.
     """

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -541,6 +541,10 @@ class Configuration(object):
         return self.__get_config().get_bool("disable_leak_update_debug_log_level")
 
     @property
+    def enable_gc_stats(self):
+        return self.__get_config().get_bool("enable_gc_stats")
+
+    @property
     def disable_all_config_updates(self):
         return self.__get_config().get_int(
             "disable_leak_all_config_updates", none_if_missing=True
@@ -1994,7 +1998,9 @@ class Configuration(object):
             description,
             apply_defaults,
         )
-
+        self.__verify_or_set_optional_bool(
+            config, "enable_gc_stats", False, description, apply_defaults
+        )
         self.__verify_or_set_optional_int(
             config, "disable_leak_all_config_updates", None, description, apply_defaults
         )

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -237,6 +237,8 @@ class TestConfiguration(TestConfigurationBase):
         self.assertEquals(config.debug_level, 0)
         self.assertEquals(config.request_deadline, 60.0)
 
+        self.assertEquals(config.enable_gc_stats, False)
+
         self.assertEquals(config.max_line_size, 9900)
         self.assertEquals(config.max_log_offset_size, 5 * 1024 * 1024)
         self.assertEquals(config.max_existing_log_offset_size, 100 * 1024 * 1024)
@@ -361,6 +363,8 @@ class TestConfiguration(TestConfigurationBase):
             debug_init: true,
             pidfile_advanced_reuse_guard: true,
 
+            enable_gc_stats: true,
+
             max_new_log_detection_time: 120,
 
             copying_thread_profile_interval: 2,
@@ -416,6 +420,8 @@ class TestConfiguration(TestConfigurationBase):
         self.assertEquals(config.internal_parse_max_line_size, 4013)
         self.assertEquals(config.copy_staleness_threshold, 4 * 60)
         self.assertEquals(config.log_deletion_delay, 5 * 60)
+
+        self.assertEquals(config.enable_gc_stats, True)
 
         self.assertEquals(config.copying_thread_profile_interval, 2)
         self.assertEquals(


### PR DESCRIPTION
This pull request adds new ``gc_stats.garbage`` metric to the agent status output (right now only to the machine readable aka json format).

This value contains a number of uncollectabe objects after a GC run (those are the objects which are not reachable anymore and can't be collected - due to a cyclic reference to itself or similar).

This will allow us to more easily detect regressions and catch memory leaks like 3 big ones which have been fixed in #435 

Do keep in mind though that this only reports uncollectable objects which are unreachable.

If some piece of code which is in use (aka reachable) incorrectly keeps a reference to some other object or similar, this won't be reported in that number.

---

The plan is to hook this metric to CodeSpeed to allow us to catch such memory leak regressions in the future more easily.

I will add new codespeed benchmark which runs agent under load with gc_stats enabled and then report that value to CodeSpeed at the end of the run.

Do keep in mind that I need to use a separate agent process run since gc stats includes overhead which would otherwise have an impact on metrics on other benchmark results.