### PR TITLE
New diskperf error check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Improvements:
 Bug fixes:
 * Fix a bug / race-condition in Docker monitor which could cause, under some scenarios, when monitoring containers running on the same host, logs to stop being ingested after the container restart. There was a relatively short time window when this could happen and it was more likely to affect containers which take longer to stop / start.
 * Update code for all the monitors to correctly use UTC timezone everywhere. Previously some of the code incorrectly used local server time instead of UTC. This means some of those monitors could exhibit incorrect / undefined behavior when running the agent on a server which has local time set to something else than UTC.
+* Update Windows System Metrics monitor to better handle a situation when disk io counters are not available.
 
 ## 2.1.13 "Celaeno" - October 15, 2020
 

--- a/scalyr_agent/builtin_monitors/windows_system_metrics.py
+++ b/scalyr_agent/builtin_monitors/windows_system_metrics.py
@@ -113,18 +113,6 @@ def _gather_metric(method, attribute=None, transform=None):
             if transform is not None:
                 value = transform(value)
             yield value, None
-        except AttributeError as e:
-            # The same issue this diskperf,
-            # but the exception catch below does not work on older windows versions.
-            message = getattr(e, "message", str(e))
-            if (
-                message == "'NoneType' object has no attribute 'read_bytes'"
-                and method == "disk_io_counters"
-            ):
-                no_diskperf = True
-            else:
-                raise e
-
         except RuntimeError as e:
             # Special case the expected exception we see if we call disk_io_counters without the
             # user executing 'diskperf -y' on their machine before use.  Yes, it is a hack relying
@@ -134,6 +122,17 @@ def _gather_metric(method, attribute=None, transform=None):
             message = getattr(e, "message", str(e))
             if (
                 message == "couldn't find any physical disk"
+                and method == "disk_io_counters"
+            ):
+                no_diskperf = True
+            else:
+                raise e
+        except AttributeError as e:
+            # The same issue with diskperf,
+            # but the exception catch above does not work on older windows versions.
+            message = getattr(e, "message", str(e))
+            if (
+                message == "'NoneType' object has no attribute 'read_bytes'"
                 and method == "disk_io_counters"
             ):
                 no_diskperf = True

--- a/scalyr_agent/builtin_monitors/windows_system_metrics.py
+++ b/scalyr_agent/builtin_monitors/windows_system_metrics.py
@@ -50,8 +50,11 @@ except ImportError:
 
 import six
 
+from scalyr_agent import scalyr_logging
 from scalyr_agent import ScalyrMonitor, UnsupportedSystem
 from scalyr_agent import define_config_option, define_metric, define_log_field
+
+global_log = scalyr_logging.getLogger(__name__)
 
 
 #
@@ -104,6 +107,8 @@ def _gather_metric(method, attribute=None, transform=None):
     def gather_metric():
         """Dynamically Generated """
         no_diskperf = False
+        is_diskio_counters_method = method == "disk_io_counters"
+
         try:
             metric = methodcaller(method)  # pylint: disable=redefined-outer-name
             value = metric(psutil)
@@ -121,9 +126,17 @@ def _gather_metric(method, attribute=None, transform=None):
             # the message changes.
             message = getattr(e, "message", str(e))
             if (
-                message == "couldn't find any physical disk"
-                and method == "disk_io_counters"
+                is_diskio_counters_method
+                and "couldn't find any physical disk" in message.lower()
             ):
+                global_log.warn(
+                    "Unable to retrieve disk io metrics. This likely means diskperf -y "
+                    "needs to be run: %s" % (str(e)),
+                    exc_info=True,
+                    limit_once_per_x_secs=86400,
+                    limit_key="win_diskperf_error",
+                    error_code="win32DiskPerDisabledError",
+                )
                 no_diskperf = True
             else:
                 raise e
@@ -132,12 +145,21 @@ def _gather_metric(method, attribute=None, transform=None):
             # but the exception catch above does not work on older windows versions.
             message = getattr(e, "message", str(e))
             if (
-                message == "'NoneType' object has no attribute 'read_bytes'"
-                and method == "disk_io_counters"
+                is_diskio_counters_method
+                and "has no attribute 'read_bytes'" in message.lower()
             ):
+                global_log.warn(
+                    "Unable to retrieve disk io metrics. This likely means diskperf -y "
+                    "needs to be run: %s" % (str(e)),
+                    exc_info=True,
+                    limit_once_per_x_secs=86400,
+                    limit_key="win_diskperf_error",
+                    error_code="win32DiskPerDisabledError",
+                )
                 no_diskperf = True
             else:
                 raise e
+
         if no_diskperf:
             yield __NO_DISK_PERF__, None
 

--- a/scalyr_agent/builtin_monitors/windows_system_metrics.py
+++ b/scalyr_agent/builtin_monitors/windows_system_metrics.py
@@ -163,7 +163,13 @@ def _gather_metric(method, attribute=None, transform=None):
         if no_diskperf:
             yield __NO_DISK_PERF__, None
 
-    gather_metric.__doc__ = doc(method, attribute)
+    try:
+        gather_metric.__doc__ = doc(method, attribute)
+    except ValueError as e:
+        if "zero length field name in format" in str(e):
+            pass
+        else:
+            raise e
     return gather_metric
 
 

--- a/tests/unit/builtin_monitors/linux_system_metrics_test.py
+++ b/tests/unit/builtin_monitors/linux_system_metrics_test.py
@@ -15,6 +15,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
+import os
 import sys
 import time
 import platform
@@ -30,6 +31,8 @@ from scalyr_agent.test_base import skipIf
 
 import mock
 import platform
+
+IS_FEDORA = os.path.exists("/etc/fedora-release")
 
 __all__ = ["LinuxSystemMetricsMonitorTest"]
 
@@ -75,6 +78,17 @@ class LinuxSystemMetricsMonitorTest(ScalyrTestCase):
 
         for metric in monitor_info.metrics:
             metric_name = metric.metric_name
+
+            if (
+                IS_FEDORA
+                and metric_name.startswith("df.")
+                and metric_name not in seen_metrics
+            ):
+                # On some newer versions of fedora, retrieving disk metrics will fail with
+                # "operation not permitted" error if not running as root so this error should not
+                # be fatal here
+                continue
+
             self.assertTrue(
                 metric_name in seen_metrics, "metric %s not seen" % (metric_name)
             )

--- a/tests/unit/builtin_monitors/test_windows_system_metrics.py
+++ b/tests/unit/builtin_monitors/test_windows_system_metrics.py
@@ -1,0 +1,40 @@
+# Copyright 2014-2020 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import mock
+
+from scalyr_agent.test_base import ScalyrTestCase
+
+from scalyr_agent.builtin_monitors.windows_system_metrics import _gather_metric
+from scalyr_agent.builtin_monitors.windows_system_metrics import __NO_DISK_PERF__
+
+__all__ = ["WindowsSystemMetricsMonitorTestCase"]
+
+
+class WindowsSystemMetricsMonitorTestCase(ScalyrTestCase):
+    @mock.patch("scalyr_agent.builtin_monitors.windows_system_metrics.methodcaller")
+    def test_gather_metrics_diskperf_not_available(self, mock_methodcaller):
+        mock_methodcaller.side_effect = RuntimeError("couldn't find any physical disk")
+        result = list(_gather_metric(method="disk_io_counters")())
+
+        self.assertEqual(result[0][0], __NO_DISK_PERF__)
+
+        mock_methodcaller.side_effect = AttributeError(
+            "'NoneType' object has no attribute 'read_bytes'"
+        )
+        result = list(_gather_metric(method="disk_io_counters")())
+
+        self.assertEqual(result[0][0], __NO_DISK_PERF__)


### PR DESCRIPTION
This small PR adds another check for an error caused by disabled "diskperf". This error may happen on older versions of windows and the existing exception catch does not work.