### PR TITLE
Fix bug in the sleep before initial sample gather code

### DIFF
--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1799,7 +1799,7 @@ class Configuration(object):
         self.__verify_or_set_optional_bool(
             config,
             "global_monitor_sample_interval_enable_jitter",
-            False,
+            True,
             description,
             apply_defaults,
             env_aware=True,

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -316,7 +316,13 @@ class ScalyrMonitor(StoppableThread):
             # To avoid all the monitors with the same sample interval running at the same time,
             # we add random sleep delay before the first same gathering.
             initial_sleep_delay = self._get_initial_sleep_delay()
-            self._sleep_but_awaken_if_stopped(initial_sleep_delay)
+
+            if initial_sleep_delay > 0:
+                self._sleep_but_awaken_if_stopped(initial_sleep_delay)
+                self._logger.debug(
+                    "Sleeping %s seconds before first sample gather interval"
+                    % (initial_sleep_delay)
+                )
 
             while not self._is_thread_stopped():
                 sample_interval = self._sample_interval_secs

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -313,12 +313,12 @@ class ScalyrMonitor(StoppableThread):
         """
         # noinspection PyBroadException
         try:
-            while not self._is_thread_stopped():
-                # To avoid all the monitors with the same sample interval running at the same time,
-                # we add random sleep delay before the first same gathering.
-                initial_sleep_delay = self._get_initial_sleep_delay()
-                self._sleep_but_awaken_if_stopped(initial_sleep_delay)
+            # To avoid all the monitors with the same sample interval running at the same time,
+            # we add random sleep delay before the first same gathering.
+            initial_sleep_delay = self._get_initial_sleep_delay()
+            self._sleep_but_awaken_if_stopped(initial_sleep_delay)
 
+            while not self._is_thread_stopped():
                 sample_interval = self._sample_interval_secs
 
                 # noinspection PyBroadException

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -317,7 +317,7 @@ class ScalyrMonitor(StoppableThread):
             # we add random sleep delay before the first same gathering.
             initial_sleep_delay = self._get_initial_sleep_delay()
 
-            if initial_sleep_delay > 0:
+            if initial_sleep_delay >= 1:
                 self._sleep_but_awaken_if_stopped(initial_sleep_delay)
                 self._logger.debug(
                     "Sleeping %s seconds before first sample gather interval"

--- a/tests/unit/scalyr_monitor_test.py
+++ b/tests/unit/scalyr_monitor_test.py
@@ -538,6 +538,7 @@ class MonitorConfigTest(ScalyrTestCase):
         self.assertEqual(monitor.counter, 3)
         self.assertEqual(mock_sleep_but_awaken_if_stopped.call_count, 3)
         self.assertEqual(mock_logger.debug.call_count, 0)
+        # 1 call is for monitor has finished message
         self.assertEqual(mock_logger.info.call_count, 1)
         self.assertEqual(mock_logger.exception.call_count, 0)
 
@@ -577,7 +578,9 @@ class MonitorConfigTest(ScalyrTestCase):
         self.assertEqual(monitor.counter, 3)
         # + 1 is for initial sleep delay before first sample gather interval
         self.assertEqual(mock_sleep_but_awaken_if_stopped.call_count, 1 + 3)
+        # 1 call is to debug function when we are initially sleeping before the gather
         self.assertEqual(mock_logger.debug.call_count, 1)
+        # 1 call is for monitor has finished message
         self.assertEqual(mock_logger.info.call_count, 1)
         self.assertEqual(mock_logger.exception.call_count, 0)
 

--- a/tests/unit/scalyr_monitor_test.py
+++ b/tests/unit/scalyr_monitor_test.py
@@ -502,6 +502,85 @@ class MonitorConfigTest(ScalyrTestCase):
 
             self.assertTrue(sleep_delay >= min_jitter and sleep_delay <= max_jitter)
 
+    def test_monitor_run_random_initial_sleep_delay_disabled(self):
+        def make_mock_thread_is_stopped(monitor):
+            def mock_is_thread_stopped(*args, **kwargs):
+                if monitor.counter >= 3:
+                    return True
+
+                monitor.counter += 1
+                return False
+
+            return mock_is_thread_stopped
+
+        mock_sleep_but_awaken_if_stopped = mock.Mock()
+
+        mock_logger = mock.Mock()
+        mock_gather_sample = mock.Mock()
+        monitor_config = MonitorConfig(
+            {"module": "test_module", "sample_interval": 10},
+            monitor_module="test_monitor",
+        )
+        global_config = mock.Mock()
+        global_config.global_monitor_sample_interval_enable_jitter = False
+        monitor = ScalyrMonitor(
+            monitor_config=monitor_config,
+            logger=mock_logger,
+            sample_interval_secs=None,
+            global_config=global_config,
+        )
+        monitor.counter = 0
+        monitor._sleep_but_awaken_if_stopped = mock_sleep_but_awaken_if_stopped
+        monitor._is_thread_stopped = make_mock_thread_is_stopped(monitor)
+        monitor.gather_sample = mock_gather_sample
+
+        monitor.run()
+        self.assertEqual(monitor.counter, 3)
+        self.assertEqual(mock_sleep_but_awaken_if_stopped.call_count, 3)
+        self.assertEqual(mock_logger.debug.call_count, 0)
+        self.assertEqual(mock_logger.info.call_count, 1)
+        self.assertEqual(mock_logger.exception.call_count, 0)
+
+    def test_monitor_run_random_initial_sleep_delay_enabled(self):
+        def make_mock_thread_is_stopped(monitor):
+            def mock_is_thread_stopped(*args, **kwargs):
+                if monitor.counter >= 3:
+                    return True
+
+                monitor.counter += 1
+                return False
+
+            return mock_is_thread_stopped
+
+        mock_sleep_but_awaken_if_stopped = mock.Mock()
+
+        mock_logger = mock.Mock()
+        mock_gather_sample = mock.Mock()
+        monitor_config = MonitorConfig(
+            {"module": "test_module", "sample_interval": 10},
+            monitor_module="test_monitor",
+        )
+        global_config = mock.Mock()
+        global_config.global_monitor_sample_interval_enable_jitter = True
+        monitor = ScalyrMonitor(
+            monitor_config=monitor_config,
+            logger=mock_logger,
+            sample_interval_secs=None,
+            global_config=global_config,
+        )
+        monitor.counter = 0
+        monitor._sleep_but_awaken_if_stopped = mock_sleep_but_awaken_if_stopped
+        monitor._is_thread_stopped = make_mock_thread_is_stopped(monitor)
+        monitor.gather_sample = mock_gather_sample
+
+        monitor.run()
+        self.assertEqual(monitor.counter, 3)
+        # + 1 is for initial sleep delay before first sample gather interval
+        self.assertEqual(mock_sleep_but_awaken_if_stopped.call_count, 1 + 3)
+        self.assertEqual(mock_logger.debug.call_count, 1)
+        self.assertEqual(mock_logger.info.call_count, 1)
+        self.assertEqual(mock_logger.exception.call_count, 0)
+
     def get(
         self,
         original_value,


### PR DESCRIPTION
This pull request fixes a bug in functionality added in #660.

The code was incorrectly inside the whole loop while it should have been outside it :facepalm:

I also added some initial basic mock based regression unit tests which would have caught this issue. Full blown end to end tests would take more work.