### PR TITLE
Disable default conf files in Debian

### DIFF
--- a/build_package.py
+++ b/build_package.py
@@ -765,6 +765,8 @@ def build_rpm_or_deb_package(is_rpm, variant, version):
         "  --before-install preinstall.sh "
         "  --after-install postinstall.sh "
         "  --before-remove preuninstall.sh "
+        "  --deb-no-default-config-files "
+        "  --no-deb-auto-config-files "
         "  --config-files /etc/scalyr-agent-2/agent.json "
         "  --config-files /usr/share/scalyr-agent-2/bin/scalyr-agent-2 "
         "  --config-files /usr/share/scalyr-agent-2/bin/scalyr-agent-2-config "


### PR DESCRIPTION
## Background

This is a fix for an issue that came up when testing Ubuntu 18 and 16 AMI images.  Out of the box, the install-scaly-agent was partially succeeding in installing the Scalyr Agent.  The install would be left in a usable state (the Scalyr Agent could be started, etc) but the system would not have the Scalyr Agent configured as a service and therefore not be set up to launch at system start.

It turns out, there is some weird (and unexplained) issue with having our multiple symlinks and conf file structure.  If the `/etc/init.d/scalyr-agent-2` symlink is marked as a conf file and it points to  the `/usr/share/scalyr-agent-2/bin/scalyr-agent-2` symlink (which is also marked as a conf file), then the symlink in `/etc/init.d` is not present on the filesystem when the post install script is run during Debian package install.  We should also point out that only the AMI images exhibited the behavior.  The same test on GCP VMs installed with Ubuntu 18 did not fail.

## Proposal

This change fixes the issue by no longer marking `/etc/init.d/scalyr-agent-2` as a conf file.  It was never meant to be marked as a conf file, but Debian, by default, marks anything in `/etc` as a conf file.  For some reason, this solves the problem.

## Risks

1.  We still do not understand why this particular conf file setup breaks the system.  So, we are just papering over the issue without understanding it.

2.  If customers have modified the `/etc/init.d/scalyr-agent` file, then this change will break them.  Since it will no longer be a conf file, new package installs will overwritten their modified copy.  Since it is the rc script, it's possible folks may have wanted to modify this (to maybe set environment variables for the agent at startup time) though since we publish it as a symlink, I don't think that's likely.  I haven't ever heard of a customer modifying it

## Alternatives

With our current understanding, the only alternative I can think of is to have the post install script create the symlink itself if it is not present on the file system.  That way, if a customer has modified the rc script, we will not overwrite it.  However, adding more weirdness / behaviors to the post install script seems like we may run into other cross distro compatibility problems down the road.