### PR TITLE
AGENT-413 Update Docker README for instructions building agent K8S image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -38,8 +38,8 @@ Use the following commands to build the respective images:
 
     cd scalyr-agent-2/docker
     python ../build_package.py --no-versioned-file-name k8s_builder
-    ./scalyr-docker-agent-syslog --extract-packages
-    docker build -t scalyr/scalyr-k8s-agent .
+    ./scalyr-k8s-agent --extract-packages
+    docker build -t scalyr/scalyr-k8s-agent -f Dockerfile.k8s .
 
 ## Running the Scalyr Agent in Docker
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,6 +34,13 @@ Use the following commands to build the respective images:
     ./scalyr-docker-agent-syslog --extract-packages
     docker build -t scalyr/scalyr-docker-agent-syslog .
 
+#### scalyr-k8s-agent
+
+    cd scalyr-agent-2/docker
+    python ../build_package.py --no-versioned-file-name k8s_builder
+    ./scalyr-docker-agent-syslog --extract-packages
+    docker build -t scalyr/scalyr-k8s-agent .
+
 ## Running the Scalyr Agent in Docker
 
 To run a Scalyr Agent container, you must do the following 3 things:


### PR DESCRIPTION
Add instructions for building the Scalyr Agent Kubernetes Docker image in `docker/README.md`.