### PR TITLE
Update AMI tests to cover Ubuntu system with yum-utils package scenario

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2070,7 +2070,8 @@ workflows:
             - build-windows-package
             - build-linux-packages
           <<: *master_and_release_only
-      - ami-tests-stable
+      - ami-tests-stable:
+          <<: *master_and_release_only
   benchmarks:
     jobs:
       - benchmarks-micro-py-27

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2070,8 +2070,7 @@ workflows:
             - build-windows-package
             - build-linux-packages
           <<: *master_and_release_only
-      - ami-tests-stable:
-          <<: *master_and_release_only
+      - ami-tests-stable
   benchmarks:
     jobs:
       - benchmarks-micro-py-27

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -43,7 +43,9 @@ if [ "${TEST_TYPE}" == "stable" ]; then
   # Run sanity test for each image concurrently in background
   # Tests below utilize installer script to test installing latest stable version of the package
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/ubuntu1804-install.log &
-  python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/ubuntu1604-install.log &
+  # NOTE: Here we also install "yum-utils" package so we test a regression where our installer
+  # would incorrectly detect yum as a package manager on Ubuntu system with yum-utils installed
+  python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=install --to-version=current --additional-packages=yum-utils --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/ubuntu1604-install.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/ubuntu1404-install.log &
   python tests/ami/packages_sanity_tests.py --distro=debian1003 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/debian1003-install.log &
   python tests/ami/packages_sanity_tests.py --distro=centos7 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/centos7-install.log &


### PR DESCRIPTION
This pull request adds regression test for a scenario where there is Ubuntu system with yum-utils package installed.

Before my fixes to the installer script, the script didn't correctly handle that scenario (it incorrectly detected package manager as being yum instead of apt).

I already ran those tests manually locally before, but it also makes sense to have it hooked up to the CI.