### PR TITLE
Test race workaround

### DIFF
--- a/scalyr_agent/builtin_monitors/tests/docker_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/docker_monitor_test.py
@@ -23,7 +23,6 @@ __author__ = "echee@scalyr.com"
 
 import os
 import threading
-import time
 from io import open
 
 
@@ -245,7 +244,7 @@ class DockerMonitorTest(ScalyrTestCase):
 
                 manager.start_manager()
                 fragment_polls.sleep_until_count_or_maxwait(
-                    40, manager_poll_interval, maxwait=1
+                    40, manager_poll_interval, maxwait=2
                 )
 
                 m1.assert_called()
@@ -254,10 +253,6 @@ class DockerMonitorTest(ScalyrTestCase):
 
                 manager.stop_manager(wait_on_join=False)
                 fake_clock.advance_time(increment_by=manager_poll_interval)
-
-                # We use sleep to avoid potential race
-                # NOTE: This is not 100% robust and deterministic, but good enough for now
-                time.sleep(2)
 
                 self.assertEquals(fragment_polls.count(), 40)
                 self.assertEquals(counter["callback_invocations"], 4)

--- a/scalyr_agent/tests/monitors_manager_test.py
+++ b/scalyr_agent/tests/monitors_manager_test.py
@@ -293,7 +293,7 @@ class MonitorsManagerTest(ScalyrTestCase):
         test_manager.set_user_agent_augment_callback(augment_user_agent_2)
 
         self.assertTrue(
-            fragment_polls.sleep_until_count_or_maxwait(20, poll_interval, 1)
+            fragment_polls.sleep_until_count_or_maxwait(20, poll_interval, 2)
         )
         self.assertEquals(counter["callback_invocations"], 10)
 


### PR DESCRIPTION
This pull request updates the test which occasionally fails on Circle CI to use longer max wait.

This should make test failure due to test timing less likely to occur.