### PR TITLE
CT-264: Support both Docker and containerd without configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Packaged by Tomaz Muraus <tomaz@scalyr.com> on Dec 2, 2020 14:00 -0800
 --->
 
 Bug fixes:
-* Fix to make sure we don't expect valid Docker socket when running in CRI mode.
+* Fix to make sure we don't expect valid Docker socket when running the kubernetes monitor in CRI mode.
 
 Misc:
 * The default value for the `SCALYR_K8S_CRI_QUERY_FILESYSTEM` kubernetes monitor configuration option has changed to `True`. This means that by default when in CRI mode, the monitor will only query the filesystem for the list of active containers, rather than first querying the Kubelet API. If you wish to revert to the original default to prefer using the Kubelet API, set `SCALYR_K8S_CRI_QUERY_FILESYSTEM` the environment variable to "false" for the Scalyr Agent daemonset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
+## 2.1.16 "TBD" - TBD
+
+<!---
+Packaged by Tomaz Muraus <tomaz@scalyr.com> on Dec 2, 2020 14:00 -0800
+--->
+
+Misc:
+* The default value for the `k8s_cri_query_filesystem` kubernetes monitor configuration option has changed to `True`. This means that by default when in CRI mode, the monitor will only query the filesystem for the list of active containers, rather than first querying the Kubelet API. If you wish to query the Kubelet API for active containers configure `k8s_cri_query_filesystem` as false.
+
 ## 2.1.15 "Endora" - December 2, 2020
 
 <!---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ Scalyr Agent 2 Changes By Release
 Packaged by Tomaz Muraus <tomaz@scalyr.com> on Dec 2, 2020 14:00 -0800
 --->
 
+Bug fixes:
+* Fix to make sure we don't expect valid Docker socket when running in CRI mode.
+
 Misc:
-* The default value for the `k8s_cri_query_filesystem` kubernetes monitor configuration option has changed to `True`. This means that by default when in CRI mode, the monitor will only query the filesystem for the list of active containers, rather than first querying the Kubelet API. If you wish to query the Kubelet API for active containers configure `k8s_cri_query_filesystem` as false.
+* The default value for the `SCALYR_K8S_CRI_QUERY_FILESYSTEM` kubernetes monitor configuration option has changed to `True`. This means that by default when in CRI mode, the monitor will only query the filesystem for the list of active containers, rather than first querying the Kubelet API. If you wish to revert to the original default to prefer using the Kubelet API, set `SCALYR_K8S_CRI_QUERY_FILESYSTEM` the environment variable to "false" for the Scalyr Agent daemonset.
 
 ## 2.1.15 "Endora" - December 2, 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ Packaged by Tomaz Muraus <tomaz@scalyr.com> on Dec 2, 2020 14:00 -0800
 --->
 
 Bug fixes:
-* Fix to make sure we don't expect valid Docker socket when running the kubernetes monitor in CRI mode.
+* Fix to make sure we don't expect a valid Docker socket when running Kubernetes monitor in CRI mode. This fixes an issue preventing the K8s monitor from running in CRI mode if Docker is not available.
 
 Misc:
-* The default value for the `SCALYR_K8S_CRI_QUERY_FILESYSTEM` kubernetes monitor configuration option has changed to `True`. This means that by default when in CRI mode, the monitor will only query the filesystem for the list of active containers, rather than first querying the Kubelet API. If you wish to revert to the original default to prefer using the Kubelet API, set `SCALYR_K8S_CRI_QUERY_FILESYSTEM` the environment variable to "false" for the Scalyr Agent daemonset.
+* The default value for the `k8s_cri_query_filesystem` Kubernetes monitor config option (set via the `SCALYR_K8S_CRI_QUERY_FILESYSTEM` environment var) has changed to `True`. This means that by default when in CRI mode, the monitor will only query the filesystem for the list of active containers, rather than first querying the Kubelet API. If you wish to revert to the original default to prefer using the Kubelet API, set `SCALYR_K8S_CRI_QUERY_FILESYSTEM` the environment variable to "false" for the Scalyr Agent daemonset.
 
 ## 2.1.15 "Endora" - December 2, 2020
 

--- a/docs/monitors/kubernetes_monitor.md
+++ b/docs/monitors/kubernetes_monitor.md
@@ -246,7 +246,7 @@ when starting \
                                                         will always try to get the list of running containers using \
                                                         docker even when the runtime is detected to be something \
                                                         different.
-|||# ``k8s_cri_query_filesystem``                   ||| Optional (defaults to False). If True, then when in CRI mode, \
+|||# ``k8s_cri_query_filesystem``                   ||| Optional (defaults to True). If True, then when in CRI mode, \
                                                         the monitor will only query the filesystem for the list of \
                                                         active containers, rather than first querying the Kubelet API. \
                                                         This is a useful optimization when the Kubelet API is known to \

--- a/docs/monitors/kubernetes_monitor.md
+++ b/docs/monitors/kubernetes_monitor.md
@@ -248,9 +248,7 @@ when starting \
                                                         different.
 |||# ``k8s_cri_query_filesystem``                   ||| Optional (defaults to True). If True, then when in CRI mode, \
                                                         the monitor will only query the filesystem for the list of \
-                                                        active containers, rather than first querying the Kubelet API. \
-                                                        This is a useful optimization when the Kubelet API is known to \
-                                                        be disabled.
+                                                        active containers, rather than first querying the Kubelet API.
 |||# ``k8s_verify_api_queries``                     ||| Optional (defaults to True). If true, then the ssl connection \
                                                         for all queries to the k8s API will be verified using the \
                                                         ca.crt certificate found in the service account directory. If \

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -357,7 +357,7 @@ define_config_option(
 define_config_option(
     __monitor__,
     "k8s_cri_query_filesystem",
-    "Optional (defaults to True). If True, then when in CRI mode, the monitor will only query the filesystem for the list of active containers, rather than first querying the Kubelet API. This is a useful optimization when the Kubelet API is known to be disabled.",
+    "Optional (defaults to True). If True, then when in CRI mode, the monitor will only query the filesystem for the list of active containers, rather than first querying the Kubelet API.",
     convert_to=bool,
     default=True,
     env_aware=True,


### PR DESCRIPTION
We seem to detect docker vs containerd correctly, so the only thing that needed to change to get this working was to move the docker API socket check to after we are sure we are running in docker. Also this PR changes the default CRI behavior to check the filesystem, as this works better in AKS and is likely to work better in a lot of environments.

One concern left: Incorrect docker sockets would crash the agent causing pod restart with a nice message before, but after this change the pod stays running but not working. the `terminate_agent` method other exception catching uses in the same code seems to not actually terminate the agent and cause a pod restart as anticipated. This probably needs to be fixed.