### PR TITLE
Use token in artifact downloading

### DIFF
--- a/scripts/circleci/upload_circleci_artifacts.py
+++ b/scripts/circleci/upload_circleci_artifacts.py
@@ -17,6 +17,7 @@
 #
 # It depends on the following environment variables being set:
 # - CIRCLE_API_TOKEN - CircleCI API access token.
+# - AGENT_PROJECT_NAME - The name of the github project.
 #
 # Usage:
 #
@@ -55,8 +56,6 @@ import requests
 
 CIRCLE_API_URL = "https://circleci.com/api/v2"
 
-CIRCLE_API_PROJECT_URL = CIRCLE_API_URL + "/project/gh/scalyr/scalyr-agent-2"
-
 # 15 min
 CIRCLE_WAIT_TIMEOUT = 60 * 15
 
@@ -65,6 +64,14 @@ try:
 except KeyError:
     print("Environment variable 'CIRCLE_API_TOKEN' is not specified.")
     raise
+
+try:
+    AGENT_REPO_NAME = compat.os_environ_unicode["AGENT_REPO_NAME"]
+except KeyError:
+    print("Environment variable 'AGENT_REPO_NAME' is not specified.")
+    raise
+
+CIRCLE_API_PROJECT_URL = CIRCLE_API_URL + "/project/gh/scalyr/" + AGENT_REPO_NAME
 
 
 def _do_request(method, url, **kwargs):

--- a/scripts/circleci/upload_circleci_artifacts.py
+++ b/scripts/circleci/upload_circleci_artifacts.py
@@ -151,8 +151,9 @@ def download_artifact_file(artifact_info, output_path):
         output_path, os.path.basename(artifact_info["path"]),
     )
 
-    with requests.Session() as session:
-        resp = session.get(url=artifact_info["url"], allow_redirects=True, stream=True)
+    resp = _do_request(
+        "GET", url=artifact_info["url"], allow_redirects=True, stream=True
+    )
 
     with open(artifact_output_path, "wb") as file:
         for chunk in resp.iter_content(chunk_size=8192):

--- a/scripts/circleci/upload_circleci_artifacts.py
+++ b/scripts/circleci/upload_circleci_artifacts.py
@@ -266,6 +266,11 @@ def wait_for_pipeline(pipeline_number,):
 
         time.sleep(10)
 
+    # not a great idea, but it looks like we can get incomplete list of workflows,
+    # even if we wait for pipeline status = 'created'.
+    # so we just wait a little to be sure that everything is created.
+    time.sleep(10)
+
     pipeline_id = pipeline_info["id"]
 
     # get pipeline workflows

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -395,7 +395,7 @@ def main(
 
     remote_script_name = "deploy.{0}".format(script_extension)
     test_package_step = ScriptDeployment(
-        rendered_template, name=remote_script_name, timeout=200
+        rendered_template, name=remote_script_name, timeout=300
     )
 
     if file_upload_steps:
@@ -406,7 +406,7 @@ def main(
         deployment = MultiStepDeployment(add=test_package_step)  # type: ignore
 
     # Add a step which always cats agent.log file at the end. This helps us troubleshoot failures.
-    cat_logs_step = ScriptDeployment(cat_logs_script_content, timeout=5)
+    cat_logs_step = ScriptDeployment(cat_logs_script_content, timeout=20)
     deployment.add(cat_logs_step)
 
     driver = get_libcloud_driver()
@@ -445,7 +445,7 @@ def main(
             ex_security_groups=SECURITY_GROUPS,
             ssh_username=distro_details["ssh_username"],
             ssh_timeout=20,
-            timeout=260,
+            timeout=300,
             deploy=deployment,
             at_exit_func=destroy_node_and_cleanup,
         )


### PR DESCRIPTION
Add token to download artifacts.
Increase timeout for the AMI tests, because they still fail with timeout error sometimes.