### PR TITLE
Also define pytest_benchmark_scale_unit function even if the nvironment variable is not set

### DIFF
--- a/benchmarks/micro/conftest.py
+++ b/benchmarks/micro/conftest.py
@@ -14,7 +14,7 @@
 
 from __future__ import absolute_import
 
-from scalyr_agent.pytest_util import PYTEST_BENCH_FORCE_UNIT  # NOQA
+from scalyr_agent.pytest_util import pytest_benchmark_scale_unit  # NOQA
 from scalyr_agent.pytest_util import pytest_benchmark_generate_json  # NOQA
 
-__all__ = ["PYTEST_BENCH_FORCE_UNIT", "pytest_benchmark_generate_json"]
+__all__ = ["pytest_benchmark_scale_unit", "pytest_benchmark_generate_json"]

--- a/scalyr_agent/pytest_util.py
+++ b/scalyr_agent/pytest_util.py
@@ -25,6 +25,8 @@ from pytest_benchmark.fixture import BenchmarkFixture
 
 from scalyr_agent import compat
 
+__all__ = ["pytest_benchmark_scale_unit", "pytest_benchmark_generate_json"]
+
 # A list of custom metrics which should be included in the generated pytest benchmark result JSON
 # file
 CUSTOM_METRICS = [

--- a/scalyr_agent/pytest_util.py
+++ b/scalyr_agent/pytest_util.py
@@ -77,6 +77,12 @@ if PYTEST_BENCH_FORCE_UNIT:
         return prefix, scale
 
 
+else:
+
+    def pytest_benchmark_scale_unit(config, unit, benchmarks, best, worst, sort):
+        pass
+
+
 @pytest.mark.hookwrapper
 def pytest_benchmark_generate_json(
     config, benchmarks, include_data, machine_info, commit_info


### PR DESCRIPTION
Small change to ``pytest_util`` module to also define and export ``pytest_benchmark_scale_unit`` function even if the corresponding environment variable is not defined.

This way, the function can more easily be re-used by other projects which rely on ``pytest_util`` module.