### PR TITLE
Run unit tests on Mac OSX

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,6 +477,46 @@ jobs:
           tox_target: "py3.5-unit-tests"
           run_microbenchmarks: true
 
+  unittest-35-osx:
+    working_directory: ~/scalyr-agent-2
+    macos:
+      xcode: "11.2.1"
+    environment:
+      PYTHON: 3.5.6
+      # Updating homebrew is slow
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - run:
+          name: install pyenv
+          command: |
+            brew install pyenv
+      - restore_cache:
+          key: deps2-tox-{{ .Branch }}-2.5-osx-venv-{{ checksum "dev-requirements.txt" }}
+      - run:
+          name: Install Python
+          command: |
+            pyenv install $PYTHON -s
+      - run:
+          name: Install Dependencies
+          command: |
+            eval "$(pyenv init -)"
+            pyenv local $PYTHON
+            python -m pip install virtualenv
+            python -m virtualenv venv
+            ./venv/bin/pip install "tox==3.14.3"
+      - save_cache:
+          key: deps2-tox-{{ .Branch }}-2.5-osx-venv-{{ checksum "dev-requirements.txt" }}
+          paths:
+            - ~/.cache/pip
+            - ~/.pyenv
+      - run:
+          name: Run Unit Tests under Python 3.5
+          command: |
+            pyenv local $PYTHON
+            source ./venv/bin/activate
+            tox -epy3.5-unit-tests
+
   unittest-27:
     working_directory: ~/scalyr-agent-2
     docker:
@@ -1124,6 +1164,7 @@ workflows:
       - unittest-26
       - unittest-27
       - unittest-35
+      - unittest-35-osx
       - smoke-standalone-26
       - smoke-standalone-27
       - smoke-standalone-35


### PR DESCRIPTION
This pull request updates Circle CI config so we also run unit tests on OS X using Python 3.5.

We don't officially support running agent on the OS X (although it more or less works out of the box), but some developers use OS X for development so we should also run at least unit tests on OS X to detected issues like the one in #499 early.