### PR TITLE
Fix master build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,11 +359,7 @@ commands:
 
       - run:
           name: Copy Created Docker Images to Cache Folders
-          command: |
-              cp  ~/agent_image/scalyr-agent-testings-fpm_package-builder ~/fpm_builder_cache/scalyr-agent-testings-fpm_package-builder
-              rm ~/agent_image/scalyr-agent-testings-fpm_package-builder
-              cp  ~/agent_image/scalyr-agent-testings-monitor-base ~/monitors_builder_cache/scalyr-agent-testings-monitor-base
-              cp ~/agent_image/* ~/agent_image_cache/
+          command: ./scripts/circleci/copy-docker-images-to-cache.sh
 
       - save_cache:
           # save fpm builder image to 'tar' file here, if this file is not found previously.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1120,10 +1120,8 @@ workflows:
           <<: *non_master_and_release
       - package-build-deb:
           <<: *non_master_and_release
-      - package-test-rpm:
-          <<: *master_and_release_only
-      - package-test-deb:
-          <<: *master_and_release_only
+      - package-test-rpm
+      - package-test-deb
       - smoke-rpm-package-py2:
           requires:
             - package-test-rpm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1120,8 +1120,10 @@ workflows:
           <<: *non_master_and_release
       - package-build-deb:
           <<: *non_master_and_release
-      - package-test-rpm
-      - package-test-deb
+      - package-test-rpm:
+          <<: *master_and_release_only
+      - package-test-deb:
+          <<: *master_and_release_only
       - smoke-rpm-package-py2:
           requires:
             - package-test-rpm

--- a/scripts/circleci/copy-docker-images-to-cache.sh
+++ b/scripts/circleci/copy-docker-images-to-cache.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright 2014-2020 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script which copies Docker images created during test runs to directory which
+# is cached
+
+if [ -f "~/agent_image/scalyr-agent-testings-fpm_package-builder" ]; then
+    cp  ~/agent_image/scalyr-agent-testings-fpm_package-builder ~/fpm_builder_cache/scalyr-agent-testings-fpm_package-builder
+    rm ~/agent_image/scalyr-agent-testings-fpm_package-builder
+fi
+
+if [ -f "~/agent_image/scalyr-agent-testings-monitor-base" ]; then
+    cp  ~/agent_image/scalyr-agent-testings-monitor-base ~/monitors_builder_cache/scalyr-agent-testings-monitor-base
+    rm ~/agent_image/scalyr-agent-testings-monitor-base
+fi
+
+cp ~/agent_image/* ~/agent_image_cache/


### PR DESCRIPTION
Small fix for master build failing.

Our Circle CI job added in #490 didn't correctly handle a scenario where a cached image file doesn't exist yet.

This pull request fixes that.