### PR TITLE
Workaround for Circle CI unittest step timing out in the unittest-35-windows job, upgrade dependencies, re-enable coverage for windows unittest job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -887,7 +887,11 @@ jobs:
       - run:
           name: Run Unit Tests under Python 3.5
           command: |
-            tox.exe -epy3.5-windows-unit-tests
+            echo "pre1"
+            #tox.exe -epy3.5-windows-unit-tests
+            echo "post2"
+            echo $?
+            exit 0
       - save_cache:
           name: Save Python Dependencies Cache
           key: deps-v3-<< pipeline.parameters.cache_version_py_dependencies >>-tox-{{ .Branch }}-3.5-windows-{{ checksum "dev-requirements.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -882,7 +882,7 @@ jobs:
           name: Install Python Dependencies
           command: |
             python.exe --version
-            python.exe -m pip install --user --upgrade "tox==3.14.3"
+            python.exe -m pip install --user --upgrade "tox==3.15.2"
             python.exe -m pip install --user --upgrade "pip==20.0.1"
       - run:
           name: Run Unit Tests under Python 3.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -887,10 +887,9 @@ jobs:
       - run:
           name: Run Unit Tests under Python 3.5
           command: |
-            # NOTE: If we don't redirect the output, Windows this step / job
-            # doesn't correctly exit even after the tox commands finishes.
-            # That's why we use redirect workaround. Sadly this means we don't
-            # see output immediately as it produced (using redirect + tee also
+            # NOTE: If we don't redirect the output, Windows this step doesn't correctly exit even
+            # after the tox commands finishes. That's why we use the redirect workaround. Sadly
+            # this means we don't see output immediately as it produced (using redirect + tee also
             # results in the job not exiting when tox command finishes).
             tox.exe -epy3.5-windows-unit-tests > output 2>&1
             EXIT_CODE=$?
@@ -2060,74 +2059,74 @@ jobs:
 
 workflows:
   version: 2
-  # static-analysis:
-  #   jobs:
-  #     - lint-checks
+  static-analysis:
+    jobs:
+      - lint-checks
   unit-tests:
     # NOTE: To avoid massive and inflated build matrix, we currently don't run tests under multiple
     # Python 3 versions
     jobs:
-      #- unittest-26
-      #- unittest-27
-      #- unittest-35
-      #- unittest-35-osx
+      - unittest-26
+      - unittest-27
+      - unittest-35
+      - unittest-35-osx
       - unittest-35-windows
-      # smoke-tests:
-      #   jobs:
-      #     - smoke-standalone-26
-      #     - smoke-standalone-27
-      #     - smoke-standalone-35
-      #     - smoke-standalone-26-tls12
-      #     - smoke-standalone-27-tls12
-      #      # NOTE: smoke test jobs below still use old smoke tests framework
-      #     - smoke-docker-json
-      #     - smoke-docker-syslog
-      #     - smoke-k8s
-      #     - smoke-monitors-tests
-      #     - sonarcloud-scan:
-      #         requires:
-      #           # NOTE: This is not ideal, but Circle CI doesn't support cross
-      #           # workflow dependencies (we can't wait on unittest-27 here) so we just wait on the
-      #           # slowest jobs
-      #           - smoke-docker-json
-      #           - smoke-docker-syslog
-      #           - smoke-k8s
-      #           - smoke-monitors-tests
-      # package-tests:
-      #   jobs:
-      #     - build-linux-packages
-      #     - build-windows-package
-      #     - package-test-rpm:
-      #         <<: *master_and_release_only
-      #     - package-test-deb:
-      #         <<: *master_and_release_only
-      #     - smoke-rpm-package-py2:
-      #         requires:
-      #           - package-test-rpm
-      #         <<: *master_and_release_only
-      #     - smoke-rpm-package-py3:
-      #         requires:
-      #           - package-test-rpm
-      #         <<: *master_and_release_only
-      #     - smoke-deb-package-py2:
-      #         requires:
-      #           - package-test-deb
-      #         <<: *master_and_release_only
-      #     - smoke-deb-package-py3:
-      #         requires:
-      #           - package-test-deb
-      #         <<: *master_and_release_only
-      #     - ami-tests-development:
-      #         requires:
-      #           - build-windows-package
-      #           - build-linux-packages
-      #         <<: *master_and_release_only
-      #     - ami-tests-stable:
-      #         <<: *master_and_release_only
+  smoke-tests:
+    jobs:
+      - smoke-standalone-26
+      - smoke-standalone-27
+      - smoke-standalone-35
+      - smoke-standalone-26-tls12
+      - smoke-standalone-27-tls12
+       # NOTE: smoke test jobs below still use old smoke tests framework
+      - smoke-docker-json
+      - smoke-docker-syslog
+      - smoke-k8s
+      - smoke-monitors-tests
+      - sonarcloud-scan:
+          requires:
+            # NOTE: This is not ideal, but Circle CI doesn't support cross
+            # workflow dependencies (we can't wait on unittest-27 here) so we just wait on the
+            # slowest jobs
+            - smoke-docker-json
+            - smoke-docker-syslog
+            - smoke-k8s
+            - smoke-monitors-tests
+  package-tests:
+    jobs:
+      - build-linux-packages
+      - build-windows-package
+      - package-test-rpm:
+          <<: *master_and_release_only
+      - package-test-deb:
+          <<: *master_and_release_only
+      - smoke-rpm-package-py2:
+          requires:
+            - package-test-rpm
+          <<: *master_and_release_only
+      - smoke-rpm-package-py3:
+          requires:
+            - package-test-rpm
+          <<: *master_and_release_only
+      - smoke-deb-package-py2:
+          requires:
+            - package-test-deb
+          <<: *master_and_release_only
+      - smoke-deb-package-py3:
+          requires:
+            - package-test-deb
+          <<: *master_and_release_only
+      - ami-tests-development:
+          requires:
+            - build-windows-package
+            - build-linux-packages
+          <<: *master_and_release_only
+      - ami-tests-stable:
+          <<: *master_and_release_only
   benchmarks:
     jobs:
-      #- benchmarks-micro-py-27
-      #- benchmarks-micro-py-35
+      - benchmarks-micro-py-27
+      - benchmarks-micro-py-35
       - benchmarks-idle-agent-py-27:
           <<: *benchmarks_master_and_release_only
       - benchmarks-idle-agent-py-35:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -887,16 +887,16 @@ jobs:
       - run:
           name: Run Unit Tests under Python 3.5
           command: |
-            echo "pre1"
+            # NOTE: If we don't redirect the output, Windows this step / job
+            # doesn't correctly exit even after the tox commands finishes.
+            # That's why we use redirect workaround. Sadly this means we don't
+            # see output immediately as it produced (using redirect + tee also
+            # results in the job not exiting when tox command finishes).
             tox.exe -epy3.5-windows-unit-tests > output 2>&1
-            echo $?
+            EXIT_CODE=$?
             cat output
-            echo "post2"
-            ps aux
-            #killall5 -9
-            #exit 0
-            ps aux
-          no_output_timeout: 1m
+            exit ${EXIT_CODE}
+          no_output_timeout: 4m
       - save_cache:
           name: Save Python Dependencies Cache
           key: deps-v3-<< pipeline.parameters.cache_version_py_dependencies >>-tox-{{ .Branch }}-3.5-windows-{{ checksum "dev-requirements.txt" }}
@@ -906,21 +906,20 @@ jobs:
           path: test-results
       - store_artifacts:
           path: test-results
-      # NOTE: coverage.py seems to be broken on Circle CI on Windows
-      # - run:
-      #     name: Submit Coverage Data to codecov.io
-      #     command: |
-      #       ls -la .coverage* || true
+      - run:
+          name: Submit Coverage Data to codecov.io
+          command: |
+            ls -la .coverage* || true
 
-      #       python.exe -m pip install "coverage==4.5.4" "codecov==2.1.3"
-      #       cp .circleci/.coveragerc_ci .coveragerc
+            python.exe -m pip install "coverage==4.5.4" "codecov==2.1.3"
+            cp .circleci/.coveragerc_ci .coveragerc
 
-      #       # Print the report
-      #       coverage.exe report -i
+            # Print the report
+            coverage.exe report -i
 
-      #       # Submit it to codecov.io
-      #       coverage.exe xml --rcfile=.coveragerc -i -o coverage.xml
-      #       ./scripts/submit-codecov-data.sh
+            # Submit it to codecov.io
+            coverage.exe xml --rcfile=.coveragerc -i -o coverage.xml
+            ./scripts/submit-codecov-data.sh
 
       # TODO: That's a temporary in-line definition from slack orb. We can remove it once
       # https://github.com/CircleCI-Public/slack-orb/pull/152 is merged

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ orbs:
 parameters:
   default_tox_version:
     type: string
-    default: "3.14.3"
+    default: "3.15.2"
   cache_version_docker_images:
     description: "Cache version suffix used for all the Docker image caches."
     type: string
@@ -72,7 +72,7 @@ commands:
       tox_version:
         description: "tox package version to use."
         type: string
-        default: "3.14.3"
+        default: "3.15.2"
       apt_dependencies:
         description: "Any optional apt dependencies which should be installed."
         type: string
@@ -272,7 +272,7 @@ commands:
       tox_version:
         description: "tox package version to use."
         type: string
-        default: "3.14.3"
+        default: "3.15.2"
       codespeed_executable:
         description: "CodeSpeed executable name."
         type: string
@@ -342,7 +342,7 @@ commands:
       tox_version:
         description: "tox package version to use."
         type: string
-        default: "3.14.3"
+        default: "3.15.2"
       pre_checkout_apt_dependencies:
         description: "Any optional apt dependencies which are installed before checkout step."
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@3.4.2
-  win: circleci/windows@2.2.0
+  win: circleci/windows@2.4.0
 
 # Global workflow level parameters
 parameters:
@@ -883,15 +883,20 @@ jobs:
           command: |
             python.exe --version
             python.exe -m pip install --user --upgrade "tox==3.15.2"
-            python.exe -m pip install --user --upgrade "pip==20.0.1"
+            python.exe -m pip install --user --upgrade "pip==20.1.1"
       - run:
           name: Run Unit Tests under Python 3.5
           command: |
             echo "pre1"
-            #tox.exe -epy3.5-windows-unit-tests
-            echo "post2"
+            tox.exe -epy3.5-windows-unit-tests > output 2>&1
             echo $?
-            exit 0
+            cat output
+            echo "post2"
+            ps aux
+            #killall5 -9
+            #exit 0
+            ps aux
+          no_output_timeout: 1m
       - save_cache:
           name: Save Python Dependencies Cache
           key: deps-v3-<< pipeline.parameters.cache_version_py_dependencies >>-tox-{{ .Branch }}-3.5-windows-{{ checksum "dev-requirements.txt" }}
@@ -2056,9 +2061,9 @@ jobs:
 
 workflows:
   version: 2
-  static-analysis:
-    jobs:
-      - lint-checks
+  # static-analysis:
+  #   jobs:
+  #     - lint-checks
   unit-tests:
     # NOTE: To avoid massive and inflated build matrix, we currently don't run tests under multiple
     # Python 3 versions
@@ -2122,8 +2127,8 @@ workflows:
       #         <<: *master_and_release_only
   benchmarks:
     jobs:
-      - benchmarks-micro-py-27
-      - benchmarks-micro-py-35
+      #- benchmarks-micro-py-27
+      #- benchmarks-micro-py-35
       - benchmarks-idle-agent-py-27:
           <<: *benchmarks_master_and_release_only
       - benchmarks-idle-agent-py-35:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2059,63 +2059,63 @@ workflows:
     # NOTE: To avoid massive and inflated build matrix, we currently don't run tests under multiple
     # Python 3 versions
     jobs:
-      - unittest-26
-      - unittest-27
-      - unittest-35
-      - unittest-35-osx
+      #- unittest-26
+      #- unittest-27
+      #- unittest-35
+      #- unittest-35-osx
       - unittest-35-windows
-  smoke-tests:
-    jobs:
-      - smoke-standalone-26
-      - smoke-standalone-27
-      - smoke-standalone-35
-      - smoke-standalone-26-tls12
-      - smoke-standalone-27-tls12
-       # NOTE: smoke test jobs below still use old smoke tests framework
-      - smoke-docker-json
-      - smoke-docker-syslog
-      - smoke-k8s
-      - smoke-monitors-tests
-      - sonarcloud-scan:
-          requires:
-            # NOTE: This is not ideal, but Circle CI doesn't support cross
-            # workflow dependencies (we can't wait on unittest-27 here) so we just wait on the
-            # slowest jobs
-            - smoke-docker-json
-            - smoke-docker-syslog
-            - smoke-k8s
-            - smoke-monitors-tests
-  package-tests:
-    jobs:
-      - build-linux-packages
-      - build-windows-package
-      - package-test-rpm:
-          <<: *master_and_release_only
-      - package-test-deb:
-          <<: *master_and_release_only
-      - smoke-rpm-package-py2:
-          requires:
-            - package-test-rpm
-          <<: *master_and_release_only
-      - smoke-rpm-package-py3:
-          requires:
-            - package-test-rpm
-          <<: *master_and_release_only
-      - smoke-deb-package-py2:
-          requires:
-            - package-test-deb
-          <<: *master_and_release_only
-      - smoke-deb-package-py3:
-          requires:
-            - package-test-deb
-          <<: *master_and_release_only
-      - ami-tests-development:
-          requires:
-            - build-windows-package
-            - build-linux-packages
-          <<: *master_and_release_only
-      - ami-tests-stable:
-          <<: *master_and_release_only
+      # smoke-tests:
+      #   jobs:
+      #     - smoke-standalone-26
+      #     - smoke-standalone-27
+      #     - smoke-standalone-35
+      #     - smoke-standalone-26-tls12
+      #     - smoke-standalone-27-tls12
+      #      # NOTE: smoke test jobs below still use old smoke tests framework
+      #     - smoke-docker-json
+      #     - smoke-docker-syslog
+      #     - smoke-k8s
+      #     - smoke-monitors-tests
+      #     - sonarcloud-scan:
+      #         requires:
+      #           # NOTE: This is not ideal, but Circle CI doesn't support cross
+      #           # workflow dependencies (we can't wait on unittest-27 here) so we just wait on the
+      #           # slowest jobs
+      #           - smoke-docker-json
+      #           - smoke-docker-syslog
+      #           - smoke-k8s
+      #           - smoke-monitors-tests
+      # package-tests:
+      #   jobs:
+      #     - build-linux-packages
+      #     - build-windows-package
+      #     - package-test-rpm:
+      #         <<: *master_and_release_only
+      #     - package-test-deb:
+      #         <<: *master_and_release_only
+      #     - smoke-rpm-package-py2:
+      #         requires:
+      #           - package-test-rpm
+      #         <<: *master_and_release_only
+      #     - smoke-rpm-package-py3:
+      #         requires:
+      #           - package-test-rpm
+      #         <<: *master_and_release_only
+      #     - smoke-deb-package-py2:
+      #         requires:
+      #           - package-test-deb
+      #         <<: *master_and_release_only
+      #     - smoke-deb-package-py3:
+      #         requires:
+      #           - package-test-deb
+      #         <<: *master_and_release_only
+      #     - ami-tests-development:
+      #         requires:
+      #           - build-windows-package
+      #           - build-linux-packages
+      #         <<: *master_and_release_only
+      #     - ami-tests-stable:
+      #         <<: *master_and_release_only
   benchmarks:
     jobs:
       - benchmarks-micro-py-27

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@
 # running test suites, and mocking Python Objects for the Scalyr Agent.
 
 # Testing tools and libraries
-tox==3.14.3
+tox==3.15.2
 mock==3.0.5
 psutil==5.7.0
 pytest==4.6.9; python_version < '3.0'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@ tox==3.14.3
 mock==3.0.5
 psutil==5.7.0
 pytest==4.6.9; python_version < '3.0'
-pytest==5.4.1; python_version >= '3.5'
+pytest==5.4.3; python_version >= '3.5'
 pytest-coverage
 pytest-timeout==1.3.4
 pytest-benchmark==3.2.3

--- a/tox.ini
+++ b/tox.ini
@@ -73,12 +73,12 @@ deps =
 commands =
     # NOTE: We disable capturing ouf output (-s flag) since it doesn't play along nicely with Windows
     # NOTE: Right not we don't run coverage since it seems to break on Circle CI
-    py.test tests/unit/ -s -vv --durations=5 -m "not memory_leak and not json_lib"
-    py.test tests/unit/test_memory_leaks.py -s -vv --durations=5
-    py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib"
-    #py.test tests/unit/ -s -vv --durations=5 -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/ --junitxml=test-results/junit-1.xml
-    #py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
-    #py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-3.xml
+    #py.test tests/unit/ -s -vv --durations=5 -m "not memory_leak and not json_lib"
+    #py.test tests/unit/test_memory_leaks.py -s -vv --durations=5
+    #py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib"
+    py.test tests/unit/ -s -vv --durations=5 -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/ --junitxml=test-results/junit-1.xml
+    py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
+    py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-3.xml
 
 # Lint target which runs all the linting tools such as black, modernize, pylint, flake8, mypy, etc.
 # NOTE: We use bash -c since we don't want tox to quote all the arguments, we want globs to

--- a/tox.ini
+++ b/tox.ini
@@ -76,9 +76,16 @@ commands =
     #py.test tests/unit/ -s -vv --durations=5 -m "not memory_leak and not json_lib"
     #py.test tests/unit/test_memory_leaks.py -s -vv --durations=5
     #py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib"
+    bash -c "echo 0"
     py.test tests/unit/ -s -vv --durations=5 -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/ --junitxml=test-results/junit-1.xml
+    bash -c "echo 1"
     py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
+    py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
+    bash -c "echo 2"
     py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-3.xml
+    echo "done"
+    bash -c "echo $?"
+    bash -c "exit 1"
 
 # Lint target which runs all the linting tools such as black, modernize, pylint, flake8, mypy, etc.
 # NOTE: We use bash -c since we don't want tox to quote all the arguments, we want globs to

--- a/tox.ini
+++ b/tox.ini
@@ -77,12 +77,12 @@ commands =
     #py.test tests/unit/test_memory_leaks.py -s -vv --durations=5
     #py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib"
     bash -c "echo 0"
-    py.test tests/unit/ -s -vv --durations=5 -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/ --junitxml=test-results/junit-1.xml
+    #py.test tests/unit/ -s -vv --durations=5 -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/ --junitxml=test-results/junit-1.xml
     bash -c "echo 1"
-    py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
-    py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
+    #py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
+    #py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
     bash -c "echo 2"
-    py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-3.xml
+    #py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-3.xml
     echo "done"
     bash -c "echo $?"
     bash -c "exit 1"

--- a/tox.ini
+++ b/tox.ini
@@ -72,20 +72,9 @@ deps =
     -r benchmarks/micro/requirements-compression-algorithms.txt
 commands =
     # NOTE: We disable capturing ouf output (-s flag) since it doesn't play along nicely with Windows
-    # NOTE: Right not we don't run coverage since it seems to break on Circle CI
-    #py.test tests/unit/ -s -vv --durations=5 -m "not memory_leak and not json_lib"
-    #py.test tests/unit/test_memory_leaks.py -s -vv --durations=5
-    #py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib"
-    bash -c "echo 0"
-    #py.test tests/unit/ -s -vv --durations=5 -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/ --junitxml=test-results/junit-1.xml
-    bash -c "echo 1"
-    #py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
-    #py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
-    bash -c "echo 2"
-    #py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-3.xml
-    echo "done"
-    bash -c "echo $?"
-    bash -c "exit 1"
+    py.test tests/unit/ -s -vv --durations=5 -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/ --junitxml=test-results/junit-1.xml
+    py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
+    py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-3.xml
 
 # Lint target which runs all the linting tools such as black, modernize, pylint, flake8, mypy, etc.
 # NOTE: We use bash -c since we don't want tox to quote all the arguments, we want globs to

--- a/windows-unit-tests-requirements.txt
+++ b/windows-unit-tests-requirements.txt
@@ -4,7 +4,7 @@ tox==3.14.3
 mock==3.0.5
 psutil==5.7.0
 pytest==4.6.9; python_version < '3.0'
-pytest==5.4.1; python_version >= '3.5'
+pytest==5.4.3; python_version >= '3.5'
 pytest-coverage
 pytest-timeout==1.3.4
 pytest-benchmark==3.2.3

--- a/windows-unit-tests-requirements.txt
+++ b/windows-unit-tests-requirements.txt
@@ -5,7 +5,7 @@ mock==3.0.5
 psutil==5.7.0
 pytest==4.6.9; python_version < '3.0'
 pytest==5.4.3; python_version >= '3.5'
-pytest-coverage
+pytest-cov==2.10.0
 pytest-timeout==1.3.4
 pytest-benchmark==3.2.3
 pytest-xdist==1.31.0

--- a/windows-unit-tests-requirements.txt
+++ b/windows-unit-tests-requirements.txt
@@ -1,6 +1,6 @@
 # Python requirements file which is used for running unit Tests on Windows
 # Testing tools and libraries
-tox==3.14.3
+tox==3.15.2
 mock==3.0.5
 psutil==5.7.0
 pytest==4.6.9; python_version < '3.0'


### PR DESCRIPTION
This pull request fixes "Run Unit Tests under Python 3.5" step not terminating and timing out in the ``unittest-35-windows`` job.

Troubleshooting it was slow and painful since I needed to push commits and changes one by one to test various things (SSH debugging didn't work).

I assume the issue is related to some upstream change and not our code.

It basically causes Circle CI job which runs tox command to not correctly exit even though the tox command itself correctly exits (I verified that with various commits and changes, the step also hangs even if we just run echo command as part of a tox target and nothing else).

I thought it may be something related to file descriptors not getting correctly closed or similar and this does seem to be the case since using the output redirect workaround works.

Workaround basically involves redirecting tox command output (stdout + stderr) to a file and then catting this file when it finishes. 

This sadly means we don't immediately see output as it is produced, but it appears to be only working workaround for this issue (I also tried redirecting the output + using tee, but it also caused the step to hang and time out).

In addition to this fix / workaround, it also includes some other changes:

- Upgrade pytest-cov, tox to the latest version
- Re-enable code coverage on Windows