### PR TITLE
[WIP] Upgrade coverage.py to latest stable version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ commands:
                 command: |
                   ls -la .coverage* || true
 
-                  pip install "coverage==4.5.4" "codecov==2.1.3"
+                  pip install -r coverage-requirements.txt
                   cp .circleci/.coveragerc_ci .coveragerc
 
                   # Print the report
@@ -436,7 +436,7 @@ commands:
                   # Each test function runs in an isolated Docker container and results in a new .coverage file which we need to combine
                   ls -la ~/artifacts/*/.coverage
 
-                  pip install "coverage==4.5.4" "codecov==2.1.3"
+                  pip install -r coverage-requirements.txt
                   cp .circleci/.coveragerc_ci .coveragerc
 
                   # Generate combined .coverage file for all our test functions

--- a/coverage-requirements.txt
+++ b/coverage-requirements.txt
@@ -1,0 +1,3 @@
+# Python requirements used by the code coverage tox targets
+coverage==5.1
+codecov==2.1.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,8 +12,6 @@ pytest-coverage
 pytest-timeout==1.3.4
 pytest-benchmark==3.2.3
 pytest-xdist==1.31.0
-coverage==4.5.4
-codecov==2.1.3
 decorator==4.4.1
 PyYAML==5.3
 six==1.13.0

--- a/tox.ini
+++ b/tox.ini
@@ -140,6 +140,10 @@ commands =
 
 # TODO: Once we make more progress, set coverage % threshold and fail a build if it's not reached
 [testenv:coverage]
+deps =
+    -r coverage-requirements.txt
+    -r dev-requirements.txt
+    -r benchmarks/micro/requirements-compression-algorithms.txt
 commands =
     rm -f .coverage
     rm -rf test-results


### PR DESCRIPTION
Small change which upgrades coverage.py dependency to the latest stable version and moves coverage related dependencies in a new requirements.txt file to avoid duplication (this way we also avoid installing it in some other scenarios where we don't need it).