### PR TITLE
Bug/duplicate upload due to race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Packaged by Steven Czerwinski <czerwin@scalyr.com> on Aug 3, 2020 12:30 -0800
 --->
 
 Bug fixes:
-* Fixed race condition in pipelined requests which could lead to duplicate log upload, especially for systems with a large number of inactive log files.  Log files would be reuploaded from their start over short period of time (seconds to minutes).
+* Fixed race condition in pipelined requests which could lead to duplicate log upload, especially for systems with a large number of inactive log files.  Log files would be reuploaded from their start over short period of time (seconds to minutes).  This bug is triggered when pipelining is enabled, either by explicitly setting the `pipeline_threshold` config option or by using a Scalyr Agent release >= 2.1.6 (pipelining was turned on by default in 2.1.6).
 
 Misc:
 * ``compression_level`` configuration option now defaults to ``6`` when using ``deflate`` ``compression_type`` (``deflate`` is the default value for the ``compression_type`` configuration option). 6 offers the best trade off between compression ratio and CPU usage. For more information, please refer to the release notes document.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
-## 2.1.8 "TBD" - July 10, 2020
+## 2.1.8 "Titan" - August 3, 2020
 
 <!---
-Packaged by Steven Czerwinski <czerwin@scalyr.com> on Jul 20, 2020 08:30 -0800
+Packaged by Steven Czerwinski <czerwin@scalyr.com> on Aug 3, 2020 12:30 -0800
 --->
+
+Bug fixes:
+* Fixed race condition in pipelined requests which could lead to duplicate log upload, especially for systems with a large number of inactive log files.  Log files would be reuploaded from their start over short period of time (seconds to minutes).
 
 Misc:
 * ``compression_level`` configuration option now defaults to ``6`` when using ``deflate`` ``compression_type`` (``deflate`` is the default value for the ``compression_type`` configuration option). 6 offers the best trade off between compression ratio and CPU usage. For more information, please refer to the release notes document.

--- a/scalyr_agent/copying_manager.py
+++ b/scalyr_agent/copying_manager.py
@@ -1241,6 +1241,9 @@ class CopyingManager(StoppableThread, LogWatcher):
 
         # We have to iterate over all of the LogFileProcessors, getting bytes from them.  We also have to
         # collect all of the callback that they give us and wrap it into one massive one.
+        # all_callbacks maps the callback for a processor keyed by the processor's unique id.  We use the unique id to
+        # provide a stable mapping, even if the list of log processors changes between now and when we process
+        # the response (which it may if pipelining is turned on and we process the other request's response).
         all_callbacks = {}
         logs_processed = 0
 

--- a/scalyr_agent/copying_manager.py
+++ b/scalyr_agent/copying_manager.py
@@ -29,7 +29,6 @@ import time
 import sys
 
 import six
-from six.moves import range
 
 import scalyr_agent.scalyr_logging as scalyr_logging
 import scalyr_agent.util as scalyr_util
@@ -1268,9 +1267,8 @@ class CopyingManager(StoppableThread, LogWatcher):
 
         while not buffer_filled and logs_processed < len(self.__log_processors):
             # Iterate, getting bytes from each LogFileProcessor until we are full.
-            (callback, buffer_filled) = self.__log_processors[
-                current_processor
-            ].perform_processing(add_events_request)
+            processor = self.__log_processors[current_processor]
+            (callback, buffer_filled) = processor.perform_processing(add_events_request)
 
             # A callback of None indicates there was some error reading the log.  Just retry again later.
             if callback is None:
@@ -1281,7 +1279,7 @@ class CopyingManager(StoppableThread, LogWatcher):
                 self.total_read_time += end_time - start_time
                 return None
 
-            all_callbacks[current_processor] = callback
+            all_callbacks[processor.unique_id] = callback
             logs_processed += 1
 
             # Advance if the buffer if not filled.  Also, even if it is filled, if we are on the first
@@ -1321,13 +1319,14 @@ class CopyingManager(StoppableThread, LogWatcher):
 
             total_bytes_copied = 0
 
-            for i in range(0, len(processor_list)):
+            for processor in processor_list:
                 # Iterate over all the processors, seeing if we had a callback for that particular processor.
-                processor = processor_list[i]
-                if i in all_callbacks:
+                if processor.unique_id in all_callbacks:
                     # noinspection PyCallingNonCallable
                     # If we did have a callback for that processor, report the status and see if we callback is done.
-                    (closed_processor, bytes_copied) = all_callbacks[i](result)
+                    (closed_processor, bytes_copied) = all_callbacks[
+                        processor.unique_id
+                    ](result)
                     keep_it = not closed_processor
                     total_bytes_copied += bytes_copied
                 else:

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -2034,6 +2034,10 @@ class LogFileProcessor(object):
         # happens).  However, this is how the old agent worked and the UI relies on it, so we just keep the old system
         # going for now.
         self.__thread_name = "Lines for file %s" % file_path
+
+        # Note: thread id is also used as a unique identifier for LogFileProcessors (see #CT-107)
+        # So even if "thread_id" is no longer used by the Scalyr API, we still need it as a unique
+        # integer identifier for the LogFileProcessor
         self.__thread_id = LogFileProcessor.generate_unique_id()
 
         self.__log_file_iterator = LogFileIterator(
@@ -2199,6 +2203,15 @@ class LogFileProcessor(object):
         result = self.__is_closed
         self.__lock.release()
         return result
+
+    @property
+    def unique_id(self):
+        """
+        @return: an identifier for the log processor that is unique for all processors for the
+            lifetime of the agent.
+        @rtype: int
+        """
+        return self.__thread_id
 
     @property
     def is_active(self):

--- a/tests/unit/copying_manager_test.py
+++ b/tests/unit/copying_manager_test.py
@@ -990,6 +990,61 @@ class CopyingManagerEnd2EndTest(BaseScalyrLogCaptureTestCase):
 
         responder_callback("success")
 
+    def test_pipelined_requests_with_processor_closes(self):
+        # Tests bug related to duplicate log upload (CT-107, AGENT-425, CT-114)
+        # The problem was related to mixing up the callbacks between two different log processors
+        # during pipeline execution and one of the log processors had been closed.
+        #
+        # To replicate, we need to upload to two log files.
+        controller = self.__create_test_instance(use_pipelining=True, test_files=2)
+        self.__append_log_lines("p_First line", "p_Second line")
+        self.__append_log_lines_to_beta("s_First line", "s_Second line")
+        # Mark the primary log file to be closed (remove its log processor) once all current bytes have
+        # been uploaded.
+        controller.close_at_eof(self.__test_log_file)
+
+        controller.perform_scan()
+        # Set up for the pipeline scan.  Just add a few more lines to the secondary file.
+        self.__append_log_lines_to_beta("s_Third line")
+        controller.perform_pipeline_scan()
+
+        (request, responder_callback) = controller.wait_for_rpc()
+        self.assertFalse(self.__was_pipelined(request))
+
+        lines = self.__extract_lines(request)
+        self.assertEquals(4, len(lines))
+        self.assertEquals("p_First line", lines[0])
+        self.assertEquals("p_Second line", lines[1])
+        self.assertEquals("s_First line", lines[2])
+        self.assertEquals("s_Second line", lines[3])
+
+        responder_callback("success")
+
+        # With the bug, at this point, the processor for the secondary log file has been removed.
+        # We can tell this by adding more log lines to it and see they aren't copied up.  However,
+        # we first have to read the request that was already created via pipelining.
+        (request, responder_callback) = controller.wait_for_rpc()
+        self.assertTrue(self.__was_pipelined(request))
+
+        lines = self.__extract_lines(request)
+        self.assertEquals(1, len(lines))
+        self.assertEquals("s_Third line", lines[0])
+
+        responder_callback("success")
+
+        # Now add in more lines to the secondary.  If the bug was present, these would not be copied up.
+        self.__append_log_lines_to_beta("s_Fourth line")
+        controller.perform_scan()
+
+        (request, responder_callback) = controller.wait_for_rpc()
+
+        self.assertFalse(self.__was_pipelined(request))
+        lines = self.__extract_lines(request)
+
+        self.assertEquals(1, len(lines))
+        self.assertEquals("s_Fourth line", lines[0])
+        responder_callback("success")
+
     def test_pipelined_requests_with_normal_error(self):
         controller = self.__create_test_instance(use_pipelining=True)
         self.__append_log_lines("First line", "Second line")
@@ -1403,15 +1458,18 @@ class CopyingManagerEnd2EndTest(BaseScalyrLogCaptureTestCase):
         return "pipelined=1.0" in request.get_timing_data()
 
     def __create_test_instance(
-        self, use_pipelining=False, root_dir=None, auto_start=True,
+        self, use_pipelining=False, root_dir=None, auto_start=True, test_files=1
     ):
         """
         :param use_pipelining:
         :param root_dir: path to root directory, if None, new tempfile will be created.
         :param auto_start: If True, manager starts right after creation, defaults to True
         This is useful if we need to stop copying manager earlier than after first full iteration.
+        :param test_files: The number of test files to configure.  Can only be 1 or 2.
         :return:
         """
+        assert 0 < test_files <= 2
+
         if root_dir is None:
             root_dir = tempfile.mkdtemp()
         config_dir = os.path.join(root_dir, "config")
@@ -1425,11 +1483,14 @@ class CopyingManagerEnd2EndTest(BaseScalyrLogCaptureTestCase):
         if not os.path.exists(log_dir):
             os.mkdir(log_dir)
 
-        self.__test_log_file = os.path.join(root_dir, "test.log")
+        self.__test_log_file = self.__create_test_file(root_dir, "test.log")
+        log_configs = [{"path": self.__test_log_file}]
 
-        if not os.path.exists(self.__test_log_file):
-            fp = open(self.__test_log_file, "w")
-            fp.close()
+        if test_files == 2:
+            self.__test_log_file_secondary = self.__create_test_file(
+                root_dir, "test_secondary.log"
+            )
+            log_configs.append({"path": self.__test_log_file_secondary})
 
         config_file = os.path.join(config_dir, "agentConfig.json")
         config_fragments_dir = os.path.join(config_dir, "configs.d")
@@ -1447,7 +1508,7 @@ class CopyingManagerEnd2EndTest(BaseScalyrLogCaptureTestCase):
                     {
                         "disable_max_send_rate_enforcement_overrides": True,
                         "api_key": "fake",
-                        "logs": [{"path": self.__test_log_file}],
+                        "logs": log_configs,
                         "pipeline_threshold": pipeline_threshold,
                     }
                 )
@@ -1465,9 +1526,41 @@ class CopyingManagerEnd2EndTest(BaseScalyrLogCaptureTestCase):
         self._controller = self._manager.controller
         return self._controller
 
+    @staticmethod
+    def __create_test_file(root_dir, filename):
+        """Creates an empty test file at the specified filename in the specified directory.
+        :param root_dir: The path of the directory
+        :type root_dir: six.text_type
+        :param filename: The filename
+        :type filename: six.text_type
+        :return: The full path to the test file
+        :rtype: six.text_type
+        """
+        result = os.path.join(root_dir, filename)
+
+        if not os.path.exists(result):
+            fp = open(result, "w")
+            fp.close()
+        return result
+
     def __append_log_lines(self, *args):
+        """Appends the specified log lines to the (primary) test file.
+        :param args: The lines to append
+        :type args: [six.text_type]
+        """
+        self.__append_log_lines_to(self.__test_log_file, *args)
+
+    def __append_log_lines_to_beta(self, *args):
+        """Appends the specified log lines to the secondary test file.
+        :param args: The lines to append
+        :type args: [six.text_type]
+        """
+        self.__append_log_lines_to(self.__test_log_file_secondary, *args)
+
+    @staticmethod
+    def __append_log_lines_to(filepath, *args):
         # NOTE: We open file in binary mode, otherwise \n gets converted to \r\n on Windows on write
-        fp = open(self.__test_log_file, "ab")
+        fp = open(filepath, "ab")
         for l in args:
             fp.write(l.encode("utf-8"))
             fp.write(b"\n")
@@ -1788,6 +1881,19 @@ class TestableCopyingManager(CopyingManager):
                 self.__copying_manager.run_and_stop_at(TestableCopyingManager.SLEEPING)
 
             return request, send_response
+
+        def close_at_eof(self, filepath):
+            """Tells the CopyingManager to mark the LogProcessor copying the specified path to close itself
+            once all bytes have been copied up to Scalyr.  This can be used to remove LogProcessors for
+            testing purposes.
+
+            :param filepath: The path of the processor.
+            :type filepath: six.text_type
+            """
+            # noinspection PyProtectedMember
+            self.__copying_manager._CopyingManager__log_paths_being_processed[
+                filepath
+            ].close_at_eof()
 
         def stop(self):
             self.__copying_manager.stop_manager()


### PR DESCRIPTION
# Background

In Scalyr Agent release 2.1.6, we essentially turned on pipelining upload requests by default.  Pipelining is when we start to prepare next `/addEvents` upload request while still waiting on the response from the previous request (i.e., reading log content, serializing the log bytes into a network request, etc).  This allows us to overlap the round-trip-time of the first request with the construction of the second.  As long as the first request is accepted by the server, we can immediately turn around and send the second request.

The pipelining feature has been in our code base for several years now and used by customers who needed this performance optimization to maximum their upload throughput.  By making it default, we now have a larger number of customers using it.  Unfortunately, it turned out there was a somewhat subtle bug in how we constructed pipeline requests that caused issues for customers with particular log patterns.

# Bug

The essence of the bug is that we erroneously rely on the list of log processors being the same from when we create an `/addEvents` request and when we receive the response for that request.  That's because we keep a map for the callbacks that must be invoked for all of the log files with content in that request keyed by the index of the log processor associated with that log file in the processor list.  If the processor list changes between when we create the request and when we receive its response, then we will mistakenly associate the wrong callbacks with the wrong log processors (log files).

In non-pipelined requests, this is not an issue because that state can't really change between when the request is created and we get the response.  No other work is done while that request is in-flight.  However, with pipelined requests, the second request is created before the first request's response is processed.  If processing the first request results in changes to the log processor list (such as removing a log processor because its log file has been deleted or become stale), then the second request's callbacks will be invoked on the wrong processors.

# Symptoms

This bug manifested in a very puzzling manner.  The end result was that a given log file would be reuploaded to Scalyr starting from its start (i.e., byte offset zero).  This was caused by a fairly complex chain of events.  At the core, because the wrong callbacks were being invoked for the wrong log file, a given log file would be marked as "done" even though it wasn't really done.  Typically, a log file is only done when it has been deleted from the file system (otherwise, we are always expecting new bytes to show up in the log file).  So, when the Scalyr Agent recorded a log file as done, but then saw it again when it next scanned for new log files -- it would assume it was a completely new log file.  After all, the old one has been "deleted" from the file system (or so it though).  This resulted in the Scalyr Agent reuploading the log file from the start.

# Solution

The solution is really pretty straight-forward.  Instead of mapping which callbacks are associated with which LogProcessors based on its position in the LogProcessor list, we use a more stable index.  In particular, LogProcessors already have a unique id.  We use that as the key to callback dictionary.  Since this key is stable even with changes to the LogProcessor list, there is no more mixing up the callbacks.