### PR TITLE
Update verify codecov config script to print response on failure and abort immediately on fatal error

### DIFF
--- a/scripts/circleci/verify-codecov-config.sh
+++ b/scripts/circleci/verify-codecov-config.sh
@@ -24,9 +24,9 @@ for (( i=0; i<$MAX_ATTEMPTS; ++i)); do
     OUTPUT=$(curl --max-time 10 --data-binary @codecov.yml https://codecov.io/validate)
     CURL_EXIT_CODE=$?
     echo "${OUTPUT}" | grep -i "Valid!" > /dev/null
-    EXIT_CODE=$?
+    GREP_EXIT_CODE=$?
 
-    if [ "${EXIT_CODE}" -eq 0 ]; then
+    if [ "${GREP_EXIT_CODE}" -eq 0 ]; then
         echo ""
         echo "codecov.yml config is valid."
         break
@@ -47,7 +47,7 @@ for (( i=0; i<$MAX_ATTEMPTS; ++i)); do
     fi
 done
 
-if [ "${EXIT_CODE}" -ne 0 ]; then
+if [ "${GREP_EXIT_CODE}" -ne 0 ]; then
     echo "Verifying codecov.yml failed after ${MAX_ATTEMPTS} attempts"
     exit 1
 fi


### PR DESCRIPTION
This pull request contains small improvement to the verify circle ci script so it prints curl output (aka response body) on validation failure.

In addition to that, we now only try to retry on a timeout and abort immediately on actual fatal error (such as the config validation failed).

This should make troubleshooting slightly faster and easier.

Before:

```bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1225  100    83  100  1142   2548  35068 --:--:-- --:--:-- --:--:-- 35687
Command exited with non-zero, retrying in 5 seconds...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1225  100    83  100  1142   3077  42344 --:--:-- --:--:-- --:--:-- 43923
Command exited with non-zero, retrying in 5 seconds...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1225  100    83  100  1142    671   9243 --:--:-- --:--:-- --:--:--  9284
Command exited with non-zero, retrying in 5 seconds...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1225  100    83  100  1142   2225  30618 --:--:-- --:--:-- --:--:-- 30864
Command exited with non-zero, retrying in 5 seconds...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1225  100    83  100  1142   2567  35321 --:--:-- --:--:-- --:--:-- 35687
Command exited with non-zero, retrying in 5 seconds...
Verifying codecov.yml failed after 5 attempts
```

After:

```bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1217  100    83  100  1134    150   2054 --:--:-- --:--:-- --:--:--  2204

curl output: Path: coverage->status->project->project
Wrong key 'default' in {'default': False}

codecov.yml config validation failed

```