### PR TITLE
Add new "--log-to-stdout" CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Minor updates
 * Docker support now requires the docker 4.1 client library
 * Changed which signal is used to execute `scalyr-agent-2 status -v` under Linux to improve handling of SIGINT. Previously ``SIGINT`` was used, now ``SIGUSR1`` is used.
 * When running in foreground mode (``--no-fork`` flag), SIGINT signal (aka CTRL+C) now starts the graceful shutdown procedure.
+* Add new ``--log-to-stdout`` CLI flag which can be used in combination with ``--no-fork`` flag. When this flag is used, agent will output all the log messaged to stdout in addition to the log files.
 
 Testing updates
 * Numerous changes to improve testing and coverage reporting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Minor updates
 * Docker support now requires the docker 4.1 client library
 * Changed which signal is used to execute `scalyr-agent-2 status -v` under Linux to improve handling of SIGINT. Previously ``SIGINT`` was used, now ``SIGUSR1`` is used.
 * When running in foreground mode (``--no-fork`` flag), SIGINT signal (aka CTRL+C) now starts the graceful shutdown procedure.
-* Add new ``--log-to-stdout`` CLI flag which can be used in combination with ``--no-fork`` flag. When this flag is used, agent will output all the log messaged to stdout in addition to the log files.
+* Add new ``--log-to-stdout`` CLI flag which can be used in combination with ``--no-fork`` flag. When this flag is used, agent will output all the log messaged to stdout instead of log files.
 
 Testing updates
 * Numerous changes to improve testing and coverage reporting

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -246,8 +246,6 @@ class ScalyrAgent(object):
         no_fork = command_options.no_fork
         no_check_remote = False
 
-        self.__log_to_stdout = log_to_stdout
-
         # We process for the 'version' command early since we do not need the configuration file for it.
         if command == "version":
             print("The Scalyr Agent 2 version is %s" % SCALYR_VERSION)
@@ -256,6 +254,14 @@ class ScalyrAgent(object):
         # Read the configuration file.  Fail if we can't read it, unless the command is stop or status.
         if config_file_path is None:
             config_file_path = self.__default_paths.config_file_path
+
+        self.__log_to_stdout = log_to_stdout
+
+        if log_to_stdout and not no_fork:
+            # --log-to-stdout makes no sense without --no-fork argument
+            raise ValueError(
+                "When --log-to-stdout argument is used, --no-fork needs to be used as well"
+            )
 
         self.__config_file_path = config_file_path
 

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -179,7 +179,7 @@ class ScalyrAgent(object):
         # Used below for a small cache for a slight optimization.
         self.__last_verify_config = None
 
-        # True if the log messages should be printed to stdout in addition to the log file
+        # True if the log messages should be logged to stdout instead of log files
         self.__log_to_stdout = False
 
     @staticmethod
@@ -1756,14 +1756,13 @@ if __name__ == "__main__":
         default="text",
         help="Format to use (text / json) for the agent status command.",
     )
-
     parser.add_option(
         "",
         "--log-to-stdout",
         action="store_true",
         dest="log_to_stdout",
         default=False,
-        help="Log all the log messages to stdout in addition to the log files.",
+        help="Log all the log messages to stdout instead of log files.",
     )
     parser.add_option(
         "",

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -179,6 +179,9 @@ class ScalyrAgent(object):
         # Used below for a small cache for a slight optimization.
         self.__last_verify_config = None
 
+        # True if the log messages should be printed to stdout in addition to the log file
+        self.__log_to_stdout = False
+
     @staticmethod
     def agent_run_method(controller, config_file_path, perform_config_check=False):
         """Begins executing the agent service on the current thread.
@@ -208,6 +211,7 @@ class ScalyrAgent(object):
         my_options.quiet = True
         my_options.verbose = False
         my_options.status_format = "text"
+        my_options.log_to_stdout = False
         my_options.no_fork = True
         my_options.no_change_user = True
         my_options.no_check_remote = False
@@ -238,8 +242,11 @@ class ScalyrAgent(object):
         quiet = command_options.quiet
         verbose = command_options.verbose
         status_format = command_options.status_format
+        log_to_stdout = command_options.log_to_stdout
         no_fork = command_options.no_fork
         no_check_remote = False
+
+        self.__log_to_stdout = log_to_stdout
 
         # We process for the 'version' command early since we do not need the configuration file for it.
         if command == "version":
@@ -459,6 +466,7 @@ class ScalyrAgent(object):
         # Begin writing to the log once we confirm we are able to, so we can log any connection errors
         scalyr_logging.set_log_destination(
             use_disk=True,
+            use_stdout=self.__log_to_stdout,
             max_bytes=self.__config.log_rotation_max_bytes,
             backup_count=self.__config.log_rotation_backup_count,
             logs_directory=self.__config.agent_log_path,
@@ -878,6 +886,7 @@ class ScalyrAgent(object):
                 )
                 scalyr_logging.set_log_destination(
                     use_disk=True,
+                    use_stdout=self.__log_to_stdout,
                     max_bytes=self.__config.log_rotation_max_bytes,
                     backup_count=self.__config.log_rotation_backup_count,
                     logs_directory=self.__config.agent_log_path,
@@ -1742,6 +1751,14 @@ if __name__ == "__main__":
         help="Format to use (text / json) for the agent status command.",
     )
 
+    parser.add_option(
+        "",
+        "--log-to-stdout",
+        action="store_true",
+        dest="log_to_stdout",
+        default=False,
+        help="Log all the log messages to stdout in addition to the log files.",
+    )
     parser.add_option(
         "",
         "--no-fork",

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -1429,11 +1429,8 @@ class AgentLogManager(object):
         max_write_burst=100000,
     ):
         """For documentation, see the scalyr_logging.set_log_destination method."""
-        if use_stdout and use_disk:
-            raise Exception("You cannot specify both use_disk and use_stdout")
-        elif not use_stdout and not use_disk:
-            raise Exception("You must specify at least one of use_stdout or use_diskk.")
-
+        # NOTE: use_stdout and use_disk are not mutually exclusive since changes in
+        # https://github.com/scalyr/scalyr-agent-2/pull/415
         self.__use_stdout = use_stdout
         self.__rotation_max_bytes = max_bytes
         self.__rotation_backup_count = backup_count

--- a/scalyr_agent/tests/agent_main_test.py
+++ b/scalyr_agent/tests/agent_main_test.py
@@ -24,7 +24,6 @@ import mock
 from scalyr_agent.__scalyr__ import DEV_INSTALL
 from scalyr_agent.__scalyr__ import MSI_INSTALL
 from scalyr_agent.test_base import ScalyrTestCase
-from scalyr_agent import compat
 
 __all__ = ["AgentMainTestCase", "ScalyrAgentProcessTestCase"]
 
@@ -158,7 +157,7 @@ class ScalyrAgentProcessTestCase(ScalyrTestCase):
             "--no-fork",
         ]
 
-        env = compat.os_environ_unicode.copy()
+        env = {}
         env["SCALYR_API_KEY"] = "test"
         process = subprocess.Popen(
             base_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
@@ -172,7 +171,7 @@ class ScalyrAgentProcessTestCase(ScalyrTestCase):
 
         # log to stdout flag is provided
         args = base_args + ["--log-to-stdout"]
-        env = compat.os_environ_unicode.copy()
+        env = {}
         env["SCALYR_API_KEY"] = "test"
         process = subprocess.Popen(
             args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env


### PR DESCRIPTION
This pull request adds new ``--log-to-stdout`` flag to the agent which can be used in combination with the existing ``--no-fork`` flag.

When this flag is used, the agent will log all the messages to stdout.

This comes handy in various scenarios such as when troubleshooting things and for local development.

In builds on top of my comments from https://github.com/scalyr/scalyr-agent-2/pull/415.

## TODO

- [x] Tests