### PR TITLE
Add namespace whitelist capability for Kubernetes

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
@@ -25,6 +25,7 @@ from scalyr_agent.monitor_utils.k8s import (
     K8sApiException,
     K8sApiAuthorizationException,
     ApiQueryOptions,
+    K8sNamespaceFilter,
 )
 import scalyr_agent.monitor_utils.k8s as k8s_utils
 
@@ -327,10 +328,10 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
                 "Error setting monitor attribute in KubernetesEventMonitor"
             )
 
-        # The namespace whose logs we should not collect.
-        self.__k8s_namespaces_to_ignore = []
-        for x in self._global_config.k8s_ignore_namespaces:
-            self.__k8s_namespaces_to_ignore.append(x.strip())
+        # The namespace whose logs we should collect.
+        self.__k8s_namespaces_to_include = K8sNamespaceFilter.from_config(
+            global_config=self._global_config
+        )
 
         (
             default_rotation_count,
@@ -797,7 +798,7 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
                                 continue
 
                             # ignore events that belong to namespaces we are not interested in
-                            if namespace in self.__k8s_namespaces_to_ignore:
+                            if namespace not in self.__k8s_namespaces_to_include:
                                 global_log.log(
                                     scalyr_logging.DEBUG_LEVEL_1,
                                     "Ignoring event due to belonging to an excluded namespace '%s'"

--- a/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
+++ b/scalyr_agent/builtin_monitors/tests/kubernetes_monitor_test.py
@@ -24,7 +24,11 @@ from string import Template
 
 import sys
 
-from scalyr_agent.monitor_utils.k8s import KubeletApi, KubeletApiException
+from scalyr_agent.monitor_utils.k8s import (
+    KubeletApi,
+    KubeletApiException,
+    K8sNamespaceFilter,
+)
 from scalyr_agent.third_party.requests.packages.urllib3.exceptions import (
     InsecureRequestWarning,
 )
@@ -64,7 +68,9 @@ class KubernetesMonitorTest(ScalyrTestCase):
         def fake_init(self):
             # Initialize variables that would have been
             self._KubernetesMonitor__container_checker = None
-            self._KubernetesMonitor__namespaces_to_ignore = []
+            self._KubernetesMonitor__namespaces_to_include = (
+                K8sNamespaceFilter.default_value()
+            )
             self._KubernetesMonitor__include_controller_info = None
             self._KubernetesMonitor__report_container_metrics = None
             self._KubernetesMonitor__metric_fetcher = None
@@ -539,7 +545,9 @@ class TestExtraServerAttributes(ScalyrTestCase):
         def fake_init(self):
             # Initialize variables that would have been
             self._KubernetesMonitor__container_checker = None
-            self._KubernetesMonitor__namespaces_to_ignore = []
+            self._KubernetesMonitor__namespaces_to_include = (
+                K8sNamespaceFilter.default_value()
+            )
             self._KubernetesMonitor__include_controller_info = None
             self._KubernetesMonitor__report_container_metrics = None
             self._KubernetesMonitor__metric_fetcher = None
@@ -622,10 +630,7 @@ class TestKubeletApi(BaseScalyrLogCaptureTestCase):
                 result = api.query_stats()
                 self.assertEqual(result, {})
                 self.assertLogFileContainsLineRegex(
-                    ".*"
-                    + re.escape(
-                        "WARNING [core] [k8s.py:2215] Accessing Kubelet with an unverified HTTPS request."
-                    )
+                    r".*WARNING \[core\] \[k8s.py:\d+\] Accessing Kubelet with an unverified HTTPS request\."
                 )
                 self.assertFalse(new_err.getvalue())
                 self.assertFalse(new_out.getvalue())

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -73,6 +73,7 @@ class Configuration(object):
     """
 
     DEFAULT_K8S_IGNORE_NAMESPACES = ["kube-system"]
+    DEFAULT_K8S_INCLUDE_NAMESPACES = ["*"]
 
     def __init__(self, file_path, default_paths, logger):
         # Captures all environment aware variables for testing purposes
@@ -1788,7 +1789,7 @@ class Configuration(object):
         self.__verify_or_set_optional_array_of_strings(
             config,
             "k8s_include_namespaces",
-            ["*"],
+            Configuration.DEFAULT_K8S_INCLUDE_NAMESPACES,
             description,
             apply_defaults,
             separators=[None, ","],

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -420,6 +420,10 @@ class Configuration(object):
         return self.__get_config().get_json_array("k8s_ignore_namespaces")
 
     @property
+    def k8s_include_namespaces(self):
+        return self.__get_config().get_json_array("k8s_include_namespaces")
+
+    @property
     def k8s_api_url(self):
         return self.__get_config().get_string("k8s_api_url")
 
@@ -1776,6 +1780,15 @@ class Configuration(object):
             config,
             "k8s_ignore_namespaces",
             Configuration.DEFAULT_K8S_IGNORE_NAMESPACES,
+            description,
+            apply_defaults,
+            separators=[None, ","],
+            env_aware=True,
+        )
+        self.__verify_or_set_optional_array_of_strings(
+            config,
+            "k8s_include_namespaces",
+            ["*"],
             description,
             apply_defaults,
             separators=[None, ","],

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -111,9 +111,6 @@ def cache(global_config):
         @param config: The configuration
         @type config: A Scalyr Configuration object
     """
-    # split comma delimited string of namespaces to ignore in to a list of strings
-    # TODOcz:
-
     cache_config = _CacheConfig(
         api_url=global_config.k8s_api_url,
         verify_api_queries=global_config.k8s_verify_api_queries,
@@ -282,7 +279,7 @@ class K8sNamespaceFilter(object):
         :rtype: K8sNamespaceFilter
         """
         return K8sNamespaceFilter(
-            global_include=["*"],
+            global_include=Configuration.DEFAULT_K8S_INCLUDE_NAMESPACES,
             global_ignore=Configuration.DEFAULT_K8S_IGNORE_NAMESPACES,
         )
 
@@ -357,6 +354,9 @@ class K8sNamespaceFilter(object):
             return self.__whitelist == other.__whitelist
         else:
             return self.__blacklist == other.__blacklist
+
+    def __ne__(self, other):
+        return not self == other
 
 
 class QualifiedName(object):

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -30,6 +30,7 @@ from scalyr_agent.json_lib import JsonObject
 import scalyr_agent.scalyr_logging as scalyr_logging
 import scalyr_agent.util as util
 from scalyr_agent.compat import os_environ_unicode
+from scalyr_agent.configuration import Configuration
 
 global_log = scalyr_logging.getLogger(__name__)
 
@@ -111,9 +112,7 @@ def cache(global_config):
         @type config: A Scalyr Configuration object
     """
     # split comma delimited string of namespaces to ignore in to a list of strings
-    namespaces_to_ignore = []
-    for x in global_config.k8s_ignore_namespaces:
-        namespaces_to_ignore.append(x.strip())
+    # TODOcz:
 
     cache_config = _CacheConfig(
         api_url=global_config.k8s_api_url,
@@ -208,6 +207,156 @@ class KubeletApiException(Exception):
     """
 
     pass
+
+
+class K8sNamespaceFilter(object):
+    """
+    Represents a filter on Kubernetes namespaces.  This filter can be be created via both whitelists and
+    blacklists.  This abstraction will then return True or False given a namespace to indicate if it
+    passes the filter (i.e., is included in the whitelist and not included in the blacklist).
+
+    For legacy reasons, it also has logic in it to differiente between global and local blacklist.  This
+    is to provide backward compatibility for when the blacklist was just an option on the Kubernetes monitor
+    (local) and not an option on the global configuration file (global).
+    """
+
+    def __init__(self, global_include, global_ignore, local_ignore=None):
+        """Constructs a filter given the different whitelist (include list) and blacklists (exclude lists).
+        Note, for convenience, all namespaces are stripped of trailing and leading whitespace.  (Whitespace
+        could be introduced via customers putting spaces between commas in the comma separate list.)
+
+        :param global_include: The list of namespaces to include.  If the list is empty or a single element of "*",
+            then all namespaces will pass the filter except for those in the blacklist (if any).
+        :param global_ignore: The list of namespaces to exclude, as specified at the global level.  If this
+            list is the same as the default list and `local_ignore` is not None, then the local_ignore list will
+            be used.
+        :param local_ignore: The list of namespaces to exclude, as specified at the local level.  This list is only
+            used if the `global_ignore` list is not the same as the default.
+        :type global_include: [six.text_type]
+        :type global_ignore: [six.text_type]
+        :type local_ignore: [six.text_type]
+        """
+
+        default_blacklist = self.__namespace_set(
+            Configuration.DEFAULT_K8S_IGNORE_NAMESPACES
+        )
+        blacklist = self.__namespace_set(global_ignore)
+        # If the global list is the same as the default one, it probably means the customer has not changed
+        # this value at the global level.  In that case, we defer to the local one if it exits.
+        if blacklist == default_blacklist and local_ignore is not None:
+            blacklist = self.__namespace_set(local_ignore)
+
+        # Only one of __whitelist or __blacklist will be None.  If __whitelist is not None, then that means
+        # we are filtering from a whitelist and only the specified namespaces should be allowed.  Otherwise, by
+        # default, we allow all namespaces except those specifically blacklisted.
+        whitelist = self.__namespace_set(global_include)
+        if not whitelist or whitelist == set("*"):
+            self.__whitelist = None
+            self.__blacklist = blacklist
+        else:
+            self.__whitelist = whitelist - blacklist
+            self.__blacklist = None
+
+    def passes(self, namespace):
+        """Returns true if the given namespace passes the filter.  This means the namespace is in the whitelist
+        (or the whitelist is *) and does not appear in the blacklist.
+        :param namespace: The namespace to test
+        :type namespace: six.text_type
+        :return: True if the namespace passes the filter.
+        :rtype: bool
+        """
+        return namespace in self
+
+    @staticmethod
+    def include_all():
+        """
+        :return: A filter that will pass all namespaces.
+        :rtype: K8sNamespaceFilter
+        """
+        return K8sNamespaceFilter(global_include=["*"], global_ignore=[])
+
+    @staticmethod
+    def default_value():
+        """Returns the filter created by the configuration when all the defaults are used.
+        :return: The default filter.
+        :rtype: K8sNamespaceFilter
+        """
+        return K8sNamespaceFilter(
+            global_include=["*"],
+            global_ignore=Configuration.DEFAULT_K8S_IGNORE_NAMESPACES,
+        )
+
+    @staticmethod
+    def from_config(global_config=None, local_config=None):
+        """Convenience method for created a filter object based on the global configuration file and
+        a monitor's configuration.
+
+        :param global_config: The global configuraiton object.  This is used to retrieve the global include and ignore
+            list.
+        :param local_config: The local configuration object, if any.  If not None, this is used to retrieve the
+            local ignore list.
+        :type global_config: Configuration
+        :type local_config: MonitorConfiguration
+        :return: The filter.
+        :rtype: K8sNamespaceFilter
+        """
+        global_ignore = global_config.k8s_ignore_namespaces
+        global_include = global_config.k8s_include_namespaces
+
+        if local_config is not None:
+            local_ignore = local_config.get("k8s_ignore_namespaces")
+        else:
+            local_ignore = None
+        return K8sNamespaceFilter(
+            global_include=global_include,
+            global_ignore=global_ignore,
+            local_ignore=local_ignore,
+        )
+
+    @staticmethod
+    def __namespace_set(namespace_list):
+        """Creates a set containing the names in the specified list.  This also (for convenience) strips out
+        leading and trailing whitespace.
+
+        :param namespace_list: The list of namespaces
+        :type namespace_list: [six.text_type]
+        :return: The set
+        :rtype: set
+        """
+        result = set()
+        if namespace_list is None:
+            return result
+
+        for x in namespace_list:
+            result.add(x.strip())
+
+        return result
+
+    def __contains__(self, key):
+        """Returns true if the given namespace passes the filter.  This means the namespace is in the whitelist
+        (or the whitelist is *) and does not appear in the blacklist.
+
+        :param key: The namespace to test
+        :type key: six.text_type
+        :return: True if the namespace passes the filter.
+        :rtype: bool
+        """
+        if self.__whitelist is not None:
+            return key in self.__whitelist
+        else:
+            return key not in self.__blacklist
+
+    def __str__(self):
+        if self.__whitelist is not None:
+            return "include_only=%s" % ",".join(self.__whitelist)
+        else:
+            return "exclude=%s" % ",".join(self.__blacklist)
+
+    def __eq__(self, other):
+        if self.__whitelist is not None:
+            return self.__whitelist == other.__whitelist
+        else:
+            return self.__blacklist == other.__blacklist
 
 
 class QualifiedName(object):

--- a/scalyr_agent/monitor_utils/tests/k8s_test.py
+++ b/scalyr_agent/monitor_utils/tests/k8s_test.py
@@ -36,6 +36,8 @@ from scalyr_agent.monitor_utils.blocking_rate_limiter import BlockingRateLimiter
 import scalyr_agent.third_party.requests as requests
 from scalyr_agent.util import FakeClock, md5_hexdigest
 import scalyr_agent.scalyr_logging as scalyr_logging
+from scalyr_agent.configuration import Configuration
+
 import time
 
 import mock
@@ -552,28 +554,131 @@ class TestK8sNamespaceFilter(ScalyrTestCase):
         self.assertTrue(test_filter.passes("scalyr"))
         self.assertTrue(test_filter.passes("your-app"))
         self.assertFalse(test_filter.passes("kube"))
+        self.assertFalse(test_filter.passes("testing"))
 
     def test_local_blacklist_overrides(self):
-        pass
+        test_filter = K8sNamespaceFilter(
+            global_include=["scalyr", "your-app", "kube"],
+            global_ignore=Configuration.DEFAULT_K8S_IGNORE_NAMESPACES,
+            local_ignore=["kube", "testing"],
+        )
+        self.assertTrue(test_filter.passes("scalyr"))
+        self.assertTrue(test_filter.passes("your-app"))
+        self.assertFalse(test_filter.passes("kube"))
+        self.assertFalse(test_filter.passes("testing"))
+
+    def test_default_global_ignore(self):
+        # Make sure, even if global ignore is the default, we use it if the local
+        # blacklist is None.
+        test_filter = K8sNamespaceFilter(
+            global_include=["scalyr", "your-app", "kube-system"],
+            global_ignore=Configuration.DEFAULT_K8S_IGNORE_NAMESPACES,
+            local_ignore=None,
+        )
+        self.assertTrue(test_filter.passes("scalyr"))
+        self.assertTrue(test_filter.passes("your-app"))
+        self.assertFalse(test_filter.passes("kube-system"))
 
     def test_include_all(self):
         test_filter = K8sNamespaceFilter.include_all()
         self.assertTrue(test_filter.passes("foo"))
 
+    def test_default_value(self):
+        test_filter = K8sNamespaceFilter.default_value()
+        self.assertTrue(test_filter.passes("foo"))
+        self.assertFalse(test_filter.passes("kube-system"))
+
     def test_from_config(self):
-        pass
+        config = mock.Mock()
+        config.k8s_include_namespaces = ["foo", "bar", "baz"]
+        config.k8s_ignore_namespaces = ["baz"]
+
+        test_filter = K8sNamespaceFilter.from_config(global_config=config)
+        self.assertTrue(test_filter.passes("foo"))
+        self.assertTrue(test_filter.passes("bar"))
+        self.assertFalse(test_filter.passes("baz"))
+        self.assertFalse(test_filter.passes("bez"))
 
     def test_from_config_with_local(self):
-        pass
+        config = mock.Mock()
+        config.k8s_include_namespaces = Configuration.DEFAULT_K8S_INCLUDE_NAMESPACES
+        config.k8s_ignore_namespaces = Configuration.DEFAULT_K8S_IGNORE_NAMESPACES
 
-    def test_default_value(self):
-        pass
+        monitor_config = {
+            "k8s_ignore_namespaces": ["baz"],
+        }
+
+        test_filter = K8sNamespaceFilter.from_config(
+            global_config=config, local_config=monitor_config
+        )
+        self.assertTrue(test_filter.passes("foo"))
+        self.assertTrue(test_filter.passes("bar"))
+        self.assertFalse(test_filter.passes("baz"))
 
     def test_str(self):
-        pass
+        test_filter = K8sNamespaceFilter(global_include=["*"], global_ignore=["kube"])
+        self.assertEquals("exclude=kube", six.text_type(test_filter))
+
+        test_filter = K8sNamespaceFilter(
+            global_include=["*"], global_ignore=["kube,foo"]
+        )
+        self.assertEquals("exclude=kube,foo", six.text_type(test_filter))
+
+        test_filter = K8sNamespaceFilter(global_include=["scalyr"], global_ignore=[])
+        self.assertEquals("include_only=scalyr", six.text_type(test_filter))
+
+        test_filter = K8sNamespaceFilter(
+            global_include=["scalyr", "foo"], global_ignore=["bar"]
+        )
+        self.assertEquals("include_only=scalyr,foo", six.text_type(test_filter))
+
+        test_filter = K8sNamespaceFilter(
+            global_include=["scalyr", "foo"], global_ignore=["foo"]
+        )
+        self.assertEquals("include_only=scalyr", six.text_type(test_filter))
 
     def test_eq(self):
-        pass
+        blacklist_filter_a = K8sNamespaceFilter(
+            global_include=["*"], global_ignore=["kube"]
+        )
+        blacklist_filter_b = K8sNamespaceFilter(
+            global_include=["*"], global_ignore=["kube-system"]
+        )
+        blacklist_filter_c = K8sNamespaceFilter(
+            global_include=["*"], global_ignore=["kube"]
+        )
+
+        whitelist_filter_a = K8sNamespaceFilter(
+            global_include=["scalyr"], global_ignore=["kube"]
+        )
+        whitelist_filter_b = K8sNamespaceFilter(
+            global_include=["scalyr", "foo"], global_ignore=["kube"]
+        )
+        whitelist_filter_c = K8sNamespaceFilter(
+            global_include=["scalyr"], global_ignore=[]
+        )
+
+        self.assertFalse(blacklist_filter_a == blacklist_filter_b)
+        self.assertTrue(blacklist_filter_a == blacklist_filter_c)
+        self.assertFalse(blacklist_filter_a == whitelist_filter_a)
+
+        self.assertFalse(whitelist_filter_a == whitelist_filter_b)
+        self.assertTrue(whitelist_filter_a == whitelist_filter_c)
+        self.assertFalse(whitelist_filter_a == blacklist_filter_a)
+
+    def test_ne(self):
+        blacklist_filter_a = K8sNamespaceFilter(
+            global_include=["*"], global_ignore=["kube"]
+        )
+        blacklist_filter_b = K8sNamespaceFilter(
+            global_include=["*"], global_ignore=["kube-system"]
+        )
+        blacklist_filter_c = K8sNamespaceFilter(
+            global_include=["*"], global_ignore=["kube"]
+        )
+
+        self.assertTrue(blacklist_filter_a != blacklist_filter_b)
+        self.assertFalse(blacklist_filter_a != blacklist_filter_c)
 
 
 class DockerClientFaker(object):


### PR DESCRIPTION
Adds in a namespace whitelist capability to Kubernetes in addition to blacklist.  This allows customers to only collect logs from pods running from a specific set of namespaces.

Note, I have not finished writing all of the test cases but I wanted you to get an early review of this because I'll need to merge this in later tonight.