### PR TITLE
Utilize shell and URL monitors in the loaded benchmark #2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ master_only: &master_only
     branches:
       only:
         - master
-        - update_benchmarks
 
 version: 2.1
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -739,7 +739,7 @@ jobs:
           command: |
             export PYTHONPATH=.
             python scripts/circleci_usage_data.py --project_slug=gh/scalyr/scalyr-agent-2 \
-                --workflow=unittest --status=success --branch=all --limit=5 \
+                --workflows=unittest,benchmarks,package-smoke-tests --status=success --branch=all --limit=5 \
                 --email=cloudtech-builds@scalyr.com
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -714,7 +714,7 @@ jobs:
       - codespeed_agent_process_benchmark:
           codespeed_executable: "Python 2.7.17 - loaded conf 3"
           codespeed_environment: "Circle CI Docker Executor Medium Size"
-          agent_config: "benchmarks/configs/agent_single_growing_log_file.json"
+          agent_config: "benchmarks/configs/agent_single_growing_log_file_with_shell_and_url_monitor.json"
           # NOTE: We set agent run time slightly longer than the insert script time run so we give a chance for memory and
           # other metrics to stabilize.
           run_time: 390

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,7 +682,7 @@ jobs:
       - codespeed_agent_process_benchmark:
           codespeed_executable: "Python 2.7.17 - loaded conf 2"
           codespeed_environment: "Circle CI Docker Executor Medium Size"
-          agent_config: "benchmarks/configs/agent_single_growing_log_file.json"
+          agent_config: "benchmarks/configs/agent_single_growing_log_file_with_shell_and_url_monitor.json"
           run_time: 140
           agent_pre_run_command: "touch /tmp/random.log"
           agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 2M 10 100 1"
@@ -698,7 +698,7 @@ jobs:
       - codespeed_agent_process_benchmark:
           codespeed_executable: "Python 3.5.9 - loaded conf 2"
           codespeed_environment: "Circle CI Docker Executor Medium Size"
-          agent_config: "benchmarks/configs/agent_single_growing_log_file.json"
+          agent_config: "benchmarks/configs/agent_single_growing_log_file_with_shell_and_url_monitor.json"
           run_time: 140
           agent_pre_run_command: "touch /tmp/random.log"
           agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 2M 10 100 1"
@@ -714,7 +714,7 @@ jobs:
       - codespeed_agent_process_benchmark:
           codespeed_executable: "Python 2.7.17 - loaded conf 3"
           codespeed_environment: "Circle CI Docker Executor Medium Size"
-          agent_config: "benchmarks/configs/agent_single_growing_log_file_with_shell_and_url_monitor.json"
+          agent_config: "benchmarks/configs/agent_single_growing_log_file.json"
           # NOTE: We set agent run time slightly longer than the insert script time run so we give a chance for memory and
           # other metrics to stabilize.
           run_time: 390

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ master_only: &master_only
     branches:
       only:
         - master
+        - update_benchmarks
 
 version: 2.1
 commands:

--- a/benchmarks/configs/agent_single_50mb_access_log_file.json
+++ b/benchmarks/configs/agent_single_50mb_access_log_file.json
@@ -7,6 +7,10 @@
          path: "/tmp/access_log_50_mb.log",
          attributes: { parser: "accessLog" },
          copy_from_start: true
+         sampling_rules: [
+            { match_expression: "POST .*", sampling_rate: 0.9 },
+            { match_expression: "GET .*", sampling_rate: 0.9 }
+         ]
      }
   ],
 

--- a/benchmarks/configs/agent_single_growing_log_file_with_shell_and_url_monitor.json
+++ b/benchmarks/configs/agent_single_growing_log_file_with_shell_and_url_monitor.json
@@ -1,0 +1,38 @@
+{
+  logs: [
+      {path: "/tmp/random.log"}
+  ],
+
+  monitors: [
+    {
+        module:  "scalyr_agent.builtin_monitors.shell_monitor",
+        id:       "kernel-version",
+        command: "uname -r",
+        sample_interval: 15
+    },
+    {
+        module:  "scalyr_agent.builtin_monitors.shell_monitor",
+        id:       "free_m",
+        command: "free -m",
+        sample_interval: 15
+    },
+    {
+        module:  "scalyr_agent.builtin_monitors.shell_monitor",
+        id:       "df_h",
+        command: "df -g",
+        sample_interval: 15
+    },
+    {
+         module:  "scalyr_agent.builtin_monitors.url_monitor",
+         id:      "google-com",
+         url:     "https://www.google.com",
+         sample_interval: 15
+    },
+    {
+         module:  "scalyr_agent.builtin_monitors.url_monitor",
+         id:      "scalyr-com",
+         url:     "https://www.scalyr.com",
+         sample_interval: 15
+    }
+  ]
+}

--- a/scripts/circleci_usage_data.py
+++ b/scripts/circleci_usage_data.py
@@ -103,7 +103,7 @@ def get_all_branches_for_repo(project_slug):
     return branches
 
 
-def get_usage_data_for_branch(
+def get_usage_data_for_branch_and_workflow(
     buff, project_slug, workflow, status="success", branch="master", limit=10
 ):
     # type: (StringIO, str, str, str, str, int) -> None
@@ -142,13 +142,14 @@ def get_usage_data_for_branch(
     items = data.get("items", [])
     items = [item for item in items if (status == "all" or item["status"] == status)]
 
-    if not items:
-        return
-
     buff.write(
         u'Usage data for recent workflow runs for workflow "%s" with status="%s" and branch "%s"\n\n'
         % (workflow, status, branch)
     )
+
+    if not items:
+        buff.write(u"No recent runs which match this criteria.\n\n")
+        return
 
     count = 0
     for item in items:
@@ -170,9 +171,9 @@ def get_usage_data_for_branch(
 
 
 def print_usage_data(
-    project_slug, workflow, status="success", branch="master", limit=10, emails=None
+    project_slug, workflows, status="success", branch="master", limit=10, emails=None
 ):
-    # type: (str, str, str, str, int, Optional[List[str]]) -> None
+    # type: (str, List[str], str, str, int, Optional[List[str]]) -> None
     if branch == "all":
         branches = get_all_branches_for_repo(
             project_slug=project_slug.replace("gh/", "")
@@ -191,14 +192,15 @@ def print_usage_data(
     )
 
     for branch in branches:
-        get_usage_data_for_branch(
-            buff=buff,
-            project_slug=project_slug,
-            workflow=workflow,
-            status=status,
-            branch=branch,
-            limit=limit,
-        )
+        for workflow in workflows:
+            get_usage_data_for_branch_and_workflow(
+                buff=buff,
+                project_slug=project_slug,
+                workflow=workflow,
+                status=status,
+                branch=branch,
+                limit=limit,
+            )
 
     value = buff.getvalue()
 
@@ -250,8 +252,8 @@ if __name__ == "__main__":
         default="gh/scalyr/scalyr-agent-2",
     )
     parser.add_argument(
-        "--workflow",
-        help="Name of the workflow to print the usage data for.",
+        "--workflows",
+        help="Name of the workflows to print the usage data for (e.g. unittest,benchmarks,e2e).",
         default="unittest",
     )
     parser.add_argument(
@@ -268,7 +270,7 @@ if __name__ == "__main__":
         "--limit",
         help="Maximum number of workflow runs per branch to print data for.",
         type=int,
-        default=10,
+        default=5,
     )
     parser.add_argument(
         "--emails",
@@ -290,9 +292,11 @@ if __name__ == "__main__":
     if emails and not MAILGUN_API_TOKEN:
         raise ValueError("MAILGUN_API_TOKEN environment variable is not set")
 
+    workflows = args.workflows.split(",")
+
     print_usage_data(
         project_slug=args.project_slug,
-        workflow=args.workflow,
+        workflows=workflows,
         status=args.status,
         branch=args.branch,
         limit=args.limit,


### PR DESCRIPTION
This pull request makes a small change to the loaded benchmark #2 to also utilize URL and shell monitors with more frequent sample interval.

This way the setup closer resembles our staging setup.

As discussed on slack (/cc @ArthurKamalov), we should also add the same (but longer running) benchmark to Kubernetes. 

This way we will cover both scenarios - short and longer running ones.