### PR TITLE
Revert temporary smoke tests timeout increases change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1159,7 +1159,7 @@ jobs:
           command: |
             docker container create --name dummy -v shared_vol:/app alpine && \
             docker cp $(pwd)/.circleci/smoketest_standalone.sh dummy:/app/ && \
-            docker run -it -v shared_vol:/app -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=900 -e PYTHON_VERSION=2.7.nossl -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} -e CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM} scalyr/scalyr-agent-ci-unittest:4 /app/smoketest_standalone.sh && \
+            docker run -it -v shared_vol:/app -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=150 -e PYTHON_VERSION=2.7.nossl -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} -e CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM} scalyr/scalyr-agent-ci-unittest:4 /app/smoketest_standalone.sh && \
             docker rm dummy;
 
       - slack/status:
@@ -1177,7 +1177,7 @@ jobs:
           command: |
             docker container create --name dummy -v shared_vol:/app alpine && \
             docker cp $(pwd)/.circleci/smoketest_standalone.sh dummy:/app/ && \
-            docker run -it -v shared_vol:/app -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=900 -e PYTHON_VERSION=2.6.nossl -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} -e CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM} scalyr/scalyr-agent-ci-unittest:4 /app/smoketest_standalone.sh && \
+            docker run -it -v shared_vol:/app -e TEST_BRANCH=${CIRCLE_BRANCH} -e MAX_WAIT=150 -e PYTHON_VERSION=2.6.nossl -e SCALYR_API_KEY=${SCALYR_API_KEY} -e READ_API_KEY=${READ_API_KEY} -e SCALYR_SERVER=${SCALYR_SERVER} -e CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM} scalyr/scalyr-agent-ci-unittest:4 /app/smoketest_standalone.sh && \
             docker rm dummy;
 
       - slack/status:
@@ -1210,7 +1210,7 @@ jobs:
       - run:
           name: Run Tests (with coverage)
           command: |
-            source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-unittest:4 json 900
+            source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-unittest:4 json 150
       - run:
           name: Submit Coverage Data to codecov.io and Combine it and Upload it to S3
           command: |
@@ -1261,7 +1261,7 @@ jobs:
       - run:
           name: Run Tests (with coverage)
           command: |
-            source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-unittest:4 syslog 900
+            source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-unittest:4 syslog 150
       - run:
           name: Submit Coverage Data to codecov.io
           command: |
@@ -1344,7 +1344,7 @@ jobs:
       - run:
           name: Run Tests (with coverage)
           command: |
-            source ./.circleci/smoketest_k8s.sh scalyr/scalyr-agent-ci-unittest:4 900 no_delete_existing_k8s_objs
+            source ./.circleci/smoketest_k8s.sh scalyr/scalyr-agent-ci-unittest:4 150 no_delete_existing_k8s_objs
       - run:
           name: Submit Coverage Data to codecov.io
           command: |

--- a/tests/smoke_tests/standalone_test.py
+++ b/tests/smoke_tests/standalone_test.py
@@ -23,6 +23,6 @@ from tests.smoke_tests.common import _test_standalone_smoke
 
 
 @pytest.mark.usefixtures("agent_environment")
-@pytest.mark.timeout(1200)
+@pytest.mark.timeout(300)
 def test_standalone_smoke():
     _test_standalone_smoke(DEV_INSTALL)

--- a/tests/smoke_tests/verifier.py
+++ b/tests/smoke_tests/verifier.py
@@ -94,7 +94,7 @@ class AgentVerifier(object):
         """
         pass
 
-    def verify(self, timeout=15 * 60):
+    def verify(self, timeout=2 * 60):
         # type: (int) -> bool
         """"
         :param timeout: How to long to wait (in seconds) before timing out if no successful response is found.
@@ -141,7 +141,7 @@ class AgentLogVerifier(AgentVerifier):
             )
         )
 
-    def verify(self, timeout=15 * 60):
+    def verify(self, timeout=2 * 60):
         # Give agent some time to start up before checking for version string.
         # This version check is done against a local agent.log file and status -v --format=json
         # output and not Scalyr API so we don't need to retry it and wait for logs to be shipped to
@@ -411,7 +411,7 @@ class DataJsonVerifierRateLimited(AgentVerifier):
             self._runner.write_line(self._data_json_log_path, json_data)
         return
 
-    def verify(self, timeout=15 * 60):
+    def verify(self, timeout=1 * 60):
         """
         We only need to check at one point in time and confirm that the amount of lines uploaded is roughly equal to
         what we expect to be uploaded with the given rate.


### PR DESCRIPTION
The query caching issue has been fixed on the server side so the temporary changes which were made to get the smoke tests passing can now be reverted.