### PR TITLE
Retry codecov report upload in timeout / failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -551,7 +551,7 @@ jobs:
           command: |
             source ../venv/bin/activate
             coverage xml --rcfile=.coveragerc -i -o coverage.xml
-            ./scripts/submit-codecov-data.sh
+            ./../scripts/submit-codecov-data.sh
 
   lint-checks:
     working_directory: ~/scalyr-agent-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -551,7 +551,7 @@ jobs:
           command: |
             source ../venv/bin/activate
             coverage xml --rcfile=.coveragerc -i -o coverage.xml
-            codecov --root=/home/circleci/scalyr-agent-2/ --disable gcov --file coverage.xml
+            ./scripts/submit-codecov-data.sh
 
   lint-checks:
     working_directory: ~/scalyr-agent-2

--- a/scripts/shell-scripts-lint.sh
+++ b/scripts/shell-scripts-lint.sh
@@ -20,7 +20,7 @@ set -e
 
 IGNORE_BINARY_DOESNT_EXIST=${IGNORE_BINARY_DOESNT_EXIST:-"1"}
 
-if ! which shellcheck > /dev/null 2>&1; then
+if ! command -v shellcheck > /dev/null 2>&1; then
     echo "shellcheck binary doesn't exist"
 
     if [ "${IGNORE_BINARY_DOESNT_EXIST}" -ne "0" ]; then
@@ -36,6 +36,8 @@ echo "Using shellcheck: ${SHELLCHECK_VERSION}"
 
 # TODO: Fix various warnings in scripts in .circleci/ directory and then bump up
 # the severity to warning
+# shellcheck disable=SC2046
 shellcheck -S error $(find . -name "*.sh" | grep -v .tox | grep -v virtualenv | grep -v benchmarks | grep -v installer)
 shellcheck -S info benchmarks/scripts/*.sh
 shellcheck -S info installer/scripts/*.sh
+shellcheck -S info scripts/*.sh

--- a/scripts/submit-codecov-data.sh
+++ b/scripts/submit-codecov-data.sh
@@ -17,7 +17,8 @@
 # It takes occasional codecov API failures into account and tries to retry
 # upload.
 
-MAX_ATTEMPTS=5
+MAX_ATTEMPTS=${MAX_ATTEMPTS:-5}
+RETRY_DELAY=${RETRY_DELAY:-5}
 
 # Work around for temporary codecov API timing out
 for (( i=0; i<$MAX_ATTEMPTS; ++i)); do
@@ -28,8 +29,8 @@ for (( i=0; i<$MAX_ATTEMPTS; ++i)); do
         break
     fi
 
-    echo "Command exited with non-zero, retrying in ${MAX_ATTEMPTS} seconds..."
-    sleep 5
+    echo "Command exited with non-zero, retrying in ${RETRY_DELAY} seconds..."
+    sleep "${RETRY_DELAY}"
 done
 
 if [ "${EXIT_CODE}" -ne 0 ]; then

--- a/scripts/submit-codecov-data.sh
+++ b/scripts/submit-codecov-data.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2014-2020 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script which submits coverage data to codecov.io.
+# It takes occasional codecov API failures into account and tries to retry
+# upload.
+
+MAX_ATTEMPTS=5
+
+# Work around for temporary codecov API timing out
+for (( i=0; i<$MAX_ATTEMPTS; ++i)); do
+    codecov --root=/home/circleci/scalyr-agent-2/ --disable gcov --file coverage.xml
+    EXIT_CODE=$?
+
+    if [ "${EXIT_CODE}" -eq 0 ]; then
+        break
+    fi
+
+    echo "Command exited with non-zero, retrying in ${MAX_ATTEMPTS} seconds..."
+    sleep 5
+done
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+    echo "Submitting code coverage to codecov.io failed after ${MAX_ATTEMPTS} attempts"
+    exit 1
+fi


### PR DESCRIPTION
Every now and then submitting report to codecov.io times out.

This pull request updates submit Circle CI job stop so we try to retry it up to 5 times in case it fails.