### PR TITLE
Fix unit test failures on OS X

### DIFF
--- a/scalyr_agent/builtin_monitors/tests/linux_process_metrics_test.py
+++ b/scalyr_agent/builtin_monitors/tests/linux_process_metrics_test.py
@@ -17,17 +17,20 @@ from __future__ import absolute_import
 
 import os
 import sys
+import platform
+
+import mock
 
 from scalyr_agent.builtin_monitors.linux_process_metrics import ProcessMonitor
 from scalyr_agent.scalyr_monitor import load_monitor_class
 from scalyr_agent.test_base import ScalyrTestCase
-
-import mock
+from scalyr_agent.test_base import skipIf
 
 __all__ = ["LinuxProcessMetricsMonitorTest"]
 
 
 class LinuxProcessMetricsMonitorTest(ScalyrTestCase):
+    @skipIf(platform.system() == "Darwin", "Skipping Linux Monitor tests on OSX")
     def test_gather_sample_by_pid_success(self):
         monitor_config = {
             "module": "linux_process_metrics",
@@ -45,6 +48,7 @@ class LinuxProcessMetricsMonitorTest(ScalyrTestCase):
         self.assertEqual(mock_logger.error.call_count, 0)
         self.assertEqual(mock_logger.emit_value.call_count, len(monitor_info.metrics))
 
+    @skipIf(platform.system() == "Darwin", "Skipping Linux Monitor tests on OSX")
     def test_gather_sample_by_commandline_success(self):
         monitor_config = {
             "module": "linux_process_metrics",
@@ -62,6 +66,7 @@ class LinuxProcessMetricsMonitorTest(ScalyrTestCase):
         self.assertEqual(mock_logger.error.call_count, 0)
         self.assertEqual(mock_logger.emit_value.call_count, len(monitor_info.metrics))
 
+    @skipIf(platform.system() == "Darwin", "Skipping Linux Monitor tests on OSX")
     def test_gather_sample_by_pid_failure_pid_doesnt_exist(self):
         monitor_config = {
             "module": "linux_process_metrics",

--- a/scalyr_agent/builtin_monitors/tests/linux_system_metrics_test.py
+++ b/scalyr_agent/builtin_monitors/tests/linux_system_metrics_test.py
@@ -24,12 +24,14 @@ from scalyr_agent.test_base import ScalyrTestCase
 from scalyr_agent.test_base import skipIf
 
 import mock
+import platform
 
 __all__ = ["LinuxSystemMetricsMonitorTest"]
 
 
 class LinuxSystemMetricsMonitorTest(ScalyrTestCase):
     @skipIf(sys.version_info < (2, 7, 0), "Skipping tests under Python 2.6")
+    @skipIf(platform.system() == "Darwin", "Skipping Linux Monitor tests on OSX")
     def test_gather_sample_success(self):
         monitor_config = {
             "module": "linux_system_metrics",

--- a/scalyr_agent/tests/agent_main_test.py
+++ b/scalyr_agent/tests/agent_main_test.py
@@ -156,7 +156,10 @@ class AgentMainTestCase(ScalyrTestCase):
         of systemd are not forgiving and don't work with it which means rc.d targets can't be
         created.
         """
-        with open(agent_main.__file__, "r") as fp:
+        # Make sure we always read the original .py file and not the cached .pyc one
+        file_path = agent_main.__file__.replace(".pyc", ".py")
+
+        with open(file_path, "r") as fp:
             content = fp.read()
 
         msg = (


### PR DESCRIPTION
This pull request fixes two potential test failures on OS X.

In first case, the problem was that depending on how tests run, the test would load and read ``.pyc`` instead of ``.py`` file.

This issue would only manifest itself when running tests under different Python versions (e.g. .pyc file was generated under one version and tests run under a different version).

And in other case, we simply skip Linux specific tests on OS X.