### PR TITLE
Add back reverted tempfile.mkstemp changes, fix Windows compatibility

### DIFF
--- a/.circleci/modernize/modernize.py
+++ b/.circleci/modernize/modernize.py
@@ -23,7 +23,7 @@
 #   -j --processes <jobs count> run concurrently.
 # Note: This is only python3 script.
 
-if False:
+if False:  # NOSONAR
     # NOTE: This is a workaround for old Python versions where typing module is not available
     # We should eventually improve that once we start producing distributions with Python
     # interpreter and dependencies bundled in.

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,35 @@
+# Configuration file for SonarCloud
+# Path to the main source code we want to scan
+sonar.sources=scalyr_agent/
+
+# Path to tests
+sonar.tests=tests/
+
+# Exclude bundled third party libs from analysis
+sonar.exclusions=scalyr_agent/third_party/**,scalyr_agent/third_party_tls/**,scalyr_agent/third_party_python2/**
+
+# Code Duplication ignores rules
+# For now we simply ignore all the paths because there are too many false positives due to the
+# license headers and "__define__metrics" line which we can't easily ignore
+#sonar.cpd.exclusions=**
+sonar.cpd.exclusions=scalyr_agent/builtin_monitors/*.py
+#sonar.cpd.python.minimumTokens=200
+#sonar.cpd.python.minimumLines=20
+
+# Python programming language specific settings
+
+# Use our custom pylint config
+sonar.python.pylint_config=./lint-configs/python/.pylintrc
+
+# Coverage related settings - currently unused (we use codecov.io for coverage)
+#sonar.python.coverage.reportPaths=coverage.xml
+#
+#sonar.python.xunit.reportPath=test-results/junit-*.xml
+
+# Custom rule settings
+# We ignore "Functions, methods and lambdas should not have too many parameters"
+# rule which conflicts with our linter rule
+sonar.issue.ignore.multicriteria=e1
+
+sonar.issue.ignore.multicriteria.e1.ruleKey=python:S107
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.py

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/scalyr/scalyr-agent-2.svg?style=svg)](https://circleci.com/gh/scalyr/scalyr-agent-2)
 [![codecov](https://codecov.io/gh/scalyr/scalyr-agent-2/branch/master/graph/badge.svg)](https://codecov.io/gh/scalyr/scalyr-agent-2)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=scalyr_scalyr-agent-2&metric=alert_status)](https://sonarcloud.io/dashboard?id=scalyr_scalyr-agent-2)
 
 This repository holds the source code for the Scalyr Agent, a daemon that collects logs and metrics from
 customer machines and transmits them to Scalyr.

--- a/benchmarks/micro/utils.py
+++ b/benchmarks/micro/utils.py
@@ -14,7 +14,7 @@
 
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     from typing import Dict
     from typing import Callable
     from typing import Optional
@@ -71,7 +71,7 @@ def generate_add_events_request(
 
     add_events_request = AddEventsRequest(base_body=base_body)
 
-    for index in range(0, num_events):
+    for _ in range(0, num_events):
         line = generate_random_line(length=line_length)
         attributes = generate_random_dict(keys_count=attributes_count)
 

--- a/benchmarks/scripts/send_microbenchmarks_data_to_codespeed.py
+++ b/benchmarks/scripts/send_microbenchmarks_data_to_codespeed.py
@@ -19,7 +19,7 @@ CodeSpeed instance.
 
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     from typing import List
 
 import glob

--- a/benchmarks/scripts/send_usage_data_to_codespeed.py
+++ b/benchmarks/scripts/send_usage_data_to_codespeed.py
@@ -40,7 +40,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from io import open
 
-if False:
+if False:  # NOSONAR
     # NOTE: This is a workaround for old Python versions where typing module is not available
     # We should eventually improve that once we start producing distributions with Python
     # interpreter and dependencies bundled in.

--- a/benchmarks/scripts/send_value_to_codespeed.py
+++ b/benchmarks/scripts/send_value_to_codespeed.py
@@ -19,7 +19,7 @@ Script which sends a single value to CodeSpeed.
 
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     # NOTE: This is a workaround for old Python versions where typing module is not available
     # We should eventually improve that once we start producing distributions with Python
     # interpreter and dependencies bundled in.

--- a/benchmarks/scripts/utils.py
+++ b/benchmarks/scripts/utils.py
@@ -23,7 +23,7 @@ import pprint
 from datetime import datetime
 from argparse import ArgumentParser  # NOQA
 
-if False:
+if False:  # NOSONAR
     from typing import List
     from typing import Dict
     from typing import Tuple

--- a/build_package.py
+++ b/build_package.py
@@ -1235,8 +1235,9 @@ def run_command(command_str, exit_on_fail=True, fail_quietly=False, command_name
     @return: The exist status and output string of the command.
     """
     # We have to use a temporary file to hold the output to stdout and stderr.
-    _, output_file = tempfile.mkstemp()
-    output_fp = open(output_file, "w")
+    output_file_fd, output_file = tempfile.mkstemp()
+
+    output_fp = os.fdopen(output_file_fd, "w")
 
     try:
         return_code = subprocess.call(

--- a/build_package.py
+++ b/build_package.py
@@ -1235,7 +1235,7 @@ def run_command(command_str, exit_on_fail=True, fail_quietly=False, command_name
     @return: The exist status and output string of the command.
     """
     # We have to use a temporary file to hold the output to stdout and stderr.
-    output_file = tempfile.mktemp()
+    _, output_file = tempfile.mkstemp()
     output_fp = open(output_file, "w")
 
     try:

--- a/pylint_plugins/bundled_imports_checker.py
+++ b/pylint_plugins/bundled_imports_checker.py
@@ -27,7 +27,7 @@ then imports some bundled module).
 from __future__ import absolute_import
 from __future__ import print_function
 
-if False:
+if False:  # NOSONAR
     from typing import List
     from typing import Tuple
     from typing import Dict

--- a/pylint_plugins/py2exe_checker.py
+++ b/pylint_plugins/py2exe_checker.py
@@ -21,7 +21,7 @@ more specifics about the checker and the invariants it enforces.
 
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     from typing import Any
     from typing import Union
 

--- a/scalyr_agent/build_info.py
+++ b/scalyr_agent/build_info.py
@@ -21,7 +21,7 @@ Keep in mind that that file is only available for package and not for dev instal
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     from typing import Dict
 
 import os

--- a/scalyr_agent/builtin_monitors/docker_monitor.py
+++ b/scalyr_agent/builtin_monitors/docker_monitor.py
@@ -606,7 +606,7 @@ class WrappedStreamResponse(object):
     def __init__(self, client, response, decode):
         self.client = client
         self.response = response
-        self.decode = self.decode
+        self.decode = decode
 
     def __iter__(self):
         # pylint: disable=bad-super-call
@@ -1148,7 +1148,7 @@ class ContainerChecker(StoppableThread):
             checkpoints = scalyr_util.read_file_as_json(
                 self.__checkpoint_file, strict_utf8=True
             )
-        except:
+        except Exception:
             self._logger.info(
                 "No checkpoint file '%s' exists.\n\tAll logs will be read starting from their current end.",
                 self.__checkpoint_file,
@@ -2084,7 +2084,7 @@ TODO:  Back fill the instructions here.
             st = os.stat(api_socket)
             if not stat.S_ISSOCK(st.st_mode):
                 raise Exception()
-        except:
+        except Exception:
             raise Exception(
                 "The file '%s' specified by the 'api_socket' configuration option does not exist or is not a socket.\n\tPlease make sure you have mapped the docker socket from the host to this container using the -v parameter.\n\tNote: Due to problems Docker has mapping symbolic links, you should specify the final file and not a path that contains a symbolic link, e.g. map /run/docker.sock rather than /var/run/docker.sock as on many unices /var/run is a symbolic link to the /run directory."
                 % api_socket

--- a/scalyr_agent/builtin_monitors/graphite_monitor.py
+++ b/scalyr_agent/builtin_monitors/graphite_monitor.py
@@ -387,7 +387,7 @@ class GraphitePickleServer(ServerProcessor):
         try:
             # Use pickle to read the binary data.
             data_object = pickle.loads(request)
-        except:  # pickle.loads is document as raising any type of exception, so have to catch them all.
+        except Exception:  # pickle.loads is document as raising any type of exception, so have to catch them all.
             self.__logger.warn(
                 "Could not parse incoming metric line from graphite pickle server, ignoring",
                 error_code="graphite_monitor/badUnpickle",

--- a/scalyr_agent/builtin_monitors/journald_monitor.py
+++ b/scalyr_agent/builtin_monitors/journald_monitor.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 
 __author__ = "imron@scalyr.com"
 
-if False:
+if False:  # NOSONAR
     from typing import Dict
 
 import datetime
@@ -180,7 +180,7 @@ def load_checkpoints(filename):
     checkpoints = {}
     try:
         checkpoints = scalyr_util.read_file_as_json(filename, strict_utf8=True)
-    except:
+    except Exception:
         global_log.log(
             scalyr_logging.DEBUG_LEVEL_1,
             "No checkpoint file '%s' exists.\n\tAll journald logs will be read starting from their current end.",

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -829,7 +829,7 @@ class WrappedStreamResponse(object):
     def __init__(self, client, response, decode):
         self.client = client
         self.response = response
-        self.decode = self.decode
+        self.decode = decode
 
     def __iter__(self):
         # pylint: disable=bad-super-call
@@ -1601,7 +1601,7 @@ class ControlledCacheWarmer(StoppableThread):
                     if consecutive_warm_pods == 10:
                         # TODO-163: Get rid of circuit breaker.
                         self._run_state.sleep_but_awaken_if_stopped(0.1)
-            except:
+            except Exception:
                 global_log.exception("cacher warmer uncaught exception")
 
     class WarmingEntry(object):
@@ -2459,7 +2459,6 @@ class ContainerChecker(object):
         self._logger = logger
 
         self.__delay = self._config.get("container_check_interval")
-        self.__log_prefix = self._config.get("docker_log_prefix")
         self.__name = self._config.get("container_name")
 
         self.__use_v2_attributes = self._config.get("k8s_use_v2_attributes")
@@ -3410,7 +3409,7 @@ cluster.
             st = os.stat(api_socket)
             if not stat.S_ISSOCK(st.st_mode):
                 raise Exception()
-        except:
+        except Exception:
             raise Exception(
                 "The file '%s' specified by the 'api_socket' configuration option does not exist or is not a socket.\n\tPlease make sure you have mapped the docker socket from the host to this container using the -v parameter.\n\tNote: Due to problems Docker has mapping symbolic links, you should specify the final file and not a path that contains a symbolic link, e.g. map /run/docker.sock rather than /var/run/docker.sock as on many unices /var/run is a symbolic link to the /run directory."
                 % api_socket

--- a/scalyr_agent/builtin_monitors/mysql_monitor.py
+++ b/scalyr_agent/builtin_monitors/mysql_monitor.py
@@ -448,7 +448,7 @@ class MysqlDB(object):
         except (ValueError, IndexError):
             self._major = self._medium = 0
             self._version = "unknown"
-        except:
+        except Exception:
             ex = sys.exc_info()[0]
             self._logger.error("Exception getting database version: %s" % ex)
             self._version = "unknown"
@@ -1058,7 +1058,7 @@ You can also use this data in [Dashboards](/help/dashboards) and [Alerts](/help/
                     elif len(hostPortParts) == 2:
                         try:
                             self._database_port = int(hostPortParts[1])
-                        except:
+                        except Exception:
                             raise Exception(
                                 "database_hostport specified is incorrect.  The format show be host:port, where port is an integer."
                             )

--- a/scalyr_agent/builtin_monitors/postgres_monitor.py
+++ b/scalyr_agent/builtin_monitors/postgres_monitor.py
@@ -22,7 +22,6 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 import sys
-import string
 from datetime import datetime
 
 import pg8000  # pylint: disable=import-error
@@ -315,9 +314,9 @@ class PostgreSQLDb(object):
             self._cursor.execute("select version();")
             r = self._cursor.fetchone()
             # assumes version is in the form of 'PostgreSQL x.y.z on ...'
-            s = string.split(r[0])
+            s = r[0].split(" ")
             version = s[1]
-        except:
+        except Exception:
             ex = sys.exc_info()[0]
             self._logger.error("Exception getting database version: %s" % ex)
         return version
@@ -334,7 +333,7 @@ class PostgreSQLDb(object):
         except (ValueError, IndexError):
             self._major = self._medium = 0
             self._version = "unknown"
-        except:
+        except Exception:
             ex = sys.exc_info()[0]
             self._logger.error("Exception getting database version: %s" % ex)
             self._version = "unknown"

--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -452,7 +452,7 @@ class NewApi(Api):
         result = value
         try:
             result = win32evtlog.EvtFormatMessage(metadata, event, field)
-        except:
+        except Exception:
             pass
 
         return result
@@ -490,7 +490,7 @@ class NewApi(Api):
             metadata = win32evtlog.EvtOpenPublisherMetadata(
                 vals[win32evtlog.EvtSystemProviderName][0]
             )
-        except:
+        except Exception:
             pass
 
         result["Message"] = self._FormattedMessage(
@@ -572,7 +572,7 @@ class NewApi(Api):
         except Exception as e:
             try:
                 self._logger.info("%s", six.text_type(e))
-            except:
+            except Exception:
                 self._logger.info("Error printing exception information")
 
     def log_event(self, event):
@@ -718,7 +718,7 @@ and System sources:
             checkpoints = scalyr_util.read_file_as_json(
                 self.__checkpoint_file, strict_utf8=True
             )
-        except:
+        except Exception:
             self._logger.info(
                 "No checkpoint file '%s' exists.\nAll logs will be read starting from their current end.",
                 self.__checkpoint_file,
@@ -744,7 +744,7 @@ and System sources:
             try:
                 if windll.wevtapi:
                     evtapi = True
-            except:
+            except Exception:
                 pass
 
         result = None

--- a/scalyr_agent/builtin_monitors/windows_system_metrics.py
+++ b/scalyr_agent/builtin_monitors/windows_system_metrics.py
@@ -596,5 +596,5 @@ class SystemMonitor(ScalyrMonitor):
                         self._logger.emit_value(
                             metric_name, metric_value, extra_fields=extra_fields
                         )
-        except:
+        except Exception:
             self._logger.exception("Failed to gather sample due to exception")

--- a/scalyr_agent/compat.py
+++ b/scalyr_agent/compat.py
@@ -14,7 +14,7 @@
 
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     from typing import Union, Tuple, Any, Generator, Iterable, Optional
 
 import sys

--- a/scalyr_agent/config_main.py
+++ b/scalyr_agent/config_main.py
@@ -757,8 +757,8 @@ def run_command(command_str, exit_on_fail=True, command_name=None, grep_for=None
     @return: The exist status of the command.
     """
     # We have to use a temporary file to hold the output to stdout and stderr.
-    _, output_file = tempfile.mkstemp()
-    output_fp = open(output_file, "w")
+    output_file_fd, output_file = tempfile.mkstemp()
+    output_fp = os.fdopen(output_file_fd, "w")
 
     try:
         # NOTE: To avoid shell injection we need to be careful that each comamnd_str which is passed

--- a/scalyr_agent/config_main.py
+++ b/scalyr_agent/config_main.py
@@ -757,7 +757,7 @@ def run_command(command_str, exit_on_fail=True, command_name=None, grep_for=None
     @return: The exist status of the command.
     """
     # We have to use a temporary file to hold the output to stdout and stderr.
-    output_file = tempfile.mktemp()
+    _, output_file = tempfile.mkstemp()
     output_fp = open(output_file, "w")
 
     try:

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -3258,7 +3258,7 @@ class Configuration(object):
             if value is not None:
                 re.compile(value)
                 return
-        except:
+        except Exception:
             raise BadConfiguration(
                 'The value for required field "%s" has a value that cannot be parsed as '
                 "string regular expression (using python syntax).  "

--- a/scalyr_agent/date_parsing_utils.py
+++ b/scalyr_agent/date_parsing_utils.py
@@ -18,7 +18,7 @@ Module containing various date parsing related utility functions.
 
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     from typing import Optional
 
 import re

--- a/scalyr_agent/json_lib/objects.py
+++ b/scalyr_agent/json_lib/objects.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import
 
 __author__ = "czerwin@scalyr.com"
 
-if False:
+if False:  # NOSONAR
     # NOTE: This is a workaround for old Python versions where typing module is not available
     # We should eventually improve that once we start producing distributions with Python
     # interpreter and dependencies bundled in.

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -2938,7 +2938,6 @@ class LogLineRedacter(object):
                     replacement_matches += 1
                     if group_hash_indicator in replacement_ex:
                         # the group needs to be hashed
-                        replaced_group = replaced_group
                         replaced_group = replaced_group.replace(
                             group_hash_indicator,
                             scalyr_util.md5_hexdigest(

--- a/scalyr_agent/monitor_utils/blocking_rate_limiter.py
+++ b/scalyr_agent/monitor_utils/blocking_rate_limiter.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 
 __author__ = "echee@scalyr.com"
 
-if False:
+if False:  # NOSONAR
     from typing import Dict
 
 import random

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -1970,7 +1970,7 @@ class KubernetesApi(object):
             if rate_limited:
                 kapi = os.path.join(kapi, "limited")
             else:
-                kapi = os.path.join(kapi, "limited")
+                kapi = os.path.join(kapi, "not_limited")
             if not os.path.exists(kapi):
                 os.mkdir(kapi, 0o755)
             fname = "%s_%.20f_%s_%s" % (

--- a/scalyr_agent/monitors_manager.py
+++ b/scalyr_agent/monitors_manager.py
@@ -17,7 +17,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     from typing import List
 
 __author__ = "czerwin@scalyr.com"
@@ -166,7 +166,7 @@ class MonitorsManager(StoppableThread):
                     scalyr_logging.DEBUG_LEVEL_0,
                     "Scalyr Monitors disabled.  Skipping monitor manager thread",
                 )
-        except:
+        except Exception:
             log.exception("Failed to start the monitors due to an exception")
 
     def stop_manager(self, wait_on_join=True, join_timeout=5):
@@ -186,7 +186,7 @@ class MonitorsManager(StoppableThread):
             try:
                 log.info("Stopping monitor %s", monitor.monitor_name)
                 monitor.stop(wait_on_join=False)
-            except:
+            except Exception:
                 log.exception(
                     "Failed to stop the metric log without join due to an exception"
                 )
@@ -199,14 +199,14 @@ class MonitorsManager(StoppableThread):
                 # noinspection PyBroadException
                 try:
                     monitor.stop(join_timeout=max_wait)
-                except:
+                except Exception:
                     log.exception("Failed to stop the metric log due to an exception")
 
         for monitor in self.__running_monitors:
             # noinspection PyBroadException
             try:
                 monitor.close_metric_log()
-            except:
+            except Exception:
                 log.exception("Failed to close the metric log due to an exception")
 
         self.stop(wait_on_join=wait_on_join, join_timeout=join_timeout)

--- a/scalyr_agent/platform_controller.py
+++ b/scalyr_agent/platform_controller.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 
 __author__ = "czerwin@scalyr.com"
 
-if False:
+if False:  # NOSONAR
     from typing import List
     from typing import Type
 

--- a/scalyr_agent/platform_posix.py
+++ b/scalyr_agent/platform_posix.py
@@ -410,7 +410,7 @@ class PosixPlatformController(PlatformController):
                         return None
                     else:
                         return ppid
-                except:
+                except Exception:
                     return None
             finally:
                 if pf is not None:

--- a/scalyr_agent/profiler.py
+++ b/scalyr_agent/profiler.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 
 __author__ = "imron@scalyr.com"
 
-if False:
+if False:  # NOSONAR
     from typing import Optional
     from typing import Dict
     from typing import List

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import
 
 __author__ = "czerwin@scalyr.com"
 
-if False:
+if False:  # NOSONAR
     from typing import Dict
 
     # Workaround for a cyclic import - scalyr_monitor depends on scalyr_logging and vice versa
@@ -207,7 +207,7 @@ def currentframe():
     # noinspection PyBroadException
     try:
         raise Exception
-    except:
+    except Exception:
         return sys.exc_info()[2].tb_frame.f_back
 
 

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import
 
 __author__ = "czerwin@scalyr.com"
 
-if False:
+if False:  # NOSONAR
     from typing import Dict
     from types import ModuleType
 

--- a/scalyr_agent/test_base.py
+++ b/scalyr_agent/test_base.py
@@ -20,7 +20,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from __future__ import print_function
 
-if False:
+if False:  # NOSONAR
     from typing import Optional
 
 from io import open

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 
 import re
 
-if False:
+if False:  # NOSONAR
     from typing import Union
     from typing import Tuple
     from typing import Callable
@@ -623,7 +623,7 @@ def get_pid_tid():
             six.text_type(os.getpid()),
             six.text_type(six.moves._thread.get_ident()),
         )
-    except:
+    except Exception:
         return "(pid=%s) (tid=Unknown)" % (six.text_type(os.getpid()))
 
 
@@ -634,7 +634,7 @@ def is_list_of_strings(vals):
         for val in vals:
             if not isinstance(val, six.string_types):
                 return False
-    except:
+    except Exception:
         # vals is not enumerable
         return False
 

--- a/scripts/circleci_usage_data.py
+++ b/scripts/circleci_usage_data.py
@@ -26,7 +26,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from scalyr_agent import compat
 
-if False:
+if False:  # NOSONAR
     from typing import Optional
     from typing import List
 

--- a/scripts/verify-add-events-api-response-headers.py
+++ b/scripts/verify-add-events-api-response-headers.py
@@ -21,7 +21,7 @@ scenarios.
 from __future__ import absolute_import
 from __future__ import print_function
 
-if False:
+if False:  # NOSONAR
     from typing import List
 
 import json

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -68,7 +68,7 @@ combination of both.
 from __future__ import absolute_import
 from __future__ import print_function
 
-if False:
+if False:  # NOSONAR
     from typing import List
     from typing import Optional
 

--- a/tests/ami/utils.py
+++ b/tests/ami/utils.py
@@ -14,7 +14,7 @@
 
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     from typing import Optional
 
 from scalyr_agent import compat

--- a/tests/common.py
+++ b/tests/common.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-if False:
+if False:  # NOSONAR
     from typing import Optional
     from typing import Union
     from typing import Tuple

--- a/tests/distribution/python_version_change_tests/common.py
+++ b/tests/distribution/python_version_change_tests/common.py
@@ -79,7 +79,7 @@ def _link_to_default_python(command):
 
     try:
         os.remove(python_path)
-    except:
+    except Exception:
         pass
 
     os.symlink(six.text_type(BINARY_DIR_PATH / real_executable_path), python_path)

--- a/tests/smoke_tests/monitors_test/mysql_test.py
+++ b/tests/smoke_tests/monitors_test/mysql_test.py
@@ -16,7 +16,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     from typing import Dict
     from typing import Any
 

--- a/tests/smoke_tests/monitors_test/nginx_test.py
+++ b/tests/smoke_tests/monitors_test/nginx_test.py
@@ -16,7 +16,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     from typing import Dict
     from typing import Any
 

--- a/tests/smoke_tests/monitors_test/shell_monitor_test.py
+++ b/tests/smoke_tests/monitors_test/shell_monitor_test.py
@@ -16,7 +16,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     from typing import Dict
     from typing import Any
 

--- a/tests/smoke_tests/monitors_test/syslog_test.py
+++ b/tests/smoke_tests/monitors_test/syslog_test.py
@@ -16,7 +16,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     from typing import Dict
     from typing import Any
 

--- a/tests/smoke_tests/monitors_test/url_monitor_test.py
+++ b/tests/smoke_tests/monitors_test/url_monitor_test.py
@@ -16,7 +16,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     from typing import Dict
     from typing import Any
 

--- a/tests/smoke_tests/verifier.py
+++ b/tests/smoke_tests/verifier.py
@@ -252,7 +252,7 @@ class AgentLogVerifier(AgentVerifier):
         print("Send query to Scalyr server.")
         try:
             response_data = self._request.send()
-        except:
+        except Exception:
             print("Query failed.")
             return
 
@@ -317,7 +317,7 @@ class DataJsonVerifier(AgentVerifier):
     def _verify(self):
         try:
             response = self._request.send()
-        except:
+        except Exception:
             print("Query failed.")
             return
 
@@ -370,7 +370,7 @@ class SystemMetricsVerifier(AgentVerifier):
     def _verify(self):
         try:
             response = self._request.send()
-        except:
+        except Exception:
             print("Query failed.")
             return
 
@@ -403,7 +403,7 @@ class ProcessMetricsVerifier(AgentVerifier):
     def _verify(self):
         try:
             response = self._request.send()
-        except:
+        except Exception:
             print("Query failed.")
             return
 

--- a/tests/unit/scalyr_logging_test.py
+++ b/tests/unit/scalyr_logging_test.py
@@ -91,7 +91,11 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
     def test_metric_logging(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
-        _, metric_file_path = tempfile.mkstemp(".log")
+        metric_file_fd, metric_file_path = tempfile.mkstemp(".log")
+
+        # NOTE: We close the fd here because we open it again below. This way file deletion at
+        # the end works correctly on Windows.
+        os.close(metric_file_fd)
 
         monitor_logger = scalyr_logging.getLogger(
             "scalyr_agent.builtin_monitors.foo(1)"
@@ -115,7 +119,12 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
     def test_metric_logging_metric_name_blacklist(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
         monitor_instance._metric_name_blacklist = ["name1", "name3"]
-        _, metric_file_path = tempfile.mkstemp(".log")
+
+        metric_file_fd, metric_file_path = tempfile.mkstemp(".log")
+
+        # NOTE: We close the fd here because we open it again below. This way file deletion at
+        # the end works correctly on Windows.
+        os.close(metric_file_fd)
 
         monitor_logger = scalyr_logging.getLogger(
             "scalyr_agent.builtin_monitors.foo(1)"
@@ -160,7 +169,12 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
         monitor_1 = ScalyrMonitor(
             monitor_config=monitor_1_config, logger=monitor_1_logger
         )
-        _, monitor_1_metric_file_path = tempfile.mkstemp(".log")
+
+        metric_file_fd, monitor_1_metric_file_path = tempfile.mkstemp(".log")
+
+        # NOTE: We close the fd here because we open it again below. This way file deletion at
+        # the end works correctly on Windows.
+        os.close(metric_file_fd)
 
         monitor_2_config = {"module": "foo2", "metric_name_blacklist": ["c", "d"]}
         monitor_2_logger = scalyr_logging.getLogger(
@@ -169,7 +183,12 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
         monitor_2 = ScalyrMonitor(
             monitor_config=monitor_2_config, logger=monitor_1_logger
         )
-        _, monitor_2_metric_file_path = tempfile.mkstemp(".log")
+
+        metric_file_fd, monitor_2_metric_file_path = tempfile.mkstemp(".log")
+
+        # NOTE: We close the fd here because we open it again below. This way file deletion at
+        # the end works correctly on Windows.
+        os.close(metric_file_fd)
 
         monitor_1_logger.openMetricLogForMonitor(monitor_1_metric_file_path, monitor_1)
 
@@ -217,7 +236,12 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
     def test_logging_to_metric_log(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
-        _, metric_file_path = tempfile.mkstemp(".log")
+
+        metric_file_fd, metric_file_path = tempfile.mkstemp(".log")
+
+        # NOTE: We close the fd here because we open it again below. This way file deletion at
+        # the end works correctly on Windows.
+        os.close(metric_file_fd)
 
         monitor_logger = scalyr_logging.getLogger(
             "scalyr_agent.builtin_monitors.foo(1)"
@@ -238,7 +262,12 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
     def test_metric_logging_with_bad_name(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
-        _, metric_file_path = tempfile.mkstemp(".log")
+
+        metric_file_fd, metric_file_path = tempfile.mkstemp(".log")
+
+        # NOTE: We close the fd here because we open it again below. This way file deletion at
+        # the end works correctly on Windows.
+        os.close(metric_file_fd)
 
         monitor_logger = scalyr_logging.getLogger(
             "scalyr_agent.builtin_monitors.foo(1)"
@@ -264,7 +293,12 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
     def test_errors_for_monitor(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
-        _, metric_file_path = tempfile.mkstemp(".log")
+
+        metric_file_fd, metric_file_path = tempfile.mkstemp(".log")
+
+        # NOTE: We close the fd here because we open it again below. This way file deletion at
+        # the end works correctly on Windows.
+        os.close(metric_file_fd)
 
         monitor_logger = scalyr_logging.getLogger(
             "scalyr_agent.builtin_monitors.foo(1)"
@@ -280,8 +314,13 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
         monitor_one = ScalyrLoggingTest.FakeMonitor("testing one")
         monitor_two = ScalyrLoggingTest.FakeMonitor("testing two")
 
-        _, metric_file_one = tempfile.mkstemp(".log")
-        _, metric_file_two = tempfile.mkstemp(".log")
+        metric_file_one_fd, metric_file_one = tempfile.mkstemp(".log")
+        metric_file_two_fd, metric_file_two = tempfile.mkstemp(".log")
+
+        # NOTE: We close the fd here because we open it again below. This way file deletion at
+        # the end works correctly on Windows.
+        os.close(metric_file_one_fd)
+        os.close(metric_file_two_fd)
 
         logger_one = scalyr_logging.getLogger("scalyr_agent.builtin_monitors.foo(1)")
         logger_two = scalyr_logging.getLogger("scalyr_agent.builtin_monitors.foo(2)")
@@ -311,7 +350,12 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
     def test_pass_in_module_with_metric(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
-        _, metric_file_path = tempfile.mkstemp(".log")
+
+        metric_file_fd, metric_file_path = tempfile.mkstemp(".log")
+
+        # NOTE: We close the fd here because we open it again below. This way file deletion at
+        # the end works correctly on Windows.
+        os.close(metric_file_fd)
 
         monitor_logger = scalyr_logging.getLogger(
             "scalyr_agent.builtin_monitors.foo(1)"

--- a/tests/unit/scalyr_logging_test.py
+++ b/tests/unit/scalyr_logging_test.py
@@ -91,7 +91,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
     def test_metric_logging(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
-        metric_file_path = tempfile.mktemp(".log")
+        _, metric_file_path = tempfile.mkstemp(".log")
 
         monitor_logger = scalyr_logging.getLogger(
             "scalyr_agent.builtin_monitors.foo(1)"
@@ -115,7 +115,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
     def test_metric_logging_metric_name_blacklist(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
         monitor_instance._metric_name_blacklist = ["name1", "name3"]
-        metric_file_path = tempfile.mktemp(".log")
+        _, metric_file_path = tempfile.mkstemp(".log")
 
         monitor_logger = scalyr_logging.getLogger(
             "scalyr_agent.builtin_monitors.foo(1)"
@@ -160,7 +160,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
         monitor_1 = ScalyrMonitor(
             monitor_config=monitor_1_config, logger=monitor_1_logger
         )
-        monitor_1_metric_file_path = tempfile.mktemp(".log")
+        _, monitor_1_metric_file_path = tempfile.mkstemp(".log")
 
         monitor_2_config = {"module": "foo2", "metric_name_blacklist": ["c", "d"]}
         monitor_2_logger = scalyr_logging.getLogger(
@@ -169,7 +169,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
         monitor_2 = ScalyrMonitor(
             monitor_config=monitor_2_config, logger=monitor_1_logger
         )
-        monitor_2_metric_file_path = tempfile.mktemp(".log")
+        _, monitor_2_metric_file_path = tempfile.mkstemp(".log")
 
         monitor_1_logger.openMetricLogForMonitor(monitor_1_metric_file_path, monitor_1)
 
@@ -217,7 +217,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
     def test_logging_to_metric_log(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
-        metric_file_path = tempfile.mktemp(".log")
+        _, metric_file_path = tempfile.mkstemp(".log")
 
         monitor_logger = scalyr_logging.getLogger(
             "scalyr_agent.builtin_monitors.foo(1)"
@@ -238,7 +238,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
     def test_metric_logging_with_bad_name(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
-        metric_file_path = tempfile.mktemp(".log")
+        _, metric_file_path = tempfile.mkstemp(".log")
 
         monitor_logger = scalyr_logging.getLogger(
             "scalyr_agent.builtin_monitors.foo(1)"
@@ -264,7 +264,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
     def test_errors_for_monitor(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
-        metric_file_path = tempfile.mktemp(".log")
+        _, metric_file_path = tempfile.mkstemp(".log")
 
         monitor_logger = scalyr_logging.getLogger(
             "scalyr_agent.builtin_monitors.foo(1)"
@@ -280,8 +280,8 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
         monitor_one = ScalyrLoggingTest.FakeMonitor("testing one")
         monitor_two = ScalyrLoggingTest.FakeMonitor("testing two")
 
-        metric_file_one = tempfile.mktemp(".log")
-        metric_file_two = tempfile.mktemp(".log")
+        _, metric_file_one = tempfile.mkstemp(".log")
+        _, metric_file_two = tempfile.mkstemp(".log")
 
         logger_one = scalyr_logging.getLogger("scalyr_agent.builtin_monitors.foo(1)")
         logger_two = scalyr_logging.getLogger("scalyr_agent.builtin_monitors.foo(2)")
@@ -311,7 +311,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
     def test_pass_in_module_with_metric(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
-        metric_file_path = tempfile.mktemp(".log")
+        _, metric_file_path = tempfile.mkstemp(".log")
 
         monitor_logger = scalyr_logging.getLogger(
             "scalyr_agent.builtin_monitors.foo(1)"

--- a/tests/unit/syslog_monitor_test.py
+++ b/tests/unit/syslog_monitor_test.py
@@ -139,7 +139,7 @@ class SyslogMonitorTestCase(unittest.TestCase):
             func()
         except Exception as e:
             self.fail("Unexpected Exception: %s" % six.text_type(e))
-        except:
+        except Exception:
             self.fail("Unexpected Exception: %s" % sys.exc_info()[0])
 
 
@@ -366,7 +366,7 @@ class SyslogMonitorConnectTest(SyslogMonitorTestCase):
             try:
                 socket.connect(addr)
                 connected = True
-            except:
+            except Exception:
                 time.sleep(0.1)
             tries += 1
 

--- a/tests/unit/test_memory_leaks.py
+++ b/tests/unit/test_memory_leaks.py
@@ -20,7 +20,7 @@ are not present anymore.
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     from typing import Any
     from typing import Set
 

--- a/tests/unit/test_profilers.py
+++ b/tests/unit/test_profilers.py
@@ -96,7 +96,11 @@ class CPUProfilerTestCase(unittest.TestCase):
 
     @mock.patch("scalyr_agent.profiler.yappi", MOCK_YAPPI)
     def test_profiling_data_is_written_on_stop(self):
-        _, data_file_path = tempfile.mkstemp()
+        data_file_fd, data_file_path = tempfile.mkstemp()
+
+        # NOTE: We close the fd here because we open it again below. This way file deletion at
+        # the end works correctly on Windows.
+        os.close(data_file_fd)
 
         MOCK_CONFIG.enable_profiling = True
         MOCK_CONFIG.profile_log_name = data_file_path
@@ -145,7 +149,11 @@ class MemoryProfilerTestCase(unittest.TestCase):
     @mock.patch("scalyr_agent.profiler.pympler", MOCK_PYMPLER)
     def test_profiling_data_is_written_on_stop(self):
         # Verify data is written on _stop method call
-        _, data_file_path = tempfile.mkstemp()
+        data_file_fd, data_file_path = tempfile.mkstemp()
+
+        # NOTE: We close the fd here because we open it again below. This way file deletion at
+        # the end works correctly on Windows.
+        os.close(data_file_fd)
 
         MOCK_CONFIG.enable_profiling = True
         MOCK_CONFIG.memory_profile_log_name = data_file_path

--- a/tests/utils/agent_runner.py
+++ b/tests/utils/agent_runner.py
@@ -20,7 +20,7 @@ import shutil
 import os
 import atexit
 
-if False:
+if False:  # NOSONAR
     from typing import Dict, Optional, Any
 
 import copy

--- a/tests/utils/image_builder.py
+++ b/tests/utils/image_builder.py
@@ -21,7 +21,7 @@ import docker
 import argparse
 import hashlib
 
-if False:
+if False:  # NOSONAR
     from typing import Optional
     from typing import List
     from typing import Type

--- a/tests/utils/log_reader.py
+++ b/tests/utils/log_reader.py
@@ -16,7 +16,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
 
-if False:
+if False:  # NOSONAR
     from typing import Optional
 
 import re


### PR DESCRIPTION
This pull request adds back ``tempfile.mkstemp`` and other changes which were reverted in #566.

It also fixes the code which utilizes ``tempfile.mkstemp`` so it works correctly on Windows in places where we delete temporary created file at the end.

## Background, Context

Those changes broke the build, because the default``os.remove`` / ``os.unlink`` behavior is not the same on Linux and Windows.

On Linux, if you will try to delete a file which is still open it will work, but on Windows it will fail.

By default, ``tempfile.mkstemp()`` returns open file handle (in addition to the temporary file path).

If we don't explicitly close that file handle, deletion of that file later on will fail on Windows.

## Proposed Fix / Change

In this PR, I use one of two approaches (depending on the context where the code it's used - if it's security sensitive where open a race could be an issue or if it's not).

In places where we can and where we want to avoid potential race with re-opening the file, we directly use open FD which is returned by tempfile.mkstemp.

In other places (mostly tests) where re-opening a file is not an issue and that file path is later on re-opened by some other code, we simply close the FD returned by tempfile.mkstemp.