### PR TITLE
Also run AMI end to end package tests in Debian 10 & Amazon Linux 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -634,7 +634,16 @@ commands:
       test_type:
         description: "Type of tests to run."
         type: enum
-        enum: ["development", "stable"]
+        enum:
+          - "development"
+          - "stable"
+        # URL to the installer script to use with the tests. We default to stable version, but
+        # you can change that value if you made changes to the installer script and you want
+        # to easily test them against all the distrod we run AMI tests on
+      installer_script_url:
+        description: "URL to the installer script which to use for the install and upgrade tests."
+        type: string
+        default: "https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh"
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -681,6 +690,7 @@ commands:
           command: |
             export ACCESS_KEY=${AWS_ACCESS_KEY}
             export SECRET_KEY=${AWS_SECRET_KEY}
+            export INSTALLER_SCRIPT_URL="<< parameters.installer_script_url >>"
 
             ./scripts/circleci/run-ami-tests-in-bg.sh << parameters.test_type >>
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1996,6 +1996,7 @@ jobs:
     steps:
       - ami-tests:
           test_type: "stable"
+          installer_script_url: "https://www.scalyr.com/scalyr-repo/4adfas/internal/latest/install-scalyr-agent-2-internal.sh"
 
   ami-tests-development:
     description: "Run scalyr agent packages sanity tests for the new packages which are built on the current revision."
@@ -2005,6 +2006,7 @@ jobs:
     steps:
       - ami-tests:
           test_type: "development"
+          installer_script_url: "https://www.scalyr.com/scalyr-repo/4adfas/internal/latest/install-scalyr-agent-2-internal.sh"
 
 workflows:
   version: 2
@@ -2069,9 +2071,7 @@ workflows:
           requires:
             - build-windows-package
             - build-linux-packages
-          <<: *master_and_release_only
-      - ami-tests-stable:
-          <<: *master_and_release_only
+      - ami-tests-stable
   benchmarks:
     jobs:
       - benchmarks-micro-py-27

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2059,9 +2059,7 @@ workflows:
           requires:
             - build-windows-package
             - build-linux-packages
-          <<: *master_and_release_only
-      - ami-tests-stable:
-          <<: *master_and_release_only
+      - ami-tests-stable
   benchmarks:
     jobs:
       - benchmarks-micro-py-27

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2059,7 +2059,9 @@ workflows:
           requires:
             - build-windows-package
             - build-linux-packages
-      - ami-tests-stable
+          <<: *master_and_release_only
+      - ami-tests-stable:
+          <<: *master_and_release_only
   benchmarks:
     jobs:
       - benchmarks-micro-py-27

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1996,7 +1996,6 @@ jobs:
     steps:
       - ami-tests:
           test_type: "stable"
-          installer_script_url: "https://www.scalyr.com/scalyr-repo/4adfas/internal/latest/install-scalyr-agent-2-internal.sh"
 
   ami-tests-development:
     description: "Run scalyr agent packages sanity tests for the new packages which are built on the current revision."
@@ -2006,7 +2005,6 @@ jobs:
     steps:
       - ami-tests:
           test_type: "development"
-          installer_script_url: "https://www.scalyr.com/scalyr-repo/4adfas/internal/latest/install-scalyr-agent-2-internal.sh"
 
 workflows:
   version: 2
@@ -2071,7 +2069,9 @@ workflows:
           requires:
             - build-windows-package
             - build-linux-packages
-      - ami-tests-stable
+          <<: *master_and_release_only
+      - ami-tests-stable:
+          <<: *master_and_release_only
   benchmarks:
     jobs:
       - benchmarks-micro-py-27

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -42,6 +42,7 @@ if [ "${TEST_TYPE}" == "stable" ]; then
   python tests/ami/packages_sanity_tests.py --distro=debian1003 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/debian1003-install.log &
   python tests/ami/packages_sanity_tests.py --distro=centos7 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/centos7-install.log &
   python tests/ami/packages_sanity_tests.py --distro=centos8 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/centos8-install.log &
+  python tests/ami/packages_sanity_tests.py --distro=amazonlinux2 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/amazonlinux2-install.log &
 else
   echo "Run sanity tests for the new packages from the current revision."
 
@@ -58,6 +59,7 @@ else
   python tests/ami/packages_sanity_tests.py --distro=debian1003 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/debian1003-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=centos7 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm &> outputs/centos7-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=centos8 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm &> outputs/centos8-upgrade.log &
+  python tests/ami/packages_sanity_tests.py --distro=amazonlinux2 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm &> outputs/amazonlinux2-upgrade.log &
 fi
 
 # Store command line args and log paths for all the jobs for a friendlier output on failure

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -39,7 +39,7 @@ if [ "${TEST_TYPE}" == "stable" ]; then
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1804-install.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1604-install.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1404-install.log &
-  python tests/ami/packages_sanity_tests.py --distro=ubuntu1003 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/debian1003-install.log &
+  python tests/ami/packages_sanity_tests.py --distro=debian1003 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/debian1003-install.log &
   python tests/ami/packages_sanity_tests.py --distro=centos7 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/centos7-install.log &
   python tests/ami/packages_sanity_tests.py --distro=centos8 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/centos8-install.log &
 else

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -19,7 +19,7 @@
 # Usage: run-ami-tests-in-bg-sh [stable|development]
 #
 
-echo "Runing AMI sanity tests concurrently in the background (this may take up to 5 minutes)..."
+echo "Runing AMI sanity tests concurrently in the background (this may take up to 5 minutes and no output may be produced by this script for up to 3 minutes)..."
 
 # Create directory which output log files will be saved
 mkdir -p outputs
@@ -39,6 +39,7 @@ if [ "${TEST_TYPE}" == "stable" ]; then
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1804-install.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1604-install.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1404-install.log &
+  python tests/ami/packages_sanity_tests.py --distro=ubuntu1003 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/debian1003-install.log &
   python tests/ami/packages_sanity_tests.py --distro=centos7 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/centos7-install.log &
   python tests/ami/packages_sanity_tests.py --distro=centos8 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/centos8-install.log &
 else
@@ -54,6 +55,7 @@ else
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1804-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1604-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1404-upgrade.log &
+  python tests/ami/packages_sanity_tests.py --distro=debian1003 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/debian1003-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=centos7 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm &> outputs/centos7-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=centos8 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm &> outputs/centos8-upgrade.log &
 fi

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -35,6 +35,7 @@ fi
 
 echo "Running AMI sanity tests concurrently in the background (this may take up to 5 minutes and no output may be produced by this script for up to 3 minutes)..."
 echo "Using INSTALLER_SCRIPT_URL=${INSTALLER_SCRIPT_URL}"
+echo ""
 
 if [ "${TEST_TYPE}" == "stable" ]; then
   echo "Run sanity tests for the stable package versions."

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -18,9 +18,6 @@
 #
 # Usage: run-ami-tests-in-bg-sh [stable|development]
 #
-
-echo "Running AMI sanity tests concurrently in the background (this may take up to 5 minutes and no output may be produced by this script for up to 3 minutes)..."
-
 # Create directory which output log files will be saved
 mkdir -p outputs
 
@@ -35,6 +32,9 @@ if [ "${TEST_TYPE}" != "stable" ] && [ "${TEST_TYPE}" != "development" ]; then
     echo "Test type: 'stable' or 'development' must be specified."
     exit 1
 fi
+
+echo "Running AMI sanity tests concurrently in the background (this may take up to 5 minutes and no output may be produced by this script for up to 3 minutes)..."
+echo "Using INSTALLER_SCRIPT_URL=${INSTALLER_SCRIPT_URL}"
 
 if [ "${TEST_TYPE}" == "stable" ]; then
   echo "Run sanity tests for the stable package versions."

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -19,12 +19,17 @@
 # Usage: run-ami-tests-in-bg-sh [stable|development]
 #
 
-echo "Runing AMI sanity tests concurrently in the background (this may take up to 5 minutes and no output may be produced by this script for up to 3 minutes)..."
+echo "Running AMI sanity tests concurrently in the background (this may take up to 5 minutes and no output may be produced by this script for up to 3 minutes)..."
 
 # Create directory which output log files will be saved
 mkdir -p outputs
 
 TEST_TYPE="$1"
+
+if [ -z "${INSTALLER_SCRIPT_URL}" ]; then
+    echo "INSTALLER_SCRIPT_URL environment variable not set"
+    exit 1
+fi
 
 if [ "${TEST_TYPE}" != "stable" ] && [ "${TEST_TYPE}" != "development" ]; then
     echo "Test type: 'stable' or 'development' must be specified."
@@ -36,13 +41,13 @@ if [ "${TEST_TYPE}" == "stable" ]; then
 
   # Run sanity test for each image concurrently in background
   # Tests below utilize installer script to test installing latest stable version of the package
-  python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1804-install.log &
-  python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1604-install.log &
-  python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/ubuntu1404-install.log &
-  python tests/ami/packages_sanity_tests.py --distro=debian1003 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/debian1003-install.log &
-  python tests/ami/packages_sanity_tests.py --distro=centos7 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/centos7-install.log &
-  python tests/ami/packages_sanity_tests.py --distro=centos8 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/centos8-install.log &
-  python tests/ami/packages_sanity_tests.py --distro=amazonlinux2 --type=install --to-version=current --installer-script-url="https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" &> outputs/amazonlinux2-install.log &
+  python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/ubuntu1804-install.log &
+  python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/ubuntu1604-install.log &
+  python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/ubuntu1404-install.log &
+  python tests/ami/packages_sanity_tests.py --distro=debian1003 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/debian1003-install.log &
+  python tests/ami/packages_sanity_tests.py --distro=centos7 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/centos7-install.log &
+  python tests/ami/packages_sanity_tests.py --distro=centos8 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/centos8-install.log &
+  python tests/ami/packages_sanity_tests.py --distro=amazonlinux2 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/amazonlinux2-install.log &
 else
   echo "Run sanity tests for the new packages from the current revision."
 
@@ -53,13 +58,13 @@ else
 
   # Tests below install latest stable version using an installer script and then upgrade to a
   # version which was built as part of a Circle CI job
-  python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1804-upgrade.log &
-  python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1604-upgrade.log &
-  python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1404-upgrade.log &
-  python tests/ami/packages_sanity_tests.py --distro=debian1003 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/debian1003-upgrade.log &
-  python tests/ami/packages_sanity_tests.py --distro=centos7 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm &> outputs/centos7-upgrade.log &
-  python tests/ami/packages_sanity_tests.py --distro=centos8 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm &> outputs/centos8-upgrade.log &
-  python tests/ami/packages_sanity_tests.py --distro=amazonlinux2 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm &> outputs/amazonlinux2-upgrade.log &
+  python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=upgrade --from-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1804-upgrade.log &
+  python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=upgrade --from-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1604-upgrade.log &
+  python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=upgrade --from-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1404-upgrade.log &
+  python tests/ami/packages_sanity_tests.py --distro=debian1003 --type=upgrade --from-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/debian1003-upgrade.log &
+  python tests/ami/packages_sanity_tests.py --distro=centos7 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/centos7-upgrade.log &
+  python tests/ami/packages_sanity_tests.py --distro=centos8 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/centos8-upgrade.log &
+  python tests/ami/packages_sanity_tests.py --distro=amazonlinux2 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/amazonlinux2-upgrade.log &
 fi
 
 # Store command line args and log paths for all the jobs for a friendlier output on failure

--- a/tests/ami/README.md
+++ b/tests/ami/README.md
@@ -9,8 +9,23 @@ and run basic installer fresh install and upgrade sanity checks.
 For example usage and which variables need to be set, please refer to the
 script file module level docstring.
 
+## Supported Distros
 
-## Using Windows images.
+Right now tests run on the following distros and operating systems on each merge to master and
+also daily as part of our Circle CI job:
+
+* Ubunut 14.04
+* Ubunut 16.04
+* Ubunut 18.04
+* Debian 10
+* CentOS 7
+* CentOS 8
+* Amazon Linux 2
+* Windows Sever 2012
+* Windows Sever 2016
+* Windows Sever 2019
+
+## Using Windows images
 
 Apache Libcloud operates EC2 instances by ssh, so we need to install OpenSSH server on windows images
 before we can use them.

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -150,6 +150,13 @@ EC2_DISTRO_DETAILS_MAP = {
         "ssh_username": "ubuntu",
         "default_python_package_name": "python",
     },
+    "debian1003": {
+        "image_id": "ami-0b9a611a02047d3b1",
+        "image_name": "Debian 10 Buster",
+        "size_id": "t2.micro",
+        "ssh_username": "admin",
+        "default_python_package_name": "python",
+    },
     # NOTE: Currently doesn't work with 4096 RSA keys due to paramiko issues
     # Need to use 2048 bit key to test this one
     "centos6": {
@@ -328,7 +335,11 @@ def main(
         package_type = "windows"
         script_extension = "ps1"
     else:
-        package_type = "deb" if distro.startswith("ubuntu") else "rpm"
+        package_type = (
+            "deb"
+            if distro.startswith("ubuntu") or distro.startswith("debian")
+            else "rpm"
+        )
         script_extension = "sh"
 
     script_filename = "test_%s.%s.j2" % (package_type, script_extension)

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -129,6 +129,7 @@ BASE_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
 SCRIPTS_DIR = os.path.join(BASE_DIR, "scripts/")
 
 EC2_DISTRO_DETAILS_MAP = {
+    # Debian based distros
     "ubuntu1404": {
         "image_id": "ami-07957d39ebba800d5",
         "image_name": "Ubuntu Server 14.04 LTS (HVM)",
@@ -157,6 +158,7 @@ EC2_DISTRO_DETAILS_MAP = {
         "ssh_username": "admin",
         "default_python_package_name": "python",
     },
+    # RHEL based distros
     # NOTE: Currently doesn't work with 4096 RSA keys due to paramiko issues
     # Need to use 2048 bit key to test this one
     "centos6": {
@@ -180,6 +182,14 @@ EC2_DISTRO_DETAILS_MAP = {
         "ssh_username": "centos",
         "default_python_package_name": "python2",
     },
+    "amazonlinux2": {
+        "image_id": "ami-09d95fab7fff3776c",
+        "image_name": "Amazon Linux 2 AMI (HVM), SSD Volume Type",
+        "size_id": "t2.micro",
+        "ssh_username": "ec2-user",
+        "default_python_package_name": "python",
+    },
+    # Windows
     "WindowsServer2019": {
         "image_id": "ami-0f9790554e2b6bc8d",
         "image_name": "WindowsServer2019-SSH",

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -548,7 +548,7 @@ def destroy_node_and_cleanup(driver, node):
         destroy_volume_with_retry(driver=driver, volume=volume)
 
 
-def destroy_volume_with_retry(driver, volume, max_retries=10, retry_sleep_delay=5):
+def destroy_volume_with_retry(driver, volume, max_retries=12, retry_sleep_delay=5):
     # type: (NodeDriver, StorageVolume, int, int) -> bool
     """
     Destroy the provided volume retrying up to max_retries time if destroy fails because the volume


### PR DESCRIPTION
This pull request updates install and upgrade AMI package end to end tests so they also run under Debian 10.

As discussed before, we run tests for various distros in parallel so adding another distro doesn't increase overall build time as long as those distro tests don't take longer than the slowest distro tests (which is Windows at this point - it can take up to 4 minutes whereas most other distros finish in 2 minutes or less).