### PR TITLE
Add workaround when building debian packages on builder VM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1806,20 +1806,26 @@ jobs:
     working_directory: ~/scalyr-agent-2
     docker:
       - image: circleci/python:3.5.9
+    # NOTE: We use larger resource class to speed up the tests. This job only runs on master merge
+    # aka not often.
+    resource_class: large
     steps:
       - codespeed_micro_benchmarks:
           codespeed_executable: "Python 3.5.9"
-          codespeed_environment: "Circle CI Docker Executor Medium Size"
+          codespeed_environment: "Circle CI Docker Executor Large Size"
           cache_key_name: "benchmarks-micro-py36"
 
   benchmarks-micro-py-27:
     working_directory: ~/scalyr-agent-2
     docker:
       - image: circleci/python:2.7.17
+    # NOTE: We use larger resource class to speed up the tests. This job only runs on master merge
+    # aka not often.
+    resource_class: large
     steps:
       - codespeed_micro_benchmarks:
           codespeed_executable: "Python 2.7.17"
-          codespeed_environment: "Circle CI Docker Executor Medium Size"
+          codespeed_environment: "Circle CI Docker Executor Large Size"
           cache_key_name: "benchmarks-micro-py27"
 
   # Job which sends notification to Slack after benchmark run has completed

--- a/build_package.py
+++ b/build_package.py
@@ -819,7 +819,8 @@ def build_rpm_or_deb_package(is_rpm, variant, version):
     # sure it works correctly - we need to make sure root user is owner for the files which are
     # packaged
     # NOTE: We only need this workaround for debian packages and not rpm ones.
-    if getpass.getuser() in ["rpmbuilder", "circleci"] and not is_rpm:
+    username = getpass.getuser()
+    if username in ["rpmbuilder", "circleci"] and not is_rpm:
         print("Using builder VM sudo workaround for file ownership issue")
         use_sudo = True
         sudo_command_string = "sudo "
@@ -894,7 +895,7 @@ def build_rpm_or_deb_package(is_rpm, variant, version):
     # We need to make sure that after we package everything up in deb, we restore the permissions
     # so Jenkins can access the files
     if use_sudo:
-        run_command("sudo chown -R rpmbuilder:rpmbuilder .")
+        run_command("sudo chown -R %s:%s ." % (username, username))
 
     # We determine the artifact name in a little bit of loose fashion.. we just glob over the current
     # directory looking for something either ending in .rpm or .deb.  There should only be one package,

--- a/build_package.py
+++ b/build_package.py
@@ -819,7 +819,7 @@ def build_rpm_or_deb_package(is_rpm, variant, version):
     # sure it works correctly - we need to make sure root user is owner for the files which are
     # packaged
     # NOTE: We only need this workaround for debian packages and not rpm ones.
-    if getpass.getuser() == "rpmbuilder" and not is_rpm:
+    if getpass.getuser() in ["rpmbuilder", "circleci"] and not is_rpm:
         print("Using builder VM sudo workaround for file ownership issue")
         use_sudo = True
         sudo_command_string = "sudo "

--- a/build_package.py
+++ b/build_package.py
@@ -41,6 +41,7 @@ import tarfile
 import tempfile
 import time
 import uuid
+import getpass
 
 from io import StringIO
 from io import BytesIO
@@ -814,8 +815,23 @@ def build_rpm_or_deb_package(is_rpm, variant, version):
         "log files and transmit them to Scalyr."
     )
 
+    # Workaround for our ancient builder VM so we can use --deb-use-file-permissions flag and make
+    # sure it works correctly - we need to make sure root user is owner for the files which are
+    # packaged
+    # NOTE: We only need this workaround for debian packages and not rpm ones.
+    if getpass.getuser() == "rpmbuilder" and not is_rpm:
+        print("Using builder VM sudo workaround for file ownership issue")
+        use_sudo = True
+        sudo_command_string = "sudo "
+    else:
+        use_sudo = False
+        sudo_command_string = ""
+
+    if use_sudo:
+        run_command("sudo chown -R root:root .")
+
     run_command(
-        'fpm -s dir -a all -t %s -n "scalyr-agent-2" -v %s '
+        '%s fpm -s dir -a all -t %s -n "scalyr-agent-2" -v %s '
         '  --license "Apache 2.0" '
         "  --vendor Scalyr %s "
         "  --maintainer czerwin@scalyr.com "
@@ -862,17 +878,23 @@ def build_rpm_or_deb_package(is_rpm, variant, version):
         # In theory it should work wth --*-user fpm flag, but it doesn't. Keep in mind that the
         # issue only applies to deb packages since --rpm-user and --rpm-root flag override the user
         # even if the --rpm-use-file-permissions flag is used.
-        "  --rpm-use-file-permissions "
-        # "  --rpm-use-file-permissions --deb-use-file-permissions "
+        # "  --rpm-use-file-permissions "
+        "  --rpm-use-file-permissions --deb-use-file-permissions "
         # NOTE: Sadly we can't use defattrdir since it breakes permissions for some other
         # directories such as /etc/init.d and we need to handle that in postinst :/
         # "  --rpm-auto-add-directories "
         # "  --rpm-defattrfile 640"
         # "  --rpm-defattrdir 751"
-        "  -C root usr etc var" % (package_type, version, iteration_arg, description),
+        "  -C root usr etc var"
+        % (sudo_command_string, package_type, version, iteration_arg, description),
         exit_on_fail=True,
         command_name="fpm",
     )
+
+    # We need to make sure that after we package everything up in deb, we restore the permissions
+    # so Jenkins can access the files
+    if use_sudo:
+        run_command("sudo chown -R rpmbuilder:rpmbuilder .")
 
     # We determine the artifact name in a little bit of loose fashion.. we just glob over the current
     # directory looking for something either ending in .rpm or .deb.  There should only be one package,

--- a/tests/ami/scripts/partial/verify_deb_files_ownership.sh.j2
+++ b/tests/ami/scripts/partial/verify_deb_files_ownership.sh.j2
@@ -9,7 +9,7 @@ if [ -f "{{ package_file }}" ]; then
     FILE_PERMISSIONS=$(ar p "{{ package_file }}" data.tar.gz | tar -zvt ./etc/scalyr-agent-2/agent.json)
     echo "${FILE_PERMISSIONS}"
 
-    echo "${FILE_PERMISSIONS}" | grep "0/0"
+    echo "${FILE_PERMISSIONS}" | grep "0/0" || echo "${FILE_PERMISSIONS}" | grep "root/root"
     if [ $? -ne 0 ]; then
         echo "Owner of the file is not root:root!"
         exit 1


### PR DESCRIPTION
This pull request adds a workaround which makes sure file permissions and ownership is correct when building deb packages on builder VM with ``--deb-use-file-permissions`` flag.

It relies on making sure package content which is packaged up is owner by root user (0:0 uid:gid) and running fpm using sudo.

We only apply this workaround when building packages on builder VM and only for deb packages.