### PR TITLE
Make sure we preserve artifacts for package tests

### DIFF
--- a/tests/distribution/python_version_change_tests/ubuntu1404_test.py
+++ b/tests/distribution/python_version_change_tests/ubuntu1404_test.py
@@ -35,7 +35,7 @@ from tests.utils.agent_runner import PACKAGE_INSTALL, AgentRunner
 
 @pytest.mark.usefixtures("agent_environment")
 @dockerized_case(UbuntuBuilder, __file__, python_executable="python_for_tests")
-def test_centos_test_versions(request):
+def test_ubuntu_test_versions(request):
     runner = AgentRunner(PACKAGE_INSTALL)
     common_version_test(
         runner,
@@ -66,7 +66,6 @@ def test_centos_test_versions(request):
 @dockerized_case(UbuntuBuilder, __file__, python_executable="python_for_tests")
 def test_ubuntu_no_python(request):
     common_test_no_python(install_deb)
-    assert True is False
 
 
 @pytest.mark.usefixtures("agent_environment")

--- a/tests/distribution/python_version_change_tests/ubuntu1404_with_py3_test.py
+++ b/tests/distribution/python_version_change_tests/ubuntu1404_with_py3_test.py
@@ -32,39 +32,8 @@ from tests.distribution.python_version_change_tests.common import (
     common_test_switch_default_to_python2,
     common_test_switch_default_to_python3,
     common_test_switch_python2_to_python3,
-    common_version_test,
 )
-from tests.common import install_deb, install_next_version_deb, remove_deb
-from tests.utils.agent_runner import AgentRunner, PACKAGE_INSTALL
-
-
-@pytest.mark.usefixtures("agent_environment")
-@dockerized_case(UbuntuBuilder, __file__)
-def test_centos_test_versions(request):
-    runner = AgentRunner(PACKAGE_INSTALL)
-    common_version_test(
-        runner,
-        install_deb,
-        remove_deb,
-        None,
-        "2.5.1",
-        "2.5.1",
-        "3.4.1",
-        install_fails=True,
-    )
-
-    common_version_test(
-        runner, install_deb, remove_deb, "config_main_py2.py", "2.5.1", "", ""
-    )
-    common_version_test(
-        runner, install_deb, remove_deb, "config_main_py2.py", "2.5.1", "", ""
-    )
-
-    common_version_test(runner, install_deb, remove_deb, "config_main.py", "", "", "")
-
-    common_version_test(
-        runner, install_deb, remove_deb, "config_main.py", "", "2.5.1", ""
-    )
+from tests.common import install_deb, install_next_version_deb
 
 
 @pytest.mark.usefixtures("agent_environment")

--- a/tests/distribution/python_version_change_tests/ubuntu1604_test.py
+++ b/tests/distribution/python_version_change_tests/ubuntu1604_test.py
@@ -34,7 +34,7 @@ from tests.utils.agent_runner import PACKAGE_INSTALL, AgentRunner
 
 @pytest.mark.usefixtures("agent_environment")
 @dockerized_case(UbuntuBuilder, __file__, python_executable="python_for_tests")
-def test_centos_test_versions(request):
+def test_ubuntu_test_versions(request):
     runner = AgentRunner(PACKAGE_INSTALL)
     common_version_test(
         runner,

--- a/tests/distribution/python_version_change_tests/ubuntu1804_test.py
+++ b/tests/distribution/python_version_change_tests/ubuntu1804_test.py
@@ -33,8 +33,13 @@ from tests.utils.agent_runner import PACKAGE_INSTALL, AgentRunner
 
 
 @pytest.mark.usefixtures("agent_environment")
-@dockerized_case(UbuntuBuilder, __file__, python_executable="python_for_tests")
-def test_centos_test_versions(request):
+@dockerized_case(
+    UbuntuBuilder,
+    __file__,
+    python_executable="python_for_tests",
+    file_paths_to_copy=["/scalyr-agent.deb"],
+)
+def test_ubuntu_test_versions(request):
     runner = AgentRunner(PACKAGE_INSTALL)
     common_version_test(
         runner,

--- a/tests/utils/dockerized.py
+++ b/tests/utils/dockerized.py
@@ -117,8 +117,10 @@ def copy_artifacts(container, file_paths, destination_path):
     if not file_paths:
         return
 
-    if not destination_path.exists():
-        return
+    try:
+        os.makedirs(destination_path)
+    except OSError:
+        pass
 
     for file_path in file_paths:
         # fetch file as tar file stream if it exists
@@ -134,11 +136,6 @@ def copy_artifacts(container, file_paths, destination_path):
                 continue
 
             raise e
-
-        try:
-            os.makedirs(destination_path)
-        except OSError:
-            pass
 
         print('Copying file path "%s" to "%s"' % (file_path, destination_path))
 


### PR DESCRIPTION
This pull request fixes small regression from #485 and makes sure we correctly preserve deb and rpm artifacts from Python version change package tests.

It also fixes some duplicate targets and invalid function names.