### PR TITLE
Make sure Docker monitor also ingests container stderr logs when running in non-raw log file mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -730,7 +730,34 @@ commands:
               export INSTALLER_SCRIPT_URL="/tmp/workspace/installScalyrAgentV2.sh"
             fi
 
-            ./scripts/circleci/run-ami-tests-in-bg.sh << parameters.test_type >>
+            set +e
+
+            max_attempts="2"
+            sleep_delay="15"
+
+            i=0
+            until [ "$i" -ge ${max_attempts} ]; do
+                echo "Running tests command"
+                ./scripts/circleci/run-ami-tests-in-bg.sh << parameters.test_type >>
+                exit_code=$?
+                if [ "${exit_code}" -eq 0 ]; then
+                    echo "Command exited with 0, breaking from the loop."
+                    break
+                else
+                    echo "Command exited with non-zero status, retrying in ${sleep_delay} seconds..."
+                fi
+                i=$((i+1))
+                sleep ${sleep_delay}
+              done
+
+              set -e
+
+              if [ "${exit_code}" -ne 0 ]; then
+                  echo "Command failed to exit with zero exit code after 2 attempts, failing (exit_code=${exit_code})"
+                  exit 1
+              fi
+
+              exit 0
       - store_artifacts:
           path: outputs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2077,9 +2077,15 @@ jobs:
             $ProgressPreference = "SilentlyContinue"
             mkdir win32evtlog-cache -Force
             if (!(Test-Path .\win32evtlog-cache\win32evtlog.pyd -PathType Leaf)) {
-                  wget -O .\win32evtlog-cache\win32evtlog.pyd https://scalyr-agent-2-ci.s3.amazonaws.com/win32evtlog.pyd
+                echo "Downloading .pyd library from S3"
+                wget -O .\win32evtlog-cache\win32evtlog.pyd https://scalyr-agent-2-ci.s3.amazonaws.com/win32evtlog.pyd
+            }
+            else {
+                echo "Using existing cached dependency on disk"
             }
 
+            echo "File hash"
+            Get-FileHash .\win32evtlog-cache\win32evtlog.pyd | Format-List
       - save_cache:
           name: Save Wix Cache
           key: windows-wix-cache-{{ .Branch }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ Bug fixes:
 * Fix line grouping code and make sure we don't throw if line data contains bad or partial unicode escape sequence.
 * Fix ``scalyr_agent/run_monitor.py`` script so it also works correctly out of the box when using source code installation.
 * Update Windows System Metrics monitor to better handle a situation when disk io counters are not available.
+* Docker monitor has been fixed that when running in "API mode" (``docker_raw_logs: false``) it also correctly ingests logs from container ``stderr``. Previously only logs from ``stdout`` have been ingested.
 
-Security fixes and improvments:
+Security fixes and improvements:
 * Agent installation artifacts have been updated so the default ``agent.json`` file which is bundled with the agent is not readable by "other" system users by default anymore. For more context, details and impact, please see [RELEASE_NOTES](https://github.com/scalyr/scalyr-agent-2/blob/master/RELEASE_NOTES.md).
 
 ## 2.1.14 "Hydrus" - November 4, 2020

--- a/docs/monitors/docker_monitor.md
+++ b/docs/monitors/docker_monitor.md
@@ -211,7 +211,8 @@ when starting to log a containers \
                                       labels (minus the prefix) as fields in the containers log_config.  Keys that \
                                       contain hyphens will automatically be converted to underscores.
 |||# ``log_timestamps``           ||| Optional (defaults to True). If true, stdout/stderr logs for logs consumed via \
-                                      Docker API will contain docker timestamps at the beginning of the line
+                                      Docker API (docker_raw_logs: false) will contain docker timestamps at the \
+                                      beginning of the line
 
 
 ## Metrics

--- a/docs/monitors/docker_monitor.md
+++ b/docs/monitors/docker_monitor.md
@@ -210,6 +210,9 @@ when starting to log a containers \
                                       container for any labels that begin with `com.scalyr.config.log.` and use those \
                                       labels (minus the prefix) as fields in the containers log_config.  Keys that \
                                       contain hyphens will automatically be converted to underscores.
+|||# ``log_timestamps``           ||| Optional (defaults to True). If true, stdout/stderr logs for logs consumed via \
+                                      Docker API will contain docker timestamps at the beginning of the line
+
 
 ## Metrics
 

--- a/scalyr_agent/builtin_monitors/docker_monitor.py
+++ b/scalyr_agent/builtin_monitors/docker_monitor.py
@@ -283,7 +283,7 @@ define_config_option(
 define_config_option(
     __monitor__,
     "log_timestamps",
-    "Optional (defaults to True). If true, stdout/stderr logs for logs consumed via Docker API will contain docker timestamps at the beginning of the line\n",
+    "Optional (defaults to True). If true, stdout/stderr logs for logs consumed via Docker API (docker_raw_logs: false) will contain docker timestamps at the beginning of the line\n",
     convert_to=bool,
     default=True,
 )

--- a/scalyr_agent/builtin_monitors/docker_monitor.py
+++ b/scalyr_agent/builtin_monitors/docker_monitor.py
@@ -279,10 +279,14 @@ define_config_option(
     env_aware=True,
 )
 
-# for now, always log timestamps to help prevent a race condition
-# define_config_option( __monitor__, 'log_timestamps',
-#                     'Optional (defaults to False). If true, stdout/stderr logs will contain docker timestamps at the beginning of the line\n',
-#                     convert_to=bool, default=False)
+# for now, always log timestamps by default to help prevent a race condition
+define_config_option(
+    __monitor__,
+    "log_timestamps",
+    "Optional (defaults to True). If true, stdout/stderr logs for logs consumed via Docker API will contain docker timestamps at the beginning of the line\n",
+    convert_to=bool,
+    default=True,
+)
 
 define_metric(
     __monitor__,
@@ -1416,6 +1420,9 @@ class ContainerChecker(StoppableThread):
                     attributes=attrs,
                     base_config=base_config,
                 )
+                result.append(
+                    {"cid": cid, "stream": "stderr", "log_config": log_config}
+                )
 
         return result
 
@@ -1479,9 +1486,7 @@ class DockerLogger(object):
         self.stream_name = name + "-" + stream
 
         self.__max_previous_lines = config.get("max_previous_lines")
-        self.__log_timestamps = (
-            True  # Note: always log timestamps for now.  config.get( 'log_timestamps' )
-        )
+        self.__log_timestamps = config.get("log_timestamps")
         self.__docker_api_version = config.get("docker_api_version")
 
         self.__last_request_lock = threading.Lock()

--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -29,7 +29,11 @@ try:
     import win32evtlogutil
     import win32con
     from ctypes import windll  # type: ignore
-except ImportError:
+
+    WIN32_IMPORT_ERROR = ""
+except ImportError as e:
+    WIN32_IMPORT_ERROR = str(e)
+
     win32evtlog = None
     win32evtlogutil = None
     win32con = None
@@ -780,8 +784,14 @@ and System sources:
             if channels:
                 msg = (
                     "Channels are not supported on the older Win32 EventLog API "
-                    "(evtapi_available=%s, windll_available=%s,event_api_import_error=%s)."
-                    % (evtapi, bool(windll), str(event_api_import_error))
+                    "(evtapi_available=%s, windll_available=%s, win32_import_error=%s, "
+                    "event_api_import_error=%s)."
+                    % (
+                        evtapi,
+                        bool(windll),
+                        WIN32_IMPORT_ERROR,
+                        str(event_api_import_error),
+                    )
                 )
                 raise Exception(msg)
 

--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -740,11 +740,15 @@ and System sources:
 
     def __get_api(self, sources, events, channels):
         evtapi = False
+        event_api_import_error = ""
         if windll:
             try:
                 if windll.wevtapi:
                     evtapi = True
-            except Exception:
+                else:
+                    event_api_import_error = "windll.wevtapi attribute doesn't exist"
+            except Exception as e:
+                event_api_import_error = str(e)
                 pass
 
         result = None
@@ -774,9 +778,12 @@ and System sources:
             result = NewApi(self._config, self._logger, channels)
         else:
             if channels:
-                raise Exception(
-                    "Channels are not supported on the older Win32 EventLog API"
+                msg = (
+                    "Channels are not supported on the older Win32 EventLog API "
+                    "(evtapi_available=%s, windll_available=%s,event_api_import_error=%s)."
+                    % (evtapi, bool(windll), str(event_api_import_error))
                 )
+                raise Exception(msg)
 
             result = OldApi(self._config, self._logger, source_list, event_filter)
 

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -128,13 +128,13 @@ done
 if [ "${FAIL_COUNTER}" -ne 0 ];
 then
     echo ""
-    echo "${FAIL_COUNTER} of the the AMI tests failed. Please check the output logs above."
+    echo "${FAIL_COUNTER} of the AMI tests failed. Please check the output logs above."
     echo "NOTE: Output for all the jobs are also available as job build artifacts."
     echo ""
     exit 1
 else
     echo ""
-    echo "All the AMI tests have completed successfuly."
+    echo "All the AMI tests have completed successfully."
     echo ""
     exit 0
 fi


### PR DESCRIPTION
A while back in #647, I fixed "docker_raw_logs: false" functionality of Docker monitor which has been broken for a while now.

Looking at the commit history, it appears that bug has been inadvertently introduced in cb4f9030455875a8b4619b794736a55a988436b7.

When fixing that functionality for #647, I originally thought we intentionally only retrieve stdout so I didn't add tests for stderr code path, but do think we want to ingest stderr as well since we do that when running in docker_raw_logs mode.

As part of this PR, I also added tess which verify that both container stdout and stderr are ingested and also verified it myself.