### PR TITLE
Fix codecov coverage data upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ commands:
                 command: |
                   ls -la .coverage* || true
 
-                  pip install "coverage==4.5.4" "codecov==2.0.15"
+                  pip install "coverage==4.5.4" "codecov==2.1.3"
                   cp .circleci/.coveragerc_ci .coveragerc
 
                   # Print the report
@@ -436,7 +436,7 @@ commands:
                   # Each test function runs in an isolated Docker container and results in a new .coverage file which we need to combine
                   ls -la ~/artifacts/*/.coverage
 
-                  pip install "coverage==4.5.4" "codecov==2.0.15"
+                  pip install "coverage==4.5.4" "codecov==2.1.3"
                   cp .circleci/.coveragerc_ci .coveragerc
 
                   # Generate combined .coverage file for all our test functions

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,7 +13,7 @@ pytest-timeout==1.3.4
 pytest-benchmark==3.2.3
 pytest-xdist==1.31.0
 coverage==4.5.4
-codecov==2.0.15
+codecov==2.1.3
 decorator==4.4.1
 PyYAML==5.3
 six==1.13.0

--- a/scripts/submit-codecov-data.sh
+++ b/scripts/submit-codecov-data.sh
@@ -22,7 +22,8 @@ RETRY_DELAY=${RETRY_DELAY:-5}
 
 # Work around for temporary codecov API timing out
 for (( i=0; i<$MAX_ATTEMPTS; ++i)); do
-    # NOTE: We pass --required flag to the binary since we also want it to rAeturn non-zero if upload fails
+    # NOTE: We pass --required flag to the binary since we also want it to return non-zero (and fail
+    # the build) if upload fails
     codecov --root=/home/circleci/scalyr-agent-2/ --disable gcov --file coverage.xml --required
     EXIT_CODE=$?
 

--- a/scripts/submit-codecov-data.sh
+++ b/scripts/submit-codecov-data.sh
@@ -22,7 +22,8 @@ RETRY_DELAY=${RETRY_DELAY:-5}
 
 # Work around for temporary codecov API timing out
 for (( i=0; i<$MAX_ATTEMPTS; ++i)); do
-    codecov --root=/home/circleci/scalyr-agent-2/ --disable gcov --file coverage.xml
+    # NOTE: We pass --required flag to the binary since we also want it to rAeturn non-zero if upload fails
+    codecov --root=/home/circleci/scalyr-agent-2/ --disable gcov --file coverage.xml --required
     EXIT_CODE=$?
 
     if [ "${EXIT_CODE}" -eq 0 ]; then


### PR DESCRIPTION
This pull request fixes codecov coverage data uploads.

## Background, Context

Codecov coverage upload started to fail with "400 bad request" error a couple of days ago (https://app.circleci.com/pipelines/github/scalyr/scalyr-agent-2/2930/workflows/05136b23-cf27-41ed-8b69-74bce5c4cdec/jobs/40054/parallel-runs/0/steps/0-108).

It looks like it's an issue with the version of the client we are currently using and a new one should fix it - https://github.com/codecov/codecov-python/pull/268.

One of the reasons why we didn't spot this issue earlier was that we didn't consider "codecov data upload fatal" error as fatal.

I fixed that by adding ``--required`` flag to ``codecov`` binary which will make it return with non-zero if the upload fails. This way we will spot issues like that sooner.