### PR TITLE
Fix failing tests, add new rc*.d symlinks tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1047,26 +1047,20 @@ workflows:
           <<: *non_master_and_release
       - package-build-deb:
           <<: *non_master_and_release
-      - package-test-rpm:
-          <<: *master_and_release_only
-      - package-test-deb:
-          <<: *master_and_release_only
+      - package-test-rpm
+      - package-test-deb
       - smoke-rpm-package-py2:
           requires:
             - package-test-rpm
-          <<: *master_and_release_only
       - smoke-rpm-package-py3:
           requires:
             - package-test-rpm
-          <<: *master_and_release_only
       - smoke-deb-package-py2:
           requires:
             - package-test-deb
-          <<: *master_and_release_only
       - smoke-deb-package-py3:
           requires:
             - package-test-deb
-          <<: *master_and_release_only
   benchmarks:
     jobs:
       - benchmarks-idle-agent-py-27:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1047,20 +1047,26 @@ workflows:
           <<: *non_master_and_release
       - package-build-deb:
           <<: *non_master_and_release
-      - package-test-rpm
-      - package-test-deb
+      - package-test-rpm:
+          <<: *master_and_release_only
+      - package-test-deb:
+          <<: *master_and_release_only
       - smoke-rpm-package-py2:
           requires:
             - package-test-rpm
+          <<: *master_and_release_only
       - smoke-rpm-package-py3:
           requires:
             - package-test-rpm
+          <<: *master_and_release_only
       - smoke-deb-package-py2:
           requires:
             - package-test-deb
+          <<: *master_and_release_only
       - smoke-deb-package-py3:
           requires:
             - package-test-deb
+          <<: *master_and_release_only
   benchmarks:
     jobs:
       - benchmarks-idle-agent-py-27:

--- a/tests/distribution/python_version_change_tests/common.py
+++ b/tests/distribution/python_version_change_tests/common.py
@@ -20,6 +20,8 @@ import os
 import time
 import json
 import shutil
+import re
+import glob
 import stat
 from io import open
 
@@ -291,14 +293,24 @@ def common_test_only_python_mapped_to_python3(
 
 def common_test_python2(install_package_fn, install_next_version_fn):
     """
-    Test package installation on machine with python2
+    Test package installation on machine with python2.
+
+    The function also verifies correct rc*.d symlinks are created.
+
     :param install_package_fn: callable that installs package with appropriate type to the current machine OS.
     """
 
     _remove_python("python")
     _remove_python("python3")
 
+    # rc.d symlinks shouldn't exist before install
+    files = _get_agent_rc_d_symlinks()
+    assert len(files) == 0
+
     stdout, _ = install_package_fn()
+
+    # But they should have been created during the postinst step
+    _assert_rc_d_symlinks_exist()
 
     # make sure that installer has found 'python2'.
     assert "The default 'python' command not found, will use python2 binary" in stdout
@@ -330,7 +342,14 @@ def common_test_python3(install_package_fn, install_next_version_fn):
     _remove_python("python")
     _remove_python("python2")
 
+    # rc.d symlinks shouldn't exist before install
+    files = _get_agent_rc_d_symlinks()
+    assert len(files) == 0
+
     stdout, _ = install_package_fn()
+
+    # But they should have been created during the postinst step
+    _assert_rc_d_symlinks_exist()
 
     # make sure that installer has found 'python3'.
     assert "The default 'python' command not found, will use python2 binary" in stdout
@@ -610,3 +629,25 @@ def _python_binary_is_symlink():
             return True
 
     return False
+
+
+def _assert_rc_d_symlinks_exist():
+    """
+    Assert that rc*.d symlinks which ensure agent is started on process exist.
+    """
+    # run levels for which we create symlinks
+    expected_rc_levels = [0, 1, 2, 3, 4, 5, 6]
+    files = _get_agent_rc_d_symlinks()
+    assert len(files) == len(expected_rc_levels)
+
+    actual_rc_levels = []
+    for file_name in files:
+        rc_level = int(re.match(r".*(rc(\d)\.d).*", file_name).groups()[1])
+        actual_rc_levels.append(rc_level)
+
+    assert sorted(expected_rc_levels) == sorted(actual_rc_levels)
+
+
+def _get_agent_rc_d_symlinks():
+    files = glob.glob("/etc/rc*.d/*scalyr-agent-2*")
+    return files

--- a/tests/smoke_tests/package_test.py
+++ b/tests/smoke_tests/package_test.py
@@ -23,7 +23,7 @@ from tests.utils.agent_runner import PACKAGE_INSTALL
 
 from tests.utils.dockerized import dockerized_case
 from tests.distribution_builders.amazonlinux2 import AmazonlinuxBuilder
-from tests.distribution_builders.ubuntu1804 import UbuntuBuilder
+from tests.distribution_builders.ubuntu1804_with_py3 import UbuntuBuilder
 from tests.common import install_rpm, install_deb
 
 


### PR DESCRIPTION
This pull request fixes tests which have started failing after #477 has been merged.

In addition to that, I updated existing ``common_test_python_{2,3}`` test to verify that rc*.d symlinks are correctly created as part of the package postinst step.

Those tests would have caught the issue we've spent so much time tracking down (but obviously not the root cause) so it should serve as a regression test / protection for the future.

I ran them under all the distros (atm we only run tests on Circle CI on CentOS 8 and Ubuntu 18.04) and they pass with the latest master.

Keep in mind that those tests don't really belong into ``python_version_change_tests`` distribution tests, but we can clean this up and move them in a more appropriate place once we start working on more end to end package tests in the near future.