### PR TITLE
Update AMI tests script to throw early if invalid path or similar is provided for the package source

### DIFF
--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -256,8 +256,14 @@ def _get_source_type(version_string):
         return "url"
     elif os.path.exists(version_string) and os.path.isfile(version_string):
         return "file"
-    else:
+    elif re.match(r"\d+\.\d+\.\d+", version_string) or version_string in ["current"]:
         return "install_script"
+    else:
+        raise ValueError(
+            'Invalid value "%s" for version_string. If it\'s a path to a file, make'
+            "sure the file exists and if it's a URL, ensure URL exists."
+            % (version_string)
+        )
 
 
 def _create_file_deployment_step(file_path, remote_file_name):


### PR DESCRIPTION
This pull request contains a small change to the AMI tests script so we fail early if the provided path for the package source doesn't exist or it's not valid.

This way we avoid unnecessary wait in this scenario which would only cause the script to fail after the node has been provisioned and when we try to upload the package file.