### PR TITLE
Log a message when sending SIGTERM and SIGKILL to the child worker process

### DIFF
--- a/scalyr_agent/copying_manager/worker.py
+++ b/scalyr_agent/copying_manager/worker.py
@@ -1238,7 +1238,8 @@ def create_shared_object_manager(worker_class, worker_proxy_class):
             # type: (Configuration, Dict, six.text_type) -> CopyingManagerWorker
             """
             Create a new worker and save it as an attribute.
-            to be able to access the worker's instance within the local process.
+
+            To be able to access the worker's instance within the local process.
 
             The arguments are the same as in the workers's constructor.
             :return: the proxy object for the worker instance.
@@ -1268,15 +1269,15 @@ def create_shared_object_manager(worker_class, worker_proxy_class):
                     self._worker.stop_worker()
                 except:
                     log.exception(
-                        "Can not stop the worker. Wait for killing the process.."
+                        "Can not stop the worker. Wait before killing the process.."
                     )
                     # can not stop worker gracefully, just wait for the main thread of the process exits and
-                    # the the worker's thread(since it is a daemon)  will be terminated too.
+                    # the worker's thread(since it is a daemon)  will be terminated too.
 
         @classmethod
         def _on_exit(cls, error=None):
             """
-            Just add more log messages beforethe process is terminated.
+            Just add more log messages before the process is terminated.
             :return:
             """
             if error:

--- a/scalyr_agent/copying_manager/worker.py
+++ b/scalyr_agent/copying_manager/worker.py
@@ -1269,7 +1269,7 @@ def create_shared_object_manager(worker_class, worker_proxy_class):
                     self._worker.stop_worker()
                 except:
                     log.exception(
-                        "Can not stop the worker. Wait before killing the process.."
+                        "Can not stop the worker. Waiting before killing the process..."
                     )
                     # can not stop worker gracefully, just wait for the main thread of the process exits and
                     # the worker's thread(since it is a daemon)  will be terminated too.

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -2598,11 +2598,17 @@ class ParentProcessAwareSyncManager(multiprocessing.managers.SyncManager):
             pass
 
         # send a terminate signal which has to send an exception and break the infinite loop in main thread.
+        from scalyr_agent import scalyr_logging
+
+        logger = scalyr_logging.getLogger(__name__)
+
+        logger.info("Sending SIGTERM to worker process with PID %s" % (os.getpid()))
         os.kill(os.getpid(), signal.SIGTERM)
 
         # To be on the safe side, give other threads some time to handle the SIGTERM gracefully and then send SIGKILL
         time.sleep(self._time_before_kill)
 
+        logger.info("Sending SIGKILL to worker process with PID %s" % (os.getpid()))
         os.kill(os.getpid(), signal.SIGKILL)
 
     @classmethod


### PR DESCRIPTION
I've tested #667 and everything seems to be working correctly :+1: 

I just added two additional log statements so we also log a message when sending SIGTERM and SIGKILL to the child worker process.

Keep in mind that those represent edge case which is triggered when parent is kill -9'ed so using info log level is fine.