### PR TITLE
Udpate codecov config to ignore top level tests/ directory

### DIFF
--- a/.circleci/.coveragerc_ci
+++ b/.circleci/.coveragerc_ci
@@ -13,3 +13,5 @@ omit =
     */venv/*
     */third_party*/*
     tests/*
+    /home/circleci/scalyr-agent-2/tests/*
+    /usr/share/scalyr-agent-2/py/tests/*

--- a/.circleci/.coveragerc_ci
+++ b/.circleci/.coveragerc_ci
@@ -12,3 +12,4 @@ omit =
     */.virtualenvs/*
     */venv/*
     */third_party*/*
+    tests/*

--- a/.circleci/.coveragerc_ci
+++ b/.circleci/.coveragerc_ci
@@ -12,6 +12,5 @@ omit =
     */.virtualenvs/*
     */venv/*
     */third_party*/*
-    tests/*
     /home/circleci/scalyr-agent-2/tests/*
     /usr/share/scalyr-agent-2/py/tests/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,4 @@ branch = True
 omit =
     */venv/*
     */third_party*/*
+    tests/*

--- a/codecov.yml
+++ b/codecov.yml
@@ -22,15 +22,13 @@ coverage:
 # relative to /home/circleci/scalyr-agent-2/ so we need to fix the paths so it works
 # correctly on codecov.io
 fixes:
-    - "/home/circleci/scalyr-agent-2/::"
+  - "/home/circleci/scalyr-agent-2/::"
 
 ignore:
-    # Ignore top level tests/ directory with end to end package tests for which we
-    # currently don't generate coverage
-    - "/home/circleci/scalyr-agent-2/tests/"
-    - "/home/circleci/scalyr-agent-2/tests/**/*"
-    - "tests/"
-    - "tests/**/*"
+  # Ignore top level tests/ directory with end to end package tests for which we
+  # currently don't generate coverage
+  - "/home/circleci/scalyr-agent-2/tests/"
+  - "/home/circleci/scalyr-agent-2/tests/**/*"
 
 comment:
   layout: "reach, diff, flags, files"

--- a/codecov.yml
+++ b/codecov.yml
@@ -27,8 +27,10 @@ fixes:
 ignore:
     # Ignore top level tests/ directory with end to end package tests for which we
     # currently don't generate coverage
-    - "/home/circleci/scalyr-agent-2/tests"
-    - "tests"
+    - "/home/circleci/scalyr-agent-2/tests/"
+    - "/home/circleci/scalyr-agent-2/tests/**/*"
+    - "tests/"
+    - "tests/**/*"
 
 comment:
   layout: "reach, diff, flags, files"

--- a/codecov.yml
+++ b/codecov.yml
@@ -27,7 +27,8 @@ fixes:
 ignore:
     # Ignore top level tests/ directory with end to end package tests for which we
     # currently don't generate coverage
-    - "tests/"
+    - "/home/circleci/scalyr-agent-2/tests"
+    - "tests"
 
 comment:
   layout: "reach, diff, flags, files"

--- a/codecov.yml
+++ b/codecov.yml
@@ -24,6 +24,11 @@ coverage:
 fixes:
     - "/home/circleci/scalyr-agent-2/::"
 
+ignore:
+    # Ignore top level tests/ directory with end to end package tests for which we
+    # currently don't generate coverage
+    - "tests/"
+
 comment:
   layout: "reach, diff, flags, files"
   behavior: default

--- a/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
@@ -294,6 +294,9 @@ class ControlledCacheWarmerTest(ScalyrTestCase):
     def test_remove_inactive(self):
         warmer = self.__warmer_test_instance
 
+        # Stop the warmer thread since we don't need it for the test
+        warmer.stop()
+
         warmer.begin_marking()
         warmer.mark_to_warm(self.CONTAINER_1, self.NAMESPACE_1, self.POD_1)
         warmer.end_marking()

--- a/scalyr_agent/monitor_utils/tests/k8s_test.py
+++ b/scalyr_agent/monitor_utils/tests/k8s_test.py
@@ -717,7 +717,7 @@ class FakeK8s(object):
     def stop(self):
         """Wakes up anything waiting on a pending requests.  Called when the test is finished.
         """
-        self.__lock.acquire()
+        self.__condition_var.acquire()
         try:
             if self.__pending_request is not None:
                 # If there is still a blocked request at the end of the test, drain it out with an arbitrary
@@ -725,9 +725,9 @@ class FakeK8s(object):
                 self.__pending_responses[
                     self.__pending_request
                 ] = self._raise_temp_error
-                self.__condition_var.notify_all()
+            self.__condition_var.notify_all()
         finally:
-            self.__lock.release()
+            self.__condition_var.release()
 
     def wait_until_request_pending(self, namespace=None, name=None):
         """Blocks the caller until there is a pending call to the cache's `query_object` method that is blocked,

--- a/scalyr_agent/test_base.py
+++ b/scalyr_agent/test_base.py
@@ -480,12 +480,12 @@ class MockHTTPServer(StoppableThread):
 
     def __init__(self, host="127.0.0.1", port=None):
         # type: (str, Optional[int]) -> None
-        super(MockHTTPServer, self).__init__(name="MockHttpServer")
-
-        from flask import Flask
-
         if not port:
             port = random.randint(5000, 20000)
+
+        super(MockHTTPServer, self).__init__(name="MockHttpServer_%s_%s" % (host, port))
+
+        from flask import Flask
 
         self.host = host
         self.port = port

--- a/scalyr_agent/test_base.py
+++ b/scalyr_agent/test_base.py
@@ -113,8 +113,8 @@ def _thread_watcher():
     properly stop.  Since it is not a daemon thread, it will block the exit of the entire process.
 
     """
-    # Sleep for 60 seconds since our test suites typically run in less than 15 seconds.
-    time.sleep(60)
+    # Sleep for 45 seconds since our test suites typically run in less than 15 seconds.
+    time.sleep(45)
 
     # If we are still alive after 60 seconds, it means some test is hung or didn't join
     # its threads properly.  Let's get some information on them.
@@ -127,6 +127,9 @@ def _thread_watcher():
         print("Active thread %s daemon=%s" % (t.getName(), six.text_type(t.isDaemon())))
         pprint(t.__dict__)
     print("Done")
+    # NOTE: We exit with non-zero here to fail early in Circle CI instead of waiting on build
+    # timeout (10 minutes)
+    sys.exit(1)
 
 
 def _start_thread_watcher_if_necessary():

--- a/scalyr_agent/test_base.py
+++ b/scalyr_agent/test_base.py
@@ -36,6 +36,9 @@ import time
 import tempfile
 import unittest
 import random
+
+from pprint import pprint
+
 import scalyr_agent.scalyr_logging as scalyr_logging
 
 import six
@@ -117,7 +120,12 @@ def _thread_watcher():
     # its threads properly.  Let's get some information on them.
     print("Detected hung test run.  Active threads are:")
     for t in threading.enumerate():
+        if t.getName() in ["MainThread", "hung thread watcher"]:
+            # Exclude itself and main thread
+            continue
+
         print("Active thread %s daemon=%s" % (t.getName(), six.text_type(t.isDaemon())))
+        pprint(t.__dict__)
     print("Done")
 
 


### PR DESCRIPTION
I noticed codecov started tracking coverage for new top level ``tests/`` directory (introduced in #463 ) for which we currently don't track coverage.

This pull request updates codecov config so we ignore that directory since it otherwise skews the stats and doesn't provide any value until we also enable coverage for those tests.