### PR TITLE
Fix submit microbenchmarks result script to support non-UTC timezones

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,9 +310,11 @@ commands:
             if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
               export PYTHONPATH=.
               python benchmarks/scripts/send_microbenchmarks_data_to_codespeed.py \
-                  --data-path="benchmark-results-*.json" \
+                  --data-path="benchmark_results/*.json" \
                   --debug
             fi
+      - store_artifacts:
+          path: ~/scalyr-agent-2/benchmark_results/
       - store_artifacts:
           path: ~/scalyr-agent-2/benchmark_histograms/
       - save_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -68,5 +68,5 @@ docs/_build/
 # Test and benchmark data
 test-results/
 microbenchmark_histograms/
-benchmark_histograms:
-benchmark-results*.json
+benchmark_histograms/
+benchmark_results/

--- a/benchmarks/scripts/send_microbenchmarks_data_to_codespeed.py
+++ b/benchmarks/scripts/send_microbenchmarks_data_to_codespeed.py
@@ -26,9 +26,10 @@ import glob
 import json
 import argparse
 import logging
+import time
 from io import open
 
-from scalyr_agent.util import rfc3339_to_datetime
+import udatetime
 
 from utils import add_common_parser_arguments
 from utils import parse_auth_credentials
@@ -66,9 +67,10 @@ def format_benchmark_data_for_codespeed(
     branch = data["commit_info"]["branch"]
     author_time = data["commit_info"]["author_time"]
 
-    author_time = author_time.split("+")[0]
-
-    revision_date = rfc3339_to_datetime(author_time).strftime("%Y-%m-%d %H:%M:%S")  # type: ignore
+    # This value can contain a timezone so we rely on 3rd party library to parse it.
+    # Our performance optimized version of the function doesn't support timezones.
+    author_time = udatetime.from_string(author_time)
+    revision_date = time.strftime("%Y-%m-%d %H:%M:%S", author_time.utctimetuple())
 
     payload = []
 

--- a/tox.ini
+++ b/tox.ini
@@ -298,7 +298,7 @@ deps =
 commands =
     bash -c "rm -rf benchmark_results/*"
     bash -c "rm -rf benchmark_histograms/*"
-    bash -c "mkdir -p benchmark_results/*"
+    bash -c "mkdir -p benchmark_results/"
     py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/1.json benchmarks/micro/test_add_events_request_serialization.py
     py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/2.json --benchmark-group-by=group benchmarks/micro/test_event_serialization.py
     py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/3.json --benchmark-group-by=group,param:log_tuple benchmarks/micro/test_json_serialization.py -k "not test_json_encode_with_custom_options"

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ setenv =
   PYTHONPATH={toxinidir}
   PY_COLORS=1
   PYTEST_COMMON_OPTS=-vv -s
-  PYTEST_COMMON_BENCHMARK_OPTS=--benchmark-only --benchmark-verbose --benchmark-name=short --benchmark-columns=min,max,mean,stddev,median,ops,rounds --benchmark-histogram=benchmark_histograms/benchmark
+  PYTEST_COMMON_BENCHMARK_OPTS=--benchmark-only --benchmark-name=short --benchmark-columns=min,max,mean,stddev,median,ops,rounds --benchmark-histogram=benchmark_histograms/benchmark
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps =
     -r dev-requirements.txt
@@ -296,8 +296,8 @@ deps =
     # developer to install it for lint tox target
     python-snappy==0.5.4
 commands =
-    bash -c "rm -f benchmark_results/*"
-    bash -c "rm -f benchmark_histograms/*"
+    bash -c "rm -rf benchmark_results/*"
+    bash -c "rm -rf benchmark_histograms/*"
     bash -c "mkdir -p benchmark_results/*"
     py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/1.json benchmarks/micro/test_add_events_request_serialization.py
     py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/2.json --benchmark-group-by=group benchmarks/micro/test_event_serialization.py

--- a/tox.ini
+++ b/tox.ini
@@ -296,11 +296,12 @@ deps =
     # developer to install it for lint tox target
     python-snappy==0.5.4
 commands =
-    bash -c "rm -f benchmark-results-*.json"
+    bash -c "rm -f benchmark_results/*"
     bash -c "rm -f benchmark_histograms/*"
-    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark-results-1.json benchmarks/micro/test_add_events_request_serialization.py
-    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark-results-2.json --benchmark-group-by=group benchmarks/micro/test_event_serialization.py
-    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark-results-3.json --benchmark-group-by=group,param:log_tuple benchmarks/micro/test_json_serialization.py -k "not test_json_encode_with_custom_options"
-    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark-results-4.json --benchmark-group-by=group,param:keys_count benchmarks/micro/test_json_serialization.py -k "test_json_encode_with_custom_options"
-    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark-results-5.json --benchmark-group-by=group,param:log_tuple benchmarks/micro/test_compression_algorithms.py
-    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark-results-6.json --benchmark-group-by=group,param:with_fraction benchmarks/micro/test_date_parsing.py
+    bash -c "mkdir -p benchmark_results/*"
+    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/1.json benchmarks/micro/test_add_events_request_serialization.py
+    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/2.json --benchmark-group-by=group benchmarks/micro/test_event_serialization.py
+    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/3.json --benchmark-group-by=group,param:log_tuple benchmarks/micro/test_json_serialization.py -k "not test_json_encode_with_custom_options"
+    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/4.json --benchmark-group-by=group,param:keys_count benchmarks/micro/test_json_serialization.py -k "test_json_encode_with_custom_options"
+    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/5.json --benchmark-group-by=group,param:log_tuple benchmarks/micro/test_compression_algorithms.py
+    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/6.json --benchmark-group-by=group,param:with_fraction benchmarks/micro/test_date_parsing.py


### PR DESCRIPTION
This pull request includes the following fixes / improvements to the micro benchmarks job:

1. Fixes the result submission script so it supports non-UTC timestamp. I noticed there was a build failure (https://circleci.com/gh/scalyr/scalyr-agent-2/34236?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification) and it appears the author_time timestamp string contains a local (non-UTC) time string.

2. Update Circle CI job so we also preserve raw benchmark result JSON files. This will make it easier to troubleshoot issues like the one above in the future.

3. Store benchmark results files in ``benchmark_results/`` directory instead of the in the repo root.