### PR TITLE
Update tcollector code so it uses Python binary which is used to run the main process

### DIFF
--- a/lint-configs/python/mypy.ini
+++ b/lint-configs/python/mypy.ini
@@ -116,3 +116,6 @@ ignore_missing_imports = True
 
 [mypy-iostat.*]
 ignore_missing_imports = True
+
+[mypy-tcollector.*]
+ignore_missing_imports = True

--- a/scalyr_agent/builtin_monitors/tests/test_tcollectors.py
+++ b/scalyr_agent/builtin_monitors/tests/test_tcollectors.py
@@ -1,0 +1,48 @@
+# Copyright 2014-2020 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import sys
+import unittest
+
+import mock
+
+from scalyr_agent.__scalyr__ import scalyr_init
+
+scalyr_init()
+
+from tcollector import tcollector
+
+
+class TcollectorCollectorsTestCase(unittest.TestCase):
+    @mock.patch("tcollector.tcollector.set_nonblocking", mock.Mock())
+    @mock.patch("tcollector.tcollector.subprocess.Popen")
+    def test_correct_python_binary_is_used_for_subprocess(self, mock_popen):
+        col = mock.Mock()
+        col.name = "foo"
+        col.filename = "filename"
+        col.interval = 5
+
+        mock_proc = mock.Mock()
+        mock_proc.pid = 100
+        mock_popen.return_value = mock_proc
+
+        self.assertEqual(mock_popen.call_count, 0)
+
+        tcollector.spawn_collector(col=col)
+
+        call_args = mock_popen.call_args_list[0][0]
+        self.assertEqual(mock_popen.call_count, 1)
+        self.assertEqual(call_args[0], [sys.executable, "filename"])

--- a/scalyr_agent/builtin_monitors/tests/test_tcollectors.py
+++ b/scalyr_agent/builtin_monitors/tests/test_tcollectors.py
@@ -23,7 +23,7 @@ from scalyr_agent.__scalyr__ import scalyr_init
 
 scalyr_init()
 
-from tcollector import tcollector
+from tcollector import tcollector  # pylint: disable=import-error
 
 
 class TcollectorCollectorsTestCase(unittest.TestCase):

--- a/scalyr_agent/tests/monitors_manager_test.py
+++ b/scalyr_agent/tests/monitors_manager_test.py
@@ -293,7 +293,7 @@ class MonitorsManagerTest(ScalyrTestCase):
         test_manager.set_user_agent_augment_callback(augment_user_agent_2)
 
         self.assertTrue(
-            fragment_polls.sleep_until_count_or_maxwait(20, poll_interval, 2)
+            fragment_polls.sleep_until_count_or_maxwait(20, poll_interval, 2.5)
         )
         self.assertEquals(counter["callback_invocations"], 10)
 

--- a/scalyr_agent/third_party/tcollector/tcollector.py
+++ b/scalyr_agent/third_party/tcollector/tcollector.py
@@ -1235,10 +1235,14 @@ def spawn_collector(col):
     # FIXME: do custom integration of Python scripts into memory/threads
     # if re.search('\.py$', col.name) is not None:
     #     ... load the py module directly instead of using a subprocess ...
+    args = [
+        sys.executable,
+        col.filename,
+    ]
     try:
         # Scalyr edit:  Add in close_fds=True
         col.proc = subprocess.Popen(
-            col.filename, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True
+            args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True
         )
     except OSError as e:
         LOG.error("Failed to spawn collector %s: %s" % (col.filename, e))


### PR DESCRIPTION
This pull request updates tcollector so it uses the Python binary which is used to run the main process (aka gain in our case).

This way it works correctly when agent runs under Python 3, but ``/usr/bin/env python`` doesn't point to Python 3 binary.

In addition to that, this way it also works correctly under various virtual environment scenarios.