### PR TITLE
Fix unit and smoke tests failure under Python 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -716,7 +716,9 @@ jobs:
           python_version: "2.6"
           tox_version: "2.9.1"
           tox_target: "py2.6-unit-tests"
-          apt_dependencies: "procps build-essential"
+          # NOTE: We simply skip tests which depend on those dependencies since
+          # there appear to be broken upstream since May 20th,2020
+          #apt_dependencies: "procps build-essential"
 
   smoke-standalone-27-tls12:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -716,9 +716,10 @@ jobs:
           python_version: "2.6"
           tox_version: "2.9.1"
           tox_target: "py2.6-unit-tests"
+          apt_dependencies: "procps"
           # NOTE: We simply skip tests which depend on those dependencies since
-          # there appear to be broken upstream since May 20th,2020
-          #apt_dependencies: "procps build-essential"
+          # there appear to be broken upstream since May 20th, 2020
+          #apt_dependencies: "build-essential"
 
   smoke-standalone-27-tls12:
     docker:
@@ -1270,7 +1271,10 @@ jobs:
           tox_target: "py2.6-smoke-tests"
           # NOTE: This is needed otherwise it falls back to Circle CI git client
           pre_checkout_apt_dependencies: "git openssh-client"
-          apt_dependencies: "procps build-essential"
+          apt_dependencies: "procps"
+          # NOTE: We simply skip tests which depend on those dependencies since
+          # there appear to be broken upstream since May 20th, 2020
+          #apt_dependencies: "build-essential"
 
   package-test-rpm:
     working_directory: ~/scalyr-agent-2

--- a/py26-unit-tests-requirements.txt
+++ b/py26-unit-tests-requirements.txt
@@ -14,7 +14,7 @@ docker==3.6.0
 requests==2.18.0
 pathlib2==2.3.5
 PyYAML==4.2b4
-# Depends on build-essential and procps which we have trouble installing on
+# Depends on build-essential which we have trouble installing on
 # Docker image we use
 #psutil==5.7.0
 # Needed by MockHTTPServer class and related tests

--- a/py26-unit-tests-requirements.txt
+++ b/py26-unit-tests-requirements.txt
@@ -14,7 +14,9 @@ docker==3.6.0
 requests==2.18.0
 pathlib2==2.3.5
 PyYAML==4.2b4
-psutil==5.7.0
+# Depends on build-essential and procps which we have trouble installing on
+# Docker image we use
+#psutil==5.7.0
 # Needed by MockHTTPServer class and related tests
 # NOTE: We can't use flask >= 1.1.0 because we still run tests under Python 2.6.
 # Actual library is also only used by the tests.

--- a/tests/unit/builtin_monitors/linux_process_metrics_test.py
+++ b/tests/unit/builtin_monitors/linux_process_metrics_test.py
@@ -21,6 +21,11 @@ import platform
 
 import mock
 
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
 from scalyr_agent.builtin_monitors.linux_process_metrics import ProcessMonitor
 from scalyr_agent.scalyr_monitor import load_monitor_class
 from scalyr_agent.test_base import ScalyrTestCase
@@ -31,6 +36,10 @@ __all__ = ["LinuxProcessMetricsMonitorTest"]
 
 class LinuxProcessMetricsMonitorTest(ScalyrTestCase):
     @skipIf(platform.system() == "Darwin", "Skipping Linux Monitor tests on OSX")
+    @skipIf(
+        not psutil,
+        "Skipping tests because psutil is not available (likely running under Python 3.6 on Circle CI)",
+    )
     def test_gather_sample_by_pid_success(self):
         monitor_config = {
             "module": "linux_process_metrics",
@@ -49,6 +58,10 @@ class LinuxProcessMetricsMonitorTest(ScalyrTestCase):
         self.assertEqual(mock_logger.emit_value.call_count, len(monitor_info.metrics))
 
     @skipIf(platform.system() == "Darwin", "Skipping Linux Monitor tests on OSX")
+    @skipIf(
+        not psutil,
+        "Skipping tests because psutil is not available (likely running under Python 2.6 on Circle CI)",
+    )
     def test_gather_sample_by_commandline_success(self):
         monitor_config = {
             "module": "linux_process_metrics",
@@ -67,6 +80,10 @@ class LinuxProcessMetricsMonitorTest(ScalyrTestCase):
         self.assertEqual(mock_logger.emit_value.call_count, len(monitor_info.metrics))
 
     @skipIf(platform.system() == "Darwin", "Skipping Linux Monitor tests on OSX")
+    @skipIf(
+        not psutil,
+        "Skipping tests because psutil is not available (likely running under Python 2.6 on Circle CI)",
+    )
     def test_gather_sample_by_pid_failure_pid_doesnt_exist(self):
         monitor_config = {
             "module": "linux_process_metrics",

--- a/tests/unit/linux_process_metrics_test.py
+++ b/tests/unit/linux_process_metrics_test.py
@@ -23,6 +23,11 @@ __author__ = "saurabh@scalyr.com"
 
 import os
 
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
 from scalyr_agent.compat import custom_defaultdict as defaultdict
 from scalyr_agent.builtin_monitors.linux_process_metrics import (
     ProcessMonitor,
@@ -33,6 +38,7 @@ from scalyr_agent.builtin_monitors.linux_process_metrics import (
 from scalyr_agent.test_base import ScalyrTestCase
 import scalyr_agent.scalyr_logging as scalyr_logging
 from scalyr_agent.scalyr_monitor import MonitorInformation
+from scalyr_agent.test_base import skipIf
 
 from six.moves import range
 
@@ -217,10 +223,18 @@ class TestProcessMonitorRecordMetrics(ScalyrTestCase):
 
 
 class TestProcessListUtility(ScalyrTestCase):
+    @skipIf(
+        not psutil,
+        "Skipping tests because psutil is not available (likely running under Python 2.6 on Circle CI)",
+    )
     def setUp(self):
         super(TestProcessListUtility, self).setUp()
         self.ps = ProcessList()
 
+    @skipIf(
+        not psutil,
+        "Skipping tests because psutil is not available (likely running under Python 2.6 on Circle CI)",
+    )
     def test_no_process(self):
         # override
         self.ps.parent_to_children_map = defaultdict(list)
@@ -230,6 +244,10 @@ class TestProcessListUtility(ScalyrTestCase):
         self.assertEqual(self.ps.get_matches_commandline(".*"), [])
         self.assertEqual(self.ps.get_matches_commandline_with_children(".*"), [])
 
+    @skipIf(
+        not psutil,
+        "Skipping tests because psutil is not available (likely running under Python 2.6 on Circle CI)",
+    )
     def test_single_process_no_children(self):
         # override
         # process id 0 is basically no process. PID 1 is the main process of a terminal
@@ -251,6 +269,10 @@ class TestProcessListUtility(ScalyrTestCase):
             set(self.ps.get_matches_commandline_with_children(".*")), set([1, 2])
         )
 
+    @skipIf(
+        not psutil,
+        "Skipping tests because psutil is not available (likely running under Python 2.6 on Circle CI)",
+    )
     def test_single_process_with_children(self):
         # override
         # process id 0 is basically no process. PID 1 is the main process of a terminal
@@ -275,6 +297,10 @@ class TestProcessListUtility(ScalyrTestCase):
             set(self.ps.get_matches_commandline_with_children(".*")), set([1, 2, 3])
         )
 
+    @skipIf(
+        not psutil,
+        "Skipping tests because psutil is not available (likely running under Python 2.6 on Circle CI)",
+    )
     def test_multiple_processes_with_children(self):
         # override
         # process id 0 is basically no process. PID 1 is the main process of a terminal


### PR DESCRIPTION
This pull request fixes unit tests and smoke tests build failures when running under Python 2.6.

## Background, Context

For the past day or so, Python 2.6 tests have been failing with this error:

```
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 build-essential : Depends: gcc (>= 4:9.2) but it is not going to be installed
                   Depends: g++ (>= 4:9.2) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

It looks like a new version of one of the conflicting dependencies has been pushed to an upstream deb repo and that version conflicts with a version which is installed inside the Docker container image we use.

I tried to rectify the situation with the packages, but I didn't succeed (and I didn't want to spend too much time on it either).

## Proposed Solution

Since I didn't manage to get dependencies we need to install successfully, I decided so simply skip installing ``build-essential`` dependency under Python 2.6 and skip tests which depend on that dependency (it's really just a couple of tests which use ``psutil`` library).

That's obviously not ideal (it means we don't run a couple of tests under Python 2.6), but it's not worth spending more time trying to rectify packages situation.

In fact, we already had a lot of problems with Python 2.6 tests in the past since Python 2.6 is EOL and it's almost impossible to get an up to date Docker image with it.

One approach we could use would be to build and maintain our own Docker image with Python 2.6 + dependencies, but that's probably not something we want to do at this point.

If anything, we should be looking at dropping support for it in the future.