### PR TITLE
Update GC profiler and make sure we only report uncollectable objects

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -1077,7 +1077,7 @@ class ScalyrAgent(object):
                                     scalyr_logging.DEBUG_LEVEL_5,
                                     "Enabling GC debug mode",
                                 )
-                                gc.set_debug(gc.DEBUG_SAVEALL)
+                                gc.set_debug(gc.DEBUG_UNCOLLECTABLE)
                         else:
                             if gc.get_debug() != 0:
                                 log.log(

--- a/scalyr_agent/builtin_monitors/tests/docker_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/docker_monitor_test.py
@@ -255,7 +255,9 @@ class DockerMonitorTest(ScalyrTestCase):
                 manager.stop_manager(wait_on_join=False)
                 fake_clock.advance_time(increment_by=manager_poll_interval)
 
-                time.sleep(1)
+                # We use sleep to avoid potential race
+                # NOTE: This is not 100% robust and deterministic, but good enough for now
+                time.sleep(2)
 
                 self.assertEquals(fragment_polls.count(), 40)
                 self.assertEquals(counter["callback_invocations"], 4)


### PR DESCRIPTION
This pull request makes a small change to the GC profiler to make sure we only report on uncollectable objects (previously we also reported on collectable ones under some circumstances).