### PR TITLE
Fix submit_to_codespeed decorator so it works under Python 2

### DIFF
--- a/benchmarks/micro/conftest.py
+++ b/benchmarks/micro/conftest.py
@@ -14,10 +14,10 @@
 
 from __future__ import absolute_import
 
-import functools
-
-import six
+import decorator
 import pytest
+
+from pytest_benchmark.fixture import BenchmarkFixture
 
 from scalyr_agent import compat
 
@@ -104,17 +104,16 @@ def submit_result_to_codespeed(func):
     """
     Decorator which marks a pytest benchmark function with "submit_result_to_codespeed" marker.
     """
-    # NOTE: Python 2 version doesn't support custom decorator so we need to skip if
-    if six.PY2:
-        return func
+    # NOTE: functools.wraps doesn't work well enough under Python 2 so we need to use decorator
+    # package
+    def wrapped_function(func, *args, **kwargs):
+        if isinstance(args[0], BenchmarkFixture):
+            benchmark = args[0]
 
-    @functools.wraps(func)
-    def wrapped_function(*args, **kwargs):
-        benchmark = kwargs["benchmark"]
         benchmark.submit_result_to_codespeed = True
         return func(*args, **kwargs)
 
-    return wrapped_function
+    return decorator.decorator(wrapped_function, func)
 
 
 # Register a custom marker

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,6 +14,7 @@ pytest-benchmark==3.2.3
 pytest-xdist==1.31.0
 coverage==4.5.4
 codecov==2.0.15
+decorator==4.4.1
 PyYAML==5.3
 six==1.13.0
 docker==4.1.0

--- a/lint-configs/python/mypy.ini
+++ b/lint-configs/python/mypy.ini
@@ -114,6 +114,9 @@ ignore_missing_imports = True
 [mypy-pytest.*]
 ignore_missing_imports = True
 
+[mypy-pytest_benchmark.*]
+ignore_missing_imports = True
+
 [mypy-iostat.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
This pull request fixes ``submit_to_codespeed`` decorator so it also works correctly under Python 2.

pytest does some weird stuff with detecting original decorators functions so using ``functools.wraps`` doesn't work out of the box under Python 2.7 (pyttest can't detect original wrapped function so the benchmarks doesn't run).