### PR TITLE
Fix callback registration for the RunState on_stop handler

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -879,7 +879,7 @@ class ScalyrAgent(object):
             try:
                 self.__run_state = RunState()
                 self.__run_state.register_on_stop_callback(
-                    scalyr_logging.close_handlers()
+                    scalyr_logging.close_handlers
                 )
                 self.__log_file_path = os.path.join(
                     self.__config.agent_log_path, "agent.log"

--- a/scalyr_agent/tests/util/util_test.py
+++ b/scalyr_agent/tests/util/util_test.py
@@ -522,6 +522,29 @@ class TestStoppableThread(ScalyrTestCase):
             self._run_counter += 1
             run_state.sleep_but_awaken_if_stopped(0.03)
 
+    def test_register_on_stop_callback(self):
+        self.callback_called = False
+
+        def fake_callback():
+            self.callback_called = True
+
+        run_state = scalyr_util.RunState()
+        run_state.register_on_stop_callback(fake_callback)
+        run_state.stop()
+        self.assertTrue(self.callback_called)
+
+    def test_remove_on_stop_callback(self):
+        self.callback_called = False
+
+        def fake_callback():
+            self.callback_called = True
+
+        run_state = scalyr_util.RunState()
+        run_state.register_on_stop_callback(fake_callback)
+        run_state.remove_on_stop_callback(fake_callback)
+        run_state.stop()
+        self.assertFalse(self.callback_called)
+
 
 class TestScriptEscalator(ScalyrTestCase):
     def tearDown(self):


### PR DESCRIPTION
After #495 has been merged, I started to notice errors like this in the log:

```bash
2020-04-21 14:36:53.500Z ERROR [core] [scalyr_logging.py:603] [error="failedAgentMain"] Main run method for agent failed due to exception :stack_trace:
  Traceback (most recent call last):
    File "scalyr_agent/agent_main.py", line 992, in __run
      config_change_check_interval
    File "/home/kami/w/scalyr/scalyr-agent-2/scalyr_agent/util.py", line 708, in sleep_but_awaken_if_stopped
      self._wait_on_condition(timeout)
    File "/home/kami/w/scalyr/scalyr-agent-2/scalyr_agent/util.py", line 792, in _wait_on_condition
      self.__condition.wait(timeout)
    File "/home/kami/.pythonz/pythons/CPython-3.6.9/lib/python3.6/threading.py", line 299, in wait
      gotit = waiter.acquire(True, timeout)
    File "/home/kami/w/scalyr/scalyr-agent-2/scalyr_agent/platform_posix.py", line 627, in handle_interrupt
      handle_terminate(signal_num, frame)
    File "/home/kami/w/scalyr/scalyr-agent-2/scalyr_agent/platform_posix.py", line 641, in handle_terminate
      self.__termination_handler()
    File "scalyr_agent/agent_main.py", line 597, in __handle_terminate
      self.__run_state.stop()
    File "/home/kami/w/scalyr/scalyr-agent-2/scalyr_agent/util.py", line 751, in stop
      callback()
  TypeError: 'NoneType' object is not callable
```

It turns out, we didn't correctly register the callback - instead of registering the callable (function) we actually immediately called the function during registration phase and passed return value of that function to the register handler (that function returned None).