### PR TITLE
Fix a bug with status report incorrectly listing running monitors as dead

### DIFF
--- a/scalyr_agent/tests/empty_monitor.py
+++ b/scalyr_agent/tests/empty_monitor.py
@@ -22,9 +22,17 @@ from __future__ import absolute_import
 
 __author__ = "imron@scalyr.com"
 
+import time
+
 from scalyr_agent.scalyr_monitor import ScalyrMonitor
 
 
 class EmptyMonitor(ScalyrMonitor):
-    def run(self):
-        pass
+    """
+    Monitor class which is running for run_time seconds.
+    """
+
+    def run(self, run_time=0.5):
+        # We need to eventually call stop otherwise the tests will hang and run forever
+        time.sleep(run_time)
+        self._run_state.stop()

--- a/scalyr_agent/tests/util/util_test.py
+++ b/scalyr_agent/tests/util/util_test.py
@@ -565,6 +565,40 @@ class TestStoppableThread(ScalyrTestCase):
 
         self.assertTrue(caught_it)
 
+    def test_is_alive(self):
+        class TestThread(StoppableThread):
+            def __init__(self):
+                self.run_counter = 0
+                StoppableThread.__init__(self, "Test thread")
+
+            def run_and_propagate(self):
+                while self._run_state.is_running():
+                    self._run_state.sleep_but_awaken_if_stopped(0.03)
+
+        test_thread_1 = TestThread()
+        test_thread_2 = StoppableThread("Testing", self._run_method)
+
+        test_threads = [test_thread_1, test_thread_2]
+
+        for test_thread in test_threads:
+            self.assertFalse(test_thread.isAlive())
+
+            if six.PY3:
+                self.assertFalse(test_thread.is_alive())
+
+            test_thread.start()
+
+            self.assertTrue(test_thread.isAlive())
+
+            if six.PY3:
+                self.assertTrue(test_thread.is_alive())
+
+            test_thread.stop()
+            self.assertFalse(test_thread.isAlive())
+
+            if six.PY3:
+                self.assertFalse(test_thread.is_alive())
+
     def _run_method(self, run_state):
         self._run_counter += 1
         while run_state.is_running():

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -1210,6 +1210,32 @@ class StoppableThread(threading.Thread):
                 self.__exception_info[2],
             )
 
+    def isAlive(self):
+        """
+        Here for compatibility with Python 2.
+        """
+        return self.is_alive()
+
+    def is_alive(self):
+        """
+        Custom isAlive() implementation because previously we relied on "_is_stopped" class instance
+        variable which is reserved / used by actual "is_alive()" implementation under Python 3.
+        """
+        # TODO: This is not 100% correct, but that's the behavior our code relies ON.
+        # Eventually we need to fix the implementation on StoppableThread so RunState defaults
+        # "_is_running" to False and then set it to True inside "run()" and only check that value
+        # here.
+        if six.PY2:
+            return super(StoppableThread, self).isAlive()
+
+        if (
+            not self._run_state.is_running()
+            or not super(StoppableThread, self).is_alive()
+        ):
+            return False
+
+        return True
+
 
 class RateLimiter(object):
     """An abstraction that can be used to enforce some sort of rate limit, expressed as a maximum number

--- a/tox.ini
+++ b/tox.ini
@@ -248,4 +248,4 @@ basepython = python3.6
 passenv =
     TERM SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
 commands =
-    py.test tests/distribution/deb_package.py -s -vv --tb=short --durations=5 {posargs}
+    py.test tests/distribution/rpm_package.py -s -vv --tb=short --durations=5 {posargs}


### PR DESCRIPTION
This pull request fixes ``isAlive()`` implementation under Python 3.

The issue was related to our Python 3 compatibility change (renaming ``_is_stopped`` instance variable on which parent ``isAlive()`` relied on) and ``Thread.is_alive()`` implementation changing under Python 3.

To make it work, I used middle of the ground approach.

Under Python 2, we leave it as it was before and under Python 3 we check ``self._run_state`` and ``self._started`` class instance variable.

This should work under all scenarios, but it still means our ``StoppableThread`` is not 100% compliant with the base Thread API.

Making it compliant will require more changes (RunState should default to ``False`` inside the constructor and only get changed to ``True`` when theread.run/start method is called, etc.), but that's out of scope for now - too big of a risk of introducing inadvertent regressions and bugs.

---

TL;DR Problem was that under Python 3, we were not consulting ``self._run_state`` for thread status so that piece of code detected monitors as dead even though they were alive. This is actually quite a big / nasty bug, but we don't utilize ``isAlive()`` in other scenarios so we didn't catch it before and it was mostly harmless.