### PR TITLE
update apiVersion and add selector to k8 manifest

### DIFF
--- a/k8s/scalyr-agent-2.yaml
+++ b/k8s/scalyr-agent-2.yaml
@@ -1,8 +1,11 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: scalyr-agent-2
 spec:
+  selector:
+    matchLabels:
+      app: scalyr-agent-2
   template:
     metadata:
       labels:


### PR DESCRIPTION
Starting from Kubernetes 1.16 `apps/v1` api version is required, also a selector on a template label is required. I hope this saves time for new adopters.  