### PR TITLE
Warn user on non-UTF-8 coding / locale and other locale related improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,12 +114,6 @@ commands:
       - checkout
       - restore_cache:
           key: deps2-tox-{{ .Branch }}-<< parameters.python_version >>-venv-{{ checksum "dev-requirements.txt" }}
-      - run:
-          name: Configure Locales
-          command: |
-            # Needed for locale tests
-            locale-gen en_US.UTF-8
-            locale-gen en en_US en_US.UTF-8
       - when:
           condition: << parameters.apt_dependencies >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,12 @@ commands:
       - checkout
       - restore_cache:
           key: deps2-tox-{{ .Branch }}-<< parameters.python_version >>-venv-{{ checksum "dev-requirements.txt" }}
+      - run:
+          name: Configure Locales
+          command: |
+            # Needed for locale tests
+            locale-gen en_US.UTF-8
+            locale-gen en en_US en_US.UTF-8
       - when:
           condition: << parameters.apt_dependencies >>
           steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Features:
 
 Improvements:
 * Improve logging in the Kubernetes monitor.
+* On agent start up we now also log locale (language code and encoding) used by the agent process. This will make it easier to troubleshoot issues which are related to the agent process not using UTF-8 coding.
 
 Bug fixes:
 * Fix a bug / race-condition in Docker monitor which could cause, under some scenarios, when monitoring containers running on the same host, logs to stop being ingested after the container restart. There was a relatively short time window when this could happen and it was more likely to affect containers which take longer to stop / start.

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -45,7 +45,6 @@ import sys
 import time
 import re
 import ssl
-import locale
 from io import open
 
 try:
@@ -1050,20 +1049,12 @@ class ScalyrAgent(object):
                 # easier for us to troubleshoot invalid locale related issues
                 lang_env_var = compat.os_environ_unicode.get("LANG", "notset")
 
-                try:
-                    language_code, encoding = locale.getdefaultlocale()
-                    if language_code and encoding:
-                        used_locale = ".".join([language_code, encoding])
-                    else:
-                        language_code = "unknown"
-                        encoding = "unknown"
-                        used_locale = "unable to retrieve locale"
-                except Exception as e:
-                    language_code = "unknown"
-                    encoding = "unknown"
-                    used_locale = "unable to retrieve locale: %s" % (str(e))
+                (
+                    language_code,
+                    encoding,
+                    used_locale,
+                ) = scalyr_util.get_language_code_coding_and_locale()
 
-                # TODO: Why do we log the same line under info and debug? Intentional?
                 msg = (
                     "Starting scalyr agent... (version=%s) (revision=%s) %s (Python version: %s) "
                     "(OpenSSL version: %s) (default fs encoding: %s) (locale: %s) (LANG env variable: %s)"

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -112,6 +112,16 @@ AGENT_LOG_FILENAME = "agent.log"
 
 AGENT_NOT_RUNNING_MESSAGE = "The agent does not appear to be running."
 
+# Message which is logged when locale used for the scalyr agent process is not UTF-8
+NON_UTF8_LOCALE_WARNING_MESSAGE = """
+Detected a non UTF-8 locale (%s) being used. You are strongly encouraged to set the locale /
+coding for the agent process to UTF-8. Otherwise things won't work when trying to monitor files
+with non-ascii content or non-ascii characters in the log file names. On Linux you can do that by
+setting LANG and LC_ALL environment variable: e.g. export LC_ALL=en_US.UTF-8.
+""".strip().replace(
+    "\n", " "
+)
+
 # Work around for a potential race which may happen when threads try to resolve a unicode hostname
 # or similar
 # See:
@@ -1049,14 +1059,7 @@ class ScalyrAgent(object):
                 # content
                 _, encoding, _ = scalyr_util.get_language_code_coding_and_locale()
                 if encoding.lower() not in "utf-8":
-                    log.warn(
-                        "Detected a non UTF-8 locale (%s) being used. You are strongly "
-                        "encouraged to set the locale / coding for the agent process to UTF-8. "
-                        "Otherwise things won't work when trying to monitor files with "
-                        "non-ascii content or non-ascii characters in the log file names. "
-                        "On Linux you can do that by setting LANG and LC_ALL environment "
-                        "variable: e.g. export LC_ALL=en_US.UTF-8." % (encoding)
-                    )
+                    log.warn(NON_UTF8_LOCALE_WARNING_MESSAGE % (encoding))
 
                 self.__controller.emit_init_log(log, self.__config.debug_init)
 

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -1058,7 +1058,7 @@ class ScalyrAgent(object):
                 # to monitor files with unicode characters inside the file names or inside the
                 # content
                 _, encoding, _ = scalyr_util.get_language_code_coding_and_locale()
-                if encoding.lower() not in "utf-8":
+                if encoding.lower() not in ["utf-8", "utf8"]:
                     log.warn(NON_UTF8_LOCALE_WARNING_MESSAGE % (encoding))
 
                 self.__controller.emit_init_log(log, self.__config.debug_init)

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -1040,42 +1040,14 @@ class ScalyrAgent(object):
                 else:
                     logs_initial_positions = None
 
-                # 2->TODO it was very helpful to see what python version does agent run on. Maybe we can keep it?
-                python_version_str = sys.version.replace("\n", "")
-                build_revision = get_build_revision()
-                openssl_version = getattr(ssl, "OPENSSL_VERSION", "unknown")
-
-                # We also include used locale and LANG env variable values since this makes it
-                # easier for us to troubleshoot invalid locale related issues
-                lang_env_var = compat.os_environ_unicode.get("LANG", "notset")
-
-                (
-                    language_code,
-                    encoding,
-                    used_locale,
-                ) = scalyr_util.get_language_code_coding_and_locale()
-
-                msg = (
-                    "Starting scalyr agent... (version=%s) (revision=%s) %s (Python version: %s) "
-                    "(OpenSSL version: %s) (default fs encoding: %s) (locale: %s) (LANG env variable: %s)"
-                    % (
-                        SCALYR_VERSION,
-                        build_revision,
-                        scalyr_util.get_pid_tid(),
-                        python_version_str,
-                        openssl_version,
-                        sys.getfilesystemencoding(),
-                        used_locale,
-                        lang_env_var,
-                    )
-                )
-
-                log.info(msg)
-                log.log(scalyr_logging.DEBUG_LEVEL_1, msg)
+                start_up_msg = scalyr_util.get_agent_start_up_message()
+                log.info(start_up_msg)
+                log.log(scalyr_logging.DEBUG_LEVEL_1, start_up_msg)
 
                 # Log warn message if non UTF-8 locale is used - this would cause issues when trying
                 # to monitor files with unicode characters inside the file names or inside the
                 # content
+                _, encoding, _ = scalyr_util.get_language_code_coding_and_locale()
                 if encoding.lower() not in "utf-8":
                     log.warn(
                         "Detected a non UTF-8 locale (%s) being used. You are strongly "

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -30,6 +30,7 @@ if False:  # NOSONAR
 
 import codecs
 import sys
+import locale
 from io import open
 
 import six
@@ -2069,6 +2070,27 @@ def get_compress_and_decompress_func(compression_algorithm, compression_level=9)
         raise ValueError("Unsupported algorithm: %s" % (compression_algorithm))
 
     return compress_func, decompress_func
+
+
+def get_language_code_coding_and_locale():
+    # type: () -> Tuple[str, str, str]
+    """
+    Return values for the currently set language code, coding and user-friendly locale string.
+    """
+    try:
+        language_code, encoding = locale.getdefaultlocale()
+        if language_code and encoding:
+            used_locale = ".".join([language_code, encoding])
+        else:
+            language_code = "unknown"
+            encoding = "unknown"
+            used_locale = "unable to retrieve locale"
+    except Exception as e:
+        language_code = "unknown"
+        encoding = "unknown"
+        used_locale = "unable to retrieve locale: %s" % (str(e))
+
+    return language_code, encoding, used_locale
 
 
 class RateLimiterToken(object):

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -51,6 +51,11 @@ import threading
 import time
 import uuid
 
+try:
+    from __scalyr__ import SCALYR_VERSION
+except ImportError:
+    from scalyr_agent.__scalyr__ import SCALYR_VERSION
+
 import scalyr_agent.json_lib as json_lib
 from scalyr_agent.json_lib import JsonParseException
 from scalyr_agent.platform_controller import CannotExecuteAsUser
@@ -2100,8 +2105,6 @@ def get_agent_start_up_message():
     """
     Return a message which is logged on agent start up.
     """
-    from scalyr_agent.agent_main import SCALYR_VERSION
-
     python_version_str = sys.version.replace("\n", "")
     build_revision = get_build_revision()
     openssl_version = getattr(ssl, "OPENSSL_VERSION", "unknown")

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -238,7 +238,7 @@ def get_json_implementation(lib_name):
             try:
                 return orjson.loads(data, *args, **kwargs)
             except Exception as e:
-                if "leading surrogate" in str(e):
+                if "leading surrogate" in str(e) or "surrogates not allowed" in str(e):
                     _, _, _json_loads = get_json_implementation("json")
                     return _json_loads(data, *args, **kwargs)
                 else:

--- a/tests/ami/scripts/test_deb.sh.j2
+++ b/tests/ami/scripts/test_deb.sh.j2
@@ -117,11 +117,13 @@ echo_with_date ""
 echo_with_date "Verifying agent.log"
 echo_with_date ""
 
+# Verify agent start up line
+sudo cat /var/log/scalyr-agent-2/agent.log | grep "Starting scalyr agent"
+
 # Ensure CA validation is not disabled with default install
 sudo cat /var/log/scalyr-agent-2/agent.log | grep -v "sslverifyoff"
 sudo cat /var/log/scalyr-agent-2/agent.log | grep -v "Server certificate validation has been disabled"
 echo_with_date ""
-
 
 {% if test_type == "upgrade" -%}
 # Upgrade to new version

--- a/tests/ami/scripts/test_rpm.sh.j2
+++ b/tests/ami/scripts/test_rpm.sh.j2
@@ -120,6 +120,9 @@ echo_with_date ""
 echo_with_date "Verifying agent.log"
 echo_with_date ""
 
+# Verify agent start up line
+sudo cat /var/log/scalyr-agent-2/agent.log | grep "Starting scalyr agent"
+
 # Ensure CA validation is not disabled with default install
 sudo cat /var/log/scalyr-agent-2/agent.log | grep -v "sslverifyoff"
 sudo cat /var/log/scalyr-agent-2/agent.log | grep -v "Server certificate validation has been disabled"

--- a/tests/ami/scripts/test_windows.ps1.j2
+++ b/tests/ami/scripts/test_windows.ps1.j2
@@ -196,6 +196,11 @@ if ("$event_log_output" -notmatch "ScalyrAgentTest")   { Throw "Matching event n
 if ("$event_log_output" -notmatch "Scalyr automated tests event")   { Throw "Matching event not found in event log" };
 
 #
+# Verify agent start up line
+#
+Select-String -Path "C:\Program Files (x86)\Scalyr\log\agent.log" -Pattern "Starting scalyr agent"
+
+#
 # Ensure CA validation is not disabled with default install
 #
 

--- a/tests/smoke_tests/verifier.py
+++ b/tests/smoke_tests/verifier.py
@@ -146,7 +146,7 @@ class AgentLogVerifier(AgentVerifier):
         # This version check is done against a local agent.log file and status -v --format=json
         # output and not Scalyr API so we don't need to retry it and wait for logs to be shipped to
         # Scalyr API.
-        time.sleep(2)
+        time.sleep(4)
         self._verify_agent_version_string()
 
         # Now call the parent verify method which calls _verify()

--- a/tests/smoke_tests/verifier.py
+++ b/tests/smoke_tests/verifier.py
@@ -14,6 +14,8 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+
+import os
 import abc
 import datetime
 import json
@@ -166,7 +168,12 @@ class AgentLogVerifier(AgentVerifier):
 
         if not local_agent_log_data:
             raise ValueError(
-                ("No data in '{0}' file.".format(self._runner.agent_log_file_path))
+                (
+                    "No data in '{0}' file. Directory content: {1}".format(
+                        self._runner.agent_log_file_path,
+                        os.listdir(self._runner.agent_logs_dir_path),
+                    )
+                )
             )
 
         print("Check start line contains correct version and revision string")

--- a/tests/unit/test_util_test.py
+++ b/tests/unit/test_util_test.py
@@ -187,3 +187,15 @@ class MiscUtilsTestCase(ScalyrTestCase):
         self.assertEqual(
             used_locale, "unable to retrieve locale: unknown locale: invalid"
         )
+
+        # Empty coding
+        os.environ["LC_ALL"] = "C"
+
+        (
+            language_code,
+            encoding,
+            used_locale,
+        ) = scalyr_util.get_language_code_coding_and_locale()
+        self.assertEqual(language_code, "unknown")
+        self.assertEqual(encoding, "unknown")
+        self.assertEqual(used_locale, "unable to retrieve locale")

--- a/tests/unit/test_util_test.py
+++ b/tests/unit/test_util_test.py
@@ -161,7 +161,7 @@ class MiscUtilsTestCase(ScalyrTestCase):
     @skipIf(platform.system() == "Darwin", "Skipping Linux Monitor tests on OSX")
     @skipIf(platform.system() == "Windows", "Skipping Linux Monitor tests on Windows")
     def test_get_language_code_coding_and_locale(self):
-        locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
+        locale.setlocale(locale.LC_ALL, "C.UTF-8")
 
         (
             language_code,
@@ -170,9 +170,9 @@ class MiscUtilsTestCase(ScalyrTestCase):
         ) = scalyr_util.get_language_code_coding_and_locale()
 
         # NOTE: On some systems UTF-8 is normalized to UTF8 so we ignore "-" in the value
-        self.assertEqual(language_code, "en_US")
+        self.assertTrue(language_code in ["C", "en_US"])
         self.assertEqual(encoding.replace("-", ""), "UTF8")
-        self.assertEqual(used_locale.replace("-", ""), "en_US.UTF8")
+        self.assertTrue(used_locale.replace("-", "") in ["C.UTF8", "en_US.UTF8"])
 
         # NOTE: To be able to test other locales we would need to install other locale packages
         os.environ["LC_ALL"] = "invalid"

--- a/tests/unit/test_util_test.py
+++ b/tests/unit/test_util_test.py
@@ -21,6 +21,7 @@ from io import open
 
 import os
 import locale
+import platform
 
 import mock
 import six
@@ -28,6 +29,7 @@ import six
 from scalyr_agent import util as scalyr_util
 from scalyr_agent.test_base import BaseScalyrLogCaptureTestCase
 from scalyr_agent.test_base import ScalyrTestCase
+from scalyr_agent.test_base import skipIf
 
 __all__ = ["LogCaptureClassTestCase"]
 
@@ -156,6 +158,8 @@ class MiscUtilsTestCase(ScalyrTestCase):
         if "LC_ALL" in os.environ:
             del os.environ["LC_ALL"]
 
+    @skipIf(platform.system() == "Darwin", "Skipping Linux Monitor tests on OSX")
+    @skipIf(platform.system() == "Windows", "Skipping Linux Monitor tests on Windows")
     def test_get_language_code_coding_and_locale(self):
         locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
 
@@ -164,9 +168,11 @@ class MiscUtilsTestCase(ScalyrTestCase):
             encoding,
             used_locale,
         ) = scalyr_util.get_language_code_coding_and_locale()
+
+        # NOTE: On some systems UTF-8 is normalized to UTF8 so we ignore "-" in the value
         self.assertEqual(language_code, "en_US")
-        self.assertEqual(encoding, "UTF-8")
-        self.assertEqual(used_locale, "en_US.UTF-8")
+        self.assertEqual(encoding.replace("-", ""), "UTF8")
+        self.assertEqual(used_locale.replace("-", ""), "en_US.UTF8")
 
         # NOTE: To be able to test other locales we would need to install other locale packages
         os.environ["LC_ALL"] = "invalid"

--- a/tests/unit/util/json_util_test.py
+++ b/tests/unit/util/json_util_test.py
@@ -167,7 +167,12 @@ class UnicodeAndLocaleEncodingAndDecodingTestCase(ScalyrTestCase):
     def tearDown(self):
         super(UnicodeAndLocaleEncodingAndDecodingTestCase, self).tearDown()
 
-        locale.setlocale(locale.LC_ALL, self.original_locale)
+        if self.original_locale:
+            try:
+                locale.setlocale(locale.LC_ALL, self.original_locale)
+            except locale.Error:
+                # unsupported localle setting error should not be fatal
+                pass
 
         if "LC_ALL" in os.environ:
             del os.environ["LC_ALL"]

--- a/tests/unit/util/json_util_test.py
+++ b/tests/unit/util/json_util_test.py
@@ -218,6 +218,14 @@ class UnicodeAndLocaleEncodingAndDecodingTestCase(ScalyrTestCase):
         loaded = util.json_decode(result)
         self.assertEqual(loaded, original_data)
 
+        # Invalid UTF-8, should fall back to standard json implementation
+        original_data = "\ud800"
+        result = util.json_encode(original_data)
+        self.assertEqual(result, '"\\ud800"')
+
+        loaded = util.json_decode('"\ud800"')
+        self.assertEqual(loaded, original_data)
+
 
 @pytest.mark.json_lib
 class TestDefaultJsonLibrary(ScalyrTestCase):

--- a/tests/unit/util/json_util_test.py
+++ b/tests/unit/util/json_util_test.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 
 __author__ = "echee@scalyr.com"
 
-
+import os
 import sys
 import unittest
 import importlib
@@ -169,6 +169,9 @@ class UnicodeAndLocaleEncodingAndDecodingTestCase(ScalyrTestCase):
 
         locale.setlocale(locale.LC_ALL, self.original_locale)
 
+        if "LC_ALL" in os.environ:
+            del os.environ["LC_ALL"]
+
     def test_non_ascii_data_non_utf_locale_coding_default_json_lib(self):
         util.set_json_lib("json")
         original_data = "čććžšđ"
@@ -181,7 +184,7 @@ class UnicodeAndLocaleEncodingAndDecodingTestCase(ScalyrTestCase):
         self.assertEqual(loaded, original_data)
 
         # Non UTF-8 Locale
-        locale.setlocale(locale.LC_ALL, "C")
+        os.environ["LC_ALL"] = "invalid"
 
         result = util.json_encode(original_data)
         self.assertEqual(result, '"\\u010d\\u0107\\u0107\\u017e\\u0161\\u0111"')
@@ -202,7 +205,7 @@ class UnicodeAndLocaleEncodingAndDecodingTestCase(ScalyrTestCase):
         self.assertEqual(loaded, original_data)
 
         # Non UTF-8 Locale
-        locale.setlocale(locale.LC_ALL, "C")
+        os.environ["LC_ALL"] = "invalid"
 
         result = util.json_encode(original_data)
         self.assertEqual(result, '"%s"' % (original_data))


### PR DESCRIPTION
This pull request updates the agent start up code to log a warning if non ``UTF-8`` coding / locale is detected.

## Background, Context

I was troubleshooting a customer issue and noticed multiple issues which could arise when locale / coding under which the agent is running is not set to UTF-8 and user is trying to monitor files with non-ascii characters in the file names / content.

Ultimately, if we encounter this scenario this represents a misconfiguration on the user side so there is not much we can do beyond warning the user and advising them to change the locale to UTF-8 (I mean in theory we could try setting locale using ``locale.setlocale``, but I'm worried this may open a can of worms and is something we should avoid - just the other day I was reading this "rant" wrt to locale mess on POSIX systems - https://github.com/mpv-player/mpv/commit/1e70e82baa9193f6f027338b0fab0f5078971fbe).

Keep in mind that some of those issues will only arise under Python 2 and not Python 3 (e.g. ``os.path.join`` only seems to throw under Python 2 if coding is not UTF-8, but not under Python 3).

In addition to the warning change, I also added a small idna encoding issue workaround (https://bugs.python.org/issue29288) and updated orjson code to fall back to native Python json implementation on unicode related errors - it appears orjson will throw whereas native Python json library won't if we try to  load / dump data with non-ascii characters when locale / coding is not set to UTF-8.

## TODO

- [x] Unit tests
- [x] Verify change on Windows