### PR TITLE
Add additional file ownership checks to deb AMI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1806,20 +1806,26 @@ jobs:
     working_directory: ~/scalyr-agent-2
     docker:
       - image: circleci/python:3.5.9
+    # NOTE: We use larger resource class to speed up the tests. This job only runs on master merge
+    # aka not often.
+    resource_class: large
     steps:
       - codespeed_micro_benchmarks:
           codespeed_executable: "Python 3.5.9"
-          codespeed_environment: "Circle CI Docker Executor Medium Size"
+          codespeed_environment: "Circle CI Docker Executor Large Size"
           cache_key_name: "benchmarks-micro-py36"
 
   benchmarks-micro-py-27:
     working_directory: ~/scalyr-agent-2
     docker:
       - image: circleci/python:2.7.17
+    # NOTE: We use larger resource class to speed up the tests. This job only runs on master merge
+    # aka not often.
+    resource_class: large
     steps:
       - codespeed_micro_benchmarks:
           codespeed_executable: "Python 2.7.17"
-          codespeed_environment: "Circle CI Docker Executor Medium Size"
+          codespeed_environment: "Circle CI Docker Executor Large Size"
           cache_key_name: "benchmarks-micro-py27"
 
   # Job which sends notification to Slack after benchmark run has completed

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -602,7 +602,9 @@ def render_script_template(
 
     template_context["verbose"] = verbose
 
-    env = Environment(loader=FileSystemLoader(SCRIPTS_DIR),)
+    env = Environment(
+        loader=FileSystemLoader(SCRIPTS_DIR), extensions=["jinja2.ext.with_"]
+    )
     template = env.from_string(script_template)
     rendered_template = template.render(**template_context)
     return rendered_template

--- a/tests/ami/scripts/partial/verify_deb_files_ownership.sh.j2
+++ b/tests/ami/scripts/partial/verify_deb_files_ownership.sh.j2
@@ -1,0 +1,19 @@
+if [ -f "{{ package_file }}" ]; then
+    echo_with_date "==========================="
+    echo_with_date "Checking {{ package_file }} package file ownership"
+    echo_with_date "==========================="
+
+    # Verify the permissions and file ownership inside the archive. Keep in mind that until we comment
+    # out fpm flag in build_package.py, permissions won't be correct since they are fixed as part of
+    # postinst step, but file ownership should be 0:0 aka owned by root:root
+    FILE_PERMISSIONS=$(ar p "{{ package_file }}" data.tar.gz | tar -zvt ./etc/scalyr-agent-2/agent.json)
+    echo "${FILE_PERMISSIONS}"
+
+    echo "${FILE_PERMISSIONS}" | grep "0/0"
+    if [ $? -ne 0 ]; then
+        echo "Owner of the file is not root:root!"
+        exit 1
+    fi
+
+    echo_with_date "File ownership inside the deb package is correct."
+fi

--- a/tests/ami/scripts/partial/verify_rpm_files_ownership.sh.j2
+++ b/tests/ami/scripts/partial/verify_rpm_files_ownership.sh.j2
@@ -1,5 +1,8 @@
 echo "test"
 echo "{{ package_file }}"
+echo "{{ foo }}"
+echo "{{ bar }}"
+echo "{{ baz }}"
 echo "test"
 if [ -f "{{ package_file }}" ]; then
     echo_with_date "==========================="

--- a/tests/ami/scripts/partial/verify_rpm_files_ownership.sh.j2
+++ b/tests/ami/scripts/partial/verify_rpm_files_ownership.sh.j2
@@ -1,0 +1,19 @@
+if [ -f "{{ package_file }}" ]; then
+    echo_with_date "==========================="
+    echo_with_date "Checking {{ package_file }} package file ownership"
+    echo_with_date "==========================="
+
+    # Verify the permissions and file ownership inside the archive. Keep in mind that until we comment
+    # out fpm flag in build_package.py, permissions won't be correct since they are fixed as part of
+    # postinst step, but file ownership should be 0:0 aka owned by root:root
+    FILE_PERMISSIONS=$(rpm -qplv "{{ package_file }}" |grep "agent\\.json")
+    echo "${FILE_PERMISSIONS}"
+
+    echo "${FILE_PERMISSIONS}" | grep "root root"
+    if [ $? -ne 0 ]; then
+        echo "Owner of the file is not root:root!"
+        exit 1
+    fi
+
+    echo_with_date "File ownership inside the rpm package is correct."
+fi

--- a/tests/ami/scripts/partial/verify_rpm_files_ownership.sh.j2
+++ b/tests/ami/scripts/partial/verify_rpm_files_ownership.sh.j2
@@ -1,3 +1,6 @@
+echo "test"
+echo "{{ package_file }}"
+echo "test"
 if [ -f "{{ package_file }}" ]; then
     echo_with_date "==========================="
     echo_with_date "Checking {{ package_file }} package file ownership"

--- a/tests/ami/scripts/partial/verify_rpm_files_ownership.sh.j2
+++ b/tests/ami/scripts/partial/verify_rpm_files_ownership.sh.j2
@@ -1,9 +1,3 @@
-echo "test"
-echo "{{ package_file }}"
-echo "{{ foo }}"
-echo "{{ bar }}"
-echo "{{ baz }}"
-echo "test"
 if [ -f "{{ package_file }}" ]; then
     echo_with_date "==========================="
     echo_with_date "Checking {{ package_file }} package file ownership"
@@ -12,10 +6,10 @@ if [ -f "{{ package_file }}" ]; then
     # Verify the permissions and file ownership inside the archive. Keep in mind that until we comment
     # out fpm flag in build_package.py, permissions won't be correct since they are fixed as part of
     # postinst step, but file ownership should be 0:0 aka owned by root:root
-    FILE_PERMISSIONS=$(rpm -qplv "{{ package_file }}" |grep "agent\\.json")
+    FILE_PERMISSIONS=$(rpm -qplv "{{ package_file }}" | grep "agent\\.json")
     echo "${FILE_PERMISSIONS}"
 
-    echo "${FILE_PERMISSIONS}" | grep "root root"
+    echo "${FILE_PERMISSIONS}" | grep "root"
     if [ $? -ne 0 ]; then
         echo "Owner of the file is not root:root!"
         exit 1

--- a/tests/ami/scripts/test_deb.sh.j2
+++ b/tests/ami/scripts/test_deb.sh.j2
@@ -78,6 +78,26 @@ should be uploaded by script or already uploaded by Libloud. #}
     {# file should be already uploaded by Libcloud, so just pass this. #}
     {% endif -%}
 
+if [ -f "install_package.deb" ]; then
+    echo_with_date "==========================="
+    echo_with_date "Checking package file ownership"
+    echo_with_date "==========================="
+
+    # Verify the permissions and file ownership inside the archive. Keep in mind that until we comment
+    # out fpm flag in build_package.py, permissions won't be correct since they are fixed as part of
+    # postinst step, but file ownership should be 0:0 aka owned by root:root
+    FILE_PERMISSIONS=$(ar p "install_package.deb" data.tar.gz | tar -zvt ./etc/scalyr-agent-2/agent.json)
+    echo "${FILE_PERMISSIONS}"
+
+    echo "${FILE_PERMISSIONS}" | grep "0/0"
+    if [ $? -ne 0 ]; then
+        echo "Owner of the file is not root:root!"
+        exit 1
+    fi
+
+    echo_with_date "File ownership inside the deb package is correct."
+fi
+
 # install Scalyr agent from package file.
 sudo DEBIAN_FRONTEND=noninteractive dpkg -i install_package.deb
 sudo sed -i 's/REPLACE_THIS/{{scalyr_api_key}}/' /etc/scalyr-agent-2/agent.json

--- a/tests/ami/scripts/test_deb.sh.j2
+++ b/tests/ami/scripts/test_deb.sh.j2
@@ -59,6 +59,9 @@ echo_with_date "==========================="
 sudo apt-get update -y
 sudo apt-get install -y "{{python_package}}"
 
+# Install dependencies
+sudo apt-get install -y binutils
+
 {% if additional_packages -%}
 sudo apt-get install -y {{additional_packages}}
 {% endif -%}

--- a/tests/ami/scripts/test_deb.sh.j2
+++ b/tests/ami/scripts/test_deb.sh.j2
@@ -81,7 +81,7 @@ should be uploaded by script or already uploaded by Libloud. #}
     {# file should be already uploaded by Libcloud, so just pass this. #}
     {% endif -%}
 
-{% with package_file=install_package.deb %}
+{% with package_file="install_package.deb" %}
 {% include "partial/verify_deb_files_ownership.sh.j2" %}
 {% endwith %}
 
@@ -163,7 +163,7 @@ wget -O upgrade_package.deb "{{ upgrade_package["source"] }}"
     {# file should be already uploaded by Libcloud, so just pass this. #}
     {% endif -%}
 
-{% with package_file=upgrade_package.deb %}
+{% with package_file="upgrade_package.deb" %}
 {% include "partial/verify_deb_files_ownership.sh.j2" %}
 {% endwith %}
 

--- a/tests/ami/scripts/test_deb.sh.j2
+++ b/tests/ami/scripts/test_deb.sh.j2
@@ -81,25 +81,9 @@ should be uploaded by script or already uploaded by Libloud. #}
     {# file should be already uploaded by Libcloud, so just pass this. #}
     {% endif -%}
 
-if [ -f "install_package.deb" ]; then
-    echo_with_date "==========================="
-    echo_with_date "Checking install_package.deb package file ownership"
-    echo_with_date "==========================="
-
-    # Verify the permissions and file ownership inside the archive. Keep in mind that until we comment
-    # out fpm flag in build_package.py, permissions won't be correct since they are fixed as part of
-    # postinst step, but file ownership should be 0:0 aka owned by root:root
-    FILE_PERMISSIONS=$(ar p "install_package.deb" data.tar.gz | tar -zvt ./etc/scalyr-agent-2/agent.json)
-    echo "${FILE_PERMISSIONS}"
-
-    echo "${FILE_PERMISSIONS}" | grep "0/0"
-    if [ $? -ne 0 ]; then
-        echo "Owner of the file is not root:root!"
-        exit 1
-    fi
-
-    echo_with_date "File ownership inside the deb package is correct."
-fi
+{% with package_file=install_package.deb %}
+{% include "partial/verify_deb_files_ownership.sh.j2" %}
+{% endwith %}
 
 # install Scalyr agent from package file.
 sudo DEBIAN_FRONTEND=noninteractive dpkg -i install_package.deb
@@ -179,25 +163,9 @@ wget -O upgrade_package.deb "{{ upgrade_package["source"] }}"
     {# file should be already uploaded by Libcloud, so just pass this. #}
     {% endif -%}
 
-if [ -f "upgrade_package.deb" ]; then
-    echo_with_date "==========================="
-    echo_with_date "Checking upgrade_package.deb package file ownership"
-    echo_with_date "==========================="
-
-    # Verify the permissions and file ownership inside the archive. Keep in mind that until we comment
-    # out fpm flag in build_package.py, permissions won't be correct since they are fixed as part of
-    # postinst step, but file ownership should be 0:0 aka owned by root:root
-    FILE_PERMISSIONS=$(ar p "upgrade_package.deb" data.tar.gz | tar -zvt ./etc/scalyr-agent-2/agent.json)
-    echo "${FILE_PERMISSIONS}"
-
-    echo "${FILE_PERMISSIONS}" | grep "0/0"
-    if [ $? -ne 0 ]; then
-        echo "Owner of the file is not root:root!"
-        exit 1
-    fi
-
-    echo_with_date "File ownership inside the deb package is correct."
-fi
+{% with package_file=upgrade_package.deb %}
+{% include "partial/verify_deb_files_ownership.sh.j2" %}
+{% endwith %}
 
 echo_with_date "Upgrade Scalyr agent from file."
 sudo DEBIAN_FRONTEND=noninteractive dpkg -i upgrade_package.deb

--- a/tests/ami/scripts/test_deb.sh.j2
+++ b/tests/ami/scripts/test_deb.sh.j2
@@ -80,7 +80,7 @@ should be uploaded by script or already uploaded by Libloud. #}
 
 if [ -f "install_package.deb" ]; then
     echo_with_date "==========================="
-    echo_with_date "Checking package file ownership"
+    echo_with_date "Checking install_package.deb package file ownership"
     echo_with_date "==========================="
 
     # Verify the permissions and file ownership inside the archive. Keep in mind that until we comment
@@ -175,6 +175,26 @@ wget -O upgrade_package.deb "{{ upgrade_package["source"] }}"
     {% elif upgrade_package["type"] == "file" -%}
     {# file should be already uploaded by Libcloud, so just pass this. #}
     {% endif -%}
+
+if [ -f "upgrade_package.deb" ]; then
+    echo_with_date "==========================="
+    echo_with_date "Checking upgrade_package.deb package file ownership"
+    echo_with_date "==========================="
+
+    # Verify the permissions and file ownership inside the archive. Keep in mind that until we comment
+    # out fpm flag in build_package.py, permissions won't be correct since they are fixed as part of
+    # postinst step, but file ownership should be 0:0 aka owned by root:root
+    FILE_PERMISSIONS=$(ar p "upgrade_package.deb" data.tar.gz | tar -zvt ./etc/scalyr-agent-2/agent.json)
+    echo "${FILE_PERMISSIONS}"
+
+    echo "${FILE_PERMISSIONS}" | grep "0/0"
+    if [ $? -ne 0 ]; then
+        echo "Owner of the file is not root:root!"
+        exit 1
+    fi
+
+    echo_with_date "File ownership inside the deb package is correct."
+fi
 
 echo_with_date "Upgrade Scalyr agent from file."
 sudo DEBIAN_FRONTEND=noninteractive dpkg -i upgrade_package.deb

--- a/tests/ami/scripts/test_rpm.sh.j2
+++ b/tests/ami/scripts/test_rpm.sh.j2
@@ -165,9 +165,6 @@ wget -O upgrade_package.deb "{{ upgrade_package["source"] }}"
     {% endif -%}
 
 {% with package_file="upgrade_package.rpm" %}
-{% set foo="test_one" %}
-{% set bar="test.one" %}
-{% set baz="upgrade_package.rpm" %}
 {% include "partial/verify_rpm_files_ownership.sh.j2" %}
 {% endwith %}
 

--- a/tests/ami/scripts/test_rpm.sh.j2
+++ b/tests/ami/scripts/test_rpm.sh.j2
@@ -75,10 +75,30 @@ echo_with_date ""
 {# type of the package is 'file' or 'url', that means that file
 should be uploaded by script or already uploaded by Libloud. #}
     {% if install_package["type"] == "url" -%}
-    wget -O install_package.deb "{{ install_package["source"] }}"
+    wget -O install_package.rpm "{{ install_package["source"] }}"
     {% elif install_package["type"] == "file" -%}
     {# file should be already uploaded by Libcloud, so just pass this. #}
     {% endif -%}
+
+if [ -f "install_package.rpm" ]; then
+    echo_with_date "==========================="
+    echo_with_date "Checking install_package.rpm package file ownership"
+    echo_with_date "==========================="
+
+    # Verify the permissions and file ownership inside the archive. Keep in mind that until we comment
+    # out fpm flag in build_package.py, permissions won't be correct since they are fixed as part of
+    # postinst step, but file ownership should be 0:0 aka owned by root:root
+    FILE_PERMISSIONS=$(rpm -qplv install_package.rpm |grep "agent\\.json")
+    echo "${FILE_PERMISSIONS}"
+
+    echo "${FILE_PERMISSIONS}" | grep "root root"
+    if [ $? -ne 0 ]; then
+        echo "Owner of the file is not root:root!"
+        exit 1
+    fi
+
+    echo_with_date "File ownership inside the rpm package is correct."
+fi
 
 # install Scalyr agent from package file.
 sudo rpm -iv install_package.rpm
@@ -159,6 +179,26 @@ wget -O upgrade_package.deb "{{ upgrade_package["source"] }}"
     {% elif upgrade_package["type"] == "file" -%}
     {# file should be already uploaded by Libcloud, so just pass this. #}
     {% endif -%}
+
+if [ -f "upgrade_package.rpm" ]; then
+    echo_with_date "==========================="
+    echo_with_date "Checking upgrade_package.rpm package file ownership"
+    echo_with_date "==========================="
+
+    # Verify the permissions and file ownership inside the archive. Keep in mind that until we comment
+    # out fpm flag in build_package.py, permissions won't be correct since they are fixed as part of
+    # postinst step, but file ownership should be 0:0 aka owned by root:root
+    FILE_PERMISSIONS=$(rpm -qplv upgrade_package.rpm |grep "agent\\.json")
+    echo "${FILE_PERMISSIONS}"
+
+    echo "${FILE_PERMISSIONS}" | grep "root root"
+    if [ $? -ne 0 ]; then
+        echo "Owner of the file is not root:root!"
+        exit 1
+    fi
+
+    echo_with_date "File ownership inside the rpm package is correct."
+fi
 
 sudo rpm -FUv upgrade_package.rpm
 sudo sed -i 's/REPLACE_THIS/{{scalyr_api_key}}/' /etc/scalyr-agent-2/agent.json

--- a/tests/ami/scripts/test_rpm.sh.j2
+++ b/tests/ami/scripts/test_rpm.sh.j2
@@ -165,6 +165,9 @@ wget -O upgrade_package.deb "{{ upgrade_package["source"] }}"
     {% endif -%}
 
 {% with package_file=upgrade_package.rpm %}
+{% set foo=test_one %}
+{% set bar=test.one %}
+{% set baz=upgrade_package.rpm %}
 {% include "partial/verify_rpm_files_ownership.sh.j2" %}
 {% endwith %}
 

--- a/tests/ami/scripts/test_rpm.sh.j2
+++ b/tests/ami/scripts/test_rpm.sh.j2
@@ -80,7 +80,7 @@ should be uploaded by script or already uploaded by Libloud. #}
     {# file should be already uploaded by Libcloud, so just pass this. #}
     {% endif -%}
 
-{% with package_file=install_package.rpm %}
+{% with package_file="install_package.rpm" %}
 {% include "partial/verify_rpm_files_ownership.sh.j2" %}
 {% endwith %}
 
@@ -164,10 +164,10 @@ wget -O upgrade_package.deb "{{ upgrade_package["source"] }}"
     {# file should be already uploaded by Libcloud, so just pass this. #}
     {% endif -%}
 
-{% with package_file=upgrade_package.rpm %}
-{% set foo=test_one %}
-{% set bar=test.one %}
-{% set baz=upgrade_package.rpm %}
+{% with package_file="upgrade_package.rpm" %}
+{% set foo="test_one" %}
+{% set bar="test.one" %}
+{% set baz="upgrade_package.rpm" %}
 {% include "partial/verify_rpm_files_ownership.sh.j2" %}
 {% endwith %}
 

--- a/tests/ami/scripts/test_rpm.sh.j2
+++ b/tests/ami/scripts/test_rpm.sh.j2
@@ -80,25 +80,9 @@ should be uploaded by script or already uploaded by Libloud. #}
     {# file should be already uploaded by Libcloud, so just pass this. #}
     {% endif -%}
 
-if [ -f "install_package.rpm" ]; then
-    echo_with_date "==========================="
-    echo_with_date "Checking install_package.rpm package file ownership"
-    echo_with_date "==========================="
-
-    # Verify the permissions and file ownership inside the archive. Keep in mind that until we comment
-    # out fpm flag in build_package.py, permissions won't be correct since they are fixed as part of
-    # postinst step, but file ownership should be 0:0 aka owned by root:root
-    FILE_PERMISSIONS=$(rpm -qplv install_package.rpm |grep "agent\\.json")
-    echo "${FILE_PERMISSIONS}"
-
-    echo "${FILE_PERMISSIONS}" | grep "root root"
-    if [ $? -ne 0 ]; then
-        echo "Owner of the file is not root:root!"
-        exit 1
-    fi
-
-    echo_with_date "File ownership inside the rpm package is correct."
-fi
+{% with package_file=install_package.rpm %}
+{% include "partial/verify_rpm_files_ownership.sh.j2" %}
+{% endwith %}
 
 # install Scalyr agent from package file.
 sudo rpm -iv install_package.rpm
@@ -180,25 +164,9 @@ wget -O upgrade_package.deb "{{ upgrade_package["source"] }}"
     {# file should be already uploaded by Libcloud, so just pass this. #}
     {% endif -%}
 
-if [ -f "upgrade_package.rpm" ]; then
-    echo_with_date "==========================="
-    echo_with_date "Checking upgrade_package.rpm package file ownership"
-    echo_with_date "==========================="
-
-    # Verify the permissions and file ownership inside the archive. Keep in mind that until we comment
-    # out fpm flag in build_package.py, permissions won't be correct since they are fixed as part of
-    # postinst step, but file ownership should be 0:0 aka owned by root:root
-    FILE_PERMISSIONS=$(rpm -qplv upgrade_package.rpm |grep "agent\\.json")
-    echo "${FILE_PERMISSIONS}"
-
-    echo "${FILE_PERMISSIONS}" | grep "root root"
-    if [ $? -ne 0 ]; then
-        echo "Owner of the file is not root:root!"
-        exit 1
-    fi
-
-    echo_with_date "File ownership inside the rpm package is correct."
-fi
+{% with package_file=upgrade_package.rpm %}
+{% include "partial/verify_rpm_files_ownership.sh.j2" %}
+{% endwith %}
 
 sudo rpm -FUv upgrade_package.rpm
 sudo sed -i 's/REPLACE_THIS/{{scalyr_api_key}}/' /etc/scalyr-agent-2/agent.json


### PR DESCRIPTION
This pull request includes two changes:

1. Change resource class for micro benchmarks to large to make that job less flaky and finish faster. Those jobs only run on merge to master so it shouldn't have large impact on credits usage. If it does, we can revert it.

2. Add additional safety check to AMI tests which verifies file ownership inside the deb package is correct. This check will allow us to catch builder VM and other invalid package file ownership permissions early on.