### PR TITLE
Add monitor utils tests to tox targets.

### DIFF
--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -345,9 +345,9 @@ class K8sNamespaceFilter(object):
 
     def __str__(self):
         if self.__whitelist is not None:
-            return "include_only=%s" % ",".join(self.__whitelist)
+            return "include_only=%s" % ",".join(sorted(self.__whitelist))
         else:
-            return "exclude=%s" % ",".join(self.__blacklist)
+            return "exclude=%s" % ",".join(sorted(self.__blacklist))
 
     def __eq__(self, other):
         if self.__whitelist is not None:

--- a/scalyr_agent/monitor_utils/tests/k8s_test.py
+++ b/scalyr_agent/monitor_utils/tests/k8s_test.py
@@ -630,7 +630,7 @@ class TestK8sNamespaceFilter(ScalyrTestCase):
         test_filter = K8sNamespaceFilter(
             global_include=["scalyr", "foo"], global_ignore=["bar"]
         )
-        self.assertEquals("include_only=scalyr,foo", six.text_type(test_filter))
+        self.assertEquals("include_only=foo,scalyr", six.text_type(test_filter))
 
         test_filter = K8sNamespaceFilter(
             global_include=["scalyr", "foo"], global_ignore=["foo"]

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
     # isolated from other tests
     # NOTE 2: We write junit XML file for nicer visualization on Circle CI
     rm -rf test-results
-    py.test scalyr_agent/tests scalyr_agent/builtin_monitors/tests -vv --durations=5 -m "not memory_leak and not json_lib" --junitxml=test-results/junit-1.xml
+    py.test scalyr_agent/tests scalyr_agent/builtin_monitors/tests scalyr_agent/monitor_utils/tests -vv --durations=5 -m "not memory_leak and not json_lib" --junitxml=test-results/junit-1.xml
     py.test scalyr_agent/tests/test_memory_leaks.py -vv --durations=5 --junitxml=test-results/junit-2.xml
     py.test scalyr_agent/tests/util/json_util_test.py -vv --durations=5 -m "json_lib" --junitxml=test-results/junit-3.xml
 
@@ -58,7 +58,7 @@ basepython = python2.6
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps = -rpy26-unit-tests-requirements.txt
 commands =
-    py.test scalyr_agent/tests scalyr_agent/builtin_monitors/tests -vv --durations=5 -m "not memory_leak and not json_lib" --junitxml=test-results/junit-1.xml
+    py.test scalyr_agent/tests scalyr_agent/builtin_monitors/tests scalyr_agent/monitor_utils/tests -vv --durations=5 -m "not memory_leak and not json_lib" --junitxml=test-results/junit-1.xml
     py.test scalyr_agent/tests/util/json_util_test.py -vv --durations=5 -m "json_lib" --junitxml=test-results/junit-2.xml
 
 # Lint target which runs all the linting tools such as black, modernize, pylint, flake8, mypy, etc.
@@ -141,7 +141,7 @@ commands =
 commands =
     rm -f .coverage
     rm -rf test-results
-    py.test  scalyr_agent/tests scalyr_agent/builtin_monitors/tests -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/ --junitxml=test-results/junit-1.xml
+    py.test  scalyr_agent/tests scalyr_agent/builtin_monitors/tests scalyr_agent/monitor_utils/tests -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/ --junitxml=test-results/junit-1.xml
     py.test scalyr_agent/tests/test_memory_leaks.py -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
     py.test scalyr_agent/tests/util/json_util_test.py -vv --durations=5 -m "json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-3.xml
 


### PR DESCRIPTION
Tests for monitors utils were not added into tox targets, so it could not calculate coverage for them too.

Also, there is a small fix that does sorting of the namespaces in `K8sNamespaceFilter` before creating a string from it, to provide stable results.
