### PR TITLE
Enable branch level coverage tracking and reporting

### DIFF
--- a/.circleci/.coveragerc_ci
+++ b/.circleci/.coveragerc_ci
@@ -3,6 +3,9 @@ source =
     /home/circleci/scalyr-agent-2/
     /usr/share/scalyr-agent-2/py/
 
+[run]
+branch = True
+
 [report]
 skip_covered=True
 omit =

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
+[run]
+branch = True
+
 [report]
 omit =
     */venv/*

--- a/build_package.py
+++ b/build_package.py
@@ -631,7 +631,7 @@ def build_container_builder(
         new_dockerfile_source = re.sub(r"(RUN\spip\s.*)", r"\1 coverage==4.5.4", data)
         new_dockerfile_source = re.sub(
             r"CMD .*\n",
-            'CMD ["coverage", "run", "/usr/share/scalyr-agent-2/py/scalyr_agent/agent_main.py", '
+            'CMD ["coverage", "run", "--branch", "/usr/share/scalyr-agent-2/py/scalyr_agent/agent_main.py", '
             '"--no-fork", "--no-change-user", "start"]',
             new_dockerfile_source,
         )


### PR DESCRIPTION
This pull request enables branch level coverage tracking and reporting.

This should give a more real picture into code coverage compared to just a simple line based code coverage reporting we currently use.

See more info on branch coverage here - https://coverage.readthedocs.io/en/v4.5.x/branch.html.

Having said that, I'm not actually 100% sure if codecov.io supports branch level coverage tracking for Python projects (will soon see when the build finishes).