### PR TITLE
Update sonar cloud settings

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -11,7 +11,9 @@ sonar.exclusions=scalyr_agent/third_party/**,scalyr_agent/third_party_tls/**,sca
 # Code Duplication ignores rules
 # For now we simply ignore all the paths because there are too many false positives due to the
 # license headers.
-sonar.cpd.exclusions=**
+#sonar.cpd.exclusions=**
+sonar.cpd.python.minimumTokens=200
+sonar.cpd.python.minimumLines=20
 
 # Python programming language specific settings
 


### PR DESCRIPTION
Just playing with Sonar Cloud settings and trying to see if we can perhaps still utilize duplicate lines and blocks detection without detecting our license headers as duplicated lines (aka false positives).