### PR TITLE
Make sure we skip "cert files exist" checks when running in a dev installation

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -1279,8 +1279,8 @@ class ScalyrAgent(object):
                     "option: file does not exist" % (ca_file)
                 )
 
-            # NOTE: We don't include intermediate certs in the Windows binary so we skip taht chek
-            # in MSI install
+            # NOTE: We don't include intermediate certs in the Windows binary so we skip that check
+            # under the MSI / Windows install
             if not is_dev_or_msi_install and not os.path.isfile(
                 intermediate_certs_file
             ):

--- a/scalyr_agent/tests/agent_main_test.py
+++ b/scalyr_agent/tests/agent_main_test.py
@@ -16,17 +16,20 @@ from __future__ import absolute_import
 
 import mock
 
+from scalyr_agent.__scalyr__ import DEV_INSTALL
+from scalyr_agent.__scalyr__ import MSI_INSTALL
 from scalyr_agent.test_base import ScalyrTestCase
 
 __all__ = ["AgentMainTestCase"]
 
 
 class AgentMainTestCase(ScalyrTestCase):
+    @mock.patch("scalyr_agent.agent_main.INSTALL_TYPE", 1)
     def test_create_client_ca_file_and_intermediate_certs_file_doesnt_exist(self):
         from scalyr_agent.agent_main import ScalyrAgent
         from scalyr_agent.platform_controller import PlatformController
 
-        # 1. file doesn't exist but cer verification is disabled
+        # 1. file doesn't exist but cert verification is disabled
         config = mock.Mock()
         config.scalyr_server = "foo.bar.com"
 
@@ -59,9 +62,6 @@ class AgentMainTestCase(ScalyrTestCase):
         config.ca_cert_path = __file__
         config.intermediate_certs_path = "/tmp/doesnt.exist"
 
-        from scalyr_agent.agent_main import ScalyrAgent
-        from scalyr_agent.platform_controller import PlatformController
-
         agent = ScalyrAgent(PlatformController())
         agent._ScalyrAgent__config = config
 
@@ -73,3 +73,61 @@ class AgentMainTestCase(ScalyrTestCase):
         self.assertRaisesRegexp(
             ValueError, expected_msg, agent._ScalyrAgent__create_client
         )
+
+    def test_ca_cert_files_checks_are_skipped_under_dev_and_msi_install(self):
+        # Skip those checks under dev and msi install because those final generated certs files
+        # are not present under dev install
+        import scalyr_agent.agent_main
+
+        from scalyr_agent.agent_main import ScalyrAgent
+        from scalyr_agent.platform_controller import PlatformController
+
+        # 1. Dev install (boths checks should be skipped)
+        scalyr_agent.agent_main.INSTALL_TYPE = DEV_INSTALL
+
+        # ca_cert_path file doesn't exist
+        config = mock.Mock()
+        config.scalyr_server = "foo.bar.com"
+
+        config.verify_server_certificate = True
+        config.ca_cert_path = "/tmp/doesnt.exist"
+
+        agent = ScalyrAgent(PlatformController())
+        agent._ScalyrAgent__config = config
+
+        self.assertTrue(agent._ScalyrAgent__create_client())
+
+        # intermediate_certs_path file doesn't exist
+        config.verify_server_certificate = True
+        config.ca_cert_path = __file__
+        config.intermediate_certs_path = "/tmp/doesnt.exist"
+
+        self.assertTrue(agent._ScalyrAgent__create_client())
+
+        # 2. MSI install (only intermediate_certs_path check should be skipped)
+        scalyr_agent.agent_main.INSTALL_TYPE = MSI_INSTALL
+
+        config = mock.Mock()
+        config.scalyr_server = "foo.bar.com"
+
+        config.verify_server_certificate = True
+        config.ca_cert_path = "/tmp/doesnt.exist"
+
+        agent = ScalyrAgent(PlatformController())
+        agent._ScalyrAgent__config = config
+
+        expected_msg = (
+            r'Invalid path "/tmp/doesnt.exist" specified for the "ca_cert_path" config '
+            "option: file does not exist"
+        )
+
+        self.assertRaisesRegexp(
+            ValueError, expected_msg, agent._ScalyrAgent__create_client
+        )
+
+        # intermediate_certs_path file doesn't exist
+        config.verify_server_certificate = True
+        config.ca_cert_path = __file__
+        config.intermediate_certs_path = "/tmp/doesnt.exist"
+
+        self.assertTrue(agent._ScalyrAgent__create_client())


### PR DESCRIPTION
This pull request should fix the issue @yanscalyr reported yesterday.

---

I updated the code so under dev installation we skip "cert files exists" checks.

Those bundle certificate files are created as part of the build process inside ``build_package.py`` so they will only be available in package installations.

In addition to that, I updated the code so we also skip "intermediate certs file exist" check on Windows installations since we don't include intermediate certs file there.