### PR TITLE
Correctly exclude some tests directories from coverage data on Windows.

### DIFF
--- a/.circleci/.coveragerc_ci
+++ b/.circleci/.coveragerc_ci
@@ -15,9 +15,12 @@ omit =
     tests/ami/*
     tests/distribution/*
     tests/distribution_builders/*
+    tests/image_builder/*
     tests\ami/*
     tests\distribution\*
     tests\distribution_builders\*
+    tests\image_builder\*
     /home/circleci/scalyr-agent-2/tests/ami/*
     /home/circleci/scalyr-agent-2/tests/distribution/*
     /home/circleci/scalyr-agent-2/tests/distribution_builders/*
+    /home/circleci/scalyr-agent-2/tests/image_builder/*

--- a/.circleci/.coveragerc_ci
+++ b/.circleci/.coveragerc_ci
@@ -12,6 +12,12 @@ omit =
     */.virtualenvs/*
     */venv/*
     */third_party*/*
+    tests/ami/*
+    tests/distribution/*
+    tests/distribution_builders/*
+    tests\ami/*
+    tests\distribution\*
+    tests\distribution_builders\*
     /home/circleci/scalyr-agent-2/tests/ami/*
     /home/circleci/scalyr-agent-2/tests/distribution/*
     /home/circleci/scalyr-agent-2/tests/distribution_builders/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,4 @@ omit =
     tests/ami/*
     tests/distribution/*
     tests/distribution_builders/*
+    tests/image_builder/*

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -40,6 +40,8 @@ sonar.cpd.exclusions=scalyr_agent/builtin_monitors/*.py
 # NOTE: Sonar requires all the coverage reports to be combined into a single
 # report
 sonar.python.coverage.reportPaths=coverage.xml
+# This matches paths in .coveragerc file
+sonar.coverage.exclusions=tests/ami/**,tests/distribution/**,tests/distribution_builders/**,tests/image_builder/**,**/tests/ami/**,**/tests/distribution/**,**/tests/distribution_builders/**,**tests/image_builder/**
 #sonar.python.xunit.reportPath=test-results/junit-*.xml
 
 # Custom rule settings


### PR DESCRIPTION
This pull request updates ``.coveragerc`` file used by Circle CI jobs to correctly exclude some test directories from coverage reports.

This is needed because paths on Windows and Linux are different and after re-enabling code coverage for Windows unit tests, some directories were now being incorrectly included in the reports.