### PR TITLE
Update Circle CI job config for micro benchmarks to notify us on slack on build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,6 +323,9 @@ commands:
           key: deps-<< pipeline.parameters.cache_version_py_dependencies >>-{{ .Branch }}-<< parameters.cache_key_name >>-venv-{{ checksum "dev-requirements.txt" }}-{{ checksum "benchmarks/scripts/requirements.txt" }}
           paths:
             - "~/.cache/pip"
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
 
   smoke-standalone-tox:
     description: "A base command for all tox based smoke test jobs"


### PR DESCRIPTION
This pull request updates Circle CI job config for micro benchmarks jobs to notify us on master failure on Slack (same as for most other jobs).

This way it will be harder to miss failures on master merge.