### PR TITLE
Print useful config settings to agent.log

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -928,6 +928,8 @@ class ScalyrAgent(object):
                 raw_scalyr_server = self.__config.raw_scalyr_server
                 self.__print_force_https_message(scalyr_server, raw_scalyr_server)
 
+                self.__config.print_useful_settings()
+
                 self.__scalyr_client = self.__create_client()
 
                 def start_worker_thread(config, logs_initial_positions=None):
@@ -1169,6 +1171,8 @@ class ScalyrAgent(object):
                     worker_thread.stop()
 
                     worker_thread = None
+
+                    new_config.print_useful_settings(self.__config)
 
                     self.__config = new_config
                     self.__controller.consume_config(new_config, new_config.file_path)

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -277,6 +277,63 @@ class Configuration(object):
             )
             scalyr_util.set_json_lib(json_library)
 
+    def print_useful_settings(self, other_config=None):
+        """
+        Prints various useful configuration settings to the agent log, so we have a record
+        in the log of the settings that are currently in use.
+
+        @param other_config: Another configuration option.  If not None, this function will
+        only print configuration options that are different between the two objects.
+        """
+
+        options = [
+            "compression_type",
+            "compression_level",
+            "pipeline_threshold",
+            "min_allowed_request_size",
+            "max_allowed_request_size",
+            "min_request_spacing_interval",
+            "max_request_spacing_interval",
+            "read_page_size",
+            "max_line_size",
+            "internal_parse_max_line_size",
+            "line_completion_wait_time",
+            "max_log_offset_size",
+            "max_existing_log_offset_size",
+        ]
+
+        # get options (if any) from the other configuration object
+        other_options = None
+        if other_config is not None:
+            other_options = {}
+            for option in options:
+                other_options[option] = getattr(other_config, option, None)
+
+        first = True
+        for option in options:
+            value = getattr(self, option, None)
+            print_value = False
+
+            # check to see if we should be printing this option which will will
+            # be True if other_config is None or if the other_config had a setting
+            # that was different from our current setting
+            if other_config is None:
+                print_value = True
+            elif (
+                other_options is not None
+                and option in other_options
+                and other_options[option] != value
+            ):
+                print_value = True
+
+            if print_value:
+                # if this is the first option we are printing, output a header
+                if first:
+                    self.__logger.info("Configuration settings")
+                    first = False
+
+                self.__logger.info("\t%s: %s" % (option, value))
+
     def __get_default_hostname(self):
         """Returns the default hostname for this host.
         @return: The default hostname for this host.

--- a/scalyr_agent/tests/configuration_test.py
+++ b/scalyr_agent/tests/configuration_test.py
@@ -51,7 +51,7 @@ from scalyr_agent.compat import os_environ_unicode
 
 import six
 from six.moves import range
-from mock import patch, Mock
+from mock import patch, Mock, call
 
 
 class TestConfigurationBase(ScalyrTestCase):
@@ -1556,6 +1556,74 @@ class TestConfiguration(TestConfigurationBase):
         config.parse()
 
         self.assertEquals(config.api_key, "hi")
+
+    def test_print_config(self):
+        """Make sure that when we print the config options that we
+        don't throw any exceptions
+        """
+
+        self._write_file_with_separator_conversion("""{api_key: "hi there"}""")
+        mock_logger = Mock()
+        config = self._create_test_configuration_instance(logger=mock_logger)
+        config.parse()
+        config.print_useful_settings()
+        mock_logger.info.assert_any_call("Configuration settings")
+        mock_logger.info.assert_any_call("\tmax_line_size: 9900")
+
+    def test_print_config_when_changed(self):
+        """
+        Test that `print_useful_settings` only outputs changed settings when compared to another
+        configuration object
+        """
+        self._write_file_with_separator_conversion(
+            """{
+            api_key: "hi there"
+            }
+        """
+        )
+        mock_logger = Mock()
+        config = self._create_test_configuration_instance(logger=mock_logger)
+        config.parse()
+
+        self._write_file_with_separator_conversion(
+            """{
+            api_key: "hi there"
+            max_line_size: 49900,
+            }
+        """
+        )
+        new_config = self._create_test_configuration_instance(logger=mock_logger)
+        new_config.parse()
+
+        new_config.print_useful_settings(other_config=config)
+
+        calls = [
+            call("Configuration settings"),
+            call("\tmax_line_size: 49900"),
+        ]
+        mock_logger.info.assert_has_calls(calls)
+
+    def test_print_config_when_not_changed(self):
+        """
+        Test that `print_useful_settings` doesn't output anything if configuration
+        options haven't changed
+        """
+        self._write_file_with_separator_conversion(
+            """{
+            api_key: "hi there",
+            max_line_size: 49900
+            }
+        """
+        )
+        mock_logger = Mock()
+        config = self._create_test_configuration_instance(logger=mock_logger)
+        config.parse()
+
+        other_config = self._create_test_configuration_instance(logger=mock_logger)
+        other_config.parse()
+
+        config.print_useful_settings(other_config=other_config)
+        mock_logger.info.assert_not_called()
 
     def test_import_vars_in_configuration_directory(self):
         os.environ["TEST_VAR"] = "bye"


### PR DESCRIPTION
This commit will cause the agent to print various useful configuration options to
`agent.log` at startup or whenever the configuration changes.

This will be useful in determining the values of the configuration options when
diagnosing customer issues