### PR TITLE
Remove monotonically increasing timestamps from the agent

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -1325,6 +1325,7 @@ class ScalyrAgent(object):
             proxies=self.__config.network_proxies,
             disable_send_requests=self.__config.disable_send_requests,
             disable_logfile_addevents_format=self.__config.disable_logfile_addevents_format,
+            enforce_monotonic_timestamps=self.__config.enforce_monotonic_timestamps,
         )
 
     def __get_file_initial_position(self, path):

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -494,6 +494,19 @@ class Configuration(object):
         return self.__get_config().get_int("k8s_ratelimit_max_concurrency")
 
     @property
+    def enforce_monotonic_timestamps(self):
+        # UNDOCUMENTED_CONFIG
+        return self.__get_config().get_bool("enforce_monotonic_timestamps")
+
+    @property
+    def include_raw_timestamp_field(self):
+        """If True, adds an attribute called `raw_timestamp` to all events parsed using the
+        parse_as_json or parse_as_cri features.  This field will be set to the timestamp included in the JSON or
+        CRI line.  When parsing Docker or K8s logs, this represents the timestamp of the log
+        message as recorded by those systems."""
+        return self.__get_config().get_bool("include_raw_timestamp_field")
+
+    @property
     def enable_profiling(self):
         return self.__get_config().get_bool("enable_profiling")
 
@@ -1951,6 +1964,24 @@ class Configuration(object):
             config,
             "disable_send_requests",
             False,
+            description,
+            apply_defaults,
+            env_aware=True,
+        )
+
+        self.__verify_or_set_optional_bool(
+            config,
+            "enforce_monotonic_timestamps",
+            False,
+            description,
+            apply_defaults,
+            env_aware=True,
+        )
+
+        self.__verify_or_set_optional_bool(
+            config,
+            "include_raw_timestamp_field",
+            True,
             description,
             apply_defaults,
             env_aware=True,

--- a/scalyr_agent/tests/scalyr_client_test.py
+++ b/scalyr_agent/tests/scalyr_client_test.py
@@ -22,6 +22,7 @@ __author__ = "czerwin@scalyr.com"
 from io import BytesIO
 
 import mock
+import time
 
 from scalyr_agent.__scalyr__ import SCALYR_VERSION
 
@@ -46,7 +47,6 @@ class AddEventsRequestTest(ScalyrTestCase):
     def setUp(self):
         super(AddEventsRequestTest, self).setUp()
         self.__body = {"token": "fakeToken"}
-        scalyr_client._set_last_timestamp(0)
 
     def test_basic_case(self):
         request = AddEventsRequest(self.__body)
@@ -244,6 +244,56 @@ class AddEventsRequestTest(ScalyrTestCase):
             b""", logs: [], threads: [], client_time: 2 }""",
         )
         request.close()
+
+    def test_monotonically_increasing_timestamp(self):
+        request = AddEventsRequest(self.__body, enforce_monotonic_timestamps=True)
+        scalyr_client._set_last_timestamp(0)
+
+        ts = 2000
+
+        expected = str(ts + 1)
+
+        self.assertTrue(
+            request.add_event(Event().set_message("eventOne"), timestamp=ts)
+        )
+        self.assertTrue(request.add_event(Event().set_message("eventTwo"), timestamp=1))
+
+        json = test_util.parse_scalyr_request(request.get_payload())
+        event = json["events"][1]
+        self.assertEquals(event["ts"], expected)
+
+    def test_no_monotonically_increasing_timestamp(self):
+        request = AddEventsRequest(self.__body)
+
+        ts = 2000
+
+        self.assertTrue(
+            request.add_event(Event().set_message("eventOne"), timestamp=ts)
+        )
+        self.assertTrue(request.add_event(Event().set_message("eventTwo"), timestamp=1))
+
+        json = test_util.parse_scalyr_request(request.get_payload())
+        event = json["events"][1]
+        self.assertEquals(event["ts"], "1")
+
+    def test_timestamp_none(self):
+        request = AddEventsRequest(self.__body)
+        request.set_client_time(100)
+
+        ts = int(time.time() * 1e9)
+
+        self.assertTrue(
+            request.add_event(Event().set_message("eventOne"), timestamp=None)
+        )
+
+        json = test_util.parse_scalyr_request(request.get_payload())
+        event = json["events"][0]
+        event_ts = int(event["ts"])
+        threshold = abs(event_ts - ts)
+
+        # allow a threshold of 1 second to have elapsed between reading the time.time and
+        # setting the event timestamp in add_event
+        self.assertTrue(threshold < 1e9)
 
     def test_sequence_id_but_no_number(self):
         request = AddEventsRequest(self.__body)
@@ -1001,6 +1051,51 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
         # Verify that the compression was indeed enabled since that's the scenario we are testing
         call_kwargs = session._ScalyrClientSession__connection.post.call_args_list[0][1]
         self.assertEqual(call_kwargs["body"], "compressed")
+
+    @mock.patch("scalyr_agent.scalyr_client.time.time", mock.Mock(return_value=0))
+    def test_send_request_timestamp_doesnt_increases_monotonically(self):
+        session = ScalyrClientSession(
+            "https://dummserver.com", "DUMMY API KEY", SCALYR_VERSION,
+        )
+
+        session._ScalyrClientSession__connection = mock.Mock()
+        session._ScalyrClientSession__receive_response = mock.Mock()
+
+        add_events_request = session.add_events_request()
+
+        ts = 2000
+
+        add_events_request.add_event(Event().set_message("eventOne"), timestamp=ts)
+        add_events_request.add_event(Event().set_message("eventTwo"), timestamp=1)
+
+        json = test_util.parse_scalyr_request(add_events_request.get_payload())
+        event = json["events"][1]
+        self.assertEquals(event["ts"], "1")
+
+    @mock.patch("scalyr_agent.scalyr_client.time.time", mock.Mock(return_value=0))
+    def test_send_request_timestamp_increases_monotonically(self):
+        session = ScalyrClientSession(
+            "https://dummserver.com",
+            "DUMMY API KEY",
+            SCALYR_VERSION,
+            enforce_monotonic_timestamps=True,
+        )
+
+        session._ScalyrClientSession__connection = mock.Mock()
+        session._ScalyrClientSession__receive_response = mock.Mock()
+        scalyr_client._set_last_timestamp(0)
+
+        add_events_request = session.add_events_request()
+
+        ts = 2000
+        expected = str(ts + 1)
+
+        add_events_request.add_event(Event().set_message("eventOne"), timestamp=ts)
+        add_events_request.add_event(Event().set_message("eventTwo"), timestamp=1)
+
+        json = test_util.parse_scalyr_request(add_events_request.get_payload())
+        event = json["events"][1]
+        self.assertEquals(event["ts"], expected)
 
     @mock.patch("scalyr_agent.scalyr_client.time.time", mock.Mock(return_value=0))
     def test_send_request_body_is_logged_raw_uncompressed_long_body_is_truncated(self):


### PR DESCRIPTION
This PR removes code from the agent that ensures all logs have a monotonically increasing timestamp.

Now, if the agent is in standalone mode, timestamps will be set to the current time when reading bytes from disk, or if the agent is in k8s, docker or any other mode that parses lines as json, then the agent will try to extract a timestamp from the json and use that.

This has been tested manually using a script that generates logs with timestamps offset from the current time, and/or timestamps that go backward and forwards in time.