### PR TITLE
Kubernetes monitor INFO level logging improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
+## 2.1.14 "TBD" - November 15, 2020
+
+<!---
+Packaged by Oliver Hsu <oliver@scalyr.com> on Nov 15, 2020 19:00 -0800
+--->
+
+Improvements:
+* Improve logging in the Kubernetes monitor.
+
 ## 2.1.13 "Celaeno" - October 15, 2020
 
 <!---

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -3458,6 +3458,7 @@ cluster.
         self.__glob_list = self._config.get("container_globs")
         self.__include_all = self._config.get("k8s_include_all_containers")
 
+        self.__log_mode = self._config.get("log_mode")
         self.__report_container_metrics = self._config.get("report_container_metrics")
         self.__report_k8s_metrics = (
             self._config.get("report_k8s_metrics") and self.__report_container_metrics
@@ -3501,7 +3502,7 @@ cluster.
         )
 
         self.__container_checker = None
-        if self._config.get("log_mode") != "syslog":
+        if self.__log_mode != "syslog":
             self.__container_checker = ContainerChecker(
                 self._config,
                 self._global_config,
@@ -4093,6 +4094,8 @@ cluster.
             "SCALYR_K8S_KUBELET_API_URL_TEMPLATE",
             "SCALYR_K8S_VERIFY_KUBELET_QUERIES",
             "SCALYR_K8S_KUBELET_CA_CERT",
+            "SCALYR_REPORT_K8S_METRICS",
+            "SCALYR_REPORT_CONTAINER_METRICS",
         ]
         for envar in envars_to_log:
             self._logger.info(
@@ -4111,7 +4114,7 @@ cluster.
                 is not None
             ):
                 self._logger.log(
-                    scalyr_logging.DEBUG_LEVEL_1,
+                    scalyr_logging.DEBUG_LEVEL_0,  # INFO
                     "Cluster name detected, enabling k8s metric reporting and controller information",
                 )
                 self.__include_controller_info = True
@@ -4156,11 +4159,16 @@ cluster.
             self.__report_k8s_metrics = False
 
         global_log.info(
-            "kubernetes_monitor parameters: ignoring namespaces: %s, report_controllers: %s, report_metrics: %s"
+            (
+                "kubernetes_monitor parameters: ignoring namespaces: %s, report_controllers: %s, "
+                "report_metrics: %s, report_k8s_metrics: %s, log_mode: %s"
+            )
             % (
                 self.__namespaces_to_include,
                 self.__include_controller_info,
                 self.__report_container_metrics,
+                self.__report_k8s_metrics,
+                self.__log_mode,
             )
         )
 

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -4158,14 +4158,19 @@ cluster.
             )
             self.__report_k8s_metrics = False
 
-        always_use_docker = self._config.get("k8s_always_use_docker")
-        always_use_cri = self._config.get("k8s_always_use_cri")
-        container_runtime = self.__container_checker._container_runtime
+        if self.__log_mode != "syslog":
+            always_use_docker = self._config.get("k8s_always_use_docker")
+            always_use_cri = self._config.get("k8s_always_use_cri")
+            container_runtime = self.__container_checker._container_runtime
 
-        if always_use_docker or (container_runtime == "docker" and not always_use_cri):
-            container_list_mode = "docker"
+            if always_use_docker or (
+                container_runtime == "docker" and not always_use_cri
+            ):
+                container_list_mode = "docker"
+            else:
+                container_list_mode = "cri (fs)"
         else:
-            container_list_mode = "cri (fs)"
+            container_list_mode = "none (in syslog mode)"
 
         global_log.info(
             (

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -4158,10 +4158,19 @@ cluster.
             )
             self.__report_k8s_metrics = False
 
+        always_use_docker = self._config.get("k8s_always_use_docker")
+        always_use_cri = self._config.get("k8s_always_use_cri")
+        container_runtime = self.__container_checker._container_runtime
+
+        if always_use_docker or (container_runtime == "docker" and not always_use_cri):
+            container_list_mode = "docker"
+        else:
+            container_list_mode = "cri (fs)"
+
         global_log.info(
             (
                 "kubernetes_monitor parameters: ignoring namespaces: %s, report_controllers: %s, "
-                "report_metrics: %s, report_k8s_metrics: %s, log_mode: %s"
+                "report_metrics: %s, report_k8s_metrics: %s, log_mode: %s, container_list_mode: %s"
             )
             % (
                 self.__namespaces_to_include,
@@ -4169,6 +4178,7 @@ cluster.
                 self.__report_container_metrics,
                 self.__report_k8s_metrics,
                 self.__log_mode,
+                container_list_mode,
             )
         )
 

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -4158,10 +4158,15 @@ cluster.
             )
             self.__report_k8s_metrics = False
 
-        if self.__log_mode != "syslog":
+        log_mode = self._config.get("log_mode")
+        if log_mode != "syslog":
             always_use_docker = self._config.get("k8s_always_use_docker")
             always_use_cri = self._config.get("k8s_always_use_cri")
-            container_runtime = self.__container_checker._container_runtime
+
+            if self.__container_checker:
+                container_runtime = self.__container_checker._container_runtime
+            else:
+                container_runtime = "unknown"
 
             if always_use_docker or (
                 container_runtime == "docker" and not always_use_cri
@@ -4182,7 +4187,7 @@ cluster.
                 self.__include_controller_info,
                 self.__report_container_metrics,
                 self.__report_k8s_metrics,
-                self.__log_mode,
+                log_mode,
                 container_list_mode,
             )
         )


### PR DESCRIPTION
This pull request includes the following logging changes to the Kubernetes monitor:

1. "Cluster name detected" message is now logged under INFO log level
2. Monitor start up info log line now also containers the value for the following monitor config options: ``log_mode``, ``report_k8s_metrics``
3. On monitor start up we now also print the values of the following environment variables: ``SCALYR_REPORT_CONTAINER_METRICS``, ``SCALYR_REPORT_K8S_METRICS``

Those changes may make it a bit easier and faster for us to troubleshoot some user issues in the future since it may allow us to skip asking the user for their config file in some scenarios.