### PR TITLE
Circle CI and tox.ini updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,12 +8,20 @@ master_and_release_only: &master_and_release_only
       only:
         - master
         - release
+        # Those short lived branches are automatically created by our StackStorm build automation
+        # so we can ensure all the jobs (including the ones which only run on master) pass before
+        # merging a PR.
+        - /automated_tests\/.*/
 
 master_only: &master_only
   filters:
     branches:
       only:
         - master
+        # Those short lived branches are automatically created by our StackStorm build automation
+        # so we can ensure all the jobs (including the ones which only run on master) pass before
+        # merging a PR.
+        - /automated_tests\/.*/
 
 non_master_and_release: &non_master_and_release
   filters:
@@ -21,6 +29,10 @@ non_master_and_release: &non_master_and_release
       ignore:
         - master
         - release
+        # Those short lived branches are automatically created by our StackStorm build automation
+        # so we can ensure all the jobs (including the ones which only run on master) pass before
+        # merging a PR.
+        - /automated_tests\/.*/
 
 version: 2.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,7 @@ commands:
                 path: ~/scalyr-agent-2/microbenchmark_histograms/
       - slack/status:
           fail_only: true
+          only_for_branches: master
 
   codespeed_agent_process_benchmark:
     description: "A base command which runs CodeSpeed agent process level benchmarks"
@@ -252,6 +253,9 @@ commands:
       # NOTE: We store the logs to ease with troubleshooting / debugging
       - store_artifacts:
           path: ~/scalyr-agent-dev/log
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
 
   smoke-standalone-tox:
     description: "A base command for all tox based smoke test jobs"
@@ -304,6 +308,10 @@ commands:
       # NOTE: We store the logs to ease with troubleshooting / debugging
       - store_artifacts:
           path: ~/scalyr-agent-dev/log
+
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
 
   run-tox-target:
     description: "Base command which runs the specified tox target."
@@ -478,6 +486,10 @@ commands:
           target_name:  << parameters.tox_target >>
           upload_coverage: << parameters.upload_coverage >>
 
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
+
   monitors-tests:
     description: "A base command for monitors smoke tests."
     parameters:
@@ -517,6 +529,10 @@ commands:
           agent_host_name: << parameters.agent_host_name_prefix >>-<< parameters.distribution >>-<< parameters.python_version >>
           target_name:  << parameters.tox_target >>
           upload_coverage: << parameters.upload_coverage >>
+
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
 
 jobs:
   unittest-38:
@@ -596,6 +612,10 @@ jobs:
             source ./venv/bin/activate
             tox -epy3.5-unit-tests
 
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
+
   unittest-27:
     working_directory: ~/scalyr-agent-2
     docker:
@@ -632,6 +652,10 @@ jobs:
             docker run -it -v shared_vol:/app -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.7.nossl -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} -e CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM} scalyr/scalyr-agent-ci-unittest:4 /app/smoketest_standalone.sh && \
             docker rm dummy;
 
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
+
   smoke-standalone-26-tls12:
     docker:
       - image: circleci/python:2.7-jessie
@@ -645,6 +669,10 @@ jobs:
             docker cp $(pwd)/.circleci/smoketest_standalone.sh dummy:/app/ && \
             docker run -it -v shared_vol:/app -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=300 -e PYTHON_VERSION=2.6.nossl -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} -e CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM} scalyr/scalyr-agent-ci-unittest:4 /app/smoketest_standalone.sh && \
             docker rm dummy;
+
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
 
   smoke-docker-json:
     working_directory: ~/scalyr-agent-2
@@ -688,6 +716,10 @@ jobs:
             ./venv/bin/coverage xml --rcfile=.coveragerc -i -o coverage.xml
             ./scripts/submit-codecov-data.sh
 
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
+
   smoke-docker-syslog:
     working_directory: ~/scalyr-agent-2
     docker:
@@ -729,6 +761,10 @@ jobs:
             # Submit it to codecov.io
             ./venv/bin/coverage xml --rcfile=.coveragerc -i -o coverage.xml
             ./scripts/submit-codecov-data.sh
+
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
 
   smoke-k8s:
     working_directory: ~/scalyr-agent-2
@@ -809,6 +845,10 @@ jobs:
             ./venv/bin/coverage xml --rcfile=.coveragerc -i -o coverage.xml
             ./scripts/submit-codecov-data.sh
 
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
+
   smoke-k8s-helm:
     machine:
       image: circleci/classic:201808-01
@@ -876,6 +916,10 @@ jobs:
             # dump services
             kubectl get svc  --all-namespaces | grep -vE '(kube-sys|docker)'
 
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
+
   lint-checks:
     working_directory: ~/scalyr-agent-2
     docker:
@@ -925,6 +969,9 @@ jobs:
           key: deps2-tox-{{ .Branch }}-lint-venv-{{ checksum "dev-requirements.txt" }}-{{ checksum "lint-requirements.txt" }}
           paths:
             - "~/.cache/pip"
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
 
   benchmarks-idle-agent-py-27:
     working_directory: ~/scalyr-agent-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,11 @@ non_master_and_release: &non_master_and_release
         - release
 
 version: 2.1
+
+orbs:
+  slack: circleci/slack@3.4.2
+
+# Global workflow level parameters
 parameters:
   default_tox_version:
     type: string
@@ -117,6 +122,8 @@ commands:
                   tox -emicro-benchmarks
             - store_artifacts:
                 path: ~/scalyr-agent-2/microbenchmark_histograms/
+      - slack/status:
+          fail_only: true
 
   codespeed_agent_process_benchmark:
     description: "A base command which runs CodeSpeed agent process level benchmarks"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,14 @@ master_and_release_only: &master_and_release_only
         # merging a PR.
         - /automated_tests\/.*/
 
+# NOTE: We intentionally don't want benchmarks to run on automated_tests/ branches.
+benchmarks_master_and_release_only: &benchmarks_master_and_release_only
+  filters:
+    branches:
+      only:
+        - master
+        - release
+
 master_only: &master_only
   filters:
     branches:
@@ -1349,23 +1357,23 @@ workflows:
   benchmarks:
     jobs:
       - benchmarks-idle-agent-py-27:
-          <<: *master_and_release_only
+          <<: *benchmarks_master_and_release_only
       - benchmarks-idle-agent-py-35:
-          <<: *master_and_release_only
+          <<: *benchmarks_master_and_release_only
       - benchmarks-idle-agent-no-monitors-py-27:
-          <<: *master_and_release_only
+          <<: *benchmarks_master_and_release_only
       - benchmarks-idle-agent-no-monitors-py-35:
-          <<: *master_and_release_only
+          <<: *benchmarks_master_and_release_only
       - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
-          <<: *master_and_release_only
+          <<: *benchmarks_master_and_release_only
       - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
-          <<: *master_and_release_only
+          <<: *benchmarks_master_and_release_only
       - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
-          <<: *master_and_release_only
+          <<: *benchmarks_master_and_release_only
       - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
-          <<: *master_and_release_only
+          <<: *benchmarks_master_and_release_only
       - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
-          <<: *master_and_release_only
+          <<: *benchmarks_master_and_release_only
   weekly-circle-ci-usage-report:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,6 @@ commands:
             pip install "tox==<< parameters.tox_version >>"
       - run:
           name: Run Unit Tests under Python << parameters.python_version >>
-          environment:
-            TERM: "xterm-256color"
           command: |
             tox -e<< parameters.tox_target >>
       - save_cache:
@@ -114,8 +112,6 @@ commands:
           steps:
             - run:
                 name: Run Microbenchmarks
-                environment:
-                  TERM: "xterm-256color"
                 command: |
                   mkdir -p microbenchmark_histograms/
                   tox -emicro-benchmarks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,10 @@ commands:
           key: deps2-tox-{{ .Branch }}-<< parameters.python_version >>-venv-{{ checksum "dev-requirements.txt" }}
           paths:
             - "~/.cache/pip"
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          path: test-results
       - when:
           condition: << parameters.upload_coverage >>
           steps:

--- a/scalyr_agent/tests/util/json_util_test.py
+++ b/scalyr_agent/tests/util/json_util_test.py
@@ -213,6 +213,7 @@ class TestDefaultJsonLibrary(ScalyrTestCase):
         reload(scalyr_agent.util)
 
         self.assertEqual(scalyr_agent.util.get_json_lib(), "json")
+        self.assertFalse(True, "test a failure")
 
 
 def main():

--- a/scalyr_agent/tests/util/json_util_test.py
+++ b/scalyr_agent/tests/util/json_util_test.py
@@ -213,7 +213,6 @@ class TestDefaultJsonLibrary(ScalyrTestCase):
         reload(scalyr_agent.util)
 
         self.assertEqual(scalyr_agent.util.get_json_lib(), "json")
-        self.assertFalse(True, "test a failure")
 
 
 def main():

--- a/tox.ini
+++ b/tox.ini
@@ -29,11 +29,13 @@ whitelist_externals =
     rm
     bash
 commands =
-    # NOTE: We run memory leak tests separately so they run in a separate
-    # process and are isolated from other tests
-    py.test scalyr_agent/tests scalyr_agent/builtin_monitors/tests -vv --durations=5 -m "not memory_leak and not json_lib"
-    py.test scalyr_agent/tests/test_memory_leaks.py -vv --durations=5
-    py.test scalyr_agent/tests/util/json_util_test.py -vv --durations=5 -m "json_lib"
+    # NOTE 1: We run memory leak tests separately so they run in a separate process and are
+    # isolated from other tests
+    # NOTE 2: We write junit XML file for nicer visualization on Circle CI
+    bash -c "rm -rf test-results/"
+    py.test scalyr_agent/tests scalyr_agent/builtin_monitors/tests -vv --durations=5 -m "not memory_leak and not json_lib" --junitxml=test-results/junit-1.xml
+    py.test scalyr_agent/tests/test_memory_leaks.py -vv --durations=5 --junitxml=test-results/junit-2.xml
+    py.test scalyr_agent/tests/util/json_util_test.py -vv --durations=5 -m "json_lib" --junitxml=test-results/junit-3.xml
 
 # Target which generates documentation for all the monitors
 [testenv:generate-monitor-docs]

--- a/tox.ini
+++ b/tox.ini
@@ -56,8 +56,8 @@ basepython = python2.6
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps = -rpy26-unit-tests-requirements.txt
 commands =
-    py.test scalyr_agent/tests scalyr_agent/builtin_monitors/tests -vv --durations=5 -m "not memory_leak and not json_lib"
-    py.test scalyr_agent/tests/util/json_util_test.py -vv --durations=5 -m "json_lib"
+    py.test scalyr_agent/tests scalyr_agent/builtin_monitors/tests -vv --durations=5 -m "not memory_leak and not json_lib" --junitxml=test-results/junit-1.xml
+    py.test scalyr_agent/tests/util/json_util_test.py -vv --durations=5 -m "json_lib" --junitxml=test-results/junit-2.xml
 
 # Lint target which runs all the linting tools such as black, modernize, pylint, flake8, mypy, etc.
 # NOTE: We use bash -c since we don't want tox to quote all the arguments, we want globs to

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
     # NOTE 1: We run memory leak tests separately so they run in a separate process and are
     # isolated from other tests
     # NOTE 2: We write junit XML file for nicer visualization on Circle CI
-    bash -c "rm -rf test-results/"
+    rm -rf test-results
     py.test scalyr_agent/tests scalyr_agent/builtin_monitors/tests -vv --durations=5 -m "not memory_leak and not json_lib" --junitxml=test-results/junit-1.xml
     py.test scalyr_agent/tests/test_memory_leaks.py -vv --durations=5 --junitxml=test-results/junit-2.xml
     py.test scalyr_agent/tests/util/json_util_test.py -vv --durations=5 -m "json_lib" --junitxml=test-results/junit-3.xml
@@ -127,7 +127,10 @@ commands =
 [testenv:coverage]
 commands =
     rm -f .coverage
-    py.test  scalyr_agent/tests scalyr_agent/builtin_monitors/tests -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/
+    rm -rf test-results
+    py.test  scalyr_agent/tests scalyr_agent/builtin_monitors/tests -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/ --junitxml=test-results/junit-1.xml
+    py.test scalyr_agent/tests/test_memory_leaks.py -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
+    py.test scalyr_agent/tests/util/json_util_test.py -vv --durations=5 -m "json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-3.xml
 
 # Smoke tests related targets
 [testenv:py2.6-smoke-tests]


### PR DESCRIPTION
This pull request includes the following changes:

1. Fix ``coverage`` tox target to make sure we run all the unit tests.

2. Update unit-test and coverage tox targets to generate junit XML report files. Those reports files are then used by Circle CI to provider a nicer visualization on test results, including test timing.

3. If there is a Circle CI job failure on master run, we will now get notified on Slack.

4. Pushing to a special ``automated_tests/`` prefixed branch will trigger builds for all the jobs (including the ones which only run on master). This will be used by our automated final sanity test which will be triggered by a Github PR / issue comment.