### PR TITLE
Update Circle CI usage data script to support multiple workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -739,7 +739,7 @@ jobs:
           command: |
             export PYTHONPATH=.
             python scripts/circleci_usage_data.py --project_slug=gh/scalyr/scalyr-agent-2 \
-                --workflow=unittest --status=success --branch=all --limit=5 \
+                --workflows=unittest,benchmarks,package-smoke-tests --status=success --branch=all --limit=5 \
                 --email=cloudtech-builds@scalyr.com
 
 workflows:

--- a/scripts/circleci_usage_data.py
+++ b/scripts/circleci_usage_data.py
@@ -103,7 +103,7 @@ def get_all_branches_for_repo(project_slug):
     return branches
 
 
-def get_usage_data_for_branch(
+def get_usage_data_for_branch_and_workflow(
     buff, project_slug, workflow, status="success", branch="master", limit=10
 ):
     # type: (StringIO, str, str, str, str, int) -> None
@@ -142,13 +142,14 @@ def get_usage_data_for_branch(
     items = data.get("items", [])
     items = [item for item in items if (status == "all" or item["status"] == status)]
 
-    if not items:
-        return
-
     buff.write(
         u'Usage data for recent workflow runs for workflow "%s" with status="%s" and branch "%s"\n\n'
         % (workflow, status, branch)
     )
+
+    if not items:
+        buff.write(u"No recent runs which match this criteria.\n\n")
+        return
 
     count = 0
     for item in items:
@@ -170,9 +171,9 @@ def get_usage_data_for_branch(
 
 
 def print_usage_data(
-    project_slug, workflow, status="success", branch="master", limit=10, emails=None
+    project_slug, workflows, status="success", branch="master", limit=10, emails=None
 ):
-    # type: (str, str, str, str, int, Optional[List[str]]) -> None
+    # type: (str, List[str], str, str, int, Optional[List[str]]) -> None
     if branch == "all":
         branches = get_all_branches_for_repo(
             project_slug=project_slug.replace("gh/", "")
@@ -191,14 +192,15 @@ def print_usage_data(
     )
 
     for branch in branches:
-        get_usage_data_for_branch(
-            buff=buff,
-            project_slug=project_slug,
-            workflow=workflow,
-            status=status,
-            branch=branch,
-            limit=limit,
-        )
+        for workflow in workflows:
+            get_usage_data_for_branch_and_workflow(
+                buff=buff,
+                project_slug=project_slug,
+                workflow=workflow,
+                status=status,
+                branch=branch,
+                limit=limit,
+            )
 
     value = buff.getvalue()
 
@@ -250,8 +252,8 @@ if __name__ == "__main__":
         default="gh/scalyr/scalyr-agent-2",
     )
     parser.add_argument(
-        "--workflow",
-        help="Name of the workflow to print the usage data for.",
+        "--workflows",
+        help="Name of the workflows to print the usage data for (e.g. unittest,benchmarks,e2e).",
         default="unittest",
     )
     parser.add_argument(
@@ -268,7 +270,7 @@ if __name__ == "__main__":
         "--limit",
         help="Maximum number of workflow runs per branch to print data for.",
         type=int,
-        default=10,
+        default=5,
     )
     parser.add_argument(
         "--emails",
@@ -290,9 +292,11 @@ if __name__ == "__main__":
     if emails and not MAILGUN_API_TOKEN:
         raise ValueError("MAILGUN_API_TOKEN environment variable is not set")
 
+    workflows = args.workflows.split(",")
+
     print_usage_data(
         project_slug=args.project_slug,
-        workflow=args.workflow,
+        workflows=workflows,
         status=args.status,
         branch=args.branch,
         limit=args.limit,


### PR DESCRIPTION
This pull request updates Circle CI usage data script so it supports multiple workflows.

Now we have two workflows (unittest, benchmarks) and once #401 is merged, we will have on more.

With this change we now track usage data for all 3 workflows.