### PR TITLE
Fix a bug in Windows cmdlet script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ master_and_release_only: &master_and_release_only
         # so we can ensure all the jobs (including the ones which only run on master) pass before
         # merging a PR.
         - /automated_tests\/.*/
-        - ami_tests_improvements_windows
+        - fix_windows_issue
 
 # NOTE: We intentionally don't want benchmarks to run on automated_tests/ branches.
 benchmarks_master_and_release_only: &benchmarks_master_and_release_only
@@ -2230,13 +2230,13 @@ workflows:
          requires:
            - package-test-deb
          <<: *master_and_release_only
-#     - ami-tests-development:
-#         requires:
-#           - build-windows-package
-#           - build-linux-packages-and-installer-script
-#         <<: *master_and_release_only
-#     - ami-tests-stable:
-#         <<: *master_and_release_only
+     - ami-tests-development:
+         requires:
+           - build-windows-package
+           - build-linux-packages-and-installer-script
+         <<: *master_and_release_only
+     - ami-tests-stable:
+         <<: *master_and_release_only
  benchmarks:
    jobs:
      - benchmarks-micro-py-27

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ master_and_release_only: &master_and_release_only
         # so we can ensure all the jobs (including the ones which only run on master) pass before
         # merging a PR.
         - /automated_tests\/.*/
+        - fix_windows_issue
 
 # NOTE: We intentionally don't want benchmarks to run on automated_tests/ branches.
 benchmarks_master_and_release_only: &benchmarks_master_and_release_only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ master_and_release_only: &master_and_release_only
         # so we can ensure all the jobs (including the ones which only run on master) pass before
         # merging a PR.
         - /automated_tests\/.*/
-        - fix_windows_issue
 
 # NOTE: We intentionally don't want benchmarks to run on automated_tests/ branches.
 benchmarks_master_and_release_only: &benchmarks_master_and_release_only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
+## 2.1.9 "TBD" - August 4, 2020
+
+<!---
+Packaged by Steven Czerwinski <czerwin@scalyr.com> on Aug 4, 2020 12:30 -0800
+--->
+
+Bug fixes:
+* Fix a regression in scalyr agent Windows cmdlet script (``ScalyrShell.cmd``) which would prevent agent from starting.
+
 ## 2.1.8 "Titan" - August 3, 2020
 
 <!---

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -404,7 +404,7 @@ def main(
         deploy_step_timeout = 320
         deploy_overall_timeout = 320
         cat_step_timeout = 10
-        max_tries = 10
+        max_tries = 3
     else:
         deploy_step_timeout = 260
         deploy_overall_timeout = 280

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -403,11 +403,13 @@ def main(
     if "windows" in distro.lower():
         deploy_step_timeout = 320
         deploy_overall_timeout = 320
+        cat_step_timeout = 10
         max_tries = 10
     else:
         deploy_step_timeout = 260
         deploy_overall_timeout = 280
         max_tries = 3
+        cat_step_timeout = 5
 
     remote_script_name = "deploy.{0}".format(script_extension)
     test_package_step = ScriptDeployment(
@@ -422,7 +424,7 @@ def main(
         deployment = MultiStepDeployment(add=test_package_step)  # type: ignore
 
     # Add a step which always cats agent.log file at the end. This helps us troubleshoot failures.
-    cat_logs_step = ScriptDeployment(cat_logs_script_content, timeout=5)
+    cat_logs_step = ScriptDeployment(cat_logs_script_content, timeout=cat_step_timeout)
     deployment.add(cat_logs_step)
 
     driver = get_libcloud_driver()

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -400,9 +400,18 @@ def main(
         verbose=verbose,
     )
 
+    if "windows" in distro.lower():
+        deploy_step_timeout = 320
+        deploy_overall_timeout = 320
+        max_tries = 10
+    else:
+        deploy_step_timeout = 260
+        deploy_overall_timeout = 280
+        max_tries = 3
+
     remote_script_name = "deploy.{0}".format(script_extension)
     test_package_step = ScriptDeployment(
-        rendered_template, name=remote_script_name, timeout=260
+        rendered_template, name=remote_script_name, timeout=deploy_step_timeout
     )
 
     if file_upload_steps:
@@ -452,9 +461,9 @@ def main(
             ex_security_groups=SECURITY_GROUPS,
             ssh_username=distro_details["ssh_username"],
             ssh_timeout=20,
-            max_tries=4,
+            max_tries=max_tries,
             wait_period=15,
-            timeout=280,
+            timeout=deploy_overall_timeout,
             deploy=deployment,
             at_exit_func=destroy_node_and_cleanup,
         )

--- a/tests/ami/requirements.txt
+++ b/tests/ami/requirements.txt
@@ -1,6 +1,6 @@
 # NOTE: We rely on change in Libcloud which allows us to specify a custom wait_period which makes
 # it less likely for us to hit EC2 rate limits when spinning up and deploying many instances
 # concurrently
-git+https://github.com/apache/libcloud.git@trunk#egg=libcloud
+git+https://github.com/apache/libcloud.git@trunk#egg=apache-libcloud
 paramiko==2.7.1
 Jinja2==2.11.1

--- a/tests/ami/scripts/test_windows.ps1.j2
+++ b/tests/ami/scripts/test_windows.ps1.j2
@@ -96,11 +96,13 @@ if ($LASTEXITCODE -ne 0) { Throw "Status command failed" }
 Write-Output $status_output
 
 # Also verify we can start the agent using the cmd script we provide
-$status_output2="C:\Program Files (x86)\Scalyr\bin\ScalyrShell.cmd status"
+ScalyrShell.cmd status;
+
+if (!$?) {
+    throw "Status command via cmdlet failed"
+}
+
 if ($LASTEXITCODE -ne 0) { Throw "Status command via cmdlet failed" }
-
-echo $status_output2
-
 
 if ("$status_output" -notmatch "$msi_version")   {
     # If there is a an internal build, we need to check version string for the 'windows version' format.

--- a/tests/ami/scripts/test_windows.ps1.j2
+++ b/tests/ami/scripts/test_windows.ps1.j2
@@ -88,14 +88,11 @@ scalyr-agent-2 start;
 
 Start-Sleep 5
 
-$status_output=scalyr-agent-2 status -v;
-echo $status_output
-
-if ($LASTEXITCODE -ne 0) { Throw "Status command failed" }
-
-Write-Output $status_output
-
 # Also verify we can start the agent using the cmd script we provide
+echo ""
+echo "Verifying agent status via cmdlet"
+echo ""
+
 ScalyrShell.cmd status;
 
 if (!$?) {
@@ -103,6 +100,21 @@ if (!$?) {
 }
 
 if ($LASTEXITCODE -ne 0) { Throw "Status command via cmdlet failed" }
+
+echo ""
+echo "cmdlet agent status verified"
+echo ""
+
+echo ""
+echo "Verifying agent status via native scalyr-agent-2 binary"
+echo ""
+
+$status_output=scalyr-agent-2 status -v;
+echo $status_output
+
+if ($LASTEXITCODE -ne 0) { Throw "Status command failed" }
+
+Write-Output $status_output
 
 if ("$status_output" -notmatch "$msi_version")   {
     # If there is a an internal build, we need to check version string for the 'windows version' format.
@@ -114,7 +126,7 @@ if ("$status_output" -notmatch "$msi_version")   {
 
     if ("$status_output" -notmatch $pattern)
     {
-        Throw "Can not find version.";
+        Throw "Can not find a matching version.";
     }
 };
 
@@ -122,11 +134,23 @@ if ("$status_output" -notmatch "agent.log")   { Throw "Can not find agent log." 
 if ("$status_output" -notmatch "windows_system_metrics")   { Throw "Can not find windows_system_metrics." };
 if ("$status_output" -notmatch "windows_process_metrics")   { Throw "Can not find windows_process_metrics." };
 
+echo ""
+echo "native agent status output verified"
+echo ""
+
 # Ensure CA validation is not disabled with default install
+echo ""
+echo "Verifying SSL cert validation is enabled by default"
+echo ""
+
 $log_output=type "C:\Program Files (x86)\Scalyr\log\agent.log"
 
 if ("$log_output" -match "sslverifyoff") { Throw "cert validation is disabled" };
 if ("$log_output" -match "certificate validation has been disabled") { Throw "cert validation is disabled" };
+
+echo ""
+echo "SSL check validation completed"
+echo ""
 
 # Verify build_info file exists
 echo ""
@@ -134,4 +158,8 @@ echo "Verifying build_info file exists"
 echo ""
 
 type "C:\Program Files (x86)\Scalyr\bin\build_info"
+echo ""
+
+echo ""
+echo "build_info validation completed"
 echo ""

--- a/tests/ami/scripts/test_windows.ps1.j2
+++ b/tests/ami/scripts/test_windows.ps1.j2
@@ -93,7 +93,9 @@ echo ""
 echo "Verifying agent status via cmdlet"
 echo ""
 
-ScalyrShell.cmd status;
+# NOTE: We pipe a character to avoid PAUSE command waiting for the user input at the end
+# and hanging
+@() | ScalyrShell.cmd status;
 
 if (!$?) {
     throw "Status command via cmdlet failed"

--- a/tests/ami/scripts/test_windows.ps1.j2
+++ b/tests/ami/scripts/test_windows.ps1.j2
@@ -82,12 +82,15 @@ Start-Sleep 5
 
 $status_output=scalyr-agent-2 status -v;
 
-echo $status_output
-
 if ($LASTEXITCODE -ne 0) { Throw "Status command failed" }
 
 Write-Output $status_output
 
+# Also verify we can start the agent using the cmd script we provide
+$status_output2="C:\Program Files (x86)\Scalyr\bin\ScalyrShell.cmd status"
+if ($LASTEXITCODE -ne 0) { Throw "Status command via cmdlet failed" }
+
+echo $status_output2
 
 
 if ("$status_output" -notmatch "$msi_version")   {

--- a/win32/ScalyrShell.cmd
+++ b/win32/ScalyrShell.cmd
@@ -1,3 +1,16 @@
+# Copyright 2014-2020 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 :: Copyright 2014-2020 Scalyr Inc.
 ::
 :: Licensed under the Apache License, Version 2.0 (the "License");

--- a/win32/ScalyrShell.cmd
+++ b/win32/ScalyrShell.cmd
@@ -1,16 +1,16 @@
-# Copyright 2014-2020 Scalyr Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+:: Copyright 2014-2020 Scalyr Inc.
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::   http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
 
 
 @ECHO OFF

--- a/win32/ScalyrShell.cmd
+++ b/win32/ScalyrShell.cmd
@@ -1,16 +1,3 @@
-# Copyright 2014-2020 Scalyr Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 :: Copyright 2014-2020 Scalyr Inc.
 ::
 :: Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +11,6 @@
 :: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 :: See the License for the specific language governing permissions and
 :: limitations under the License.
-
 
 @ECHO OFF
 TITLE Scalyr Agent 2


### PR DESCRIPTION
This pull request fixes a bug (syntax error) in Windows cmdlet script which prevents it from running with the latest version of the agent.

Sadly the issue was never caught by our AMI end to end tests since they don't use cmdlet but start the agent directly using the binary.

This has now been fixed. Having said that, I would still like to merge #608 into master and them merge it into this branch so I can add some additional assertions and improvements (without changes in #608, Windows AMI tests script has a bunch of short comings).