### PR TITLE
CT-109: Unmatched group error

### DIFF
--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -2876,9 +2876,11 @@ class LogLineRedacter(object):
             return input_line, False
 
         modified_it = False
+        redaction_rule_applying = None
 
         try:
             for redaction_rule in self.__redaction_rules:
+                redaction_rule_applying = redaction_rule
                 (input_line, redaction) = self.__apply_redaction_rule(
                     input_line, redaction_rule
                 )
@@ -2886,14 +2888,16 @@ class LogLineRedacter(object):
         except re.error as e:
             if e.message == "unmatched group":  # pylint: disable=no-member
                 log.error(
-                    "Error while getting the default gateway: %s. Please make sure any redaction rules only reference groups that are guaranteed to match.",
+                    'Error while applying redaction rule "%s": %s. Please make sure any redaction rules only reference groups that are guaranteed to match.',
+                    six.text_type(redaction_rule_applying.pattern),
                     six.text_type(e.message),  # pylint: disable=no-member
                     limit_once_per_x_secs=300,
                     limit_key="redaction_unmatched_group",
                 )
             else:
                 log.error(
-                    "Error while applying redaction rule: %s",
+                    'Error while applying redaction rule "%s": %s',
+                    six.text_type(redaction_rule_applying.pattern),
                     six.text_type(e.message),  # pylint: disable=no-member
                     limit_once_per_x_secs=300,
                     limit_key="redaction_generic_re_error",

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -2889,7 +2889,7 @@ class LogLineRedacter(object):
             if e.message == "unmatched group":  # pylint: disable=no-member
                 log.error(
                     'Error while applying redaction rule "%s": %s. Please make sure any redaction rules only reference groups that are guaranteed to match.',
-                    six.text_type(redaction_rule_applying.pattern),
+                    six.text_type(redaction_rule_applying.redaction_expression.pattern),
                     six.text_type(e.message),  # pylint: disable=no-member
                     limit_once_per_x_secs=300,
                     limit_key="redaction_unmatched_group",
@@ -2897,7 +2897,7 @@ class LogLineRedacter(object):
             else:
                 log.error(
                     'Error while applying redaction rule "%s": %s',
-                    six.text_type(redaction_rule_applying.pattern),
+                    six.text_type(redaction_rule_applying.redaction_expression.pattern),
                     six.text_type(e.message),  # pylint: disable=no-member
                     limit_once_per_x_secs=300,
                     limit_key="redaction_generic_re_error",

--- a/tests/unit/log_processing_test.py
+++ b/tests/unit/log_processing_test.py
@@ -1187,6 +1187,10 @@ class TestLogLineRedactor(ScalyrTestCase):
             redactor, "foo secretoption=czerwin", "foo secretoption=fake", True
         )
 
+    @unittest.skipIf(
+        sys.version_info >= (3, 0, 0),
+        "`unmatched group` issue with `sub` and `subn` not present on python 3",
+    )
     def test_regular_expression_with_unmatched_capture_group(self):
         redactor = LogLineRedacter("/var/fake_log")
         redactor.add_redaction_rule('secret(.*)=.*(;|("))', "secret\\1=fake\\3")

--- a/tests/unit/log_processing_test.py
+++ b/tests/unit/log_processing_test.py
@@ -1187,6 +1187,12 @@ class TestLogLineRedactor(ScalyrTestCase):
             redactor, "foo secretoption=czerwin", "foo secretoption=fake", True
         )
 
+    def test_regular_expression_with_unmatched_capture_group(self):
+        redactor = LogLineRedacter("/var/fake_log")
+        redactor.add_redaction_rule('secret(.*)=.*(;|("))', "secret\\1=fake\\3")
+
+        self._run_case(redactor, "foo secretoption=czerwin;", "", True)
+
     def test_unicode_redactions(self):
         redacter = LogLineRedacter("/var/fake_log")
         # 2->TODO there is a bugfix of 're.subn' in  python3.7 and higher.

--- a/tests/unit/log_processing_test.py
+++ b/tests/unit/log_processing_test.py
@@ -1187,7 +1187,7 @@ class TestLogLineRedactor(ScalyrTestCase):
             redactor, "foo secretoption=czerwin", "foo secretoption=fake", True
         )
 
-    @unittest.skipIf(
+    @skipIf(
         sys.version_info >= (3, 0, 0),
         "`unmatched group` issue with `sub` and `subn` not present on python 3",
     )


### PR DESCRIPTION
Turns out if `re` tries to use an optional group that it never matched it will throw an exception instead of just using an empty string like most other implementations, which causes us to not upload a lot of logs if a customer trips over it. This PR makes us handle that case a bit more gracefully, only not uploading the one log that actually had the issue and giving a hopefully helpful error.