### PR TITLE
Workaround for master build failure (don't use built image cache)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,9 +297,9 @@ commands:
             python -m tests.distribution_builders.<< parameters.distribution >>.cmd --dockerfile > ~/Dockerfile
             cat ~/Dockerfile
 
-      - restore_cache:
-          # here the 'tar' file of the docker image is stored. Use it to restore agent image without building it.
-          key: smoke-distribution-image-{{ .Branch }}-<< parameters.distribution >>-{{ checksum "~/Dockerfile" }}-{{ checksum "dev-requirements.txt" }}-<< pipeline.parameters.cache_version >>
+     #  - restore_cache:
+     #      # here the 'tar' file of the docker image is stored. Use it to restore agent image without building it.
+     #      key: smoke-distribution-image-{{ .Branch }}-<< parameters.distribution >>-{{ checksum "~/Dockerfile" }}-{{ checksum "dev-requirements.txt" }}-<< pipeline.parameters.cache_version >>
 
       - run:
           name: Run Unit Tests under Python << parameters.python_version >>
@@ -323,11 +323,12 @@ commands:
                 exit 1
             fi
 
-      - save_cache:
+      # - save_cache:
           # save agent image to 'tar' file here, if this file is not found previously.
-          key: smoke-distribution-image-{{ .Branch }}-<< parameters.distribution >>-{{ checksum "~/Dockerfile" }}-{{ checksum "dev-requirements.txt" }}-<< pipeline.parameters.cache_version >>
-          paths:
-            - "~/agent_image"
+          # TODO: Workaround for incorrect handle of caching since we cache the whole agent_source/ directory.
+      #     key: smoke-distribution-image-{{ .Branch }}-<< parameters.distribution >>-{{ checksum "~/Dockerfile" }}-{{ checksum "dev-requirements.txt" }}-<< pipeline.parameters.cache_version >>
+      #     paths:
+      #       - "~/agent_image"
 
       - save_cache:
           key: deps2-tox-{{ .Branch }}-3.6-venv-{{ checksum "dev-requirements.txt" }}
@@ -977,37 +978,10 @@ jobs:
 
 workflows:
   version: 2
-  unittest:
-    jobs:
-      - lint-checks
-      - unittest-38
-      - unittest-37
-      - unittest-36
-      - unittest-35
-      - unittest-27
-      - unittest-26
-      - smoke-standalone-38
-      - smoke-standalone-37
-      - smoke-standalone-36
-      - smoke-standalone-35
-      - smoke-standalone-27
-      - smoke-standalone-26
-      # smoke test jobs above are still uses old smoke tests.
-      - smoke-docker-json
-      - smoke-docker-syslog
-      - smoke-k8s
-      - smoke-standalone-27-tls12
-      - smoke-standalone-26-tls12
-      - coverage:
-          requires:
-            - unittest-27
-            - smoke-docker-json
-            - smoke-docker-syslog
-            - smoke-k8s
   package-tests:
     jobs:
-      - package-test-rpm:
-      - package-test-deb:
+      - package-test-rpm
+      - package-test-deb
   weekly-circle-ci-usage-report:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -978,10 +978,75 @@ jobs:
 
 workflows:
   version: 2
+  unittest:
+    jobs:
+      - lint-checks
+      - unittest-38
+      - unittest-37
+      - unittest-36
+      - unittest-35
+      - unittest-27
+      - unittest-26
+      - smoke-standalone-38
+      - smoke-standalone-37
+      - smoke-standalone-36
+      - smoke-standalone-35
+      - smoke-standalone-27
+      - smoke-standalone-26
+      # smoke test jobs above are still uses old smoke tests.
+      - smoke-docker-json
+      - smoke-docker-syslog
+      - smoke-k8s
+      - smoke-standalone-27-tls12
+      - smoke-standalone-26-tls12
+      - coverage:
+          requires:
+            - unittest-27
+            - smoke-docker-json
+            - smoke-docker-syslog
+            - smoke-k8s
   package-tests:
     jobs:
-      - package-test-rpm
-      - package-test-deb
+      - package-test-rpm:
+           <<: *master_only
+      - package-test-deb:
+           <<: *master_only
+      - smoke-rpm-package-py2:
+          requires:
+            - package-test-rpm
+          <<: *master_only
+      - smoke-rpm-package-py3:
+          requires:
+            - package-test-rpm
+          <<: *master_only
+      - smoke-deb-package-py2:
+          requires:
+            - package-test-deb
+          <<: *master_only
+      - smoke-deb-package-py3:
+          requires:
+            - package-test-deb
+          <<: *master_only
+  benchmarks:
+    jobs:
+      - benchmarks-idle-agent-py-27:
+          <<: *master_only
+      - benchmarks-idle-agent-py-35:
+          <<: *master_only
+      - benchmarks-idle-agent-no-monitors-py-27:
+          <<: *master_only
+      - benchmarks-idle-agent-no-monitors-py-35:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
+          <<: *master_only
+      - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
+          <<: *master_only
   weekly-circle-ci-usage-report:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1007,45 +1007,7 @@ workflows:
   package-tests:
     jobs:
       - package-test-rpm:
-           <<: *master_only
       - package-test-deb:
-           <<: *master_only
-      - smoke-rpm-package-py2:
-          requires:
-            - package-test-rpm
-          <<: *master_only
-      - smoke-rpm-package-py3:
-          requires:
-            - package-test-rpm
-          <<: *master_only
-      - smoke-deb-package-py2:
-          requires:
-            - package-test-deb
-          <<: *master_only
-      - smoke-deb-package-py3:
-          requires:
-            - package-test-deb
-          <<: *master_only
-  benchmarks:
-    jobs:
-      - benchmarks-idle-agent-py-27:
-          <<: *master_only
-      - benchmarks-idle-agent-py-35:
-          <<: *master_only
-      - benchmarks-idle-agent-no-monitors-py-27:
-          <<: *master_only
-      - benchmarks-idle-agent-no-monitors-py-35:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
-          <<: *master_only
-      - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
-          <<: *master_only
   weekly-circle-ci-usage-report:
     triggers:
       - schedule:

--- a/tests/utils/dockerized.py
+++ b/tests/utils/dockerized.py
@@ -63,7 +63,7 @@ def dockerized_case(builder_cls, file_path):
                         stream, _ = container.get_archive(
                             "/var/log/scalyr-agent-2/agent.log"
                         )
-                    except Exception as e:
+                    except docker.errors.NotFound as e:
                         # Not all the test files produce agent.log so we simply ignore the error
                         # if agent log file doesn't exist
                         msg = str(e).lower()


### PR DESCRIPTION
I added a new test in #472 and new package tests started to fail on master (they were all passing locally).

It looks like there is an issue where we incorrectly handle Docker image caching so the tests are using old and out of date agent_source/ directory.

This is a short term workaround (don't use cache), but in the future we need to figure out a better approach and solution that since re-building whole image on any change in the agent repo is unacceptable (and wasteful).