### PR TITLE
Use correct cache key for micro benchmarks cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,7 @@ commands:
     steps:
       - checkout
       - restore_cache:
-          key: deps1-{{ .Branch }}-<< parameters.cache_key_name >>-venv-{{ checksum "benchmarks/scripts/requirements.txt" }}
+          key: deps-<< pipeline.parameters.cache_version_py_dependencies >>-{{ .Branch }}-<< parameters.cache_key_name >>-venv-{{ checksum "requirements.txt" }}-{{ checksum "benchmarks/scripts/requirements.txt" }}
       - run:
           name: Install Dependencies
           command: |
@@ -318,7 +318,7 @@ commands:
       - store_artifacts:
           path: ~/scalyr-agent-2/benchmark_histograms/
       - save_cache:
-          key: deps1-{{ .Branch }}-<< parameters.cache_key_name >>-venv-{{ checksum "benchmarks/scripts/requirements.txt" }}
+          key: deps-<< pipeline.parameters.cache_version_py_dependencies >>-{{ .Branch }}-<< parameters.cache_key_name >>-venv-{{ checksum "requirements.txt" }}-{{ checksum "benchmarks/scripts/requirements.txt" }}
           paths:
             - "~/.cache/pip"
 


### PR DESCRIPTION
Small fix for the build - we weren't using the correct cache key for micro benchmarks dependency cache so dependencies weren't reinstall when running the Circle CI job.