### PR TITLE
Allow user to specify a blacklist of metric names which shouldn't be logged and shipped to Scalyr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Features
 * Agent will use whatever version of Python `/usr/bin/env python` points to on Linux.
 * RPM and Debian packages no longer declare dependency on Python to promote cross-distribution compatibility.  The dependency is now verifed at package install time.
 * Added option to `scalyr-agent status -v` to emit JSON (``--format=[text|json]``).
+* Add new ``metric_name_blacklist`` supported attribute to each monitor configuration section. With this attribute, user can define a list of metric names which should be excluded and not shipped to Scalyr.
 
 Bugs
 * Fix authentication issue in `kubernetes_monitor` when accessing kublet API.

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -334,10 +334,6 @@ class Configuration(object):
 
         return monitor_config
 
-    @property
-    def metric_name_blacklist(self):
-        return self.__get_config().get_json_array("metric_name_blacklist")
-
     # k8s cache options
     @property
     def k8s_ignore_namespaces(self):
@@ -1638,16 +1634,6 @@ class Configuration(object):
         )
         self.__verify_or_set_optional_string(
             config, "https_proxy", None, description, apply_defaults, env_aware=True
-        )
-        # Blacklist for metric names which should be excluded from being sent to Scalyr
-        self.__verify_or_set_optional_array_of_strings(
-            config,
-            "metric_name_blacklist",
-            [],
-            description,
-            apply_defaults,
-            separators=[None, ","],
-            env_aware=True,
         )
         self.__verify_or_set_optional_array_of_strings(
             config,

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -251,9 +251,7 @@ class Configuration(object):
 
             self.__monitor_configs = list(self.__config.get_json_array("monitors"))
 
-            # TODO: Is a good idea to call this on each Configuration object instantiation? We could
-            # probably use a single global singleton instance
-            platform_controller = PlatformController.new_platform()
+            platform_controller = PlatformController.existing_platform()
 
             # We add in special marker for monitor configuration objects which refer to built-in
             # monitors so we can handle those differently inside the MonitorManager

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -334,6 +334,10 @@ class Configuration(object):
 
         return monitor_config
 
+    @property
+    def metric_name_blacklist(self):
+        return self.__get_config().get_json_array("metric_name_blacklist")
+
     # k8s cache options
     @property
     def k8s_ignore_namespaces(self):
@@ -1635,7 +1639,16 @@ class Configuration(object):
         self.__verify_or_set_optional_string(
             config, "https_proxy", None, description, apply_defaults, env_aware=True
         )
-
+        # Blacklist for metric names which should be excluded from being sent to Scalyr
+        self.__verify_or_set_optional_array_of_strings(
+            config,
+            "metric_name_blacklist",
+            [],
+            description,
+            apply_defaults,
+            separators=[None, ","],
+            env_aware=True,
+        )
         self.__verify_or_set_optional_array_of_strings(
             config,
             "k8s_ignore_namespaces",

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -42,7 +42,6 @@ from scalyr_agent.json_lib.objects import (
 from scalyr_agent.monitor_utils.blocking_rate_limiter import BlockingRateLimiter
 from scalyr_agent.util import JsonReadFileException
 from scalyr_agent.config_util import BadConfiguration, get_config_from_env
-from scalyr_agent.platform_controller import PlatformController
 
 from scalyr_agent.__scalyr__ import get_install_root
 from scalyr_agent.compat import os_environ_unicode
@@ -251,19 +250,6 @@ class Configuration(object):
 
             self.__monitor_configs = list(self.__config.get_json_array("monitors"))
 
-            platform_controller = PlatformController.existing_platform()
-
-            # We add in special marker for monitor configuration objects which refer to built-in
-            # monitors so we can handle those differently inside the MonitorManager
-            for monitor_config in self.__monitor_configs:
-                if platform_controller._is_built_in_system_metrics_monitor(
-                    config=self, monitor_config=monitor_config
-                ):
-                    monitor_config["builtin_monitor"] = True
-                if platform_controller._is_built_in_process_metrics_monitor(
-                    config=self, monitor_config=monitor_config
-                ):
-                    monitor_config["builtin_monitor"] = True
         except BadConfiguration as e:
             self.__last_error = e
             raise e

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -42,6 +42,7 @@ from scalyr_agent.json_lib.objects import (
 from scalyr_agent.monitor_utils.blocking_rate_limiter import BlockingRateLimiter
 from scalyr_agent.util import JsonReadFileException
 from scalyr_agent.config_util import BadConfiguration, get_config_from_env
+from scalyr_agent.platform_controller import PlatformController
 
 from scalyr_agent.__scalyr__ import get_install_root
 from scalyr_agent.compat import os_environ_unicode
@@ -250,6 +251,21 @@ class Configuration(object):
 
             self.__monitor_configs = list(self.__config.get_json_array("monitors"))
 
+            # TODO: Is a good idea to call this on each Configuration object instantiation? We could
+            # probably use a single global singleton instance
+            platform_controller = PlatformController.new_platform()
+
+            # We add in special marker for monitor configuration objects which refer to built-in
+            # monitors so we can handle those differently inside the MonitorManager
+            for monitor_config in self.__monitor_configs:
+                if platform_controller._is_built_in_system_metrics_monitor(
+                    config=self, monitor_config=monitor_config
+                ):
+                    monitor_config["builtin_monitor"] = True
+                if platform_controller._is_built_in_process_metrics_monitor(
+                    config=self, monitor_config=monitor_config
+                ):
+                    monitor_config["builtin_monitor"] = True
         except BadConfiguration as e:
             self.__last_error = e
             raise e

--- a/scalyr_agent/monitors_manager.py
+++ b/scalyr_agent/monitors_manager.py
@@ -269,8 +269,8 @@ class MonitorsManager(StoppableThread):
         for monitor in configuration.monitor_configs:
             # We skip adding implicit default monitors. This way we prevent duplicate monitors, but
             # we still allow users to configure default built-in monitors via agent config.
-            is_default = monitor.get("is_default", False)
-            if is_default:
+            is_builtin_monitor = monitor.get("builtin_monitor", False)
+            if is_builtin_monitor:
                 continue
 
             all_monitors.append(monitor.copy())

--- a/scalyr_agent/monitors_manager.py
+++ b/scalyr_agent/monitors_manager.py
@@ -255,6 +255,8 @@ class MonitorsManager(StoppableThread):
         all_monitors = []
         default_monitors = []
 
+        # NOTE: It's important that "get_default_monitors" is called first because that function
+        # also marks config entries for the default built-in monitors
         for monitor in platform_controller.get_default_monitors(configuration):
             default_monitors.append(
                 configuration.parse_monitor_config(
@@ -267,7 +269,8 @@ class MonitorsManager(StoppableThread):
         for monitor in configuration.monitor_configs:
             # We skip adding implicit default monitors. This way we prevent duplicate monitors, but
             # we still allow users to configure default built-in monitors via agent config.
-            if monitor in default_monitors:
+            is_default = monitor.get("is_default", False)
+            if is_default:
                 continue
 
             all_monitors.append(monitor.copy())

--- a/scalyr_agent/monitors_manager.py
+++ b/scalyr_agent/monitors_manager.py
@@ -377,9 +377,7 @@ class MonitorsManager(StoppableThread):
     def _get_all_monitor_configs(configuration, platform_controller):
         # type: (Configuration, PlatformController) -> List[dict]
         """
-        Return monitor config dictionaries for all the monitors.
-
-        This includes user-configured monitors and defauilt built-in implicit monitors.
+        Return monitor config dictionaries for all the monitors excluding the built-in ones.
         """
         # Get all the monitors we will be running.  This is determined by the config file and the platform's default
         # monitors.  This is a just of json objects containing the configuration.  We get json objects because we
@@ -388,7 +386,9 @@ class MonitorsManager(StoppableThread):
 
         for monitor in configuration.monitor_configs:
             # We skip adding implicit default monitors. This way we prevent duplicate monitors, but
-            # we still allow users to configure default built-in monitors via agent config.
+            # we still allow users to configure default built-in monitors via agent config (e.g.
+            # user can change sample interval for a built-in monitor or specify a metric name
+            # blacklist)
             is_builtin_monitor = monitor.get("builtin_monitor", False)
             if is_builtin_monitor:
                 continue

--- a/scalyr_agent/monitors_manager.py
+++ b/scalyr_agent/monitors_manager.py
@@ -17,6 +17,9 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
+if False:
+    from typing import List
+
 __author__ = "czerwin@scalyr.com"
 
 import os
@@ -26,6 +29,8 @@ from scalyr_agent.agent_status import MonitorManagerStatus
 from scalyr_agent.agent_status import MonitorStatus
 from scalyr_agent.scalyr_monitor import load_monitor_class, ScalyrMonitor
 from scalyr_agent.util import StoppableThread
+from scalyr_agent.configuration import Configuration
+from scalyr_agent.platform_controller import PlatformController
 
 from scalyr_agent.__scalyr__ import get_package_root
 
@@ -248,34 +253,9 @@ class MonitorsManager(StoppableThread):
         @type configuration: scalyr_agent.Configuration
         @type platform_controller: scalyr_agent.platform_controller.PlatformController
         """
-        # Get all the monitors we will be running.  This is determined by the config file and the platform's default
-        # monitors.  This is a just of json objects containing the configuration.  We get json objects because we
-        # may need to modify them.
-
-        all_monitors = []
-        default_monitors = []
-
-        # NOTE: It's important that "get_default_monitors" is called first because that function
-        # also marks config entries for the default built-in monitors
-        for monitor in platform_controller.get_default_monitors(configuration):
-            default_monitors.append(
-                configuration.parse_monitor_config(
-                    monitor,
-                    'monitor with module name "%s" requested by platform'
-                    % monitor["module"],
-                ).copy()
-            )
-
-        for monitor in configuration.monitor_configs:
-            # We skip adding implicit default monitors. This way we prevent duplicate monitors, but
-            # we still allow users to configure default built-in monitors via agent config.
-            is_builtin_monitor = monitor.get("builtin_monitor", False)
-            if is_builtin_monitor:
-                continue
-
-            all_monitors.append(monitor.copy())
-
-        all_monitors.extend(default_monitors)
+        all_monitors = MonitorsManager._get_all_monitor_configs(
+            configuration, platform_controller
+        )
 
         # We need to go back and fill in the monitor id if it is not set.  We do this by keeping a count of
         # how many monitors we have with the same module name (just considering the last element of the module
@@ -392,3 +372,36 @@ class MonitorsManager(StoppableThread):
             scalyr_logging.getLogger("%s(%s)" % (module_name, monitor_id)),
             global_config=global_config,
         )
+
+    @staticmethod
+    def _get_all_monitor_configs(configuration, platform_controller):
+        # type: (Configuration, PlatformController) -> List[dict]
+        """
+        Return monitor config dictionaries for all the monitors.
+
+        This includes user-configured monitors and defauilt built-in implicit monitors.
+        """
+        # Get all the monitors we will be running.  This is determined by the config file and the platform's default
+        # monitors.  This is a just of json objects containing the configuration.  We get json objects because we
+        # may need to modify them.
+        all_monitors = []
+
+        for monitor in configuration.monitor_configs:
+            # We skip adding implicit default monitors. This way we prevent duplicate monitors, but
+            # we still allow users to configure default built-in monitors via agent config.
+            is_builtin_monitor = monitor.get("builtin_monitor", False)
+            if is_builtin_monitor:
+                continue
+
+            all_monitors.append(monitor.copy())
+
+        for monitor in platform_controller.get_default_monitors(configuration):
+            all_monitors.append(
+                configuration.parse_monitor_config(
+                    monitor,
+                    'monitor with module name "%s" requested by platform'
+                    % monitor["module"],
+                ).copy()
+            )
+
+        return all_monitors

--- a/scalyr_agent/monitors_manager.py
+++ b/scalyr_agent/monitors_manager.py
@@ -377,7 +377,7 @@ class MonitorsManager(StoppableThread):
     def _get_all_monitor_configs(configuration, platform_controller):
         # type: (Configuration, PlatformController) -> List[dict]
         """
-        Return monitor config dictionaries for all the monitors excluding the built-in ones.
+        Return monitor config dictionaries for all the monitors, including the built it ones.
         """
         # Get all the monitors we will be running.  This is determined by the config file and the platform's default
         # monitors.  This is a just of json objects containing the configuration.  We get json objects because we
@@ -385,14 +385,6 @@ class MonitorsManager(StoppableThread):
         all_monitors = []
 
         for monitor in configuration.monitor_configs:
-            # We skip adding implicit default monitors. This way we prevent duplicate monitors, but
-            # we still allow users to configure default built-in monitors via agent config (e.g.
-            # user can change sample interval for a built-in monitor or specify a metric name
-            # blacklist)
-            is_builtin_monitor = monitor.get("builtin_monitor", False)
-            if is_builtin_monitor:
-                continue
-
             all_monitors.append(monitor.copy())
 
         for monitor in platform_controller.get_default_monitors(configuration):

--- a/scalyr_agent/platform_controller.py
+++ b/scalyr_agent/platform_controller.py
@@ -90,7 +90,7 @@ class PlatformController(object):
         """
         Return an existing instance of the previously registered platform class.
 
-        The instance is instantiatd on first call to the this method. On subsequent calls, existing
+        The instance is instantiated on first call to the this method. On subsequent calls, existing
         cached instance is returned.
         """
         global PLATFORM_INSTANCE

--- a/scalyr_agent/platform_controller.py
+++ b/scalyr_agent/platform_controller.py
@@ -29,6 +29,10 @@ import sys
 
 from scalyr_agent.__scalyr__ import INSTALL_TYPE
 
+# Holds a reference to the existing PlatformController instance which is populated when first
+# calling "PlatformController.existing_instance()".
+PLATFORM_INSTANCE = None
+
 
 class PlatformController(object):
     def __init__(self):
@@ -80,6 +84,21 @@ class PlatformController(object):
             if result.can_handle_current_platform():
                 return result
         return None
+
+    @staticmethod
+    def existing_platform():
+        """
+        Return an existing instance of the previously registered platform class.
+
+        The instance is instantiatd on first call to the this method. On subsequent calls, existing
+        cached instance is returned.
+        """
+        global PLATFORM_INSTANCE
+
+        if not PLATFORM_INSTANCE:
+            PLATFORM_INSTANCE = PlatformController.new_platform()
+
+        return PLATFORM_INSTANCE
 
     @property
     def install_type(self):

--- a/scalyr_agent/platform_linux.py
+++ b/scalyr_agent/platform_linux.py
@@ -154,6 +154,7 @@ class LinuxPlatformController(PosixPlatformController):
         return (
             monitor_config["module"]
             == "scalyr_agent.builtin_monitors.linux_system_metrics"
+            and monitor_config.get("id", None, True) is None  # type: ignore
         )
 
     def _is_built_in_process_metrics_monitor(self, config, monitor_config):

--- a/scalyr_agent/platform_windows.py
+++ b/scalyr_agent/platform_windows.py
@@ -374,6 +374,7 @@ class WindowsPlatformController(PlatformController):
         return (
             monitor_config["module"]
             == "scalyr_agent.builtin_monitors.windows_system_metrics"
+            and monitor_config.get("id", None, True) is None  # type: ignore
         )
 
     def _is_built_in_process_metrics_monitor(self, config, monitor_config):

--- a/scalyr_agent/platform_windows.py
+++ b/scalyr_agent/platform_windows.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 import atexit
 import errno
 from scalyr_agent import compat
+from scalyr_agent.configuration import Configuration
 
 __author__ = "guy.hoozdis@gmail.com"
 
@@ -335,6 +336,56 @@ class WindowsPlatformController(PlatformController):
                 )
             )
         return result
+
+    def _get_config_for_built_in_windows_metrics_monitor(self, config):
+        # type: (Configuration) -> dict
+        """
+        Retrieve monitor configuration for the default built-in implicit Windows system metrics
+        monitor.
+
+        :rtype: ``dict``
+        """
+        monitor_configs = config.monitor_configs
+
+        config_dicts = [
+            item
+            for item in monitor_configs
+            if item["module"] == "scalyr_agent.builtin_monitors.windows_system_metrics"
+        ]
+
+        # NOTE: If there are multiple entries, we assume first one refers to the built in monitor.
+        # In fact, system metrics one should be a singleton anyway and there shouldn't be more than
+        # one instance running.
+        if len(config_dicts) >= 1:
+            return config_dicts[0]
+
+        return {}
+
+    def _get_config_for_built_in_agent_process_metrics_monitor(self, config):
+        # type: (Configuration) -> dict
+        """
+        Retrieve monitor configuration for the default built-in implicit agent Windows process
+        metrics monitor.
+
+        :rtype: ``dict``
+        """
+        monitor_configs = config.monitor_configs
+
+        config_dicts = [
+            item
+            for item in monitor_configs
+            if item["module"] == "scalyr_agent.builtin_monitors.windows_process_metrics"
+            and item["id"] == "agent"
+            and item["pid"] == "$$"
+        ]
+
+        # NOTE: If there are multiple entries, we assume first one refers to the built in monitor.
+        # In fact, system metrics one should be a singleton anyway and there shouldn't be more than
+        # one instance running.
+        if len(config_dicts) >= 1:
+            return config_dicts[0]
+
+        return {}
 
     def get_file_owner(self, file_path):
         """Returns the user name of the owner of the specified file.

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -372,7 +372,7 @@ class AgentLogger(logging.Logger):
                 metric_name=metric_name, metric_value=metric_value
             )
 
-        if metric_name in monitor._metric_name_blacklist:
+        if metric_name in getattr(monitor, "_metric_name_blacklist", []):
             monitor._logger.info(
                 'Metric "%s" is blacklisted so the value wont be reported to Scalyr.'
                 % (metric_name),

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -360,9 +360,9 @@ class AgentLogger(logging.Logger):
                 "Cannot report metric values until metric log file is opened."
             )
 
-        string_buffer = io.StringIO()
         if not isinstance(metric_name, _METRIC_NAME_SUPPORTED_TYPES):
             raise UnsupportedValueType(metric_name=metric_name)
+
         metric_name = self.force_valid_metric_or_field_name(
             metric_name, is_metric=True, logger=self
         )
@@ -372,6 +372,16 @@ class AgentLogger(logging.Logger):
                 metric_name=metric_name, metric_value=metric_value
             )
 
+        if metric_name in monitor._metric_name_blacklist:
+            monitor._logger.info(
+                'Metric "%s" is blacklisted so the value wont be reported to Scalyr.'
+                % (metric_name),
+                limit_once_per_x_secs=86400,
+                limit_key="blacklistedMetricName",
+            )
+            return
+
+        string_buffer = io.StringIO()
         string_buffer.write("%s %s" % (metric_name, util.json_encode(metric_value)))
 
         if extra_fields is not None:

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -373,11 +373,13 @@ class AgentLogger(logging.Logger):
             )
 
         if metric_name in getattr(monitor, "_metric_name_blacklist", []):
+            # NOTE: If there there tons of blacklisted metrics, this could cause log object to grow
+            # because we need to store emit time for each limit key. So something to keep in mind.
             monitor._logger.info(
                 'Metric "%s" is blacklisted so the value wont be reported to Scalyr.'
                 % (metric_name),
                 limit_once_per_x_secs=86400,
-                limit_key="blacklistedMetricName",
+                limit_key="blacklisted-metric-name-%s" % (metric_name),
             )
             return
 

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -375,11 +375,14 @@ class AgentLogger(logging.Logger):
         if metric_name in getattr(monitor, "_metric_name_blacklist", []):
             # NOTE: If there there tons of blacklisted metrics, this could cause log object to grow
             # because we need to store emit time for each limit key. So something to keep in mind.
+            monitor_name = getattr(monitor, "raw_monitor_name", "unknown")
+            limit_key = "blacklisted-metric-name-%s-%s" % (monitor_name, metric_name)
+
             monitor._logger.info(
                 'Metric "%s" is blacklisted so the value wont be reported to Scalyr.'
                 % (metric_name),
                 limit_once_per_x_secs=86400,
-                limit_key="blacklisted-metric-name-%s" % (metric_name),
+                limit_key=limit_key,
             )
             return
 

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -163,6 +163,9 @@ class ScalyrMonitor(StoppableThread):
             "monitor_log_flush_delay", convert_to=float, default=0.0, min_value=0
         )
 
+        # List of metrics name which shouldn't be logged and sent to Scalyr
+        self._metric_name_blacklist = self._global_config.metric_name_blacklist
+
         # If true, will adjust the sleep time between gather_sample calls by the time spent in gather_sample, rather
         # than sleeping the full sample_interval_secs time.
         self._adjust_sleep_by_gather_time = False

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -111,6 +111,13 @@ class ScalyrMonitor(StoppableThread):
         self._logger = logger
         self.monitor_name = monitor_config["module"]
 
+        # Holds raw monitor name without the part which are specific to monitor instances
+        if "." in monitor_config["module"]:
+            split = monitor_config["module"].split(".")
+            self.raw_monitor_name = split[-1]
+        else:
+            self.raw_monitor_name = monitor_config["module"]
+
         # save the global config
         self._global_config = global_config
 

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -164,7 +164,10 @@ class ScalyrMonitor(StoppableThread):
         )
 
         # List of metrics name which shouldn't be logged and sent to Scalyr
-        self._metric_name_blacklist = self._global_config.metric_name_blacklist
+        if global_config:
+            self._metric_name_blacklist = self._global_config.metric_name_blacklist
+        else:
+            self._metric_name_blacklist = []
 
         # If true, will adjust the sleep time between gather_sample calls by the time spent in gather_sample, rather
         # than sleeping the full sample_interval_secs time.

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -38,6 +38,7 @@ from threading import Lock
 import six
 
 import scalyr_agent.scalyr_logging as scalyr_logging
+from scalyr_agent.json_lib.objects import ArrayOfStrings
 
 from scalyr_agent.config_util import (
     convert_config_param,
@@ -164,10 +165,9 @@ class ScalyrMonitor(StoppableThread):
         )
 
         # List of metrics name which shouldn't be logged and sent to Scalyr
-        if global_config:
-            self._metric_name_blacklist = self._global_config.metric_name_blacklist
-        else:
-            self._metric_name_blacklist = []
+        self._metric_name_blacklist = self._config.get(
+            "metric_name_blacklist", convert_to=ArrayOfStrings, default=[]
+        )
 
         # If true, will adjust the sleep time between gather_sample calls by the time spent in gather_sample, rather
         # than sleeping the full sample_interval_secs time.

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -21,6 +21,7 @@ __author__ = "czerwin@scalyr.com"
 
 import os
 import tempfile
+import json
 from io import open
 
 from scalyr_agent.configuration import Configuration, BadConfiguration
@@ -48,6 +49,30 @@ from scalyr_agent.compat import os_environ_unicode
 import six
 from six.moves import range
 from mock import patch, Mock
+
+
+MONITOR_CONFIGS = [
+    # Refers to the built-in monitor
+    {
+        "module": "scalyr_agent.builtin_monitors.linux_process_metrics",
+        "id": "agent",
+        "pid": "$$",
+        "metric_name_blacklist": ["metric1"],
+        "sample_interval": 10,
+    },
+    # Refers to the built-in monitor
+    {
+        "module": "scalyr_agent.builtin_monitors.linux_system_metrics",
+        "metric_name_blacklist": ["metric2"],
+    },
+    # Refers to a user defined monitor
+    {
+        "module": "scalyr_agent.builtin_monitors.linux_process_metrics",
+        "id": "my-process",
+        "commandline": ".*my-process.*",
+        "metric_name_blacklist": ["metric3"],
+    },
+]
 
 
 class TestConfigurationBase(ScalyrTestCase):
@@ -2007,3 +2032,72 @@ class TestJournaldLogConfigManager(TestConfigurationBase):
             config_description=None,
             valid_values=["bar", "baz"],
         )
+
+    def test_built_in_monitor_handling(self):
+        config_obj = {
+            "api_key": "foo",
+            "monitors": MONITOR_CONFIGS,
+            "implicit_metric_monitor": False,
+            "implicit_agent_process_metrics_monitor": False,
+        }
+
+        self._write_file_with_separator_conversion(json.dumps(config_obj))
+        config = self._create_test_configuration_instance()
+        config.parse()
+
+        # Implicit monitors are disabled, no monitor configuration should be marked as built in on
+        self.assertEqual(len(config.monitor_configs), 3)
+        self.assertFalse(config.monitor_configs[0].get("builtin_monitor", False))
+        self.assertFalse(config.monitor_configs[1].get("builtin_monitor", False))
+        self.assertFalse(config.monitor_configs[2].get("builtin_monitor", False))
+
+        # Both implicit monitors are enabled
+        config_obj = {
+            "api_key": "foo",
+            "monitors": MONITOR_CONFIGS,
+        }
+
+        self._write_file_with_separator_conversion(json.dumps(config_obj))
+        config = self._create_test_configuration_instance()
+        config.parse()
+
+        self.assertEqual(len(config.monitor_configs), 3)
+        self.assertTrue(config.monitor_configs[0]["builtin_monitor"])
+        self.assertTrue(config.monitor_configs[1]["builtin_monitor"])
+        self.assertFalse(config.monitor_configs[2].get("builtin_monitor", False))
+
+        # System metrics monitor is enabled
+        config_obj = {
+            "api_key": "foo",
+            "monitors": MONITOR_CONFIGS,
+            "implicit_metric_monitor": True,
+            "implicit_agent_process_metrics_monitor": False,
+        }
+
+        self._write_file_with_separator_conversion(json.dumps(config_obj))
+        config = self._create_test_configuration_instance()
+        config.parse()
+
+        # Implicit monitors are disabled, no monitor configuration should be marked as built in on
+        self.assertEqual(len(config.monitor_configs), 3)
+        self.assertFalse(config.monitor_configs[0].get("builtin_monitor", False))
+        self.assertTrue(config.monitor_configs[1]["builtin_monitor"])
+        self.assertFalse(config.monitor_configs[2].get("builtin_monitor", False))
+
+        # Process metrics monitor is enabled
+        config_obj = {
+            "api_key": "foo",
+            "monitors": MONITOR_CONFIGS,
+            "implicit_metric_monitor": False,
+            "implicit_agent_process_metrics_monitor": True,
+        }
+
+        self._write_file_with_separator_conversion(json.dumps(config_obj))
+        config = self._create_test_configuration_instance()
+        config.parse()
+
+        # Implicit monitors are disabled, no monitor configuration should be marked as built in on
+        self.assertEqual(len(config.monitor_configs), 3)
+        self.assertTrue(config.monitor_configs[0]["builtin_monitor"])
+        self.assertFalse(config.monitor_configs[1].get("builtin_monitor", False))
+        self.assertFalse(config.monitor_configs[2].get("builtin_monitor", False))

--- a/scalyr_agent/tests/linux_system_metrics_test.py
+++ b/scalyr_agent/tests/linux_system_metrics_test.py
@@ -33,7 +33,8 @@ class TestSystemMetricConfiguration(TestConfigurationBase):
             logs: [ { path:"/var/log/tomcat6/access.log" }],
             monitors: [
                 {
-                    module: "scalyr_agent.builtin_monitors.linux_system_metrics",
+                    "module": "scalyr_agent.builtin_monitors.linux_system_metrics",
+                    "id": "system-metrics-1",
                     "monitor_log_write_rate": -1,
                     "monitor_log_max_write_burst": -1
                 }

--- a/scalyr_agent/tests/monitors_manager_test.py
+++ b/scalyr_agent/tests/monitors_manager_test.py
@@ -21,19 +21,14 @@ from __future__ import absolute_import
 __author__ = "czerwin@scalyr.com"
 
 import re
-import copy
 
 import scalyr_agent.util as scalyr_util
 
 from scalyr_agent.test_base import ScalyrTestCase
 from scalyr_agent.test_util import ScalyrTestUtils
 from scalyr_agent.util import FakeClockCounter
-from scalyr_agent.platform_controller import PlatformController
-from scalyr_agent.monitors_manager import MonitorsManager
-from scalyr_agent.tests.configuration_test import MONITOR_CONFIGS
 
 import six
-import mock
 
 
 class MonitorsManagerTest(ScalyrTestCase):
@@ -43,7 +38,6 @@ class MonitorsManagerTest(ScalyrTestCase):
             [],
         )
         self.assertEquals(len(test_manager.monitors), 1)
-        self.assertEquals(test_manager.monitors[0].monitor_name, "test_monitor()")
 
     def test_multiple_modules_and_platform_monitors(self):
         test_manager, _ = ScalyrTestUtils.create_test_monitors_manager(
@@ -304,26 +298,3 @@ class MonitorsManagerTest(ScalyrTestCase):
         # set_daemon=True obviates the following (saves a few seconds in cleanup):
         test_manager.stop_manager(wait_on_join=False)
         fake_clock.advance_time(increment_by=poll_interval)
-
-    def test_get_all_monitor_configs_handling_of_builtin_monitors(self):
-        """
-        Test case which verifies that "_get_all_monitor_configs" method correctly handles
-        configuration for built-in monitors and makes sure we don't start multiple instances of
-        built in monitors.
-        """
-        platform_controller = PlatformController.new_platform()
-
-        monitor_configs = copy.copy(MONITOR_CONFIGS)
-        monitor_configs[0]["builtin_monitor"] = True
-        monitor_configs[1]["builtin_monitor"] = True
-
-        configuration = mock.Mock()
-        configuration.implicit_metric_monitor = False
-        configuration.implicit_agent_process_metrics_monitor = False
-        configuration.monitor_configs = monitor_configs
-
-        result = MonitorsManager._get_all_monitor_configs(
-            configuration, platform_controller
-        )
-        self.assertEqual(len(result), 1)
-        self.assertFalse(result[0].get("builtin_monitor", False))

--- a/scalyr_agent/tests/monitors_manager_test.py
+++ b/scalyr_agent/tests/monitors_manager_test.py
@@ -20,8 +20,8 @@ from __future__ import absolute_import
 
 __author__ = "czerwin@scalyr.com"
 
-
 import re
+import copy
 
 import scalyr_agent.util as scalyr_util
 
@@ -313,7 +313,7 @@ class MonitorsManagerTest(ScalyrTestCase):
         """
         platform_controller = PlatformController.new_platform()
 
-        monitor_configs = MONITOR_CONFIGS.copy()
+        monitor_configs = copy.copy(MONITOR_CONFIGS)
         monitor_configs[0]["builtin_monitor"] = True
         monitor_configs[1]["builtin_monitor"] = True
 

--- a/scalyr_agent/tests/scalyr_logging_test.py
+++ b/scalyr_agent/tests/scalyr_logging_test.py
@@ -26,6 +26,8 @@ __author__ = "czerwin@scalyr.com"
 import os
 import tempfile
 
+import mock
+
 import scalyr_agent.scalyr_logging as scalyr_logging
 
 from scalyr_agent.test_base import BaseScalyrLogCaptureTestCase
@@ -107,6 +109,44 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
             file_path=metric_file_path, expression="foo=5"
         )
         self.assertLogFileDoesntContainsLineRegex(expression="foo=5")
+
+        monitor_logger.closeMetricLog()
+
+    def test_metric_logging_metric_name_blacklist(self):
+        monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
+        monitor_instance._metric_name_blacklist = ["name1", "name3"]
+        metric_file_path = tempfile.mktemp(".log")
+
+        monitor_logger = scalyr_logging.getLogger(
+            "scalyr_agent.builtin_monitors.foo(1)"
+        )
+        monitor_logger.openMetricLogForMonitor(metric_file_path, monitor_instance)
+        monitor_logger.emit_value("name1", 5, {"foo": 5})
+        monitor_logger.emit_value("name2", 6, {"foo": 6})
+        monitor_logger.emit_value("name3", 7, {"foo": 7})
+        monitor_logger.emit_value("name4", 8, {"foo": 8})
+
+        self.assertEquals(monitor_instance.reported_lines, 2)
+
+        # The value should only appear in the metric log file and not the main one.
+        self.assertLogFileContainsLineRegex(
+            file_path=metric_file_path, expression="name2"
+        )
+        self.assertLogFileContainsLineRegex(
+            file_path=metric_file_path, expression="foo=6"
+        )
+        self.assertLogFileContainsLineRegex(
+            file_path=metric_file_path, expression="name4"
+        )
+        self.assertLogFileContainsLineRegex(
+            file_path=metric_file_path, expression="foo=8"
+        )
+        self.assertLogFileDoesntContainsLineRegex(
+            file_path=metric_file_path, expression="name1"
+        )
+        self.assertLogFileDoesntContainsLineRegex(
+            file_path=metric_file_path, expression="name3"
+        )
 
         monitor_logger.closeMetricLog()
 
@@ -442,6 +482,8 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
             self.__name = name
             self.reported_lines = 0
             self.errors = 0
+            self._logger = mock.Mock()
+            self._metric_name_blacklist = []
 
         def increment_counter(self, reported_lines=0, errors=0):
             """Increment some of the counters pertaining to the performance of this monitor.


### PR DESCRIPTION
This pull request implements a change which allows user to define a blacklist of metrics name (new ``metric_name_blacklist`` configuration option) which allows user to define which metric names should not be logged and shipped to Scalyr (as per discussion in #402).

## Note on Implementation Details

There are many ways to tackle this problem and I decided to go with a simple "metric name" blacklist based approach.

I think this should work reasonable well for most common use cases and it also introduces the smaller performance penalty compared to a more complex approach which may utilize globs, other fields, etc.

Another thing worth noting is that this is really the "last resort" approach - ideally those metrics should be filtered out at the source - via monitor configuration or similar. But where there is not possible / similar, this new approach can be used.

## Global vs monitor specific configuration option

Right now this configuration is global, but we could also make it monitor specific.

One problem with utilizing monitor specific configuration option is that we would need a bit of a special scenario for handling built in monitors (linux system and linux process metrics).

## Example Configuration

```javascript
...
metric_name_blacklist: ["app.cpu", "app.mem.majflt"]
...