### PR TITLE
Log OpenSSL version against which Python is linked to in the agent start up line

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -44,6 +44,7 @@ import os
 import sys
 import time
 import re
+import ssl
 from io import open
 
 try:
@@ -974,15 +975,18 @@ class ScalyrAgent(object):
                 # 2->TODO it was very helpful to see what python version does agent run on. Maybe we can keep it?
                 python_version_str = sys.version.replace("\n", "")
                 build_revision = get_build_revision()
+                openssl_version = getattr(ssl, "OPENSSL_VERSION", "unknown")
 
                 # TODO: Why do we log the same line under info and debug? Intentional?
                 msg = (
-                    "Starting scalyr agent... (version=%s) (revision=%s) %s (Python version: %s)"
+                    "Starting scalyr agent... (version=%s) (revision=%s) %s (Python version: %s) "
+                    "(OpenSSL version: %s)"
                     % (
                         SCALYR_VERSION,
                         build_revision,
                         scalyr_util.get_pid_tid(),
                         python_version_str,
+                        openssl_version,
                     )
                 )
 

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -256,8 +256,14 @@ def _get_source_type(version_string):
         return "url"
     elif os.path.exists(version_string) and os.path.isfile(version_string):
         return "file"
-    else:
+    elif re.match(r"\d+\.\d+\.\d+", version_string) or version_string in ["current"]:
         return "install_script"
+    else:
+        raise ValueError(
+            'Invalid value "%s" for version_string. If it\'s a path to a file, make'
+            "sure the file exists and if it's a URL, ensure URL exists."
+            % (version_string)
+        )
 
 
 def _create_file_deployment_step(file_path, remote_file_name):

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -256,7 +256,7 @@ def _get_source_type(version_string):
         return "url"
     elif os.path.exists(version_string) and os.path.isfile(version_string):
         return "file"
-    elif re.match(r"\d+\.\d+\.\d+", version_string) or version_string in ["current"]:
+    elif re.match(r"\d+\.\d+\.\d+", version_string) or version_string == "current":
         return "install_script"
     else:
         raise ValueError(


### PR DESCRIPTION
This pull request updates agent start up line to also log OpenSSL version against which Python binary which the agent is using to run is linked to.

This change should make it easier for us to troubleshoot some type of issues.