### PR TITLE
Run lint checks on tcollector directory

### DIFF
--- a/scalyr_agent/builtin_monitors/tests/docker_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/docker_monitor_test.py
@@ -23,7 +23,6 @@ __author__ = "echee@scalyr.com"
 
 import os
 import threading
-import time
 from io import open
 
 
@@ -245,7 +244,7 @@ class DockerMonitorTest(ScalyrTestCase):
 
                 manager.start_manager()
                 fragment_polls.sleep_until_count_or_maxwait(
-                    40, manager_poll_interval, maxwait=1
+                    40, manager_poll_interval, maxwait=2.5
                 )
 
                 m1.assert_called()
@@ -254,10 +253,6 @@ class DockerMonitorTest(ScalyrTestCase):
 
                 manager.stop_manager(wait_on_join=False)
                 fake_clock.advance_time(increment_by=manager_poll_interval)
-
-                # We use sleep to avoid potential race
-                # NOTE: This is not 100% robust and deterministic, but good enough for now
-                time.sleep(2)
 
                 self.assertEquals(fragment_polls.count(), 40)
                 self.assertEquals(counter["callback_invocations"], 4)

--- a/scalyr_agent/third_party/tcollector/__init__.py
+++ b/scalyr_agent/third_party/tcollector/__init__.py
@@ -1,2 +1,3 @@
 from __future__ import unicode_literals
-all = [ 'tcollector', 'collectors']
+
+all = ["tcollector", "collectors"]

--- a/scalyr_agent/third_party/tcollector/collectors/0/dfstat.py
+++ b/scalyr_agent/third_party/tcollector/collectors/0/dfstat.py
@@ -53,7 +53,7 @@ try:
     if "TCOLLECTOR_SAMPLE_INTERVAL" in os.environ:
         COLLECTION_INTERVAL = float(os.environ["TCOLLECTOR_SAMPLE_INTERVAL"])
     if "TCOLLECTOR_LOCAL_DISKS_ONLY" in os.environ:
-        LOCAL_DISKS_ONLY = os.environ["TCOLLECTOR_LOCAL_DISKS_ONLY"].lower() == 'true'
+        LOCAL_DISKS_ONLY = os.environ["TCOLLECTOR_LOCAL_DISKS_ONLY"].lower() == "true"
 except ValueError:
     pass
 
@@ -68,11 +68,11 @@ def main():
 
         # Scalyr edit: conditional options on whether to restrict to local disks only or not.
         if LOCAL_DISKS_ONLY:
-            df_options = '-PlTk'
-            df_inodes_options = '-PlTi'
+            df_options = "-PlTk"
+            df_inodes_options = "-PlTi"
         else:
-            df_options = '-PTk'
-            df_inodes_options = '-PTi'
+            df_options = "-PTk"
+            df_inodes_options = "-PTi"
 
         ts = int(time.time())
         # 1kblocks
@@ -82,7 +82,7 @@ def main():
             # Scalyr edit.  We've found some systems list the same mount point multiple times in the df output.
             # To prevent duplicte timestamp warnings, we keep track of which mount points we've reported.
             reported_mounts = {}
-            for line in stdout.decode("utf-8").split("\n"): # pylint: disable=E1103
+            for line in stdout.decode("utf-8").split("\n"):  # pylint: disable=E1103
                 fields = line.split()
                 # skip header/blank lines
                 if not line or not fields[2].isdigit():
@@ -97,7 +97,7 @@ def main():
                 if fields[6] == "/dev":
                     continue
                 # /dev/shm, /lib/init_rw, /lib/modules, etc
-                #if fields[6].startswith(("/lib/", "/dev/")):  # python2.5+
+                # if fields[6].startswith(("/lib/", "/dev/")):  # python2.5+
                 if fields[6].startswith("/lib/"):
                     continue
                 if fields[6].startswith("/dev/"):
@@ -123,7 +123,9 @@ def main():
                     % (ts, fields[4], mount, fields[1])
                 )
         else:
-            print("df %s returned %r" % (df_options, df_proc.returncode), file=sys.stderr)
+            print(
+                "df %s returned %r" % (df_options, df_proc.returncode), file=sys.stderr
+            )
 
         ts = int(time.time())
         # inodes
@@ -133,7 +135,7 @@ def main():
             # Scalyr edit.  We've found some systems list the same mount point multiple times in the df output.
             # To prevent duplicte timestamp warnings, we keep track of which mount points we've reported.
             reported_mounts = {}
-            for line in stdout.decode("utf-8").split("\n"): # pylint: disable=E1103
+            for line in stdout.decode("utf-8").split("\n"):  # pylint: disable=E1103
                 fields = line.split()
                 if not line or not fields[2].isdigit():
                     continue
@@ -158,10 +160,14 @@ def main():
                     % (ts, fields[4], mount, fields[1])
                 )
         else:
-            print("df %s returned %r" % (df_inodes_options, df_proc.returncode), file=sys.stderr)
+            print(
+                "df %s returned %r" % (df_inodes_options, df_proc.returncode),
+                file=sys.stderr,
+            )
 
         sys.stdout.flush()
         time.sleep(COLLECTION_INTERVAL)
+
 
 if __name__ == "__main__":
     main()

--- a/scalyr_agent/third_party/tcollector/collectors/0/dfstat.py
+++ b/scalyr_agent/third_party/tcollector/collectors/0/dfstat.py
@@ -36,7 +36,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 import os
-import socket
 import subprocess
 import sys
 import time

--- a/scalyr_agent/third_party/tcollector/collectors/0/ifstat.py
+++ b/scalyr_agent/third_party/tcollector/collectors/0/ifstat.py
@@ -20,7 +20,6 @@ from __future__ import unicode_literals
 import os
 import sys
 import time
-import socket
 import re
 from io import open
 
@@ -63,7 +62,7 @@ except ValueError:
     pass
 
 # Scalyr edit:  Check environment variable for for additional network interface suffix.
-NETWORK_INTERFACE_SUFFIX = "\d+"
+NETWORK_INTERFACE_SUFFIX = r"\d+"
 try:
     if "TCOLLECTOR_INTERFACE_SUFFIX" in os.environ:
         NETWORK_INTERFACE_SUFFIX = os.environ["TCOLLECTOR_INTERFACE_SUFFIX"]
@@ -99,7 +98,7 @@ def main():
             for interface in network_interface_prefixes:
                 # 2->TODO is it important to expect at least one space character?
                 m = re.match(
-                    "\s*(%s%s):(.*)" % (interface, NETWORK_INTERFACE_SUFFIX), line
+                    r"\s*(%s%s):(.*)" % (interface, NETWORK_INTERFACE_SUFFIX), line
                 )
                 if m:
                     break

--- a/scalyr_agent/third_party/tcollector/collectors/0/ifstat.py
+++ b/scalyr_agent/third_party/tcollector/collectors/0/ifstat.py
@@ -32,8 +32,16 @@ from io import open
 # we tag each metric with direction=in or =out
 # and iface=
 
-FIELDS = ("bytes", "packets", "errs", "dropped",
-           None, None, None, None,)
+FIELDS = (
+    "bytes",
+    "packets",
+    "errs",
+    "dropped",
+    None,
+    None,
+    None,
+    None,
+)
 
 COLLECTION_INTERVAL = 30  # seconds
 
@@ -55,19 +63,20 @@ except ValueError:
     pass
 
 # Scalyr edit:  Check environment variable for for additional network interface suffix.
-NETWORK_INTERFACE_SUFFIX = '\d+'
+NETWORK_INTERFACE_SUFFIX = "\d+"
 try:
     if "TCOLLECTOR_INTERFACE_SUFFIX" in os.environ:
         NETWORK_INTERFACE_SUFFIX = os.environ["TCOLLECTOR_INTERFACE_SUFFIX"]
 except ValueError:
     pass
 
+
 def main():
     """ifstat main loop"""
     interval = COLLECTION_INTERVAL
 
     # Scalyr edit:
-    network_interface_prefixes = NETWORK_INTERFACE_PREFIX.split(',')
+    network_interface_prefixes = NETWORK_INTERFACE_PREFIX.split(",")
     for i in range(len(network_interface_prefixes)):
         network_interface_prefixes[i] = network_interface_prefixes[i].strip()
 
@@ -89,7 +98,9 @@ def main():
             m = None
             for interface in network_interface_prefixes:
                 # 2->TODO is it important to expect at least one space character?
-                m = re.match("\s*(%s%s):(.*)" % (interface, NETWORK_INTERFACE_SUFFIX), line)
+                m = re.match(
+                    "\s*(%s%s):(.*)" % (interface, NETWORK_INTERFACE_SUFFIX), line
+                )
                 if m:
                     break
             if not m:
@@ -103,12 +114,12 @@ def main():
                     )
                     print(
                         "proc.net.%s %d %s iface=%s direction=out"
-                        % (FIELDS[i], ts, stats[i+8], m.group(1))
+                        % (FIELDS[i], ts, stats[i + 8], m.group(1))
                     )
 
         sys.stdout.flush()
         time.sleep(interval)
 
+
 if __name__ == "__main__":
     main()
-

--- a/scalyr_agent/third_party/tcollector/collectors/0/iostat.py
+++ b/scalyr_agent/third_party/tcollector/collectors/0/iostat.py
@@ -89,24 +89,25 @@ except ValueError:
 
 # Docs come from the Linux kernel's Documentation/iostats.txt
 FIELDS_DISK = (
-    "read_requests",        # Total number of reads completed successfully.
-    "read_merged",          # Adjacent read requests merged in a single req.
-    "read_sectors",         # Total number of sectors read successfully.
-    "msec_read",            # Total number of ms spent by all reads.
-    "write_requests",       # total number of writes completed successfully.
-    "write_merged",         # Adjacent write requests merged in a single req.
-    "write_sectors",        # total number of sectors written successfully.
-    "msec_write",           # Total number of ms spent by all writes.
-    "ios_in_progress",      # Number of actual I/O requests currently in flight.
-    "msec_total",           # Amount of time during which ios_in_progress >= 1.
+    "read_requests",  # Total number of reads completed successfully.
+    "read_merged",  # Adjacent read requests merged in a single req.
+    "read_sectors",  # Total number of sectors read successfully.
+    "msec_read",  # Total number of ms spent by all reads.
+    "write_requests",  # total number of writes completed successfully.
+    "write_merged",  # Adjacent write requests merged in a single req.
+    "write_sectors",  # total number of sectors written successfully.
+    "msec_write",  # Total number of ms spent by all writes.
+    "ios_in_progress",  # Number of actual I/O requests currently in flight.
+    "msec_total",  # Amount of time during which ios_in_progress >= 1.
     "msec_weighted_total",  # Measure of recent I/O completion time and backlog.
-    )
+)
 
-FIELDS_PART = ("read_issued",
-               "read_sectors",
-               "write_issued",
-               "write_sectors",
-              )
+FIELDS_PART = (
+    "read_issued",
+    "read_sectors",
+    "write_issued",
+    "write_sectors",
+)
 
 
 def main():
@@ -144,14 +145,14 @@ def main():
                 for i in range(11):
                     print(
                         "%s%s %d %s dev=%s"
-                        % (metric, FIELDS_DISK[i], ts, values[i+3], device)
+                        % (metric, FIELDS_DISK[i], ts, values[i + 3], device)
                     )
             elif len(values) == 7:
                 # partial stats line
                 for i in range(4):
                     print(
                         "%s%s %d %s dev=%s"
-                        % (metric, FIELDS_PART[i], ts, values[i+3], device)
+                        % (metric, FIELDS_PART[i], ts, values[i + 3], device)
                     )
             else:
                 print("Cannot parse /proc/diskstats line: ", line, file=sys.stderr)
@@ -161,7 +162,5 @@ def main():
         time.sleep(COLLECTION_INTERVAL)
 
 
-
 if __name__ == "__main__":
     main()
-

--- a/scalyr_agent/third_party/tcollector/collectors/0/iostat.py
+++ b/scalyr_agent/third_party/tcollector/collectors/0/iostat.py
@@ -72,7 +72,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 import os
-import socket
 import sys
 import time
 from io import open

--- a/scalyr_agent/third_party/tcollector/collectors/0/netstat.py
+++ b/scalyr_agent/third_party/tcollector/collectors/0/netstat.py
@@ -117,18 +117,18 @@ def main():
     # more confusing than anything else and it's not well documented
     # what type of sockets are or aren't included in this count.
     regexp = re.compile(
-        "sockets: used \d+\n"
-        "TCP: inuse (?P<tcp_inuse>\d+) orphan (?P<orphans>\d+)"
-        " tw (?P<tw_count>\d+) alloc (?P<tcp_sockets>\d+)"
-        " mem (?P<tcp_pages>\d+)\n"
-        "UDP: inuse (?P<udp_inuse>\d+)"
+        r"sockets: used \d+\n"
+        r"TCP: inuse (?P<tcp_inuse>\d+) orphan (?P<orphans>\d+)"
+        r" tw (?P<tw_count>\d+) alloc (?P<tcp_sockets>\d+)"
+        r" mem (?P<tcp_pages>\d+)\n"
+        r"UDP: inuse (?P<udp_inuse>\d+)"
         # UDP memory accounting was added in v2.6.25-rc1
-        "(?: mem (?P<udp_pages>\d+))?\n"
+        r"(?: mem (?P<udp_pages>\d+))?\n"
         # UDP-Lite (RFC 3828) was added in v2.6.20-rc2
-        "(?:UDPLITE: inuse (?P<udplite_inuse>\d+)\n)?"
-        "RAW: inuse (?P<raw_inuse>\d+)\n"
-        "FRAG: inuse (?P<ip_frag_nqueues>\d+)"
-        " memory (?P<ip_frag_mem>\d+)\n"
+        r"(?:UDPLITE: inuse (?P<udplite_inuse>\d+)\n)?"
+        r"RAW: inuse (?P<raw_inuse>\d+)\n"
+        r"FRAG: inuse (?P<ip_frag_nqueues>\d+)"
+        r" memory (?P<ip_frag_mem>\d+)\n"
     )
 
     def print_sockstat(metric, value, tags=""):  # Note: tags must start with ' '

--- a/scalyr_agent/third_party/tcollector/collectors/0/netstat.py
+++ b/scalyr_agent/third_party/tcollector/collectors/0/netstat.py
@@ -116,30 +116,31 @@ def main():
     # socket types but not others.  So we don't report it because it's
     # more confusing than anything else and it's not well documented
     # what type of sockets are or aren't included in this count.
-    regexp = re.compile("sockets: used \d+\n"
-                        "TCP: inuse (?P<tcp_inuse>\d+) orphan (?P<orphans>\d+)"
-                        " tw (?P<tw_count>\d+) alloc (?P<tcp_sockets>\d+)"
-                        " mem (?P<tcp_pages>\d+)\n"
-                        "UDP: inuse (?P<udp_inuse>\d+)"
-                        # UDP memory accounting was added in v2.6.25-rc1
-                        "(?: mem (?P<udp_pages>\d+))?\n"
-                        # UDP-Lite (RFC 3828) was added in v2.6.20-rc2
-                        "(?:UDPLITE: inuse (?P<udplite_inuse>\d+)\n)?"
-                        "RAW: inuse (?P<raw_inuse>\d+)\n"
-                        "FRAG: inuse (?P<ip_frag_nqueues>\d+)"
-                        " memory (?P<ip_frag_mem>\d+)\n")
+    regexp = re.compile(
+        "sockets: used \d+\n"
+        "TCP: inuse (?P<tcp_inuse>\d+) orphan (?P<orphans>\d+)"
+        " tw (?P<tw_count>\d+) alloc (?P<tcp_sockets>\d+)"
+        " mem (?P<tcp_pages>\d+)\n"
+        "UDP: inuse (?P<udp_inuse>\d+)"
+        # UDP memory accounting was added in v2.6.25-rc1
+        "(?: mem (?P<udp_pages>\d+))?\n"
+        # UDP-Lite (RFC 3828) was added in v2.6.20-rc2
+        "(?:UDPLITE: inuse (?P<udplite_inuse>\d+)\n)?"
+        "RAW: inuse (?P<raw_inuse>\d+)\n"
+        "FRAG: inuse (?P<ip_frag_nqueues>\d+)"
+        " memory (?P<ip_frag_mem>\d+)\n"
+    )
 
     def print_sockstat(metric, value, tags=""):  # Note: tags must start with ' '
         if value is not None:
             print("net.sockstat.%s %d %s%s" % (metric, ts, value, tags))
-
 
     # If a line in /proc/net/netstat doesn't start with a word in that dict,
     # we'll ignore it.  We use the value to build the metric name.
     known_netstatstypes = {
         "TcpExt:": "tcp",
         "IpExt:": "ip",  # We don't collect anything from here for now.
-        }
+    }
 
     # Any stat in /proc/net/netstat that doesn't appear in this dict will be
     # ignored.  If we find a match, we'll use the (metricname, tags).
@@ -236,16 +237,14 @@ def main():
         # We received something but had to drop it because the socket's
         # receive queue was full.
         "TCPBacklogDrop": ("receive.queue.full", None),
-        }
-
+    }
 
     def print_netstat(statstype, metric, value, tags=""):
         if tags:
             space = " "
         else:
             tags = space = ""
-        print("net.stat.%s.%s %d %s%s%s" % (statstype, metric, ts, value,
-                                            space, tags))
+        print("net.stat.%s.%s %d %s%s%s" % (statstype, metric, ts, value, space, tags))
 
     statsdikt = {}
     while True:
@@ -265,19 +264,17 @@ def main():
 
         # The difference between the first two values is the number of
         # sockets allocated vs the number of sockets actually in use.
-        print_sockstat("num_sockets",   m.group("tcp_sockets"),   " type=tcp")
-        print_sockstat("num_timewait",  m.group("tw_count"))
-        print_sockstat("sockets_inuse", m.group("tcp_inuse"),     " type=tcp")
-        print_sockstat("sockets_inuse", m.group("udp_inuse"),     " type=udp")
+        print_sockstat("num_sockets", m.group("tcp_sockets"), " type=tcp")
+        print_sockstat("num_timewait", m.group("tw_count"))
+        print_sockstat("sockets_inuse", m.group("tcp_inuse"), " type=tcp")
+        print_sockstat("sockets_inuse", m.group("udp_inuse"), " type=udp")
         print_sockstat("sockets_inuse", m.group("udplite_inuse"), " type=udplite")
-        print_sockstat("sockets_inuse", m.group("raw_inuse"),     " type=raw")
+        print_sockstat("sockets_inuse", m.group("raw_inuse"), " type=raw")
 
         print_sockstat("num_orphans", m.group("orphans"))
-        print_sockstat("memory", int(m.group("tcp_pages")) * page_size,
-                       " type=tcp")
+        print_sockstat("memory", int(m.group("tcp_pages")) * page_size, " type=tcp")
         if m.group("udp_pages") is not None:
-          print_sockstat("memory", int(m.group("udp_pages")) * page_size,
-                         " type=udp")
+            print_sockstat("memory", int(m.group("udp_pages")) * page_size, " type=udp")
         print_sockstat("memory", m.group("ip_frag_mem"), " type=ipfrag")
         print_sockstat("ipfragqueues", m.group("ip_frag_nqueues"))
 
@@ -297,7 +294,8 @@ def main():
             if line[0] not in known_netstatstypes:
                 print(
                     "Unrecoginized line in /proc/net/netstat: %r (file=%r)"
-                    % (line, stats), file=sys.stderr
+                    % (line, stats),
+                    file=sys.stderr,
                 )
                 continue
             statstype = line.pop(0)
@@ -319,6 +317,7 @@ def main():
 
         sys.stdout.flush()
         time.sleep(interval)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scalyr_agent/third_party/tcollector/collectors/0/procstats.py
+++ b/scalyr_agent/third_party/tcollector/collectors/0/procstats.py
@@ -20,7 +20,6 @@ from __future__ import unicode_literals
 import os
 import sys
 import time
-import socket
 import subprocess
 import re
 from io import open
@@ -133,7 +132,7 @@ def main():
         f_uptime.seek(0)
         ts = int(time.time())
         for line in f_uptime:
-            m = re.match("(\S+)\s+(\S+)", line)
+            m = re.match(r"(\S+)\s+(\S+)", line)
             if m:
                 print("proc.uptime.total %d %s" % (ts, m.group(1)))
                 print("proc.uptime.now %d %s" % (ts, m.group(2)))
@@ -142,7 +141,7 @@ def main():
         f_meminfo.seek(0)
         ts = int(time.time())
         for line in f_meminfo:
-            m = re.match("(\w+):\s+(\d+)", line)
+            m = re.match(r"(\w+):\s+(\d+)", line)
             if m:
                 print("proc.meminfo.%s %d %s" % (m.group(1).lower(), ts, m.group(2)))
 
@@ -150,7 +149,7 @@ def main():
         f_vmstat.seek(0)
         ts = int(time.time())
         for line in f_vmstat:
-            m = re.match("(\w+)\s+(\d+)", line)
+            m = re.match(r"(\w+)\s+(\d+)", line)
             if not m:
                 continue
             if m.group(1) in (
@@ -167,7 +166,7 @@ def main():
         f_stat.seek(0)
         ts = int(time.time())
         for line in f_stat:
-            m = re.match("(\w+)\s+(.*)", line)
+            m = re.match(r"(\w+)\s+(.*)", line)
             if not m:
                 continue
             if m.group(1) == "cpu":
@@ -197,7 +196,7 @@ def main():
         f_loadavg.seek(0)
         ts = int(time.time())
         for line in f_loadavg:
-            m = re.match("(\S+)\s+(\S+)\s+(\S+)\s+(\d+)/(\d+)\s+", line)
+            m = re.match(r"(\S+)\s+(\S+)\s+(\S+)\s+(\d+)/(\d+)\s+", line)
             if not m:
                 continue
             print("proc.loadavg.1min %d %s" % (ts, m.group(1)))

--- a/scalyr_agent/third_party/tcollector/collectors/0/procstats.py
+++ b/scalyr_agent/third_party/tcollector/collectors/0/procstats.py
@@ -44,7 +44,7 @@ def open_sysfs_numa_stats():
     except OSError as error:
         (errno, msg) = error.args
         if errno == 2:  # No such file or directory
-            return []   # We don't have NUMA stats.
+            return []  # We don't have NUMA stats.
         raise
 
     nodes = [node for node in nodes if node.startswith("node")]
@@ -64,14 +64,15 @@ def print_numa_stats(numafiles):
     """From a list of opened files, extracts and prints NUMA stats."""
     for numafile in numafiles:
         numafile.seek(0)
-        node_id = int(numafile.name[numafile.name.find("/node/node")+10:-9])
+        node_id = int(numafile.name[numafile.name.find("/node/node") + 10 : -9])
         ts = int(time.time())
         stats = dict(line.split() for line in numafile.read().splitlines())
-        for stat, tag in (# hit: process wanted memory from this node and got it
-                          ("numa_hit", "hit"),
-                          # miss: process wanted another node and got it from
-                          # this one instead.
-                          ("numa_miss", "miss")):
+        for stat, tag in (  # hit: process wanted memory from this node and got it
+            ("numa_hit", "hit"),
+            # miss: process wanted another node and got it from
+            # this one instead.
+            ("numa_miss", "miss"),
+        ):
             print(
                 "sys.numa.zoneallocs %d %s node=%d type=%s"
                 % (ts, stats[stat], node_id, tag)
@@ -87,10 +88,7 @@ def print_numa_stats(numafiles):
         )
         # When is memory allocated to a node that's local or remote to where
         # the process is running.
-        for stat, tag in (
-                ("local_node", "local"),
-                ("other_node", "remote")
-        ):
+        for stat, tag in (("local_node", "local"), ("other_node", "remote")):
             print(
                 "sys.numa.allocation %d %s node=%d type=%s"
                 % (ts, stats[stat], node_id, tag)
@@ -100,6 +98,7 @@ def print_numa_stats(numafiles):
             "sys.numa.interleave %d %s node=%d type=hit"
             % (ts, stats["interleave_hit"], node_id)
         )
+
 
 # Scalyr - print number of cpus
 def print_cpu_stats():
@@ -112,6 +111,7 @@ def print_cpu_stats():
             print("sys.cpu.count %d %s" % (ts, fields[0]))
     else:
         print("nproc --all returned %r" % nproc.returncode, file=sys.stderr)
+
 
 def main():
     """procstats main loop"""
@@ -144,10 +144,7 @@ def main():
         for line in f_meminfo:
             m = re.match("(\w+):\s+(\d+)", line)
             if m:
-                print(
-                    "proc.meminfo.%s %d %s"
-                    % (m.group(1).lower(), ts, m.group(2))
-                )
+                print("proc.meminfo.%s %d %s" % (m.group(1).lower(), ts, m.group(2)))
 
         # proc.vmstat
         f_vmstat.seek(0)
@@ -156,8 +153,14 @@ def main():
             m = re.match("(\w+)\s+(\d+)", line)
             if not m:
                 continue
-            if m.group(1) in ("pgpgin", "pgpgout", "pswpin",
-                              "pswpout", "pgfault", "pgmajfault"):
+            if m.group(1) in (
+                "pgpgin",
+                "pgpgout",
+                "pswpin",
+                "pswpout",
+                "pgfault",
+                "pgmajfault",
+            ):
                 print("proc.vmstat.%s %d %s" % (m.group(1), ts, m.group(2)))
 
         # proc.stat
@@ -178,18 +181,12 @@ def main():
                 print("proc.stat.cpu %d %s type=softirq" % (ts, fields[6]))
                 # really old kernels don't have this field
                 if len(fields) > 7:
-                    print(
-                        "proc.stat.cpu %d %s type=steal" % (ts, fields[7])
-                    )
+                    print("proc.stat.cpu %d %s type=steal" % (ts, fields[7]))
                     # old kernels don't have this field
                     if len(fields) > 8:
-                        print(
-                            "proc.stat.cpu %d %s type=guest" % (ts, fields[8])
-                        )
+                        print("proc.stat.cpu %d %s type=guest" % (ts, fields[8]))
             elif m.group(1) == "intr":
-                print(
-                    "proc.stat.intr %d %s" % (ts, m.group(2).split()[0])
-                )
+                print("proc.stat.intr %d %s" % (ts, m.group(2).split()[0]))
             elif m.group(1) == "ctxt":
                 print("proc.stat.ctxt %d %s" % (ts, m.group(2)))
             elif m.group(1) == "processes":
@@ -221,6 +218,6 @@ def main():
         sys.stdout.flush()
         time.sleep(COLLECTION_INTERVAL)
 
+
 if __name__ == "__main__":
     main()
-

--- a/scalyr_agent/third_party/tcollector/tcollector.py
+++ b/scalyr_agent/third_party/tcollector/tcollector.py
@@ -47,6 +47,7 @@ from six.moves.queue import Full
 
 import six
 from six.moves import range
+from six.moves import reload_module
 
 
 # global variables.
@@ -1050,7 +1051,7 @@ def load_config_module(name, options, tags):
         # Strip the trailing .py
         module = __import__(name[:-3], d, d)
     else:
-        module = reload(name)
+        module = reload_module(name)
     onload = module.__dict__.get("onload")
     if callable(onload):
         try:

--- a/scalyr_agent/third_party/tcollector/tcollector.py
+++ b/scalyr_agent/third_party/tcollector/tcollector.py
@@ -52,13 +52,14 @@ from six.moves import range
 # global variables.
 COLLECTORS = {}
 GENERATION = 0
-DEFAULT_LOG = '/var/log/tcollector.log'
-LOG = logging.getLogger('tcollector')
+DEFAULT_LOG = "/var/log/tcollector.log"
+LOG = logging.getLogger("tcollector")
 ALIVE = True
 # If the SenderThread catches more than this many consecutive uncaught
 # exceptions, something is not right and tcollector will shutdown.
 # Hopefully some kind of supervising daemon will then restart it.
 MAX_UNCAUGHT_EXCEPTIONS = 100
+
 
 def register_collector(collector):
     """Register a collector with the COLLECTORS global"""
@@ -69,8 +70,11 @@ def register_collector(collector):
     if collector.name in COLLECTORS:
         col = COLLECTORS[collector.name]
         if col.proc is not None:
-            LOG.error('%s still has a process (pid=%d) and is being reset,'
-                      ' terminating', col.name, col.proc.pid)
+            LOG.error(
+                "%s still has a process (pid=%d) and is being reset," " terminating",
+                col.name,
+                col.proc.pid,
+            )
             col.shutdown()
 
     COLLECTORS[collector.name] = collector
@@ -138,16 +142,15 @@ class Collector(object):
         try:
             out = self.proc.stderr.read()
             if out:
-                LOG.debug('reading %s got %d bytes on stderr',
-                          self.name, len(out))
+                LOG.debug("reading %s got %d bytes on stderr", self.name, len(out))
                 for line in out.splitlines():
-                    LOG.warning('%s: %s', self.name, line)
+                    LOG.warning("%s: %s", self.name, line)
         except IOError as error:
             (err, msg) = error.args
             if err != errno.EAGAIN:
                 raise
         except:
-            LOG.exception('uncaught exception in stderr read')
+            LOG.exception("uncaught exception in stderr read")
 
         # we have to use a buffer because sometimes the collectors will write
         # out a bunch of data points at one time and we get some weird sized
@@ -157,8 +160,9 @@ class Collector(object):
             if stdout_data:
                 self.buffer += stdout_data.decode("utf-8")
             if len(self.buffer):
-                LOG.debug('reading %s, buffer now %d bytes',
-                          self.name, len(self.buffer))
+                LOG.debug(
+                    "reading %s, buffer now %d bytes", self.name, len(self.buffer)
+                )
         except IOError as error:
             (err, msg) = error.args
             if err != errno.EAGAIN:
@@ -166,12 +170,12 @@ class Collector(object):
         except:
             # sometimes the process goes away in another thread and we don't
             # have it anymore, so log an error and bail
-            LOG.exception('uncaught exception in stdout read')
+            LOG.exception("uncaught exception in stdout read")
             return
 
         # iterate for each line we have
         while self.buffer:
-            idx = self.buffer.find('\n')
+            idx = self.buffer.find("\n")
             if idx == -1:
                 break
 
@@ -179,7 +183,7 @@ class Collector(object):
             line = self.buffer[0:idx].strip()
             if line:
                 self.datalines.append(line)
-            self.buffer = self.buffer[idx+1:]
+            self.buffer = self.buffer[idx + 1 :]
 
     def collect(self):
         """Reads input from the collector and returns the lines up to whomever
@@ -216,14 +220,16 @@ class Collector(object):
                 for attempt in range(5):
                     if self.proc.poll() is not None:
                         return
-                    LOG.info('Waiting %ds for PID %d to exit...'
-                             % (5 - attempt, self.proc.pid))
+                    LOG.info(
+                        "Waiting %ds for PID %d to exit..."
+                        % (5 - attempt, self.proc.pid)
+                    )
                     time.sleep(1)
                 kill(self.proc, signal.SIGKILL)
                 self.proc.wait()
         except:
             # we really don't want to die as we're trying to exit gracefully
-            LOG.exception('ignoring uncaught exception while shutting down')
+            LOG.exception("ignoring uncaught exception while shutting down")
 
     def evict_old_keys(self, cut_off):
         """Remove old entries from the cache used to detect duplicate values.
@@ -250,7 +256,7 @@ class StdinCollector(Collector):
        will be blocking."""
 
     def __init__(self):
-        super(StdinCollector, self).__init__('stdin', 0, '<stdin>')
+        super(StdinCollector, self).__init__("stdin", 0, "<stdin>")
 
         # hack to make this work.  nobody else will rely on self.proc
         # except as a test in the stdin mode.
@@ -268,7 +274,6 @@ class StdinCollector(Collector):
             self.datalines.append(line.rstrip())
         else:
             ALIVE = False
-
 
     def shutdown(self):
 
@@ -297,8 +302,10 @@ class ReaderThread(threading.Thread):
               run_state: A RunState instance that is used to signal when this
                 thread should be stopped.
         """
-        assert evictinterval > dedupinterval, "%r <= %r" % (evictinterval,
-                                                            dedupinterval)
+        assert evictinterval > dedupinterval, "%r <= %r" % (
+            evictinterval,
+            dedupinterval,
+        )
         super(ReaderThread, self).__init__()
 
         self.readerq = ReaderQueue(100000)
@@ -319,7 +326,9 @@ class ReaderThread(threading.Thread):
         # select or other thing to wait for input on our children,
         # while breaking out every once in a while to setup selects
         # on new children.
-        while (self.run_state is None and ALIVE) or (self.run_state is not None and self.run_state.is_running()):
+        while (self.run_state is None and ALIVE) or (
+            self.run_state is not None and self.run_state.is_running()
+        ):
             for col in all_living_collectors():
                 for line in col.collect():
                     self.process_line(col, line)
@@ -347,16 +356,18 @@ class ReaderThread(threading.Thread):
 
         col.lines_received += 1
         if len(line) >= 1024:  # Limit in net.opentsdb.tsd.PipelineFactory
-            LOG.warning('%s line too long: %s', col.name, line)
+            LOG.warning("%s line too long: %s", col.name, line)
             col.lines_invalid += 1
             return
-        parsed = re.match('^([-_./a-zA-Z0-9]+)\s+' # Metric name.
-                          '(\d+)\s+'               # Timestamp.
-                          '(\S+?)'                 # Value (int or float).
-                          '((?:\s+[-_./a-zA-Z0-9]+=[-~_./a-zA-Z0-9]+)*)$', # Tags
-                          line)
+        parsed = re.match(
+            "^([-_./a-zA-Z0-9]+)\s+"  # Metric name.
+            "(\d+)\s+"  # Timestamp.
+            "(\S+?)"  # Value (int or float).
+            "((?:\s+[-_./a-zA-Z0-9]+=[-~_./a-zA-Z0-9]+)*)$",  # Tags
+            line,
+        )
         if parsed is None:
-            LOG.warning('%s sent invalid data: %s', col.name, line)
+            LOG.warning("%s sent invalid data: %s", col.name, line)
             col.lines_invalid += 1
             return
         metric, timestamp, value, tags = parsed.groups()
@@ -375,10 +386,17 @@ class ReaderThread(threading.Thread):
         if key in col.values:
             # if the timestamp isn't > than the previous one, ignore this value
             if timestamp <= col.values[key][3]:
-                LOG.error("Timestamp out of order: metric=%s%s,"
-                          " old_ts=%d >= new_ts=%d - ignoring data point"
-                          " (value=%r, collector=%s)", metric, tags,
-                          col.values[key][3], timestamp, value, col.name)
+                LOG.error(
+                    "Timestamp out of order: metric=%s%s,"
+                    " old_ts=%d >= new_ts=%d - ignoring data point"
+                    " (value=%r, collector=%s)",
+                    metric,
+                    tags,
+                    col.values[key][3],
+                    timestamp,
+                    value,
+                    col.name,
+                )
                 col.lines_invalid += 1
                 return
 
@@ -387,8 +405,9 @@ class ReaderThread(threading.Thread):
             # we send the timestamp when this metric first became the current
             # value instead of the last.  Fall through if we reach
             # the dedup interval so we can print the value.
-            if (col.values[key][0] == value and
-                (timestamp - col.values[key][3] < self.dedupinterval)):
+            if col.values[key][0] == value and (
+                timestamp - col.values[key][3] < self.dedupinterval
+            ):
                 col.values[key] = (value, True, line, col.values[key][3])
                 return
 
@@ -397,10 +416,14 @@ class ReaderThread(threading.Thread):
             # replay the last value we skipped (if changed) so the jumps in
             # our graph are accurate,
             # Scalyr edit:  Added the dedupinterval > 0 term.
-            if ((self.dedupinterval > 0) and
-                    (col.values[key][1] or
-                    (timestamp - col.values[key][3] >= self.dedupinterval)) and
-                    (col.values[key][0] != value)):
+            if (
+                (self.dedupinterval > 0)
+                and (
+                    col.values[key][1]
+                    or (timestamp - col.values[key][3] >= self.dedupinterval)
+                )
+                and (col.values[key][0] != value)
+            ):
                 col.lines_sent += 1
                 if not self.readerq.nput(col.values[key][2]):
                     self.lines_dropped += 1
@@ -478,17 +501,22 @@ class SenderThread(threading.Thread):
 
                 self.send_data()
                 errors = 0  # We managed to do a successful iteration.
-            except (ArithmeticError, EOFError, EnvironmentError, LookupError,
-                    ValueError) as e:
+            except (
+                ArithmeticError,
+                EOFError,
+                EnvironmentError,
+                LookupError,
+                ValueError,
+            ) as e:
                 errors += 1
                 if errors > MAX_UNCAUGHT_EXCEPTIONS:
                     shutdown()
                     raise
-                LOG.exception('Uncaught exception in SenderThread, ignoring')
+                LOG.exception("Uncaught exception in SenderThread, ignoring")
                 time.sleep(1)
                 continue
             except:
-                LOG.exception('Uncaught exception in SenderThread, going to exit')
+                LOG.exception("Uncaught exception in SenderThread, going to exit")
                 shutdown()
                 raise
 
@@ -504,9 +532,9 @@ class SenderThread(threading.Thread):
 
         # we use the version command as it is very low effort for the TSD
         # to respond
-        LOG.debug('verifying our TSD connection is alive')
+        LOG.debug("verifying our TSD connection is alive")
         try:
-            self.tsd.sendall('version\n')
+            self.tsd.sendall("version\n")
         except socket.error as msg:
             self.tsd = None
             return False
@@ -537,29 +565,37 @@ class SenderThread(threading.Thread):
             # helps to see what is going on with the tcollector.
             if self.self_report_stats:
                 strs = [
-                        ('reader.lines_collected',
-                         '', self.reader.lines_collected),
-                        ('reader.lines_dropped',
-                         '', self.reader.lines_dropped)
-                       ]
+                    ("reader.lines_collected", "", self.reader.lines_collected),
+                    ("reader.lines_dropped", "", self.reader.lines_dropped),
+                ]
 
                 for col in all_living_collectors():
-                    strs.append((
-                        'collector.lines_sent',
-                        'collector=' + col.name, col.lines_sent
-                    ))
-                    strs.append((
-                        'collector.lines_received',
-                        'collector=' + col.name, col.lines_received
-                    ))
-                    strs.append((
-                        'collector.lines_invalid',
-                        'collector=' + col.name, col.lines_invalid
-                    ))
+                    strs.append(
+                        (
+                            "collector.lines_sent",
+                            "collector=" + col.name,
+                            col.lines_sent,
+                        )
+                    )
+                    strs.append(
+                        (
+                            "collector.lines_received",
+                            "collector=" + col.name,
+                            col.lines_received,
+                        )
+                    )
+                    strs.append(
+                        (
+                            "collector.lines_invalid",
+                            "collector=" + col.name,
+                            col.lines_invalid,
+                        )
+                    )
 
                 ts = int(time.time())
-                strout = ["tcollector.%s %d %d %s"
-                          % (x[0], ts, x[2], x[1]) for x in strs]
+                strout = [
+                    "tcollector.%s %d %d %s" % (x[0], ts, x[2], x[1]) for x in strs
+                ]
                 for string in strout:
                     self.sendq.append(string)
 
@@ -591,12 +627,13 @@ class SenderThread(threading.Thread):
             try_delay *= 1 + random.random()
             if try_delay > 600:
                 try_delay *= 0.5
-            LOG.debug('SenderThread blocking %0.2f seconds', try_delay)
+            LOG.debug("SenderThread blocking %0.2f seconds", try_delay)
             time.sleep(try_delay)
 
             # Now actually try the connection.
-            adresses = socket.getaddrinfo(self.host, self.port, socket.AF_UNSPEC,
-                                          socket.SOCK_STREAM, 0)
+            adresses = socket.getaddrinfo(
+                self.host, self.port, socket.AF_UNSPEC, socket.SOCK_STREAM, 0
+            )
             for family, socktype, proto, canonname, sockaddr in adresses:
                 try:
                     self.tsd = socket.socket(family, socktype, proto)
@@ -605,25 +642,29 @@ class SenderThread(threading.Thread):
                     # if we get here it connected
                     break
                 except socket.error as msg:
-                    LOG.warning('Connection attempt failed to %s:%d: %s',
-                                self.host, self.port, msg)
+                    LOG.warning(
+                        "Connection attempt failed to %s:%d: %s",
+                        self.host,
+                        self.port,
+                        msg,
+                    )
                 self.tsd.close()
                 self.tsd = None
             if not self.tsd:
-                LOG.error('Failed to connect to %s:%d', self.host, self.port)
+                LOG.error("Failed to connect to %s:%d", self.host, self.port)
 
     def send_data(self):
         """Sends outstanding data in self.sendq to the TSD in one operation."""
 
         # construct the output string
-        out = ''
+        out = ""
         for line in self.sendq:
-            line = 'put ' + line + self.tagstr
-            out += line + '\n'
-            LOG.debug('SENDING: %s', line)
+            line = "put " + line + self.tagstr
+            out += line + "\n"
+            LOG.debug("SENDING: %s", line)
 
         if not out:
-            LOG.debug('send_data no data?')
+            LOG.debug("send_data no data?")
             return
 
         # try sending our data.  if an exception occurs, just error and
@@ -635,7 +676,7 @@ class SenderThread(threading.Thread):
                 self.tsd.sendall(out)
             self.sendq = []
         except socket.error as msg:
-            LOG.error('failed to send data: %s', msg)
+            LOG.error("failed to send data: %s", msg)
             try:
                 self.tsd.close()
             except socket.error:
@@ -653,80 +694,155 @@ def setup_logging(logfile=DEFAULT_LOG, max_bytes=None, backup_count=None):
     if backup_count is not None and max_bytes is not None:
         assert backup_count > 0
         assert max_bytes > 0
-        ch = RotatingFileHandler(logfile, 'a', max_bytes, backup_count)
+        ch = RotatingFileHandler(logfile, "a", max_bytes, backup_count)
     else:  # Setup stream handler.
         ch = logging.StreamHandler(sys.stdout)
 
-    ch.setFormatter(logging.Formatter('%(asctime)s %(name)s[%(process)d] '
-                                      '%(levelname)s: %(message)s'))
+    ch.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(name)s[%(process)d] " "%(levelname)s: %(message)s"
+        )
+    )
     LOG.addHandler(ch)
+
 
 # Scalyr edit: Added this override
 def override_logging(logger):
     global LOG
     LOG = logger
 
+
 def parse_cmdline(argv):
     """Parses the command-line."""
 
     # get arguments
-    default_cdir = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])),
-                                'collectors')
-    parser = OptionParser(description='Manages collectors which gather '
-                                       'data and report back.')
-    parser.add_option('-c', '--collector-dir', dest='cdir', metavar='DIR',
-                      default=default_cdir,
-                      help='Directory where the collectors are located.')
-    parser.add_option('-d', '--dry-run', dest='dryrun', action='store_true',
-                      default=False,
-                      help='Don\'t actually send anything to the TSD, '
-                           'just print the datapoints.')
-    parser.add_option('-H', '--host', dest='host', default='localhost',
-                      metavar='HOST',
-                      help='Hostname to use to connect to the TSD.')
-    parser.add_option('--no-tcollector-stats', dest='no_tcollector_stats',
-                      default=False, action='store_true',
-                      help='Prevent tcollector from reporting its own stats to TSD')
-    parser.add_option('-s', '--stdin', dest='stdin', action='store_true',
-                      default=False,
-                      help='Run once, read and dedup data points from stdin.')
-    parser.add_option('-p', '--port', dest='port', type='int',
-                      default=4242, metavar='PORT',
-                      help='Port to connect to the TSD instance on. '
-                           'default=%default')
-    parser.add_option('-v', dest='verbose', action='store_true', default=False,
-                      help='Verbose mode (log debug messages).')
-    parser.add_option('-t', '--tag', dest='tags', action='append',
-                      default=[], metavar='TAG',
-                      help='Tags to append to all timeseries we send, '
-                           'e.g.: -t TAG=VALUE -t TAG2=VALUE')
-    parser.add_option('-P', '--pidfile', dest='pidfile',
-                      default='/var/run/tcollector.pid',
-                      metavar='FILE', help='Write our pidfile')
-    parser.add_option('--dedup-interval', dest='dedupinterval', type='int',
-                      default=300, metavar='DEDUPINTERVAL',
-                      help='Number of seconds in which successive duplicate '
-                           'datapoints are suppressed before sending to the TSD. '
-                           'default=%default')
-    parser.add_option('--evict-interval', dest='evictinterval', type='int',
-                      default=6000, metavar='EVICTINTERVAL',
-                      help='Number of seconds after which to remove cached '
-                           'values of old data points to save memory. '
-                           'default=%default')
-    parser.add_option('--max-bytes', dest='max_bytes', type='int',
-                      default=64 * 1024 * 1024,
-                      help='Maximum bytes per a logfile.')
-    parser.add_option('--backup-count', dest='backup_count', type='int',
-                      default=0, help='Maximum number of logfiles to backup.')
-    parser.add_option('--logfile', dest='logfile', type='str',
-                      default=DEFAULT_LOG,
-                      help='Filename where logs are written to.')
+    default_cdir = os.path.join(
+        os.path.dirname(os.path.realpath(sys.argv[0])), "collectors"
+    )
+    parser = OptionParser(
+        description="Manages collectors which gather " "data and report back."
+    )
+    parser.add_option(
+        "-c",
+        "--collector-dir",
+        dest="cdir",
+        metavar="DIR",
+        default=default_cdir,
+        help="Directory where the collectors are located.",
+    )
+    parser.add_option(
+        "-d",
+        "--dry-run",
+        dest="dryrun",
+        action="store_true",
+        default=False,
+        help="Don't actually send anything to the TSD, " "just print the datapoints.",
+    )
+    parser.add_option(
+        "-H",
+        "--host",
+        dest="host",
+        default="localhost",
+        metavar="HOST",
+        help="Hostname to use to connect to the TSD.",
+    )
+    parser.add_option(
+        "--no-tcollector-stats",
+        dest="no_tcollector_stats",
+        default=False,
+        action="store_true",
+        help="Prevent tcollector from reporting its own stats to TSD",
+    )
+    parser.add_option(
+        "-s",
+        "--stdin",
+        dest="stdin",
+        action="store_true",
+        default=False,
+        help="Run once, read and dedup data points from stdin.",
+    )
+    parser.add_option(
+        "-p",
+        "--port",
+        dest="port",
+        type="int",
+        default=4242,
+        metavar="PORT",
+        help="Port to connect to the TSD instance on. " "default=%default",
+    )
+    parser.add_option(
+        "-v",
+        dest="verbose",
+        action="store_true",
+        default=False,
+        help="Verbose mode (log debug messages).",
+    )
+    parser.add_option(
+        "-t",
+        "--tag",
+        dest="tags",
+        action="append",
+        default=[],
+        metavar="TAG",
+        help="Tags to append to all timeseries we send, "
+        "e.g.: -t TAG=VALUE -t TAG2=VALUE",
+    )
+    parser.add_option(
+        "-P",
+        "--pidfile",
+        dest="pidfile",
+        default="/var/run/tcollector.pid",
+        metavar="FILE",
+        help="Write our pidfile",
+    )
+    parser.add_option(
+        "--dedup-interval",
+        dest="dedupinterval",
+        type="int",
+        default=300,
+        metavar="DEDUPINTERVAL",
+        help="Number of seconds in which successive duplicate "
+        "datapoints are suppressed before sending to the TSD. "
+        "default=%default",
+    )
+    parser.add_option(
+        "--evict-interval",
+        dest="evictinterval",
+        type="int",
+        default=6000,
+        metavar="EVICTINTERVAL",
+        help="Number of seconds after which to remove cached "
+        "values of old data points to save memory. "
+        "default=%default",
+    )
+    parser.add_option(
+        "--max-bytes",
+        dest="max_bytes",
+        type="int",
+        default=64 * 1024 * 1024,
+        help="Maximum bytes per a logfile.",
+    )
+    parser.add_option(
+        "--backup-count",
+        dest="backup_count",
+        type="int",
+        default=0,
+        help="Maximum number of logfiles to backup.",
+    )
+    parser.add_option(
+        "--logfile",
+        dest="logfile",
+        type="str",
+        default=DEFAULT_LOG,
+        help="Filename where logs are written to.",
+    )
     (options, args) = parser.parse_args(args=argv[1:])
     if options.dedupinterval < 2:
-      parser.error('--dedup-interval must be at least 2 seconds')
+        parser.error("--dedup-interval must be at least 2 seconds")
     if options.evictinterval <= options.dedupinterval:
-      parser.error('--evict-interval must be strictly greater than '
-                   '--dedup-interval')
+        parser.error(
+            "--evict-interval must be strictly greater than " "--dedup-interval"
+        )
     return (options, args)
 
 
@@ -734,8 +850,9 @@ def main(argv):
     """The main tcollector entry point and loop."""
 
     options, args = parse_cmdline(argv)
-    setup_logging(options.logfile, options.max_bytes or None,
-                  options.backup_count or None)
+    setup_logging(
+        options.logfile, options.max_bytes or None, options.backup_count or None
+    )
 
     if options.verbose:
         LOG.setLevel(logging.DEBUG)  # up our level
@@ -746,31 +863,31 @@ def main(argv):
     # validate everything
     tags = {}
     for tag in options.tags:
-        if re.match('^[-_.a-z0-9]+=\S+$', tag, re.IGNORECASE) is None:
+        if re.match("^[-_.a-z0-9]+=\S+$", tag, re.IGNORECASE) is None:
             assert False, 'Tag string "%s" is invalid.' % tag
-        k, v = tag.split('=', 1)
+        k, v = tag.split("=", 1)
         if k in tags:
             assert False, 'Tag "%s" already declared.' % k
         tags[k] = v
 
     options.cdir = os.path.realpath(options.cdir)
     if not os.path.isdir(options.cdir):
-        LOG.fatal('No such directory: %s', options.cdir)
+        LOG.fatal("No such directory: %s", options.cdir)
         return 1
     modules = load_etc_dir(options, tags)
 
     # tsdb does not require a host tag, but we do.  we are always running on a
     # host.  FIXME: we should make it so that collectors may request to set
     # their own host tag, or not set one.
-    if not 'host' in tags and not options.stdin:
-        tags['host'] = socket.gethostname()
-        LOG.warning('Tag "host" not specified, defaulting to %s.', tags['host'])
+    if not "host" in tags and not options.stdin:
+        tags["host"] = socket.gethostname()
+        LOG.warning('Tag "host" not specified, defaulting to %s.', tags["host"])
 
     # prebuild the tag string from our tags dict
-    tagstr = ''
+    tagstr = ""
     if tags:
-        tagstr = ' '.join('%s=%s' % (k, v) for k, v in six.iteritems(tags))
-        tagstr = ' ' + tagstr.strip()
+        tagstr = " ".join("%s=%s" % (k, v) for k, v in six.iteritems(tags))
+        tagstr = " " + tagstr.strip()
 
     # gracefully handle death for normal termination paths and abnormal
     atexit.register(shutdown)
@@ -783,10 +900,16 @@ def main(argv):
     reader.start()
 
     # and setup the sender to start writing out to the tsd
-    sender = SenderThread(reader, options.dryrun, options.host, options.port,
-                          not options.no_tcollector_stats, tagstr)
+    sender = SenderThread(
+        reader,
+        options.dryrun,
+        options.host,
+        options.port,
+        not options.no_tcollector_stats,
+        tagstr,
+    )
     sender.start()
-    LOG.info('SenderThread startup complete')
+    LOG.info("SenderThread startup complete")
 
     # if we're in stdin mode, build a stdin collector and just join on the
     # reader thread since there's nothing else for us to do here
@@ -796,10 +919,11 @@ def main(argv):
     else:
         sys.stdin.close()
         main_loop(options, modules, sender, tags)
-    LOG.debug('Shutting down -- joining the reader thread.')
+    LOG.debug("Shutting down -- joining the reader thread.")
     reader.join()
-    LOG.debug('Shutting down -- joining the sender thread.')
+    LOG.debug("Shutting down -- joining the sender thread.")
     sender.join()
+
 
 def stdin_loop(options, modules, sender, tags):
     """The main loop of the program that runs when we are in stdin mode."""
@@ -811,8 +935,10 @@ def stdin_loop(options, modules, sender, tags):
         reload_changed_config_modules(modules, options, sender, tags)
         now = int(time.time())
         if now >= next_heartbeat:
-            LOG.info('Heartbeat (%d collectors running)'
-                     % sum(1 for col in all_living_collectors()))
+            LOG.info(
+                "Heartbeat (%d collectors running)"
+                % sum(1 for col in all_living_collectors())
+            )
             next_heartbeat = now + 600
 
 
@@ -828,7 +954,15 @@ def reset_for_new_run():
 
 
 # Scalyr edit:  Added last three arguments.
-def main_loop(options, modules, sender, tags, output_heartbeats=True, run_state=None, sample_interval_secs=30.0):
+def main_loop(
+    options,
+    modules,
+    sender,
+    tags,
+    output_heartbeats=True,
+    run_state=None,
+    sample_interval_secs=30.0,
+):
     """The main loop of the program that runs when we're not in stdin mode.
 
     The last argument is a function that if invoked will return true if the collector has been terminated.
@@ -839,7 +973,9 @@ def main_loop(options, modules, sender, tags, output_heartbeats=True, run_state=
     # This relies on the individual collectors checking this variable.
     os.environ["TCOLLECTOR_SAMPLE_INTERVAL"] = six.text_type(sample_interval_secs)
     # Scalyr edit: Set the environment variable used by ifstat.py to determine different network interface names.
-    os.environ["TCOLLECTOR_INTERFACE_PREFIX"] = ",".join(options.network_interface_prefixes)
+    os.environ["TCOLLECTOR_INTERFACE_PREFIX"] = ",".join(
+        options.network_interface_prefixes
+    )
     os.environ["TCOLLECTOR_INTERFACE_SUFFIX"] = options.network_interface_suffix
     # Scalyr edit: Set the environment variable for dfstat.py
     os.environ["TCOLLECTOR_LOCAL_DISKS_ONLY"] = six.text_type(options.local_disks_only)
@@ -856,8 +992,10 @@ def main_loop(options, modules, sender, tags, output_heartbeats=True, run_state=
             time.sleep(15)
         now = int(time.time())
         if output_heartbeats and now >= next_heartbeat:
-            LOG.info('Heartbeat (%d collectors running)'
-                     % sum(1 for col in all_living_collectors()))
+            LOG.info(
+                "Heartbeat (%d collectors running)"
+                % sum(1 for col in all_living_collectors())
+            )
             next_heartbeat = now + 600
 
 
@@ -865,9 +1003,11 @@ def list_config_modules(etcdir):
     """Returns an iterator that yields the name of all the config modules."""
     if not os.path.isdir(etcdir):
         return iter(())  # Empty iterator.
-    return (name for name in os.listdir(etcdir)
-            if (name.endswith('.py')
-                and os.path.isfile(os.path.join(etcdir, name))))
+    return (
+        name
+        for name in os.listdir(etcdir)
+        if (name.endswith(".py") and os.path.isfile(os.path.join(etcdir, name)))
+    )
 
 
 def load_etc_dir(options, tags):
@@ -876,7 +1016,7 @@ def load_etc_dir(options, tags):
     Returns: A dict of path -> (module, timestamp).
     """
 
-    etcdir = os.path.join(options.cdir, 'etc')
+    etcdir = os.path.join(options.cdir, "etc")
     # Save the path so we can restore it later.
     original_path = sys.path
     sys.path = list(original_path)
@@ -905,20 +1045,20 @@ def load_config_module(name, options, tags):
     """
 
     if isinstance(name, six.text_type):
-      LOG.info('Loading %s', name)
-      d = {}
-      # Strip the trailing .py
-      module = __import__(name[:-3], d, d)
+        LOG.info("Loading %s", name)
+        d = {}
+        # Strip the trailing .py
+        module = __import__(name[:-3], d, d)
     else:
-      module = reload(name)
-    onload = module.__dict__.get('onload')
+        module = reload(name)
+    onload = module.__dict__.get("onload")
     if callable(onload):
         try:
             onload(options, tags)
         except:
             # Scalyr edit:  Add this line to disable the fatal log.
-            if not 'no_fatal_on_error' in options:
-                LOG.fatal('Exception while loading %s', name)
+            if not "no_fatal_on_error" in options:
+                LOG.fatal("Exception while loading %s", name)
             raise
     return module
 
@@ -932,10 +1072,9 @@ def reload_changed_config_modules(modules, options, sender, tags):
     Returns: whether or not anything has changed.
     """
 
-    etcdir = os.path.join(options.cdir, 'etc')
+    etcdir = os.path.join(options.cdir, "etc")
     current_modules = set(list_config_modules(etcdir))
-    current_paths = set(os.path.join(etcdir, name)
-                        for name in current_modules)
+    current_paths = set(os.path.join(etcdir, name) for name in current_modules)
     changed = False
 
     # Reload any module that has changed.
@@ -944,14 +1083,14 @@ def reload_changed_config_modules(modules, options, sender, tags):
             continue
         mtime = os.path.getmtime(path)
         if mtime > timestamp:
-            LOG.info('Reloading %s, file has changed', path)
+            LOG.info("Reloading %s, file has changed", path)
             module = load_config_module(module, options, tags)
             modules[path] = (module, mtime)
             changed = True
 
     # Remove any module that has been removed.
     for path in set(modules).difference(current_paths):
-        LOG.info('%s has been removed, tcollector should be restarted', path)
+        LOG.info("%s has been removed, tcollector should be restarted", path)
         del modules[path]
         changed = True
 
@@ -965,9 +1104,8 @@ def reload_changed_config_modules(modules, options, sender, tags):
 
     # Scalyr edit:  Added and not sender is None
     if changed and not sender is None:
-        sender.tagstr = ' '.join('%s=%s' % (k, v)
-                                 for k, v in six.iteritems(tags))
-        sender.tagstr = ' ' + sender.tagstr.strip()
+        sender.tagstr = " ".join("%s=%s" % (k, v) for k, v in six.iteritems(tags))
+        sender.tagstr = " " + sender.tagstr.strip()
     return changed
 
 
@@ -1015,7 +1153,7 @@ def shutdown_signal(signum, frame):
 
 
 def kill(proc, signum=signal.SIGTERM):
-  os.kill(proc.pid, signum)
+    os.kill(proc.pid, signum)
 
 
 # Scalyr edit.  Added invoke_exit argument and the pre-die routine.
@@ -1030,7 +1168,7 @@ def shutdown(invoke_exit=True):
     # notify threads of program termination
     ALIVE = False
 
-    LOG.info('shutting down children')
+    LOG.info("shutting down children")
 
     # to help more quickly kill all collectors, do a pass where we tell them to die
     # but do not wait for termination.
@@ -1042,7 +1180,7 @@ def shutdown(invoke_exit=True):
         col.shutdown()
 
     if invoke_exit:
-        LOG.info('exiting')
+        LOG.info("exiting")
         sys.exit(1)
 
 
@@ -1064,17 +1202,23 @@ def reap_children():
         # is used to indicate that we don't want to restart this collector.
         # any other status code is an error and is logged.
         if status == 13:
-            LOG.info('removing %s from the list of collectors (by request)',
-                      col.name)
+            LOG.info("removing %s from the list of collectors (by request)", col.name)
             col.dead = True
         elif status != 0:
-            LOG.warning('collector %s terminated after %d seconds with '
-                        'status code %d, marking dead',
-                        col.name, now - col.lastspawn, status)
+            LOG.warning(
+                "collector %s terminated after %d seconds with "
+                "status code %d, marking dead",
+                col.name,
+                now - col.lastspawn,
+                status,
+            )
             col.dead = True
         else:
-            register_collector(Collector(col.name, col.interval, col.filename,
-                                         col.mtime, col.lastspawn))
+            register_collector(
+                Collector(
+                    col.name, col.interval, col.filename, col.mtime, col.lastspawn
+                )
+            )
 
 
 def set_nonblocking(fd):
@@ -1086,17 +1230,18 @@ def set_nonblocking(fd):
 def spawn_collector(col):
     """Takes a Collector object and creates a process for it."""
 
-    LOG.info('%s (interval=%d) needs to be spawned', col.name, col.interval)
+    LOG.info("%s (interval=%d) needs to be spawned", col.name, col.interval)
 
     # FIXME: do custom integration of Python scripts into memory/threads
     # if re.search('\.py$', col.name) is not None:
     #     ... load the py module directly instead of using a subprocess ...
     try:
         # Scalyr edit:  Add in close_fds=True
-        col.proc = subprocess.Popen(col.filename, stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE, close_fds=True)
+        col.proc = subprocess.Popen(
+            col.filename, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True
+        )
     except OSError as e:
-        LOG.error('Failed to spawn collector %s: %s' % (col.filename, e))
+        LOG.error("Failed to spawn collector %s: %s" % (col.filename, e))
         return
     # The following line needs to move below this line because it is used in
     # other logic and it makes no sense to update the last spawn time if the
@@ -1106,10 +1251,10 @@ def spawn_collector(col):
     set_nonblocking(col.proc.stderr.fileno())
     if col.proc.pid > 0:
         col.dead = False
-        LOG.info('spawned %s (pid=%d)', col.name, col.proc.pid)
+        LOG.info("spawned %s (pid=%d)", col.name, col.proc.pid)
         return
     # FIXME: handle errors better
-    LOG.error('failed to spawn collector: %s', col.filename)
+    LOG.error("failed to spawn collector: %s", col.filename)
 
 
 def spawn_children():
@@ -1134,23 +1279,34 @@ def spawn_children():
             if col.nextkill > now:
                 continue
             if col.killstate == 0:
-                LOG.warning('warning: %s (interval=%d, pid=%d) overstayed '
-                            'its welcome, SIGTERM sent',
-                            col.name, col.interval, col.proc.pid)
+                LOG.warning(
+                    "warning: %s (interval=%d, pid=%d) overstayed "
+                    "its welcome, SIGTERM sent",
+                    col.name,
+                    col.interval,
+                    col.proc.pid,
+                )
                 kill(col.proc)
                 col.nextkill = now + 5
                 col.killstate = 1
             elif col.killstate == 1:
-                LOG.error('error: %s (interval=%d, pid=%d) still not dead, '
-                           'SIGKILL sent',
-                           col.name, col.interval, col.proc.pid)
+                LOG.error(
+                    "error: %s (interval=%d, pid=%d) still not dead, " "SIGKILL sent",
+                    col.name,
+                    col.interval,
+                    col.proc.pid,
+                )
                 kill(col.proc, signal.SIGKILL)
                 col.nextkill = now + 5
                 col.killstate = 2
             else:
-                LOG.error('error: %s (interval=%d, pid=%d) needs manual '
-                           'intervention to kill it',
-                           col.name, col.interval, col.proc.pid)
+                LOG.error(
+                    "error: %s (interval=%d, pid=%d) needs manual "
+                    "intervention to kill it",
+                    col.name,
+                    col.interval,
+                    col.proc.pid,
+                )
                 col.nextkill = now + 300
 
 
@@ -1171,11 +1327,11 @@ def populate_collectors(coldir):
             continue
         interval = int(interval)
 
-        for colname in os.listdir('%s/%d' % (coldir, interval)):
-            if colname.startswith('.'):
+        for colname in os.listdir("%s/%d" % (coldir, interval)):
+            if colname.startswith("."):
                 continue
 
-            filename = '%s/%d/%s' % (coldir, interval, colname)
+            filename = "%s/%d/%s" % (coldir, interval, colname)
             if os.path.isfile(filename):
                 mtime = os.path.getmtime(filename)
 
@@ -1190,37 +1346,40 @@ def populate_collectors(coldir):
                     # add now.  there is probably a more robust way of doing
                     # this...
                     if col.interval != interval:
-                        LOG.error('two collectors with the same name %s and '
-                                   'different intervals %d and %d',
-                                   colname, interval, col.interval)
+                        LOG.error(
+                            "two collectors with the same name %s and "
+                            "different intervals %d and %d",
+                            colname,
+                            interval,
+                            col.interval,
+                        )
                         continue
 
                     # we have to increase the generation or we will kill
                     # this script again
                     col.generation = GENERATION
                     if col.mtime < mtime:
-                        LOG.info('%s has been updated on disk', col.name)
+                        LOG.info("%s has been updated on disk", col.name)
                         col.mtime = mtime
                         if not col.interval:
                             col.shutdown()
-                            LOG.info('Respawning %s', col.name)
-                            register_collector(Collector(colname, interval,
-                                                         filename, mtime))
+                            LOG.info("Respawning %s", col.name)
+                            register_collector(
+                                Collector(colname, interval, filename, mtime)
+                            )
                 else:
-                    register_collector(Collector(colname, interval, filename,
-                                                 mtime))
+                    register_collector(Collector(colname, interval, filename, mtime))
 
     # now iterate over everybody and look for old generations
     to_delete = []
     for col in all_collectors():
         if col.generation < GENERATION:
-            LOG.info('collector %s removed from the filesystem, forgetting',
-                      col.name)
+            LOG.info("collector %s removed from the filesystem, forgetting", col.name)
             col.shutdown()
             to_delete.append(col.name)
     for name in to_delete:
         del COLLECTORS[name]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/scalyr_agent/third_party/tcollector/test_collectors/0/random_collector.py
+++ b/scalyr_agent/third_party/tcollector/test_collectors/0/random_collector.py
@@ -23,5 +23,6 @@ def main():
         sys.stdout.flush()
         time.sleep(5)
 
+
 if __name__ == "__main__":
     main()

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ basepython =
     {py3.7-unit-tests}: python3.7
     {py3.8-unit-tests}: python3.8
 setenv =
-  LINT_FILES_TO_CHECK=*.py scripts/*.py benchmarks/scripts/*.py pylint_plugins/*.py .circleci/*.py .circleci/modernize/ scalyr_agent/
+  LINT_FILES_TO_CHECK=*.py scripts/*.py benchmarks/scripts/*.py pylint_plugins/*.py .circleci/*.py .circleci/modernize/ scalyr_agent/ scalyr_agent/third_party/tcollector/
   # Which Python binary to use for various lint targets
   LINT_PYTHON_BINARY={env:LINT_PYTHON_BINARY:python3.6}
   PYTHONPATH={toxinidir}


### PR DESCRIPTION
In #445, I noticed we don't run lint checks on tcollectors directory since it's located inside ``third_party/`` directory which contains other dependencies we want to ignore.

In ideal world, we would leave any third party dependencies as is and wouldn't touch it (so we can update it from upstream in the future, etc.), but sadly we don't have much choice here - we already made some functionality and other changes and fixes to tcollectors package (ideally, we should also try to get some of those accepted upstream).