### PR TITLE
Fix PYTHONPATH for agent benchmarks Circle CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ commands:
           # and are handles as secrets: CODESPEED_AUTH
           environment:
             CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"
-            CODESPEED_PROJECT: "scalyr-agent-2-process-benchmarks"
+            CODESPEED_PROJECT: "scalyr-agent-2-procbenchmarks"
             CODESPEED_EXECUTABLE: "<< parameters.codespeed_executable >>"
             CODESPEED_ENVIRONMENT: "<< parameters.codespeed_environment >>"
             CODESPEED_BRANCH: "${CIRCLE_BRANCH}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1361,66 +1361,65 @@ jobs:
 
 workflows:
   version: 2
-  unit-tests:
-    # NOTE: To avoid massive and inflated build matrix, we currently don't run tests under multiple
-    # Python 3 versions
-    jobs:
-      - lint-checks
-      - unittest-26
-      - unittest-27
-      - unittest-35
-      - unittest-35-osx
-  smoke-tests:
-    jobs:
-      - smoke-standalone-26
-      - smoke-standalone-27
-      - smoke-standalone-35
-      - smoke-standalone-26-tls12
-      - smoke-standalone-27-tls12
-       # NOTE: smoke test jobs below still use old smoke tests framework
-      - smoke-docker-json
-      - smoke-docker-syslog
-      - smoke-k8s
-      - smoke-monitors-tests
-  package-tests:
-    jobs:
-      # NOTE: package-build-* jobs only run for PR / non-master builds. Those jobs
-      # product deb and rpm packages which can be used for testing.
-      # On master build, we run package-test-* jobs which also produce packages which
-      # can be used for testing. This means it's redundant to run both jobs at the same
-      # time since as long as one set of those jobs runs, packages will be produced.
-      # The reason why we run package-build-*, but not package-test-* jobs for each PR
-      # is that those jobs are much faster.
-      - package-build-rpm:
-          <<: *non_master_and_release
-      - package-build-deb:
-          <<: *non_master_and_release
-      - package-test-rpm:
-          <<: *master_and_release_only
-      - package-test-deb:
-          <<: *master_and_release_only
-      - smoke-rpm-package-py2:
-          requires:
-            - package-test-rpm
-          <<: *master_and_release_only
-      - smoke-rpm-package-py3:
-          requires:
-            - package-test-rpm
-          <<: *master_and_release_only
-      - smoke-deb-package-py2:
-          requires:
-            - package-test-deb
-          <<: *master_and_release_only
-      - smoke-deb-package-py3:
-          requires:
-            - package-test-deb
-          <<: *master_and_release_only
+  # unit-tests:
+  #   # NOTE: To avoid massive and inflated build matrix, we currently don't run tests under multiple
+  #   # Python 3 versions
+  #   jobs:
+  #     - lint-checks
+  #     - unittest-26
+  #     - unittest-27
+  #     - unittest-35
+  #     - unittest-35-osx
+  # smoke-tests:
+  #   jobs:
+  #     - smoke-standalone-26
+  #     - smoke-standalone-27
+  #     - smoke-standalone-35
+  #     - smoke-standalone-26-tls12
+  #     - smoke-standalone-27-tls12
+  #      # NOTE: smoke test jobs below still use old smoke tests framework
+  #     - smoke-docker-json
+  #     - smoke-docker-syslog
+  #     - smoke-k8s
+  #     - smoke-monitors-tests
+  # package-tests:
+  #   jobs:
+  #     # NOTE: package-build-* jobs only run for PR / non-master builds. Those jobs
+  #     # product deb and rpm packages which can be used for testing.
+  #     # On master build, we run package-test-* jobs which also produce packages which
+  #     # can be used for testing. This means it's redundant to run both jobs at the same
+  #     # time since as long as one set of those jobs runs, packages will be produced.
+  #     # The reason why we run package-build-*, but not package-test-* jobs for each PR
+  #     # is that those jobs are much faster.
+  #     - package-build-rpm:
+  #         <<: *non_master_and_release
+  #     - package-build-deb:
+  #         <<: *non_master_and_release
+  #     - package-test-rpm:
+  #         <<: *master_and_release_only
+  #     - package-test-deb:
+  #         <<: *master_and_release_only
+  #     - smoke-rpm-package-py2:
+  #         requires:
+  #           - package-test-rpm
+  #         <<: *master_and_release_only
+  #     - smoke-rpm-package-py3:
+  #         requires:
+  #           - package-test-rpm
+  #         <<: *master_and_release_only
+  #     - smoke-deb-package-py2:
+  #         requires:
+  #           - package-test-deb
+  #         <<: *master_and_release_only
+  #     - smoke-deb-package-py3:
+  #         requires:
+  #           - package-test-deb
+  #         <<: *master_and_release_only
   benchmarks:
     jobs:
       - benchmarks-micro-py-27
       - benchmarks-micro-py-35
-      - benchmarks-idle-agent-py-27:
-          <<: *benchmarks_master_and_release_only
+      - benchmarks-idle-agent-py-27
       - benchmarks-idle-agent-py-35:
           <<: *benchmarks_master_and_release_only
       - benchmarks-idle-agent-no-monitors-py-27:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,6 +218,7 @@ commands:
             # branch / revision
             export TZ=UTC
             export COMMIT_DATE=$(git show --quiet --date='format-local:%Y-%m-%d %H:%M:%S' --format="%cd" ${CIRCLE_SHA1})
+            export PYTHONPATH=.
 
             # Run any pre agent run script (if defined)
             if [ ! -z "<< parameters.agent_pre_run_command >>" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1361,65 +1361,66 @@ jobs:
 
 workflows:
   version: 2
-  # unit-tests:
-  #   # NOTE: To avoid massive and inflated build matrix, we currently don't run tests under multiple
-  #   # Python 3 versions
-  #   jobs:
-  #     - lint-checks
-  #     - unittest-26
-  #     - unittest-27
-  #     - unittest-35
-  #     - unittest-35-osx
-  # smoke-tests:
-  #   jobs:
-  #     - smoke-standalone-26
-  #     - smoke-standalone-27
-  #     - smoke-standalone-35
-  #     - smoke-standalone-26-tls12
-  #     - smoke-standalone-27-tls12
-  #      # NOTE: smoke test jobs below still use old smoke tests framework
-  #     - smoke-docker-json
-  #     - smoke-docker-syslog
-  #     - smoke-k8s
-  #     - smoke-monitors-tests
-  # package-tests:
-  #   jobs:
-  #     # NOTE: package-build-* jobs only run for PR / non-master builds. Those jobs
-  #     # product deb and rpm packages which can be used for testing.
-  #     # On master build, we run package-test-* jobs which also produce packages which
-  #     # can be used for testing. This means it's redundant to run both jobs at the same
-  #     # time since as long as one set of those jobs runs, packages will be produced.
-  #     # The reason why we run package-build-*, but not package-test-* jobs for each PR
-  #     # is that those jobs are much faster.
-  #     - package-build-rpm:
-  #         <<: *non_master_and_release
-  #     - package-build-deb:
-  #         <<: *non_master_and_release
-  #     - package-test-rpm:
-  #         <<: *master_and_release_only
-  #     - package-test-deb:
-  #         <<: *master_and_release_only
-  #     - smoke-rpm-package-py2:
-  #         requires:
-  #           - package-test-rpm
-  #         <<: *master_and_release_only
-  #     - smoke-rpm-package-py3:
-  #         requires:
-  #           - package-test-rpm
-  #         <<: *master_and_release_only
-  #     - smoke-deb-package-py2:
-  #         requires:
-  #           - package-test-deb
-  #         <<: *master_and_release_only
-  #     - smoke-deb-package-py3:
-  #         requires:
-  #           - package-test-deb
-  #         <<: *master_and_release_only
+  unit-tests:
+    # NOTE: To avoid massive and inflated build matrix, we currently don't run tests under multiple
+    # Python 3 versions
+    jobs:
+      - lint-checks
+      - unittest-26
+      - unittest-27
+      - unittest-35
+      - unittest-35-osx
+  smoke-tests:
+    jobs:
+      - smoke-standalone-26
+      - smoke-standalone-27
+      - smoke-standalone-35
+      - smoke-standalone-26-tls12
+      - smoke-standalone-27-tls12
+       # NOTE: smoke test jobs below still use old smoke tests framework
+      - smoke-docker-json
+      - smoke-docker-syslog
+      - smoke-k8s
+      - smoke-monitors-tests
+  package-tests:
+    jobs:
+      # NOTE: package-build-* jobs only run for PR / non-master builds. Those jobs
+      # product deb and rpm packages which can be used for testing.
+      # On master build, we run package-test-* jobs which also produce packages which
+      # can be used for testing. This means it's redundant to run both jobs at the same
+      # time since as long as one set of those jobs runs, packages will be produced.
+      # The reason why we run package-build-*, but not package-test-* jobs for each PR
+      # is that those jobs are much faster.
+      - package-build-rpm:
+          <<: *non_master_and_release
+      - package-build-deb:
+          <<: *non_master_and_release
+      - package-test-rpm:
+          <<: *master_and_release_only
+      - package-test-deb:
+          <<: *master_and_release_only
+      - smoke-rpm-package-py2:
+          requires:
+            - package-test-rpm
+          <<: *master_and_release_only
+      - smoke-rpm-package-py3:
+          requires:
+            - package-test-rpm
+          <<: *master_and_release_only
+      - smoke-deb-package-py2:
+          requires:
+            - package-test-deb
+          <<: *master_and_release_only
+      - smoke-deb-package-py3:
+          requires:
+            - package-test-deb
+          <<: *master_and_release_only
   benchmarks:
     jobs:
       - benchmarks-micro-py-27
       - benchmarks-micro-py-35
-      - benchmarks-idle-agent-py-27
+      - benchmarks-idle-agent-py-27:
+          <<: *benchmarks_master_and_release_only
       - benchmarks-idle-agent-py-35:
           <<: *benchmarks_master_and_release_only
       - benchmarks-idle-agent-no-monitors-py-27:


### PR DESCRIPTION
This pull request fixes PYTHONPATH for benchmarks Circle CI job (it was broken accidentally by #489).

In addition to that, it also fixes CodeSpeed executable name (previous one was too long).