### PR TITLE
Workaround for Windows event log AMI test failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2035,6 +2035,8 @@ jobs:
     executor:
       name: win/default
       size: "medium"
+      # windows-server-2019-vs2019:previous
+      version: "previous"
       shell: powershell.exe
     steps:
       - checkout


### PR DESCRIPTION
This fixes the issue with event log Windows AMI tests failure which started happening 2 days ago.

It looks like my suspicion was correct and the root cause was indeed change / update in the Circle CI Windows executor image.

I still don't know exactly what changed (which lib, perhaps vs studio version or similar), but it's better than nothing.

I hope I also get access to actual version string to which ``previous`` version currently refers to to avoid surprises and breakages in the near future.

Some context at https://twitter.com/CircleCI/status/1337438659344293891.