### PR TITLE
Log redis cluster replication offsets

### DIFF
--- a/docs/monitors/redis_monitor.md
+++ b/docs/monitors/redis_monitor.md
@@ -77,3 +77,10 @@ Here is an example with two hosts with passwords:
     for most monitors, however if you are expecting a high volume of logs you should set this to a low enough value
     such that the number of messages you receive in this interval does not exceed the value of `lines_to_fetch`, otherwise
     some log lines will be dropped.
+
+## Configuration Reference
+
+|||# Option                          ||| Usage
+|||# ``log_cluster_replication_info``||| Optional (defaults to false). If true, the monitor will record redis \
+                                         cluster's replication offsets, difference between master and replica, and how \
+                                         many seconds the replica is falling behind

--- a/scalyr_agent/builtin_monitors/redis_monitor.py
+++ b/scalyr_agent/builtin_monitors/redis_monitor.py
@@ -47,6 +47,7 @@ define_config_option(
     default=False,
 )
 
+
 class RedisHost(object):
     """Class that holds various information about a specific redis connection
     """
@@ -448,7 +449,9 @@ Here is an example with two hosts with passwords:
         )
 
         # Whether to record cluster replication information
-        self.log_cluster_replication_info = self._config.get("log_cluster_replication_info")
+        self.log_cluster_replication_info = self._config.get(
+            "log_cluster_replication_info"
+        )
 
         # Redis-py requires None rather than 0 if no timeout
         if self.__connection_timeout == 0:


### PR DESCRIPTION
This commit enables current redis monitor to log replication information of redis cluster.

Specifically, if the agent is running on a redis cluster master, redis
monitor will log replication offsets of both master and replica, as well
as offset differences and how many seconds the replica is falling behind