### PR TITLE
Also run install only tests inside the AMI tests job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -618,12 +618,11 @@ commands:
           fail_only: true
           only_for_branches: master
 
-
   ami-tests:
     description: "Run scalyr agent packages sanity tests based on EC2/Libcloud."
     parameters:
       test_type:
-        description: "This parameter allows to decide which type of test has to be done. "
+        description: "Type of tests to run."
         type: enum
         enum: ["development", "stable"]
     steps:
@@ -676,9 +675,6 @@ commands:
             ./scripts/circleci/run-ami-tests-in-bg.sh << parameters.test_type >>
       - store_artifacts:
           path: outputs
-
-
-
 
 jobs:
   unittest-38:
@@ -1898,9 +1894,8 @@ jobs:
       - store_artifacts:
           path: artifacts
 
-
-  stable-ami-tests:
-    description: "Run scalyr agent packages sanity tests for the stable packages from the Scalyr repository."
+  ami-tests-stable:
+    description: "Run scalyr agent packages install sanity tests for the stable packages from the Scalyr repository."
     working_directory: ~/scalyr-agent-2
     docker:
       - image: circleci/python:3.6-jessie
@@ -1908,7 +1903,7 @@ jobs:
       - ami-tests:
           test_type: "stable"
 
-  development-ami-tests:
+  ami-tests-development:
     description: "Run scalyr agent packages sanity tests for the new packages which are built on the current revision."
     working_directory: ~/scalyr-agent-2
     docker:
@@ -1917,87 +1912,30 @@ jobs:
       - ami-tests:
           test_type: "development"
 
-
-#  ami-tests:
-#    description: "Run scalyr agent packages sanity tests based on EC2/Libcloud."
-#    working_directory: ~/scalyr-agent-2
-#    docker:
-#      - image: circleci/python:3.6-jessie
-#    steps:
-#      - add_ssh_keys:
-#            fingerprints:
-#              - "7b:26:91:6b:a0:9d:31:50:4c:8d:31:a3:a6:b8:f2:7a"
-#      - checkout
-#      - attach_workspace:
-#          at: /tmp/workspace
-#      - restore_cache:
-#          name: "Restore Python Dependencies cache"
-#          key: deps-<<pipeline.parameters.cache_version_py_dependencies>>-{{ .Branch }}-ami-tests-{{ checksum "tests/ami/requirements.txt" }}
-#      - run:
-#          name: Install Python Dependencies
-#          command: |
-#            # NOTE: We need to upgrade pip otherwise installation from git fails
-#            python -m pip install --user --upgrade pip
-#
-#            # Install dependencies
-#            python -m pip install --user "requests"
-#            python -m pip install --user -r tests/ami/requirements.txt
-#      - save_cache:
-#          name: "Save Python Dependencies cache"
-#          key: deps-<<pipeline.parameters.cache_version_py_dependencies>>-{{ .Branch }}-ami-tests-{{ checksum "tests/ami/requirements.txt" }}
-#          paths:
-#            - "~/.cache/pip"
-#      - run:
-#          # Step which cleans up any old nodes which might have been left running because a
-#          # previous build was canceled half way through or similar
-#          name: Clean Up Old Stray EC2 Instances
-#          environment:
-#            KEY_NAME: "circleci"
-#            PRIVATE_KEY_PATH: "~/.ssh/id_rsa_7b26916ba09d31504c8d31a3a6b8f27a"
-#            PYTHONPATH: "."
-#          command: |
-#            export ACCESS_KEY=${AWS_ACCESS_KEY}
-#            export SECRET_KEY=${AWS_SECRET_KEY}
-#
-#            ./tests/ami/cleanup_old_test_instances.py
-#      - run:
-#          name: Run package tests on EC2 instances
-#          environment:
-#            KEY_NAME: "circleci"
-#            PRIVATE_KEY_PATH: "~/.ssh/id_rsa_7b26916ba09d31504c8d31a3a6b8f27a"
-#            PYTHONPATH: "."
-#          command: |
-#            export ACCESS_KEY=${AWS_ACCESS_KEY}
-#            export SECRET_KEY=${AWS_SECRET_KEY}
-#
-#            ./scripts/circleci/run-ami-tests-in-bg.sh
-#      - store_artifacts:
-#          path: outputs
-
 workflows:
   version: 2
-#  unit-tests:
-#    # NOTE: To avoid massive and inflated build matrix, we currently don't run tests under multiple
-#    # Python 3 versions
-#    jobs:
-#      - lint-checks
-#      - unittest-26
-#      - unittest-27
-#      - unittest-35
-#      - unittest-35-osx
-#      - unittest-35-windows
-#  smoke-tests:
-#    jobs:
-#      - smoke-standalone-26
-#      - smoke-standalone-27
-#      - smoke-standalone-35
-#      - smoke-standalone-26-tls12
-#      - smoke-standalone-27-tls12
-#       # NOTE: smoke test jobs below still use old smoke tests framework
-#      - smoke-docker-json
-#      - smoke-docker-syslog
-#      - smoke-k8s
-#      - smoke-monitors-tests
+  unit-tests:
+    # NOTE: To avoid massive and inflated build matrix, we currently don't run tests under multiple
+    # Python 3 versions
+    jobs:
+      - lint-checks
+      - unittest-26
+      - unittest-27
+      - unittest-35
+      - unittest-35-osx
+      - unittest-35-windows
+  smoke-tests:
+    jobs:
+      - smoke-standalone-26
+      - smoke-standalone-27
+      - smoke-standalone-35
+      - smoke-standalone-26-tls12
+      - smoke-standalone-27-tls12
+       # NOTE: smoke test jobs below still use old smoke tests framework
+      - smoke-docker-json
+      - smoke-docker-syslog
+      - smoke-k8s
+      - smoke-monitors-tests
   package-tests:
     jobs:
       - build-linux-packages
@@ -2022,41 +1960,57 @@ workflows:
           requires:
             - package-test-deb
           <<: *master_and_release_only
-      - development-ami-tests:
+      - ami-tests-development:
           requires:
             - build-windows-package
             - build-linux-packages
           #<<: *master_and_release_only
-      - stable-ami-tests
-#  benchmarks:
-#    jobs:
-#      - benchmarks-micro-py-27
-#      - benchmarks-micro-py-35
-#      - benchmarks-idle-agent-py-27:
-#          <<: *benchmarks_master_and_release_only
-#      - benchmarks-idle-agent-py-35:
-#          <<: *benchmarks_master_and_release_only
-#      - benchmarks-idle-agent-no-monitors-py-27:
-#          <<: *benchmarks_master_and_release_only
-#      - benchmarks-idle-agent-no-monitors-py-35:
-#          <<: *benchmarks_master_and_release_only
-#      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
-#          <<: *benchmarks_master_and_release_only
-#      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
-#          <<: *benchmarks_master_and_release_only
-#      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
-#          <<: *benchmarks_master_and_release_only
-#      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
-#          <<: *benchmarks_master_and_release_only
-#      - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
-#          <<: *benchmarks_master_and_release_only
-#  weekly-circle-ci-usage-report:
-#    triggers:
-#      - schedule:
-#          cron: "0 0 * * 0"
-#          filters:
-#            branches:
-#              only:
-#                - master
-#    jobs:
-#      - send-circle-ci-usage-report
+      - ami-tests-stable
+  benchmarks:
+    jobs:
+      - benchmarks-micro-py-27
+      - benchmarks-micro-py-35
+      - benchmarks-idle-agent-py-27:
+          <<: *benchmarks_master_and_release_only
+      - benchmarks-idle-agent-py-35:
+          <<: *benchmarks_master_and_release_only
+      - benchmarks-idle-agent-no-monitors-py-27:
+          <<: *benchmarks_master_and_release_only
+      - benchmarks-idle-agent-no-monitors-py-35:
+          <<: *benchmarks_master_and_release_only
+      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
+          <<: *benchmarks_master_and_release_only
+      - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
+          <<: *benchmarks_master_and_release_only
+      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
+          <<: *benchmarks_master_and_release_only
+      - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
+          <<: *benchmarks_master_and_release_only
+      - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
+          <<: *benchmarks_master_and_release_only
+
+  weekly-circle-ci-usage-report:
+    triggers:
+      - schedule:
+          cron: "0 0 * * 0"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - send-circle-ci-usage-report
+
+  # We run AMI based package install tests which utilize installer script on
+  # daily basis.
+  # This helps us detect various installer script and other potential upstream
+  # issues.
+  daily-stable-ami-package-install-tests:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - ami-tests-stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1964,8 +1964,9 @@ workflows:
           requires:
             - build-windows-package
             - build-linux-packages
-          #<<: *master_and_release_only
-      - ami-tests-stable
+          <<: *master_and_release_only
+      - ami-tests-stable:
+          <<: *master_and_release_only
   benchmarks:
     jobs:
       - benchmarks-micro-py-27

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1944,7 +1944,7 @@ workflows:
           requires:
             - build-windows-package
             - build-linux-packages
-          <<: *master_and_release_only
+          #<<: *master_and_release_only
   benchmarks:
     jobs:
       - benchmarks-micro-py-27

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -23,7 +23,7 @@ mkdir -p outputs
 
 # Run sanity test for each image concurrently in background
 # Tests below utilize installer script to test installing latest stable version of the package
-python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=install--to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1804-install.log &
+python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1804-install.log &
 python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1604-install.log &
 python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1404-install.log &
 

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -21,14 +21,23 @@ echo "Runing AMI sanity tests concurrently in the background (this may take up t
 # Create directory which output log files will be saved
 mkdir -p outputs
 
-# run sanity test for each image concurrently in backgroung.
-python tests/ami/packages_sanity_tests.py --distro=WindowsServer2012 --type=install --to-version=/tmp/workspace/ScalyrAgentInstaller.msi &> outputs/WindowsServer2012.log &
-python tests/ami/packages_sanity_tests.py --distro=WindowsServer2016 --type=install --to-version=/tmp/workspace/ScalyrAgentInstaller.msi &> outputs/WindowsServer2016.log &
-python tests/ami/packages_sanity_tests.py --distro=WindowsServer2019 --type=install --to-version=/tmp/workspace/ScalyrAgentInstaller.msi &> outputs/WindowsServer2019.log &
-python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1804.log &
-python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1604.log &
-python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1404.log &
-python tests/ami/packages_sanity_tests.py --distro=centos7 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm &> outputs/centos7.log &
+# Run sanity test for each image concurrently in background
+# Tests below utilize installer script to test installing latest stable version of the package
+python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=install--to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1804-install.log &
+python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1604-install.log &
+python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1404-install.log &
+
+# Tests below install package which is built as part of a Circle CI job
+python tests/ami/packages_sanity_tests.py --distro=WindowsServer2012 --type=install --to-version=/tmp/workspace/ScalyrAgentInstaller.msi &> outputs/WindowsServer2012-install.log &
+python tests/ami/packages_sanity_tests.py --distro=WindowsServer2016 --type=install --to-version=/tmp/workspace/ScalyrAgentInstaller.msi &> outputs/WindowsServer2016-install.log &
+python tests/ami/packages_sanity_tests.py --distro=WindowsServer2019 --type=install --to-version=/tmp/workspace/ScalyrAgentInstaller.msi &> outputs/WindowsServer2019-install.log &
+
+# Tests below install latest stable version using an installer script and then upgrade to a
+# version which was built as part of a Circle CI job
+python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1804-upgrade.log &
+python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1604-upgrade.log &
+python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1404-upgrade.log &
+python tests/ami/packages_sanity_tests.py --distro=centos7 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm &> outputs/centos7-upgrade.log &
 
 # Store command line args and log paths for all the jobs for a friendlier output on failure
 JOBS_COMMAND_LINE_ARGS=()
@@ -40,7 +49,9 @@ do
     JOBS_COMMAND_LINE_ARGS[${job_pid}]=${JOB_COMMAND_LINE_ARGS}
 
     DISTRO_NAME=$(echo "${JOB_COMMAND_LINE_ARGS}" | awk -F "distro=" '{print $2}' | awk '{print $1}')
-    JOBS_LOG_FILE_PATHS[${job_pid}]="outputs/${DISTRO_NAME}.log"
+    TEST_TYPE=$(echo "${JOB_COMMAND_LINE_ARGS}" | awk -F "type=" '{print $2}' | awk '{print $1}')
+
+    JOBS_LOG_FILE_PATHS[${job_pid}]="outputs/${DISTRO_NAME}-${TEST_TYPE}.log"
 done
 
 echo ""

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -55,6 +55,7 @@ else
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1604-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1404-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=centos7 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm &> outputs/centos7-upgrade.log &
+  python tests/ami/packages_sanity_tests.py --distro=centos8 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm &> outputs/centos8-upgrade.log &
 fi
 
 # Store command line args and log paths for all the jobs for a friendlier output on failure

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -39,6 +39,8 @@ if [ "${TEST_TYPE}" == "stable" ]; then
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1804-install.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1604-install.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1404-install.log &
+  python tests/ami/packages_sanity_tests.py --distro=centos7 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/centos7-install.log &
+  python tests/ami/packages_sanity_tests.py --distro=centos8 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/centos8-install.log &
 else
   echo "Run sanity tests for the new packages from the current revision."
 

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -16,9 +16,8 @@
 # Script which runs AMI based install and upgrade tests for various distros in
 # parallel.
 #
-# Usage: run-ami-tests-in-bg-sh [stabel|development
+# Usage: run-ami-tests-in-bg-sh [stable|development]
 #
-
 
 echo "Runing AMI sanity tests concurrently in the background (this may take up to 5 minutes)..."
 
@@ -27,13 +26,12 @@ mkdir -p outputs
 
 TEST_TYPE="$1"
 
-if [ "$TEST_TYPE" != "stable" ] && [ "$TEST_TYPE" != "development" ]; then
+if [ "${TEST_TYPE}" != "stable" ] && [ "${TEST_TYPE}" != "development" ]; then
     echo "Test type: 'stable' or 'development' must be specified."
     exit 1
 fi
 
-if [ "$TEST_TYPE" == "stable" ]; then
-
+if [ "${TEST_TYPE}" == "stable" ]; then
   echo "Run sanity tests for the stable package versions."
 
   # Run sanity test for each image concurrently in background
@@ -42,8 +40,7 @@ if [ "$TEST_TYPE" == "stable" ]; then
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1604-install.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1404-install.log &
 else
-
-  echo "Run sanity tests for the bew packages from the current revision."
+  echo "Run sanity tests for the new packages from the current revision."
 
   # Tests below install package which is built as part of a Circle CI job
   python tests/ami/packages_sanity_tests.py --distro=WindowsServer2012 --type=install --to-version=/tmp/workspace/ScalyrAgentInstaller.msi &> outputs/WindowsServer2012-install.log &

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -642,13 +642,6 @@ if __name__ == "__main__":
     )
     args = parser.parse_args(sys.argv[1:])
 
-    if args.distro == "centos8" and args.type == "upgrade":
-        raise ValueError(
-            "upgrade test is not supported on CentOS 8, because scalyr-agent-2 "
-            '2.0.x package depends on "python" package which is not available on '
-            "CentOS 8."
-        )
-
     if args.type == "install" and not args.to_version:
         raise ValueError("--to-version needs to be provided for install test")
 

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -275,10 +275,11 @@ def main(
     to_version,
     python_package,
     installer_script_url,
+    additional_packages=None,
     destroy_node=False,
     verbose=False,
 ):
-    # type: (str, str, str, str, str, str, bool, bool) -> None
+    # type: (str, str, str, str, str, str, str, bool, bool) -> None
 
     # deployment objects for package files will be stored here.
     file_upload_steps = []
@@ -351,6 +352,7 @@ def main(
         install_package=install_package_info,
         upgrade_package=upgrade_package_info,
         installer_script_url=installer_script_url,
+        additional_packages=additional_packages,
         verbose=verbose,
     )
 
@@ -458,9 +460,10 @@ def render_script_template(
     install_package=None,
     upgrade_package=None,
     installer_script_url=None,
+    additional_packages=None,
     verbose=False,
 ):
-    # type: (str, dict, str, str, Optional[Dict], Optional[Dict], Optional[str], bool) -> str
+    # type: (str, dict, str, str, Optional[Dict], Optional[Dict], Optional[str], Optional[str], bool) -> str
     """
     Render the provided script template with common context.
     """
@@ -481,6 +484,7 @@ def render_script_template(
 
     template_context["install_package"] = install_package
     template_context["upgrade_package"] = upgrade_package
+    template_context["additional_packages"] = additional_packages
 
     template_context["verbose"] = verbose
 
@@ -611,6 +615,12 @@ if __name__ == "__main__":
         required=False,
     )
     parser.add_argument(
+        "--additional-packages",
+        help=("Optional string of additional system level packages to install."),
+        required=False,
+    )
+
+    parser.add_argument(
         "--installer-script-url",
         help=("URL to the installer script to use."),
         default=DEFAULT_INSTALLER_SCRIPT_URL,
@@ -685,6 +695,7 @@ if __name__ == "__main__":
         to_version=args.to_version,
         python_package=args.python_package,
         installer_script_url=args.installer_script_url,
+        additional_packages=args.additional_packages,
         destroy_node=not args.no_destroy_node,
         verbose=args.verbose,
     )

--- a/tests/ami/scripts/test_deb.sh.j2
+++ b/tests/ami/scripts/test_deb.sh.j2
@@ -45,6 +45,10 @@ cat /etc/*-release
 sudo apt-get update -y
 sudo apt-get install -y "{{python_package}}"
 
+{% if additional_packages -%}
+sudo apt-get install -y {{additional_packages}}
+{% endif -%}
+
 # Install Sclayr agent.
 echo ""
 echo "Installing Scalyr agent"

--- a/tests/ami/scripts/test_rpm.sh.j2
+++ b/tests/ami/scripts/test_rpm.sh.j2
@@ -47,6 +47,11 @@ cat /etc/*-release
 sudo yum install -y wget
 sudo yum install -y "{{python_package}}"
 
+# Install any optional additional packages
+{% if additional_packages -%}
+sudo yum install -y {{additional_packages}}
+{% endif -%}
+
 # Install Sclayr agent.
 echo ""
 echo "Installing Scalyr agent"

--- a/tests/smoke_tests/verifier.py
+++ b/tests/smoke_tests/verifier.py
@@ -327,6 +327,11 @@ class DataJsonVerifier(AgentVerifier):
             print("Query failed.")
             return
 
+        if "matches" not in response:
+            print('Response is missing "matches" field')
+            print("Response data: %s" % (str(response)))
+            return
+
         matches = response["matches"]
         if len(matches) < self._lines_count:
             print(


### PR DESCRIPTION
This pull request updates AMI-tests script and Circle CI job so we also run install only tests which utilize latest stable version of the installer script to verify that installation of the latest stable agent package using the installer script works correctly.

---

We already have upgrade tests which also tests the install scenario / path, but it also doesn't hurt to have additional separate tests for the install only path (at least right now when we run those jobs in parallel and costs are very low).