### PR TITLE
Fix invalid handling of bad / partial unicode sequences in the LineGrouper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
+## 2.1.15 "TBD" - November 20, 2020
+
+<!---
+Packaged by Tomaz Muraus <tomaz@scalyr.com> on Nov 20, 2020 14:00 -0800
+--->
+
+Bug fixes:
+* Fix line grouping code and make sure we don't throw if line data contains bad or partial unicode escape sequence.
+
 ## 2.1.14 "Hydrus" - November 4, 2020
 
 <!---

--- a/scalyr_agent/builtin_monitors/linux_process_metrics.py
+++ b/scalyr_agent/builtin_monitors/linux_process_metrics.py
@@ -924,7 +924,7 @@ class ProcessList(object):
         regex = r"\s*(\d+)\s+(\d+)\s+(.*)"
         # 2->TODO stdout is binary in Python3
         sub_proc_output = sub_proc.stdout.read()
-        sub_proc_output = sub_proc_output.decode("utf-8")
+        sub_proc_output = sub_proc_output.decode("utf-8", "replace")
         for line in sub_proc_output.splitlines(True):
             match = re.search(regex, line)
             if match:

--- a/scalyr_agent/compat.py
+++ b/scalyr_agent/compat.py
@@ -121,7 +121,9 @@ if six.PY2:
             for element in iterable:
                 if type(element) is tuple:
                     yield tuple(
-                        v.decode("utf-8") if type(v) is six.binary_type else v
+                        v.decode("utf-8", "replace")
+                        if type(v) is six.binary_type
+                        else v
                         for v in element
                     )
                 else:

--- a/scalyr_agent/line_matcher.py
+++ b/scalyr_agent/line_matcher.py
@@ -220,8 +220,8 @@ class LineGrouper(LineMatcher):
     """
 
     # Value for the "errors" argument which is passed to the bytes.decode() function call.
-    # This should really only be set to something else than ignore inside the tests.
-    DECODE_ERRORS_VALUE = "ignore"
+    # This should really only be set to something else than ignore / replace inside the tests.
+    DECODE_ERRORS_VALUE = "replace"
 
     def __init__(
         self,

--- a/scalyr_agent/line_matcher.py
+++ b/scalyr_agent/line_matcher.py
@@ -219,6 +219,10 @@ class LineGrouper(LineMatcher):
     multiline should continue.
     """
 
+    # Value for the "errors" argument which is passed to the bytes.decode() function call.
+    # This should really only be set to something else than ignore inside the tests.
+    DECODE_ERRORS_VALUE = "ignore"
+
     def __init__(
         self,
         start_pattern,
@@ -260,7 +264,7 @@ class LineGrouper(LineMatcher):
         # This way we still ingest rest of the data even if part of it is malformed or corrupted.
 
         # check to see if this line starts a multiline
-        start_line_decoded = start_line.decode("utf-8", "ignore")
+        start_line_decoded = start_line.decode("utf-8", self.DECODE_ERRORS_VALUE)
         start = self._start_line(start_line_decoded)
         if start:
             max_length -= len(start_line)
@@ -274,7 +278,7 @@ class LineGrouper(LineMatcher):
             elif next_line:
 
                 # see if we are continuing the line
-                next_line_decoded = next_line.decode("utf-8", "ignore")
+                next_line_decoded = next_line.decode("utf-8", self.DECODE_ERRORS_VALUE)
                 cont = self._continue_line(next_line_decoded)
                 if cont:
                     line = start_line
@@ -291,7 +295,9 @@ class LineGrouper(LineMatcher):
                                 self, file_like, max_length
                             )
                             # Only check if this line is a continuation if we got the full line.
-                            next_line_decoded = next_line.decode("utf-8", "ignore")
+                            next_line_decoded = next_line.decode(
+                                "utf-8", self.DECODE_ERRORS_VALUE
+                            )
                             cont = not partial and self._continue_line(
                                 next_line_decoded
                             )

--- a/scalyr_agent/line_matcher.py
+++ b/scalyr_agent/line_matcher.py
@@ -256,8 +256,11 @@ class LineGrouper(LineMatcher):
         if partial:
             return start_line, partial
 
+        # NOTE: When decoding line data we simply ignore any invalid or partial unicode sequences
+        # This way we still ingest rest of the data even if part of it is malformed or corrupted.
+
         # check to see if this line starts a multiline
-        start_line_decoded = start_line.decode("utf-8")
+        start_line_decoded = start_line.decode("utf-8", "ignore")
         start = self._start_line(start_line_decoded)
         if start:
             max_length -= len(start_line)
@@ -271,7 +274,7 @@ class LineGrouper(LineMatcher):
             elif next_line:
 
                 # see if we are continuing the line
-                next_line_decoded = next_line.decode("utf-8")
+                next_line_decoded = next_line.decode("utf-8", "ignore")
                 cont = self._continue_line(next_line_decoded)
                 if cont:
                     line = start_line
@@ -288,7 +291,7 @@ class LineGrouper(LineMatcher):
                                 self, file_like, max_length
                             )
                             # Only check if this line is a continuation if we got the full line.
-                            next_line_decoded = next_line.decode("utf-8")
+                            next_line_decoded = next_line.decode("utf-8", "ignore")
                             cont = not partial and self._continue_line(
                                 next_line_decoded
                             )

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -703,7 +703,7 @@ class LogFileIterator(object):
         if self.__parse_format == "cri":
             # 2->TODO decode line to parse it.
             timestamp, stream, tags, message = _parse_cri_log(
-                result.line.decode("utf-8")
+                result.line.decode("utf-8", "replace")
             )
             if message is None:
                 log.warning(
@@ -724,7 +724,7 @@ class LogFileIterator(object):
             try:
                 # 2->TODO decode line to parse it.
                 # TODO: optimize
-                attrs = scalyr_util.json_decode(result.line.decode("utf-8"))
+                attrs = scalyr_util.json_decode(result.line.decode("utf-8", "replace"))
 
                 # NOTE: To speed things up we avoid iterating over the whole object but manipulate
                 # parsed object in place. That can be up to 10x faster, but it depends on the object

--- a/scalyr_agent/platform_posix.py
+++ b/scalyr_agent/platform_posix.py
@@ -1283,7 +1283,7 @@ class StatusReporter(object):
                 message = self.__fp.read()
                 if len(message) == int(num_bytes):
                     # 2->TODO return unicode
-                    return message.decode("utf-8")
+                    return message.decode("utf-8", "replace")
             time.sleep(0.20)
 
     @property

--- a/scalyr_agent/test_util.py
+++ b/scalyr_agent/test_util.py
@@ -190,7 +190,7 @@ def parse_scalyr_request(payload):
         length = compat.struct_unpack_unicode(">i", x.group(1))[0]
         # Grab the string content as raw bytes.
         raw_string = payload[x.end(1) : x.end(1) + length]
-        text_string = raw_string.decode("utf-8")
+        text_string = raw_string.decode("utf-8", "replace")
         rewritten_payload += scalyr_util.json_encode(text_string, binary=True)
         last_processed_index = x.end(1) + length - 1
     rewritten_payload += payload[last_processed_index + 1 : len(payload)]
@@ -205,4 +205,4 @@ def parse_scalyr_request(payload):
     # NOTE: Special case for Windows where path is C:\ which we don't want to convert
     rewritten_payload = rewritten_payload.replace(b'"C":\\', b"C:\\")
 
-    return scalyr_util.json_decode(rewritten_payload.decode("utf-8"))
+    return scalyr_util.json_decode(rewritten_payload.decode("utf-8", "replace"))

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -553,7 +553,7 @@ def create_unique_id():
     """
     # 2->TODO this function should return unicode.
     base64_id = base64.urlsafe_b64encode(sha1(uuid.uuid1().bytes).digest())
-    return base64_id.decode("utf-8")
+    return base64_id.decode("utf-8", "replace")
 
 
 def create_uuid3(namespace, name):
@@ -1811,7 +1811,7 @@ class RedirectorClient(StoppableThread):
                 bytes_to_read = code >> 1
                 stream_id = code % 2
 
-                content = self.__channel.read(bytes_to_read).decode("utf-8")
+                content = self.__channel.read(bytes_to_read).decode("utf-8", "replace")
 
                 if stream_id == RedirectorServer.STDOUT_STREAM_ID:
                     self.__stdout.write(content)

--- a/tests/unit/builtin_monitors/docker_monitor_test.py
+++ b/tests/unit/builtin_monitors/docker_monitor_test.py
@@ -85,8 +85,7 @@ class ContainerCheckerTestCase(ScalyrTestCase):
         )
         # We mock start time which is used in the calculation to make tests more stable
         mock_start_time = 12345
-        # TODO: Fix and use utcfromtimestamp when PR #647 is merged
-        mock_start_time_dt = datetime.datetime.fromtimestamp(mock_start_time)
+        mock_start_time_dt = datetime.datetime.utcfromtimestamp(mock_start_time)
         container_checker._ContainerChecker__start_time = mock_start_time
 
         # 1. Existing log file is not available, should use start_time timestamp

--- a/tests/unit/log_processing_test.py
+++ b/tests/unit/log_processing_test.py
@@ -335,7 +335,7 @@ class TestLogFileIterator(ScalyrTestCase):
         self.log_file.scan_for_new_bytes()
 
         expected_msg = "invalid start byte"
-        self.assertRaisesRegex(
+        self.assertRaisesRegexp(
             UnicodeDecodeError, expected_msg, lambda: self.readline().line
         )
 
@@ -343,7 +343,7 @@ class TestLogFileIterator(ScalyrTestCase):
         self.assertEqual(result, line_data[1])
 
         expected_msg = "invalid start byte"
-        self.assertRaisesRegex(
+        self.assertRaisesRegexp(
             UnicodeDecodeError, expected_msg, lambda: self.readline().line
         )
 

--- a/tests/unit/log_processing_test.py
+++ b/tests/unit/log_processing_test.py
@@ -347,8 +347,9 @@ class TestLogFileIterator(ScalyrTestCase):
             UnicodeDecodeError, expected_msg, lambda: self.readline().line
         )
 
-    def test_line_groupers_non_utf8_data_errors_ignore(self):
-        LineGrouper.DECODE_ERRORS_VALUE = "ignore"
+    def test_line_groupers_non_utf8_data_errors_replace(self):
+        # errors="replace"
+        LineGrouper.DECODE_ERRORS_VALUE = "replace"
 
         log_config = {
             "path": self.__path,
@@ -360,7 +361,6 @@ class TestLogFileIterator(ScalyrTestCase):
             ),
         }
 
-        # errors="ignore"
         log_config = DEFAULT_CONFIG.parse_log_config(log_config)
         matcher = LineMatcher.create_line_matchers(log_config, 100, 60)
         self.log_file.set_line_matcher(matcher)

--- a/tests/unit/log_processing_test.py
+++ b/tests/unit/log_processing_test.py
@@ -40,6 +40,7 @@ from scalyr_agent.log_processing import (
     LogFileProcessor,
     LogMatcher,
 )
+from scalyr_agent.line_matcher import LineGrouper
 from scalyr_agent.log_processing import FileSystem
 from scalyr_agent.log_processing import _parse_cri_log as parse_cri_log
 from scalyr_agent.json_lib import JsonObject
@@ -299,6 +300,101 @@ class TestLogFileIterator(ScalyrTestCase):
 
         for line in expected:
             self.assertEqual(line, self.readline().line)
+
+    def test_line_groupers_non_utf8_data_errors_strict(self):
+        # If errors="strict", code should fail
+        LineGrouper.DECODE_ERRORS_VALUE = "strict"
+
+        log_config = {
+            "path": self.__path,
+            "lineGroupers": JsonArray(
+                DEFAULT_CONTINUE_THROUGH,
+                DEFAULT_CONTINUE_PAST,
+                DEFAULT_HALT_BEFORE,
+                DEFAULT_HALT_WITH,
+            ),
+        }
+
+        log_config = DEFAULT_CONFIG.parse_log_config(log_config)
+        matcher = LineMatcher.create_line_matchers(log_config, 100, 60)
+        self.log_file.set_line_matcher(matcher)
+        self.log_file.set_parameters(200, 200)
+
+        line_data = [
+            b"--multi\n--continue\n--\xBA\xDD\\xAT\xA0some more\n",
+            b"single line\n",
+            b"multi\\\n--\xBA\xDD\\xAT\xA0continue\\\n--some more\n",
+            b"single line\n",
+            b"--begin\n--continue\xBA\xDD\\xAT\xA0\n",
+            b"--end\n",
+            b"--start\n--continue\n--stop\n",
+            b"the end\n",
+        ]
+
+        self.append_file(self.__path, b"".join(line_data))
+        self.log_file.scan_for_new_bytes()
+
+        expected_msg = "invalid start byte"
+        self.assertRaisesRegex(
+            UnicodeDecodeError, expected_msg, lambda: self.readline().line
+        )
+
+        result = self.readline().line
+        self.assertEqual(result, line_data[1])
+
+        expected_msg = "invalid start byte"
+        self.assertRaisesRegex(
+            UnicodeDecodeError, expected_msg, lambda: self.readline().line
+        )
+
+    def test_line_groupers_non_utf8_data_errors_ignore(self):
+        LineGrouper.DECODE_ERRORS_VALUE = "ignore"
+
+        log_config = {
+            "path": self.__path,
+            "lineGroupers": JsonArray(
+                DEFAULT_CONTINUE_THROUGH,
+                DEFAULT_CONTINUE_PAST,
+                DEFAULT_HALT_BEFORE,
+                DEFAULT_HALT_WITH,
+            ),
+        }
+
+        # errors="ignore"
+        log_config = DEFAULT_CONFIG.parse_log_config(log_config)
+        matcher = LineMatcher.create_line_matchers(log_config, 100, 60)
+        self.log_file.set_line_matcher(matcher)
+        self.log_file.set_parameters(200, 200)
+
+        # Lines contains corrupted / bad utf8 sequence
+        # UnicodeDecodeError: 'utf-8' codec can't decode byte 0xba in position 2: invalid start byte
+        line_data = [
+            b"--multi\n--continue\n--\xBA\xDD\\xAT\xA0some more\n",
+            b"single line\n",
+            b"multi\\\n--\xBA\xDD\\xAT\xA0continue\\\n--some more\n",
+            b"single line\n",
+            b"--begin\n--continue\xBA\xDD\\xAT\xA0\n",
+            b"--end\n",
+            b"--start\n--continue\n--stop\n",
+            b"the end\n",
+        ]
+        expected = [
+            b"--multi\n--continue\n--\xba\xdd\\xAT\xa0some more\n",
+            b"single line\n",
+            b"multi\\\n--\xBA\xDD\\xAT\xA0continue\\\n--some more\n",
+            b"single line\n",
+            b"--begin\n--continue\xba\xdd\\xAT\xa0\n",
+            b"--end\n",
+            b"--start\n--continue\n--stop\n",
+            b"the end\n",
+        ]
+
+        self.append_file(self.__path, b"".join(line_data))
+        self.log_file.scan_for_new_bytes()
+
+        for line in expected:
+            actual_line = self.readline().line
+            self.assertEqual(line, actual_line)
 
     def test_multiple_line_grouper_options(self):
         log_config = {


### PR DESCRIPTION
This pull request fixes ``LineGrouper`` class and makes sure we ignore any decoding errors we get when we try to decode bytes to utf-8 string.

Previously, this code would throw on partial / bad / corrupted unicode sequences.

## Background, Context

A user reported an issue with agent throwing ``UnicodeDecodeError`` inside the line matcher code.

After digging in, I saw our code doesn't correctly handle and ignore bad unicode sequences, but it fails on decode.

Keep in mind that this issue would only affect users which had line grouping rules defined.

## Open Questions

There are some more places in our code base where we rely on a default "strict" behavior of ``bytes.decode()``.

To be on the safe side, I think we should update all of those places to gracefully handle unicode decoded errors.

## TODO

- [ ] Changelog entry
- [ ] Update rest of the code