### PR TITLE
Postgres and mysql monitors fix

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,7 +13,7 @@ pytest-timeout==1.3.4
 pytest-benchmark==3.2.3
 pytest-xdist==1.31.0
 coverage==4.5.4
-codecov==2.1.3
+codecov==2.1.9
 decorator==4.4.1
 PyYAML==5.3
 six==1.13.0

--- a/scalyr_agent/builtin_monitors/postgres_monitor.py
+++ b/scalyr_agent/builtin_monitors/postgres_monitor.py
@@ -68,7 +68,7 @@ define_config_option(
     __monitor__,
     "database_port",
     "Name of port on the host machine the agent will connect to PostgreSQL to retrieve monitoring data.",
-    convert_to=six.text_type,
+    convert_to=int,
 )
 define_config_option(
     __monitor__,

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -204,15 +204,12 @@ def get_json_implementation(lib_name):
             This function falls back to native json library when there is a big unsigned 64 bit integer.
             :return:
             """
-            options = None
-            if SORT_KEYS:
-                options = orjson.OPT_SORT_KEYS
 
             def dump():
                 if fp is not None:
-                    return orjson.dump(obj, fp, option=options)
+                    return orjson.dump(obj, fp)
                 else:
-                    return orjson.dumps(obj, option=options)
+                    return orjson.dumps(obj)
 
             try:
                 return dump()

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -199,7 +199,33 @@ def get_json_implementation(lib_name):
         except ImportError as e:
             raise ImportError(ORJSON_NOT_AVAILABLE_MSG % (str(e)))
 
-        return lib_name, orjson.dumps, orjson.loads
+        def orjson_dumps_custom(obj, fp):
+            """
+            This function falls back to native json library when there is a big unsigned 64 bit integer.
+            :return:
+            """
+            options = None
+            if SORT_KEYS:
+                options = orjson.OPT_SORT_KEYS
+
+            def dump():
+                if fp is not None:
+                    return orjson.dump(obj, fp, option=options)
+                else:
+                    return orjson.dumps(obj, option=options)
+
+            try:
+                return dump()
+            except orjson.JSONEncodeError as e:
+                # if there is an integer size error, fall back to native json
+                if str(e) == "Integer exceeds 64-bit range":
+                    _, _json_dumps, _ = get_json_implementation("json")
+
+                    return _json_dumps(obj, fp)
+                else:
+                    raise
+
+        return lib_name, orjson_dumps_custom, orjson.loads
 
     else:
         if lib_name != "json":

--- a/scripts/submit-codecov-data.sh
+++ b/scripts/submit-codecov-data.sh
@@ -16,7 +16,6 @@
 # Script which submits coverage data to codecov.io.
 # It takes occasional codecov API failures into account and tries to retry
 # upload.
-exit 0
 
 MAX_ATTEMPTS=${MAX_ATTEMPTS:-5}
 RETRY_DELAY=${RETRY_DELAY:-5}

--- a/scripts/submit-codecov-data.sh
+++ b/scripts/submit-codecov-data.sh
@@ -25,7 +25,7 @@ RETRY_DELAY=${RETRY_DELAY:-5}
 for (( i=0; i<$MAX_ATTEMPTS; ++i)); do
     # NOTE: We pass --required flag to the binary since we also want it to return non-zero (and fail
     # the build) if upload fails
-    codecov --root=/home/circleci/scalyr-agent-2/ --disable gcov --file coverage.xml --required
+    codecov --root=/home/circleci/scalyr-agent-2/ --disable gcov --file coverage.xml --required --verbose
     EXIT_CODE=$?
 
     if [ "${EXIT_CODE}" -eq 0 ]; then

--- a/scripts/submit-codecov-data.sh
+++ b/scripts/submit-codecov-data.sh
@@ -40,3 +40,5 @@ if [ "${EXIT_CODE}" -ne 0 ]; then
     echo "Submitting code coverage to codecov.io failed after ${MAX_ATTEMPTS} attempts"
     exit 1
 fi
+
+echo "Data successfully submitted to codecov.io"

--- a/scripts/submit-codecov-data.sh
+++ b/scripts/submit-codecov-data.sh
@@ -26,7 +26,7 @@ echo "Submitting coverage data to codecov.io"
 for (( i=0; i<$MAX_ATTEMPTS; ++i)); do
     # NOTE: We pass --required flag to the binary since we also want it to return non-zero (and fail
     # the build) if upload fails
-    codecov --root=/home/circleci/scalyr-agent-2/ --disable gcov --file coverage.xml --required --verbose
+    codecov --root=/home/circleci/scalyr-agent-2/ --disable gcov --file coverage.xml --required
     EXIT_CODE=$?
 
     if [ "${EXIT_CODE}" -eq 0 ]; then

--- a/scripts/submit-codecov-data.sh
+++ b/scripts/submit-codecov-data.sh
@@ -21,6 +21,8 @@ exit 0
 MAX_ATTEMPTS=${MAX_ATTEMPTS:-5}
 RETRY_DELAY=${RETRY_DELAY:-5}
 
+echo "Submitting coverage data to codecov.io"
+
 # Work around for temporary codecov API timing out
 for (( i=0; i<$MAX_ATTEMPTS; ++i)); do
     # NOTE: We pass --required flag to the binary since we also want it to return non-zero (and fail

--- a/tests/image_builder/monitors/base/Dockerfile
+++ b/tests/image_builder/monitors/base/Dockerfile
@@ -1,7 +1,14 @@
 FROM ubuntu:18.04
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update -y
 RUN apt install -y mysql-server
+RUN apt install -y postgresql
+
+
+USER postgres
+RUN service postgresql start && createuser root && createdb root && psql -c "alter user root superuser;" && service postgresql stop
+USER root
 
 RUN apt install -y python python3
 

--- a/tests/image_builder/monitors/common/pg_init.sql
+++ b/tests/image_builder/monitors/common/pg_init.sql
@@ -1,0 +1,3 @@
+CREATE USER scalyr_test_user with PASSWORD 'scalyr_test_password';
+CREATE DATABASE scalyr_test_user
+CREATE DATABASE scalyr_test_db

--- a/tests/smoke_tests/monitors_test/mysql_test.py
+++ b/tests/smoke_tests/monitors_test/mysql_test.py
@@ -32,6 +32,7 @@ from tests.utils.agent_runner import AgentRunner
 from tests.utils.dockerized import dockerized_case
 from tests.image_builder.monitors.common import CommonMonitorBuilder
 from tests.utils.log_reader import LogMetricReader
+from tests.utils.log_reader import AgentLogReader
 
 import six
 
@@ -107,7 +108,9 @@ def _test(request, python_version):
     )
 
     reader = MySqlLogReader(runner.mysql_log_path)
-    reader.start()
+    agent_log_reader = AgentLogReader(runner.agent_log_file_path)
+
+    agent_log_reader.wait(5)
 
     metrics_to_check = [
         "mysql.global.com_insert",
@@ -116,7 +119,7 @@ def _test(request, python_version):
         "mysql.global.com_update",
     ]
 
-    previous_metric_values = reader.get_metrics(metrics_to_check)
+    previous_metric_values = reader.wait_for_metrics_exist(metrics_to_check)
 
     rows = mysql_cursor.execute("SELECT * FROM test_table")
 
@@ -155,7 +158,7 @@ def _test(request, python_version):
 
     reader.wait_for_metrics_increase(metrics_to_check, previous_metric_values)
 
-    current_metrics = reader.get_metrics(metrics_to_check)
+    current_metrics = reader.wait_for_metrics_exist(metrics_to_check)
 
     diff = dict(
         (name, current_metrics[name] - previous_metric_values[name])
@@ -169,7 +172,7 @@ def _test(request, python_version):
         "mysql.global.com_insert": 2,
     }
 
-    runner.stop()
+    agent_log_reader.go_to_end()
 
 
 @pytest.mark.usefixtures("agent_environment")

--- a/tests/smoke_tests/monitors_test/nginx_test.py
+++ b/tests/smoke_tests/monitors_test/nginx_test.py
@@ -79,7 +79,7 @@ def _test(request, python_version):
         "nginx.connections.writing",
         "nginx.connections.waiting",
     ]
-    metrics = reader.get_metrics(metric_names)
+    metrics = reader.wait_for_metrics_exist(metric_names)
 
     assert list(sorted(metrics.keys())) == sorted(metric_names)
 

--- a/tests/smoke_tests/monitors_test/postgres_test.py
+++ b/tests/smoke_tests/monitors_test/postgres_test.py
@@ -45,7 +45,9 @@ DATABASE = "scalyr_test_db"
 def postgresql_client():
     os.system("service postgresql start")
 
-    os.system('psql -c "CREATE USER {} WITH PASSWORD \'{}\'";'.format(USERNAME, PASSWORD))
+    os.system(
+        "psql -c \"CREATE USER {} WITH PASSWORD '{}'\";".format(USERNAME, PASSWORD)
+    )
     os.system('psql -c "CREATE DATABASE {};"'.format(USERNAME))
     os.system('psql -c "CREATE DATABASE {};"'.format(DATABASE))
 
@@ -87,11 +89,12 @@ class PostgresAgentRunner(AgentRunner):
                 "database_port": 5432,
                 "database_username": USERNAME,
                 "id": "mydb",
-                "module": "scalyr_agent.builtin_monitors.postgres_monitor"
+                "module": "scalyr_agent.builtin_monitors.postgres_monitor",
             }
         )
 
         return config
+
 
 class PostgresLogReader(LogMetricReader):
     LINE_PATTERN = r"\s*(?P<timestamp>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}.\d+Z)\s\[postgres_monitor\((?P<instance_id>[^\]]+)\)\]\s(?P<metric_name>[^\s]+)\s(?P<metric_value>.+)"
@@ -124,11 +127,9 @@ def _test(request, python_version):
     reader = PostgresLogReader(runner.mysql_log_path)
     reader.start()
 
-    metrics_to_check = [
-        "postgres.database.size"
-    ]
+    metrics_to_check = ["postgres.database.size"]
 
-    previous_metric_values = reader.wait_for_metrics_exist(metrics_to_check)
+    reader.wait_for_metrics_exist(metrics_to_check)
 
     postgres_cursor.execute("SELECT * FROM test_table")
 
@@ -136,7 +137,9 @@ def _test(request, python_version):
 
     assert len(rows) == 0
 
-    postgres_cursor.execute('INSERT INTO test_table (text) values (\'row1\') RETURNING id')
+    postgres_cursor.execute(
+        "INSERT INTO test_table (text) values ('row1') RETURNING id"
+    )
     (row1_id,) = postgres_cursor.fetchone()
 
     postgres_cursor.execute("SELECT * FROM test_table")
@@ -144,7 +147,9 @@ def _test(request, python_version):
 
     assert len(rows) == 1
 
-    postgres_cursor.execute("INSERT INTO test_table (text) values ('row2') RETURNING id")
+    postgres_cursor.execute(
+        "INSERT INTO test_table (text) values ('row2') RETURNING id"
+    )
     (row2_id,) = postgres_cursor.fetchone()
 
     postgres_cursor.execute("SELECT * FROM test_table")

--- a/tests/smoke_tests/monitors_test/postgres_test.py
+++ b/tests/smoke_tests/monitors_test/postgres_test.py
@@ -1,0 +1,183 @@
+# Copyright 2014-2020 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+
+if False:  # NOSONAR
+    from typing import Dict
+    from typing import Any
+
+import time
+import os
+
+import pytest
+
+from scalyr_agent.third_party import pg8000
+
+from tests.utils.agent_runner import AgentRunner
+
+from tests.utils.dockerized import dockerized_case
+from tests.image_builder.monitors.common import CommonMonitorBuilder
+from tests.utils.log_reader import LogMetricReader, AgentLogReader
+
+import six
+
+HOST = "localhost"
+USERNAME = "scalyr_test_user"
+PASSWORD = "scalyr_test_password"
+DATABASE = "scalyr_test_db"
+
+
+@pytest.fixture()
+def postgresql_client():
+    os.system("service postgresql start")
+
+    os.system('psql -c "CREATE USER {} WITH PASSWORD \'{}\'";'.format(USERNAME, PASSWORD))
+    os.system('psql -c "CREATE DATABASE {};"'.format(USERNAME))
+    os.system('psql -c "CREATE DATABASE {};"'.format(DATABASE))
+
+    time.sleep(3)
+
+    client = pg8000.connect(host=HOST, user=USERNAME, password=PASSWORD, db=DATABASE)
+
+    yield client
+    client.close()
+
+
+@pytest.fixture()
+def postgres_cursor(postgresql_client):
+    cursor = postgresql_client.cursor()
+
+    yield cursor
+
+    cursor.close()
+
+
+class PostgresAgentRunner(AgentRunner):
+    def __init__(self):
+        super(PostgresAgentRunner, self).__init__(
+            enable_coverage=True, send_to_server=False
+        )
+
+        self.mysql_log_path = self.add_log_file(
+            self.agent_logs_dir_path / "postgres_monitor.log"
+        )
+
+    @property
+    def _agent_config(self):  # type: () -> Dict[six.text_type, Any]
+        config = super(PostgresAgentRunner, self)._agent_config
+        config["monitors"].append(
+            {
+                "database_host": HOST,
+                "database_name": DATABASE,
+                "database_password": PASSWORD,
+                "database_port": 5432,
+                "database_username": USERNAME,
+                "id": "mydb",
+                "module": "scalyr_agent.builtin_monitors.postgres_monitor"
+            }
+        )
+
+        return config
+
+class PostgresLogReader(LogMetricReader):
+    LINE_PATTERN = r"\s*(?P<timestamp>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}.\d+Z)\s\[postgres_monitor\((?P<instance_id>[^\]]+)\)\]\s(?P<metric_name>[^\s]+)\s(?P<metric_value>.+)"
+
+
+def _test(request, python_version):
+    postgres_cursor = request.getfixturevalue("postgres_cursor")
+
+    runner = PostgresAgentRunner()
+
+    runner.start(executable=python_version)
+
+    time.sleep(1)
+
+    agent_log_reader = AgentLogReader(runner.agent_log_file_path)
+    agent_log_reader.start()
+
+    # wait for agent logs about postgres monitor is started.
+    agent_log_reader.wait_for_matching_line(
+        pattern=r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+Z INFO \[core\] \[monitors_manager\.py:\d+\] Starting monitor postgres_monitor\(mydb\)"
+    )
+
+    # just wait more to be sure that there are no errors in the agent.log.
+    agent_log_reader.wait(3)
+
+    postgres_cursor.execute(
+        "CREATE TABLE test_table( id SERIAL PRIMARY KEY, text VARCHAR(255));"
+    )
+
+    reader = PostgresLogReader(runner.mysql_log_path)
+    reader.start()
+
+    metrics_to_check = [
+        "postgres.database.size"
+    ]
+
+    previous_metric_values = reader.wait_for_metrics_exist(metrics_to_check)
+
+    postgres_cursor.execute("SELECT * FROM test_table")
+
+    rows = postgres_cursor.fetchall()
+
+    assert len(rows) == 0
+
+    postgres_cursor.execute('INSERT INTO test_table (text) values (\'row1\') RETURNING id')
+    (row1_id,) = postgres_cursor.fetchone()
+
+    postgres_cursor.execute("SELECT * FROM test_table")
+    rows = postgres_cursor.fetchall()
+
+    assert len(rows) == 1
+
+    postgres_cursor.execute("INSERT INTO test_table (text) values ('row2') RETURNING id")
+    (row2_id,) = postgres_cursor.fetchone()
+
+    postgres_cursor.execute("SELECT * FROM test_table")
+    rows = postgres_cursor.fetchall()
+
+    assert len(rows) == 2
+
+    postgres_cursor.execute("DELETE FROM test_table WHERE id={0};".format(row2_id))
+
+    postgres_cursor.execute("SELECT * FROM test_table;")
+    rows = postgres_cursor.fetchall()
+
+    assert len(rows) == 1
+
+    postgres_cursor.execute(
+        "UPDATE test_table SET text='updated_row1' WHERE id={0};".format(row1_id)
+    )
+
+    postgres_cursor.execute("SELECT text FROM test_table WHERE id={0}".format(row1_id))
+
+    (row1_text,) = postgres_cursor.fetchone()
+    assert row1_text == "updated_row1"
+
+    agent_log_reader.go_to_end()
+
+
+@pytest.mark.usefixtures("agent_environment")
+@dockerized_case(CommonMonitorBuilder, __file__)
+def test_postgres_python2(request):
+    _test(request, python_version="python2")
+
+
+@pytest.mark.usefixtures("agent_environment")
+@dockerized_case(CommonMonitorBuilder, __file__)
+def test_postgres_python3(request):
+    _test(request, python_version="python3")

--- a/tests/smoke_tests/monitors_test/postgres_test.py
+++ b/tests/smoke_tests/monitors_test/postgres_test.py
@@ -47,7 +47,9 @@ def postgresql_client():
     os.system("service postgresql start")
 
     os.system(
-        "psql -c \"CREATE USER {} WITH PASSWORD '{}'\";".format(shlex.quote(USERNAME), shlex.quote(PASSWORD))
+        "psql -c \"CREATE USER {} WITH PASSWORD '{}'\";".format(
+            shlex.quote(USERNAME), shlex.quote(PASSWORD)
+        )
     )
     os.system('psql -c "CREATE DATABASE {};"'.format(shlex.quote(USERNAME)))
     os.system('psql -c "CREATE DATABASE {};"'.format(shlex.quote(DATABASE)))

--- a/tests/smoke_tests/monitors_test/postgres_test.py
+++ b/tests/smoke_tests/monitors_test/postgres_test.py
@@ -22,6 +22,7 @@ if False:  # NOSONAR
 
 import time
 import os
+import shlex
 
 import pytest
 
@@ -46,10 +47,10 @@ def postgresql_client():
     os.system("service postgresql start")
 
     os.system(
-        "psql -c \"CREATE USER {} WITH PASSWORD '{}'\";".format(USERNAME, PASSWORD)
+        "psql -c \"CREATE USER {} WITH PASSWORD '{}'\";".format(shlex.quote(USERNAME), shlex.quote(PASSWORD))
     )
-    os.system('psql -c "CREATE DATABASE {};"'.format(USERNAME))
-    os.system('psql -c "CREATE DATABASE {};"'.format(DATABASE))
+    os.system('psql -c "CREATE DATABASE {};"'.format(shlex.quote(USERNAME)))
+    os.system('psql -c "CREATE DATABASE {};"'.format(shlex.quote(DATABASE)))
 
     time.sleep(3)
 

--- a/tests/smoke_tests/monitors_test/shell_monitor_test.py
+++ b/tests/smoke_tests/monitors_test/shell_monitor_test.py
@@ -26,7 +26,7 @@ import pytest
 import six
 
 from tests.utils.agent_runner import AgentRunner
-from tests.utils.log_reader import LogReader
+from tests.utils.log_reader import LogReader, AgentLogReader
 from tests.utils.dockerized import dockerized_case
 from tests.image_builder.monitors.common import CommonMonitorBuilder
 
@@ -61,14 +61,14 @@ def _test(python_version):
     runner.start(executable=python_version)
     time.sleep(1)
     reader = LogReader(runner.shell_monitor_log_path)
-    reader.start(wait_for_data=False)
+    agent_log_reader = AgentLogReader(runner.agent_log_file_path)
 
-    last_line = reader.wait_for_new_line()
+    last_line = reader.wait_for_next_line()
 
     assert "Hello" in last_line
     assert "[shell_monitor(echo)]" in last_line
 
-    runner.stop()
+    agent_log_reader.go_to_end()
 
 
 @pytest.mark.usefixtures("agent_environment")

--- a/tests/smoke_tests/monitors_test/syslog_test.py
+++ b/tests/smoke_tests/monitors_test/syslog_test.py
@@ -28,7 +28,7 @@ import pytest
 import six
 
 from tests.utils.agent_runner import AgentRunner
-from tests.utils.log_reader import LogReader
+from tests.utils.log_reader import LogReader, AgentLogReader
 from tests.utils.dockerized import dockerized_case
 from tests.image_builder.monitors.common import CommonMonitorBuilder
 
@@ -66,28 +66,28 @@ def _test(python_version):
     runner.start(executable=python_version)
     time.sleep(1)
     reader = LogReader(runner.syslog_log_path)
-
-    reader.start(wait_for_data=False)
+    agent_log_reader = AgentLogReader(runner.agent_log_file_path)
 
     os.system("logger message1 --port {0} --udp --server 127.0.0.1".format(UDP_PORT))
 
-    last_line = reader.wait_for_new_line()
+    last_line = reader.wait_for_next_line()
 
     assert "message1" in last_line
 
     os.system("logger message2 --port {0} --tcp --server 127.0.0.1".format(TCP_PORT))
 
-    last_line = reader.wait_for_new_line()
+    last_line = reader.wait_for_next_line()
 
     assert "message2" in last_line
 
     os.system("logger message3 --port {0} --udp --server 127.0.0.1".format(UDP_PORT))
 
-    last_line = reader.wait_for_new_line()
+    last_line = reader.wait_for_next_line()
 
     assert "message3" in last_line
 
-    runner.stop()
+    agent_log_reader.go_to_end()
+
 
 
 @pytest.mark.usefixtures("agent_environment")

--- a/tests/smoke_tests/monitors_test/syslog_test.py
+++ b/tests/smoke_tests/monitors_test/syslog_test.py
@@ -89,7 +89,6 @@ def _test(python_version):
     agent_log_reader.go_to_end()
 
 
-
 @pytest.mark.usefixtures("agent_environment")
 @dockerized_case(CommonMonitorBuilder, __file__)
 def test_syslog_python2(request):

--- a/tests/smoke_tests/monitors_test/url_monitor_test.py
+++ b/tests/smoke_tests/monitors_test/url_monitor_test.py
@@ -27,7 +27,7 @@ import pytest
 import six
 
 from tests.utils.agent_runner import AgentRunner
-from tests.utils.log_reader import LogReader
+from tests.utils.log_reader import LogReader, AgentLogReader
 from tests.utils.dockerized import dockerized_case
 from tests.image_builder.monitors.common import CommonMonitorBuilder
 
@@ -68,15 +68,15 @@ def _test(python_version):
     runner.start(executable=python_version)
     time.sleep(1)
     reader = LogReader(runner.url_monitor_log_path)
-    reader.start(wait_for_data=False)
+    agent_log_reader = AgentLogReader(runner.agent_log_file_path)
 
-    last_line = reader.wait_for_new_line()
+    last_line = reader.wait_for_next_line()
 
     assert 'response "Hello"' in last_line
     assert "status=200" in last_line
     assert "[url_monitor(instance)]" in last_line
 
-    runner.stop()
+    agent_log_reader.go_to_end()
     process.terminate()
 
 

--- a/tests/unit/util/json_util_test.py
+++ b/tests/unit/util/json_util_test.py
@@ -27,7 +27,6 @@ import importlib
 import six
 import mock
 import pytest
-import orjson
 
 from scalyr_agent import util
 from scalyr_agent.test_base import ScalyrTestCase
@@ -35,6 +34,7 @@ from scalyr_agent.test_base import skipIf
 
 if six.PY3:
     reload = importlib.reload
+    import orjson
 
 JSON = 1
 UJSON = 2
@@ -81,9 +81,10 @@ class EncodeDecodeTest(ScalyrTestCase):
         self.__test_encode_decode(r"-1234567890123456789", -1234567890123456789)
 
     def test_64_bit_int(self):
-        # this should throw an error because orjson can not serialize more than signed 64 integer.
-        with self.assertRaises(orjson.JSONEncodeError):
-            orjson.dumps(18446744073709551615)
+        if six.PY3:
+            # this should throw an error because orjson can not serialize more than signed 64 integer.
+            with self.assertRaises(orjson.JSONEncodeError):
+                orjson.dumps(18446744073709551615)
 
         # here we do the regular json tests to be sure that
         # we fall back to native json library in case of too bit integer.

--- a/tests/unit/util/json_util_test.py
+++ b/tests/unit/util/json_util_test.py
@@ -79,6 +79,9 @@ class EncodeDecodeTest(ScalyrTestCase):
     def test_negative_long(self):
         self.__test_encode_decode(r"-1234567890123456789", -1234567890123456789)
 
+    def test_long_long_int(self):
+        self.__test_encode_decode("18446744073709551615", 18446744073709551615)
+
     def test_bool(self):
         self.__test_encode_decode(r"false", False)
         self.__test_encode_decode(r"true", True)

--- a/tests/unit/util/json_util_test.py
+++ b/tests/unit/util/json_util_test.py
@@ -27,6 +27,7 @@ import importlib
 import six
 import mock
 import pytest
+import orjson
 
 from scalyr_agent import util
 from scalyr_agent.test_base import ScalyrTestCase
@@ -79,7 +80,13 @@ class EncodeDecodeTest(ScalyrTestCase):
     def test_negative_long(self):
         self.__test_encode_decode(r"-1234567890123456789", -1234567890123456789)
 
-    def test_long_long_int(self):
+    def test_64_bit_int(self):
+        # this should throw an error because orjson can not serialize more than signed 64 integer.
+        with self.assertRaises(orjson.JSONEncodeError):
+            orjson.dumps(18446744073709551615)
+
+        # here we do the regular json tests to be sure that
+        # we fall back to native json library in case of too bit integer.
         self.__test_encode_decode("18446744073709551615", 18446744073709551615)
 
     def test_bool(self):

--- a/tests/utils/log_reader.py
+++ b/tests/utils/log_reader.py
@@ -15,6 +15,7 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
+from six.moves import range
 
 if False:  # NOSONAR
     from typing import Optional
@@ -24,7 +25,6 @@ import threading
 import time
 from io import open
 import collections
-import queue
 
 import six
 
@@ -77,7 +77,9 @@ class LogReader(threading.Thread):
                 return line
 
             if time.time() >= timeout_time:
-                raise LogReaderTimeoutError("Timeout of %s seconds reached while waiting for metrics" % timeout)
+                raise LogReaderTimeoutError(
+                    "Timeout of %s seconds reached while waiting for metrics" % timeout
+                )
 
             time.sleep(0.01)
 
@@ -161,6 +163,7 @@ class LogMetricReader(LogReader):
         self.current_metrics[name] = value
 
     def wait_for_metrics_exist(self, names, timeout=10):
+        timeout_time = time.time() + timeout
         while True:
             needed_metrics = dict()
             for name in names:
@@ -182,7 +185,9 @@ class LogMetricReader(LogReader):
 
             time.sleep(0.01)
 
-    def wait_for_metrics_change(self, metric_names, previous_values, predicate, timeout=10):
+    def wait_for_metrics_change(
+        self, metric_names, previous_values, predicate, timeout=10
+    ):
         timeout_time = time.time() + timeout
         while True:
             try:
@@ -211,5 +216,8 @@ class LogMetricReader(LogReader):
 
     def wait_for_metrics_increment(self, metric_names, previous_values, timeout=10):
         self.wait_for_metrics_change(
-            metric_names, previous_values, lambda cur, prev: prev + 1 == cur, timeout=timeout
+            metric_names,
+            previous_values,
+            lambda cur, prev: prev + 1 == cur,
+            timeout=timeout,
         )

--- a/tests/utils/log_reader.py
+++ b/tests/utils/log_reader.py
@@ -32,8 +32,6 @@ import collections
 
 import six
 
-import logging
-
 ErrorPatternInfo = collections.namedtuple("ErrorPatternInfo", ["pattern", "message"])
 
 

--- a/tests/utils/log_reader.py
+++ b/tests/utils/log_reader.py
@@ -32,6 +32,8 @@ import collections
 
 import six
 
+import logging
+
 ErrorPatternInfo = collections.namedtuple("ErrorPatternInfo", ["pattern", "message"])
 
 

--- a/tests/utils/log_reader.py
+++ b/tests/utils/log_reader.py
@@ -128,7 +128,7 @@ class LogReader(threading.Thread):
         but there is need to check all new lines (for errors specified by 'add_error_check' for example.).
         It does not block or wait, it just reads and processes new lines until EOF.
         """
-        #TODO: make LogReader do this autimatically by using ContextManager.
+        # TODO: make LogReader do this autimatically by using ContextManager.
 
         for _ in self._line_generator():
             pass

--- a/tests/utils/log_reader.py
+++ b/tests/utils/log_reader.py
@@ -128,6 +128,7 @@ class LogReader(threading.Thread):
         but there is need to check all new lines (for errors specified by 'add_error_check' for example.).
         It does not block or wait, it just reads and processes new lines until EOF.
         """
+        #TODO: make LogReader do this autimatically by using ContextManager.
 
         for _ in self._line_generator():
             pass

--- a/tests/utils/tests/test_log_reader.py
+++ b/tests/utils/tests/test_log_reader.py
@@ -1,0 +1,125 @@
+from __future__ import absolute_import
+import pytest
+import tempfile
+import time
+from io import open
+
+try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib
+
+from tests.utils.log_reader import (
+    LogReader,
+    LogReaderError,
+    LogMetricReader,
+    LogReaderTimeoutError,
+)
+
+from concurrent.futures import ThreadPoolExecutor
+
+
+def write_line(line, path):
+    with open(path, "a") as fp:
+        fp.write(line)
+        fp.write("\n")
+
+
+def test_log_reader():
+    log_file_fd, log_file_path = tempfile.mkstemp(prefix="scalyr_tesing")
+    log_file_path = pathlib.Path(log_file_path)
+
+    reader = LogReader(str(log_file_path))
+
+    with log_file_path.open("a") as fp:
+        fp.write("line1\n")
+
+    assert reader.wait_for_next_line() == "line1"
+    assert reader.last_line == "line1"
+
+    with log_file_path.open("a") as fp:
+        fp.write("line2\n")
+        fp.write("line3\n")
+
+    assert reader.wait_for_matching_line("line3") == "line3"
+    assert reader.last_line == "line3"
+
+    with log_file_path.open("a") as fp:
+        fp.write("line4\n")
+        fp.write("line5\n")
+
+    reader.wait(0.5)
+
+    assert reader.last_line == "line5"
+
+    reader.add_error_check(r"error \d+")
+
+    with log_file_path.open("a") as fp:
+        fp.write("line6\n")
+        fp.write("error 5\n")
+
+    assert reader.wait_for_next_line() == "line6"
+
+    with pytest.raises(LogReaderError):
+        reader.wait_for_next_line()
+
+
+def test_log_metric_reader():
+    log_file_fd, log_file_path = tempfile.mkstemp(prefix="scalyr_tesing")
+    log_file_path = pathlib.Path(log_file_path)
+
+    class MyLogMetricReader(LogMetricReader):
+        LINE_PATTERN = r"(?P<metric_name>[^:]+):\s*(?P<metric_value>.+)"
+
+    reader = MyLogMetricReader(str(log_file_path))
+
+    assert reader.current_metrics == {}
+
+    write_line("metric1: 23", log_file_path)
+
+    assert reader.current_metrics == {}
+
+    assert reader.wait_for_metrics_exist(["metric1"]) == {"metric1": 23}
+
+    write_line("metric2: 44", log_file_path)
+    write_line("metric1: 24", log_file_path)
+
+    reader.go_to_end()
+
+    assert reader.current_metrics == {"metric1": 24, "metric2": 44}
+
+    executor = ThreadPoolExecutor()
+
+    wait_future = executor.submit(
+        reader.wait_for_metrics_equal, expected={"metric1": 26, "metric2": 45}
+    )
+
+    time.sleep(0.1)
+
+    assert not wait_future.done()
+
+    write_line("metric2: 45", log_file_path)
+
+    time.sleep(0.1)
+
+    assert not wait_future.done()
+
+    write_line("metric1: 26", log_file_path)
+    time.sleep(0.1)
+
+    wait_future.result()
+
+    assert wait_future.done()
+
+    assert reader.current_metrics == {"metric1": 26, "metric2": 45}
+
+    write_line("metric1: 100", log_file_path)
+    write_line("metric2: 200", log_file_path)
+
+    reader.wait_for_metrics_equal(expected={"metric1": 100, "metric2": 200})
+
+    # test_timeout
+    with pytest.raises(LogReaderTimeoutError):
+        reader.wait_for_metrics_equal(
+            expected={"metric1": 300, "metric2": 400}, timeout=0.2
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -306,7 +306,9 @@ basepython = python3.6
 passenv =
     TERM SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
 commands =
-    py.test tests/smoke_tests/monitors_test/ -s -vv --tb=short --durations=5 {posargs}
+
+    py.test tests/utils/tests/ tests/smoke_tests/monitors_test/ -s -vv --tb=short --durations=5 {posargs}
+
 
 # Benchmark related targets below
 [testenv:micro-benchmarks]

--- a/windows-unit-tests-requirements.txt
+++ b/windows-unit-tests-requirements.txt
@@ -10,7 +10,7 @@ pytest-timeout==1.3.4
 pytest-benchmark==3.2.3
 pytest-xdist==1.31.0
 coverage==4.5.4
-codecov==2.1.3
+codecov==2.1.9
 decorator==4.4.1
 PyYAML==5.3
 six==1.13.0


### PR DESCRIPTION
* Fix postgres_monitor error caused by wrong type conversion during the parsing of the config file.
* Fall back to native json library if orjson can not handle unsigned 64bit integers. 

Monitor tests and log analyzing tools were also improved.