### PR TITLE
Add longer running agent benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ master_only: &master_only
     branches:
       only:
         - master
+        - longer_running_benchmark
 
 version: 2.1
 commands:
@@ -739,7 +740,7 @@ jobs:
           agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-3"
           capture_line_counts: true
           cache_key_name: "benchmarks-loaded-agent-growing-log-file-108-py-27"
-          dry_run: "true"
+          dry_run: true
 
   send-circle-ci-usage-report:
     description: "Job which emails weekly Circle CI usage report"
@@ -758,50 +759,9 @@ jobs:
 
 workflows:
   version: 2
-  unittest:
-    jobs:
-      - lint-checks
-      - unittest-38
-      - unittest-37
-      - unittest-36
-      - unittest-35
-      - unittest-27
-      - unittest-26
-      - smoke-standalone-37
-      - smoke-standalone-27
-      - smoke-standalone-26
-      - smoke-standalone-27-tls12
-      - smoke-standalone-26-tls12
-      - smoke-docker-json
-      - smoke-docker-syslog
-      - smoke-k8s
-      - coverage:
-          requires:
-            - unittest-27
-            - smoke-docker-json
-            - smoke-docker-syslog
-            - smoke-k8s
   benchmarks:
     jobs:
-      - benchmarks-idle-agent-py-27:
-          <<: *master_only
-      - benchmarks-idle-agent-py-35:
-          <<: *master_only
-      - benchmarks-idle-agent-no-monitors-py-27:
-          <<: *master_only
-      - benchmarks-idle-agent-no-monitors-py-35:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
-          <<: *master_only
       - benchmarks-loaded-agent-single-growing-log-file-108mb-py-27:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-gc-stats-py-27:
           <<: *master_only
 
   weekly-circle-ci-usage-report:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -721,6 +721,26 @@ jobs:
           capture_line_counts: true
           cache_key_name: "benchmarks-loaded-agent-growing-log-file-py-35"
 
+  benchmarks-loaded-agent-single-growing-log-file-108mb-py-27:
+    working_directory: ~/scalyr-agent-2
+    docker:
+      - image: circleci/python:2.7.17
+    steps:
+      - codespeed_agent_process_benchmark:
+          codespeed_executable: "Python 2.7.17 - loaded conf 3"
+          codespeed_environment: "Circle CI Docker Executor Medium Size"
+          agent_config: "benchmarks/configs/agent_single_growing_log_file.json"
+          run_time: 360
+          agent_pre_run_command: "touch /tmp/random.log"
+          # NOTE: We write a chunk every 1 seconds for a total of 10 minutes.
+          # Each chunk is 0.2 MB in size which means we write a total of 108 MB of data
+          # (360 / 1 * 0.3)
+          agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 300K 360 100 1  &> /tmp/write_lines_script.log &"
+          agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-3"
+          capture_line_counts: true
+          cache_key_name: "benchmarks-loaded-agent-growing-log-file-108-py-27"
+          dry_run: "true"
+
   send-circle-ci-usage-report:
     description: "Job which emails weekly Circle CI usage report"
     working_directory: ~/scalyr-agent-2
@@ -778,6 +798,8 @@ workflows:
       - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
           <<: *master_only
       - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-growing-log-file-108mb-py-27:
           <<: *master_only
       - benchmarks-loaded-agent-single-50mb-log-file-with-parser-gc-stats-py-27:
           <<: *master_only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -722,7 +722,7 @@ jobs:
           capture_line_counts: true
           cache_key_name: "benchmarks-loaded-agent-growing-log-file-py-35"
 
-  benchmarks-loaded-agent-single-growing-log-file-108mb-py-27:
+  benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
     working_directory: ~/scalyr-agent-2
     docker:
       - image: circleci/python:2.7.17
@@ -733,13 +733,13 @@ jobs:
           agent_config: "benchmarks/configs/agent_single_growing_log_file.json"
           run_time: 360
           agent_pre_run_command: "touch /tmp/random.log"
-          # NOTE: We write a chunk every 1 seconds for a total of 10 minutes.
-          # Each chunk is 0.2 MB in size which means we write a total of 108 MB of data
-          # (360 / 1 * 0.3)
-          agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 300K 360 100 1  &> /tmp/write_lines_script.log &"
+          # NOTE: We write a chunk every 1 seconds for a total of 5 minutes.
+          # Each chunk is 0.5 MB in size which means we write a total of 180 MB of data
+          # (360 / 1 * 0.5)
+          agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 500K 360 100 1  &> /tmp/write_lines_script.log &"
           agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-3"
           capture_line_counts: true
-          cache_key_name: "benchmarks-loaded-agent-growing-log-file-108-py-27"
+          cache_key_name: "benchmarks-loaded-agent-growing-log-file-180-py-27"
           dry_run: true
 
   send-circle-ci-usage-report:
@@ -761,7 +761,7 @@ workflows:
   version: 2
   benchmarks:
     jobs:
-      - benchmarks-loaded-agent-single-growing-log-file-108mb-py-27:
+      - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
           <<: *master_only
 
   weekly-circle-ci-usage-report:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ master_only: &master_only
     branches:
       only:
         - master
+        - longer_running_benchmark
 
 version: 2.1
 commands:
@@ -744,29 +745,6 @@ jobs:
 
 workflows:
   version: 2
-  unittest:
-    jobs:
-      - lint-checks
-      - unittest-38
-      - unittest-37
-      - unittest-36
-      - unittest-35
-      - unittest-27
-      - unittest-26
-      - smoke-standalone-37
-      - smoke-standalone-27
-      - smoke-standalone-26
-      - smoke-standalone-27-tls12
-      - smoke-standalone-26-tls12
-      - smoke-docker-json
-      - smoke-docker-syslog
-      - smoke-k8s
-      - coverage:
-          requires:
-            - unittest-27
-            - smoke-docker-json
-            - smoke-docker-syslog
-            - smoke-k8s
   benchmarks:
     jobs:
       - benchmarks-idle-agent-py-27:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ master_only: &master_only
     branches:
       only:
         - master
-        - longer_running_benchmark
 
 version: 2.1
 commands:
@@ -745,6 +744,29 @@ jobs:
 
 workflows:
   version: 2
+  unittest:
+    jobs:
+      - lint-checks
+      - unittest-38
+      - unittest-37
+      - unittest-36
+      - unittest-35
+      - unittest-27
+      - unittest-26
+      - smoke-standalone-37
+      - smoke-standalone-27
+      - smoke-standalone-26
+      - smoke-standalone-27-tls12
+      - smoke-standalone-26-tls12
+      - smoke-docker-json
+      - smoke-docker-syslog
+      - smoke-k8s
+      - coverage:
+          requires:
+            - unittest-27
+            - smoke-docker-json
+            - smoke-docker-syslog
+            - smoke-k8s
   benchmarks:
     jobs:
       - benchmarks-idle-agent-py-27:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -652,6 +652,7 @@ jobs:
           agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/access_log_50_mb.log"
           agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-1"
           run_time: 140
+          capture_agent_status_metrics: true
           capture_line_counts: true
           cache_key_name: "benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27"
 
@@ -669,22 +670,6 @@ jobs:
           run_time: 140
           capture_line_counts: true
           cache_key_name: "benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35"
-
-  benchmarks-loaded-agent-single-50mb-log-file-with-parser-gc-stats-py-27:
-    working_directory: ~/scalyr-agent-2
-    docker:
-      - image: circleci/python:2.7.17
-    steps:
-      - codespeed_agent_process_benchmark:
-          codespeed_executable: "Python 2.7.17 - loaded conf gc"
-          codespeed_environment: "Circle CI Docker Executor Medium Size"
-          agent_config: "benchmarks/configs/agent_single_50mb_access_log_file_gc_metrics.json"
-          agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/access_log_50_mb.log"
-          agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-1-gc-stats"
-          run_time: 140
-          capture_agent_status_metrics: true
-          capture_line_counts: true
-          cache_key_name: "benchmarks-loaded-agent-single-50mb-log-file-with-parser-gc-stats-py-27"
 
   # NOTE: For the benchmarks below to work correctly "/tmp/random.log" file
   # which is being written to during the benchmark must existing before the
@@ -799,8 +784,6 @@ workflows:
       - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
           <<: *master_only
       - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-gc-stats-py-27:
           <<: *master_only
       - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
           <<: *master_only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ master_only: &master_only
     branches:
       only:
         - master
-        - longer_running_benchmark
 
 version: 2.1
 commands:
@@ -731,16 +730,17 @@ jobs:
           codespeed_executable: "Python 2.7.17 - loaded conf 3"
           codespeed_environment: "Circle CI Docker Executor Medium Size"
           agent_config: "benchmarks/configs/agent_single_growing_log_file.json"
-          run_time: 360
+          # NOTE: We set agent run time slightly longer than the insert script time run so we give a chance for memory and
+          # other metrics to stabilize.
+          run_time: 380
           agent_pre_run_command: "touch /tmp/random.log"
           # NOTE: We write a chunk every 1 seconds for a total of 5 minutes.
           # Each chunk is 0.5 MB in size which means we write a total of 180 MB of data
           # (360 / 1 * 0.5)
-          agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 500K 360 100 1  &> /tmp/write_lines_script.log &"
+          agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 500K 350 100 1  &> /tmp/write_lines_script.log &"
           agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-3"
           capture_line_counts: true
           cache_key_name: "benchmarks-loaded-agent-growing-log-file-180-py-27"
-          dry_run: true
 
   send-circle-ci-usage-report:
     description: "Job which emails weekly Circle CI usage report"
@@ -759,8 +759,49 @@ jobs:
 
 workflows:
   version: 2
+  unittest:
+    jobs:
+      - lint-checks
+      - unittest-38
+      - unittest-37
+      - unittest-36
+      - unittest-35
+      - unittest-27
+      - unittest-26
+      - smoke-standalone-37
+      - smoke-standalone-27
+      - smoke-standalone-26
+      - smoke-standalone-27-tls12
+      - smoke-standalone-26-tls12
+      - smoke-docker-json
+      - smoke-docker-syslog
+      - smoke-k8s
+      - coverage:
+          requires:
+            - unittest-27
+            - smoke-docker-json
+            - smoke-docker-syslog
+            - smoke-k8s
   benchmarks:
     jobs:
+      - benchmarks-idle-agent-py-27:
+          <<: *master_only
+      - benchmarks-idle-agent-py-35:
+          <<: *master_only
+      - benchmarks-idle-agent-no-monitors-py-27:
+          <<: *master_only
+      - benchmarks-idle-agent-no-monitors-py-35:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-gc-stats-py-27:
+          <<: *master_only
       - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
           <<: *master_only
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -717,12 +717,12 @@ jobs:
           agent_config: "benchmarks/configs/agent_single_growing_log_file.json"
           # NOTE: We set agent run time slightly longer than the insert script time run so we give a chance for memory and
           # other metrics to stabilize.
-          run_time: 380
+          run_time: 390
           agent_pre_run_command: "touch /tmp/random.log"
-          # NOTE: We write a chunk every 1 seconds for a total of 5 minutes.
-          # Each chunk is 0.5 MB in size which means we write a total of 180 MB of data
-          # (360 / 1 * 0.5)
-          agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 500K 350 100 1  &> /tmp/write_lines_script.log &"
+          # NOTE: We write a chunk every 1 seconds for a total of 6 minutes.
+          # Each chunk is 0.5 MB in size which means we write a total of 360 * 1
+          # / 0.5 MB of data
+          agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 500K 360 100 1 &> /tmp/write_lines_script.log &"
           agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-3"
           capture_line_counts: true
           cache_key_name: "benchmarks-loaded-agent-growing-log-file-180-py-27"


### PR DESCRIPTION
This pull request updates a list of our CodeSpeed benchmarks and adds another "under load" benchmark which runs the agent under Python 2.7.

This benchmark runs longer than the other loaded ones, so it may give us some insight on the memory usage behavior when running agent under continuous load for a longer period of time.