### PR TITLE
Run lint checks on smoke_tests/ directory

### DIFF
--- a/smoke_tests/tools/compat/__init__.py
+++ b/smoke_tests/tools/compat/__init__.py
@@ -17,4 +17,4 @@ from __future__ import absolute_import
 try:
     from pathlib import Path  # type: ignore
 except ImportError:
-    from pathlib2 import Path  # type: ignore
+    from pathlib2 import Path  # type: ignore  # NOQA

--- a/smoke_tests/tools/package/__init__.py
+++ b/smoke_tests/tools/package/__init__.py
@@ -28,7 +28,9 @@ def get_agent_distribution_builder(distribution, python_version):
 
     dockerfiles_directory_path = Path(__file__).parent / "distribution_dockerfiles"
 
-    fpm_builder_dockerfile_path = dockerfiles_directory_path / "Dockerfile.fpm_package_builder"
+    fpm_builder_dockerfile_path = (
+        dockerfiles_directory_path / "Dockerfile.fpm_package_builder"
+    )
 
     fpm_package_builder_dockerfile_content = fpm_builder_dockerfile_path.read_text()
 
@@ -55,6 +57,7 @@ def get_agent_distribution_builder(distribution, python_version):
         return AmazonLinuxSmokeImageBuilder
 
     elif distribution == UBUNTU:
+
         class _UbuntuSmokeImageBuilder(AgentImageBuilder):
             PYTHON_VERSION = python_version
             COPY_AGENT_SOURCE = True

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ basepython =
     {py3.7-unit-tests,py3.7-smoke-tests}: python3.7
     {py3.8-unit-tests,py3.8-smoke-tests}: python3.8
 setenv =
-  LINT_FILES_TO_CHECK=*.py scripts/*.py benchmarks/scripts/*.py pylint_plugins/*.py .circleci/*.py .circleci/modernize/ scalyr_agent/ scalyr_agent/third_party/tcollector/
+  LINT_FILES_TO_CHECK=*.py scripts/*.py benchmarks/scripts/*.py smoke_tests/ pylint_plugins/*.py .circleci/*.py .circleci/modernize/ scalyr_agent/ scalyr_agent/third_party/tcollector/
   # Which Python binary to use for various lint targets
   LINT_PYTHON_BINARY={env:LINT_PYTHON_BINARY:python3.6}
   PYTHONPATH={toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ basepython =
     {py3.7-unit-tests,py3.7-smoke-tests}: python3.7
     {py3.8-unit-tests,py3.8-smoke-tests}: python3.8
 setenv =
-  LINT_FILES_TO_CHECK=*.py scripts/*.py benchmarks/scripts/*.py smoke_tests/ pylint_plugins/*.py .circleci/*.py .circleci/modernize/ scalyr_agent/ scalyr_agent/third_party/tcollector/
+  LINT_FILES_TO_CHECK={env:LINT_FILES_TO_CHECK:*.py scripts/*.py benchmarks/scripts/*.py smoke_tests/ pylint_plugins/*.py .circleci/*.py .circleci/modernize/ scalyr_agent/ scalyr_agent/third_party/tcollector/}
   # Which Python binary to use for various lint targets
   LINT_PYTHON_BINARY={env:LINT_PYTHON_BINARY:python3.6}
   PYTHONPATH={toxinidir}


### PR DESCRIPTION
Small change to make sure we also run lint checks on ``smoke_tests/`` directory.

In addition to that, I also added a change so user can specify on which files to run the lint check. This comes handy when you want to run lint check on a subset of files.

For example:

```bash
LINT_FILES_TO_CHECK=smoke_tests/ tox -elint
```