### PR TITLE
Fix missing dependency causing pylint to fail

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -109,6 +109,7 @@ deps =
     -r dev-requirements.txt
     -r lint-requirements.txt
     -r benchmarks/scripts/requirements.txt
+    -r tests/ami/requirements.txt
 commands =
     bash -c 'pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins pylint_plugins.bundled_imports_checker {env:LINT_FILES_TO_CHECK}'
 


### PR DESCRIPTION
Pylint fails when you run it by itself (such as `tox -e pylint`).
This is because `tests/ami` introduced a requirement on `libcloud`
that was not reflected in the `pylint` target.  The normal
`tox -e lint` did not fail because the appropriate dependencies
were added there.