### PR TITLE
Include information on configured number of workers and unique API keys in the User-Agent header

### DIFF
--- a/py26-unit-tests-requirements.txt
+++ b/py26-unit-tests-requirements.txt
@@ -5,7 +5,6 @@
 importlib==1.0.4
 mock==0.8.0
 pytest==3.2.5
-tlslite-ng==0.7.5
 ecdsa==0.13.3
 certvalidator==0.11.1
 asn1crypto==0.24.0

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1546,12 +1546,15 @@ class Configuration(object):
         return result
 
     def get_number_of_configured_workers_and_api_keys(self):
-        # type: () -> Tuple[bool, int, int]
+        # type: () -> Tuple[str, int, int]
         """
         Return total number of configured workers and a total number of unique API keys those
         workers are configured with.
 
-        If multiple workers / api keys functionality is not enabled (False, 1, 1) is returned.
+        It returns a tuple of (worker_type, workers_count, unique api_keys count). Value value for
+        worker_type is "threaded" and "multiprocess."
+
+        If multiple workers / api keys functionality is not enabled (*, 1, 1) is returned.
         """
         workers_count = 0
         api_keys_set = set([])
@@ -1562,7 +1565,12 @@ class Configuration(object):
         api_keys_count = len(api_keys_set)
         del api_keys_set
 
-        return self.use_multiprocess_copying_workers, workers_count, api_keys_count
+        if self.use_multiprocess_copying_workers:
+            worker_type = "multiprocess"
+        else:
+            worker_type = "threaded"
+
+        return worker_type, workers_count, api_keys_count
 
     @property
     def use_multiprocess_copying_workers(self):

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1560,6 +1560,7 @@ class Configuration(object):
             workers_count += api_key_config["workers"]
 
         api_keys_count = len(api_keys_set)
+        del api_keys_set
 
         return self.use_multiprocess_copying_workers, workers_count, api_keys_count
 

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -21,6 +21,9 @@ from __future__ import absolute_import
 
 __author__ = "czerwin@scalyr.com"
 
+if False:
+    from typing import Tuple
+
 import os
 import re
 import sys
@@ -1541,6 +1544,24 @@ class Configuration(object):
             result.append(dict(api_key_config))
 
         return result
+
+    def get_number_of_configured_workers_and_api_keys(self):
+        # type: () -> Tuple[bool, int, int]
+        """
+        Return total number of configured workers and a total number of unique API keys those
+        workers are configured with.
+
+        If multiple workers / api keys functionality is not enabled (False, 1, 1) is returned.
+        """
+        workers_count = 0
+        api_keys_set = set([])
+        for api_key_config in self.__api_key_configs:
+            api_keys_set.add(api_key_config["api_key"])
+            workers_count += api_key_config["workers"]
+
+        api_keys_count = len(api_keys_set)
+
+        return self.use_multiprocess_copying_workers, workers_count, api_keys_count
 
     @property
     def use_multiprocess_copying_workers(self):

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -921,7 +921,7 @@ class ScalyrClientSession(object):
                     + "-"
                     + str(openssl_version[3])
                 )
-                openssl_version_string = "openssl-%s" % (openssl_version_string)
+                openssl_version_string = "o-%s" % (openssl_version_string)
             except Exception:
                 openssl_version_string = None
         else:
@@ -941,10 +941,10 @@ class ScalyrClientSession(object):
             "\\Administrators"
         ):
             # Indicates agent running as a privileged / admin user
-            user_string = "admin-1"
+            user_string = "a-1"
         else:
             # Indicates agent running as a regular user
-            user_string = "admin-0"
+            user_string = "a-0"
 
         sharded_copy_manager_string = ""
 

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -250,8 +250,8 @@ class ScalyrClientSession(object):
         @param compression_level: An int containing the compression level of compression to use, from 1-9.  Defaults to 9 (max)
         @param enforce_monotonic_timestamps: A bool that indicates whether event timestamps in the same session
             should be monotonically increasing or not.  Defaults to False
-        @param workers_api_keys_tuple: Tuple containing a total number of configured workers and unique
-            API keys.
+        @param workers_api_keys_tuple: Tuple containing worker type (multiprocess, threaded) total
+            number of configured workers and number of unique API keys configured.
 
         @type server: six.text_type
         @type api_key: six.text_type
@@ -960,13 +960,9 @@ class ScalyrClientSession(object):
             and len(workers_api_keys_tuple) == 3
             and workers_api_keys_tuple[1] > 1
         ):
-            (
-                use_multiprocess_workers,
-                workers_count,
-                api_keys_count,
-            ) = workers_api_keys_tuple
+            (worker_type, workers_count, api_keys_count,) = workers_api_keys_tuple
 
-            if use_multiprocess_workers:
+            if worker_type == "multiprocess":
                 sharded_copy_manager_string = "mw-2|"
             else:
                 sharded_copy_manager_string = "mw-1|"

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -956,6 +956,7 @@ class ScalyrClientSession(object):
         # process based workers configured with <num_api_keys> unique API keys.
         if (
             workers_api_keys_tuple
+            and isinstance(workers_api_keys_tuple, tuple)
             and len(workers_api_keys_tuple) == 3
             and workers_api_keys_tuple[1] > 1
         ):

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -1764,11 +1764,11 @@ class TestConfiguration(TestConfigurationBase):
         self.assertEqual(sorted(expected_line), sorted(logged_line))
 
         (
-            mpw_enabled,
+            worker_type,
             workers_count,
             api_keys_count,
         ) = config.get_number_of_configured_workers_and_api_keys()
-        self.assertFalse(mpw_enabled)
+        self.assertEqual(worker_type, "threaded")
         self.assertEqual(workers_count, 8)
         self.assertEqual(api_keys_count, 3)
 
@@ -1790,11 +1790,11 @@ class TestConfiguration(TestConfigurationBase):
         config.parse()
 
         (
-            mpw_enabled,
+            worker_type,
             workers_count,
             api_keys_count,
         ) = config.get_number_of_configured_workers_and_api_keys()
-        self.assertFalse(mpw_enabled)
+        self.assertEqual(worker_type, "threaded")
         self.assertEqual(workers_count, 3)
         self.assertEqual(api_keys_count, 2)
 
@@ -1810,11 +1810,11 @@ class TestConfiguration(TestConfigurationBase):
         new_config.parse()
 
         (
-            mpw_enabled,
+            worker_type,
             workers_count,
             api_keys_count,
         ) = new_config.get_number_of_configured_workers_and_api_keys()
-        self.assertFalse(mpw_enabled)
+        self.assertEqual(worker_type, "threaded")
         self.assertEqual(workers_count, 11)
         self.assertEqual(api_keys_count, 2)
 
@@ -2852,11 +2852,11 @@ class TestApiKeysConfiguration(TestConfigurationBase):
         )
 
         (
-            mpw_enabled,
+            worker_type,
             workers_count,
             api_keys_count,
         ) = config.get_number_of_configured_workers_and_api_keys()
-        self.assertFalse(mpw_enabled)
+        self.assertEqual(worker_type, "threaded")
         self.assertEqual(workers_count, 1)
         self.assertEqual(api_keys_count, 1)
 
@@ -2882,11 +2882,11 @@ class TestApiKeysConfiguration(TestConfigurationBase):
         )
 
         (
-            mpw_enabled,
+            worker_type,
             workers_count,
             api_keys_count,
         ) = config.get_number_of_configured_workers_and_api_keys()
-        self.assertFalse(mpw_enabled)
+        self.assertEqual(worker_type, "threaded")
         self.assertEqual(workers_count, 4)
         self.assertEqual(api_keys_count, 1)
 
@@ -3048,11 +3048,11 @@ class TestApiKeysConfiguration(TestConfigurationBase):
         )
 
         (
-            mpw_enabled,
+            worker_type,
             workers_count,
             api_keys_count,
         ) = config.get_number_of_configured_workers_and_api_keys()
-        self.assertFalse(mpw_enabled)
+        self.assertEqual(worker_type, "threaded")
         self.assertEqual(workers_count, 5)
         self.assertEqual(api_keys_count, 2)
 
@@ -3125,11 +3125,11 @@ class TestApiKeysConfiguration(TestConfigurationBase):
         assert config.use_multiprocess_copying_workers
 
         (
-            mpw_enabled,
+            worker_type,
             workers_count,
             api_keys_count,
         ) = config.get_number_of_configured_workers_and_api_keys()
-        self.assertTrue(mpw_enabled)
+        self.assertEqual(worker_type, "multiprocess")
         self.assertEqual(workers_count, 1)
         self.assertEqual(api_keys_count, 1)
 

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -1763,6 +1763,15 @@ class TestConfiguration(TestConfigurationBase):
         logged_line = mock_logger.info.call_args_list[-1][0][0]
         self.assertEqual(sorted(expected_line), sorted(logged_line))
 
+        (
+            mpw_enabled,
+            workers_count,
+            api_keys_count,
+        ) = config.get_number_of_configured_workers_and_api_keys()
+        self.assertFalse(mpw_enabled)
+        self.assertEqual(workers_count, 8)
+        self.assertEqual(api_keys_count, 3)
+
     def test_print_config_when_changed(self):
         """
         Test that `print_useful_settings` only outputs changed settings when compared to another
@@ -1780,6 +1789,15 @@ class TestConfiguration(TestConfigurationBase):
         config = self._create_test_configuration_instance(logger=mock_logger)
         config.parse()
 
+        (
+            mpw_enabled,
+            workers_count,
+            api_keys_count,
+        ) = config.get_number_of_configured_workers_and_api_keys()
+        self.assertFalse(mpw_enabled)
+        self.assertEqual(workers_count, 3)
+        self.assertEqual(api_keys_count, 2)
+
         self._write_file_with_separator_conversion(
             """{
             api_key: "hi there",
@@ -1790,6 +1808,15 @@ class TestConfiguration(TestConfigurationBase):
         )
         new_config = self._create_test_configuration_instance(logger=mock_logger)
         new_config.parse()
+
+        (
+            mpw_enabled,
+            workers_count,
+            api_keys_count,
+        ) = new_config.get_number_of_configured_workers_and_api_keys()
+        self.assertFalse(mpw_enabled)
+        self.assertEqual(workers_count, 11)
+        self.assertEqual(api_keys_count, 2)
 
         new_config.print_useful_settings(other_config=config)
 
@@ -2824,6 +2851,15 @@ class TestApiKeysConfiguration(TestConfigurationBase):
             workers=config.default_workers_per_api_key,
         )
 
+        (
+            mpw_enabled,
+            workers_count,
+            api_keys_count,
+        ) = config.get_number_of_configured_workers_and_api_keys()
+        self.assertFalse(mpw_enabled)
+        self.assertEqual(workers_count, 1)
+        self.assertEqual(api_keys_count, 1)
+
     def test_overwrite_default_api_keys(self):
         self._write_file_with_separator_conversion(
             """ {
@@ -2844,6 +2880,15 @@ class TestApiKeysConfiguration(TestConfigurationBase):
         assert config.api_key_configs[0] == JsonObject(
             api_key=config.api_key, id="default", workers=4,
         )
+
+        (
+            mpw_enabled,
+            workers_count,
+            api_keys_count,
+        ) = config.get_number_of_configured_workers_and_api_keys()
+        self.assertFalse(mpw_enabled)
+        self.assertEqual(workers_count, 4)
+        self.assertEqual(api_keys_count, 1)
 
     def test_default_api_keys_and_second(self):
         self._write_file_with_separator_conversion(
@@ -3002,6 +3047,15 @@ class TestApiKeysConfiguration(TestConfigurationBase):
             workers=4, api_key="key2", id="second",
         )
 
+        (
+            mpw_enabled,
+            workers_count,
+            api_keys_count,
+        ) = config.get_number_of_configured_workers_and_api_keys()
+        self.assertFalse(mpw_enabled)
+        self.assertEqual(workers_count, 5)
+        self.assertEqual(api_keys_count, 2)
+
     def test_log_file_bind_to_worker_entries_with_non_existing_id(self):
         self._write_file_with_separator_conversion(
             """ {
@@ -3069,6 +3123,15 @@ class TestApiKeysConfiguration(TestConfigurationBase):
         config.parse()
 
         assert config.use_multiprocess_copying_workers
+
+        (
+            mpw_enabled,
+            workers_count,
+            api_keys_count,
+        ) = config.get_number_of_configured_workers_and_api_keys()
+        self.assertTrue(mpw_enabled)
+        self.assertEqual(workers_count, 1)
+        self.assertEqual(api_keys_count, 1)
 
     @skipIf(platform.system() == "Windows", "Skipping tests under Windows")
     @skipIf(

--- a/tests/unit/scalyr_client_test.py
+++ b/tests/unit/scalyr_client_test.py
@@ -1110,7 +1110,7 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
             "https://dummserver.com",
             "DUMMY API KEY",
             SCALYR_VERSION,
-            workers_api_keys_tuple=(False, 1, 1),
+            workers_api_keys_tuple=("threaded", 1, 1),
         )
 
         user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
@@ -1121,7 +1121,7 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
             "https://dummserver.com",
             "DUMMY API KEY",
             SCALYR_VERSION,
-            workers_api_keys_tuple=(False, 3, 2),
+            workers_api_keys_tuple=("threaded", 3, 2),
         )
 
         user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
@@ -1132,7 +1132,7 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
             "https://dummserver.com",
             "DUMMY API KEY",
             SCALYR_VERSION,
-            workers_api_keys_tuple=(True, 4, 3),
+            workers_api_keys_tuple=("multiprocess", 4, 3),
         )
 
         user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]

--- a/tests/unit/scalyr_client_test.py
+++ b/tests/unit/scalyr_client_test.py
@@ -1025,7 +1025,7 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
 
         user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
         split = user_agent.split(";")
-        self.assertEqual(split[-3], "openssl-1.0.2-13")
+        self.assertEqual(split[-3], "o-1.0.2-13")
         self.assertTrue(split[1].startswith("python-"))
 
         # with requests
@@ -1039,7 +1039,7 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
         user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
         split = user_agent.split(";")
         self.assertEqual(split[-1], "requests-2.15.1")
-        self.assertEqual(split[-4], "openssl-1.0.2-13")
+        self.assertEqual(split[-4], "o-1.0.2-13")
         self.assertTrue(split[1].startswith("python-"))
 
     @skipIf(sys.platform.startswith("win"), "Skipping test on Windows")
@@ -1055,7 +1055,7 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
 
         user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
         split = user_agent.split(";")
-        self.assertTrue("admin-0" in split)
+        self.assertTrue("a-0" in split)
 
         mock_platform = mock.Mock()
         mock_platform.get_current_user.return_value = "User"
@@ -1079,7 +1079,7 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
 
         user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
         split = user_agent.split(";")
-        self.assertTrue("admin-1" in split)
+        self.assertTrue("a-1" in split)
 
         mock_platform = mock.Mock()
         mock_platform.get_current_user.return_value = "MyDomain\\Administrators"
@@ -1091,7 +1091,7 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
 
         user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
         split = user_agent.split(";")
-        self.assertTrue("admin-1" in split)
+        self.assertTrue("a-1" in split)
 
     @skipIf(sys.platform.startswith("win"), "Skipping test on Windows")
     def test_get_user_agent_worker_and_api_key_info(self):

--- a/tests/unit/scalyr_client_test.py
+++ b/tests/unit/scalyr_client_test.py
@@ -1025,7 +1025,7 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
 
         user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
         split = user_agent.split(";")
-        self.assertEqual(split[-2], "openssl-1.0.2-13")
+        self.assertEqual(split[-3], "openssl-1.0.2-13")
         self.assertTrue(split[1].startswith("python-"))
 
         # with requests
@@ -1039,7 +1039,7 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
         user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
         split = user_agent.split(";")
         self.assertEqual(split[-1], "requests-2.15.1")
-        self.assertEqual(split[-3], "openssl-1.0.2-13")
+        self.assertEqual(split[-4], "openssl-1.0.2-13")
         self.assertTrue(split[1].startswith("python-"))
 
     @skipIf(sys.platform.startswith("win"), "Skipping test on Windows")
@@ -1092,6 +1092,52 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
         user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
         split = user_agent.split(";")
         self.assertTrue("admin-1" in split)
+
+    @skipIf(sys.platform.startswith("win"), "Skipping test on Windows")
+    def test_get_user_agent_worker_and_api_key_info(self):
+        session = ScalyrClientSession(
+            "https://dummserver.com",
+            "DUMMY API KEY",
+            SCALYR_VERSION,
+            workers_api_keys_tuple=None,
+        )
+
+        user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
+        split = user_agent.split(";")
+        self.assertTrue("mw-0" in split)
+
+        session = ScalyrClientSession(
+            "https://dummserver.com",
+            "DUMMY API KEY",
+            SCALYR_VERSION,
+            workers_api_keys_tuple=(False, 1, 1),
+        )
+
+        user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
+        split = user_agent.split(";")
+        self.assertTrue("mw-0" in split)
+
+        session = ScalyrClientSession(
+            "https://dummserver.com",
+            "DUMMY API KEY",
+            SCALYR_VERSION,
+            workers_api_keys_tuple=(False, 3, 2),
+        )
+
+        user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
+        split = user_agent.split(";")
+        self.assertTrue("mw-1|3|2" in split)
+
+        session = ScalyrClientSession(
+            "https://dummserver.com",
+            "DUMMY API KEY",
+            SCALYR_VERSION,
+            workers_api_keys_tuple=(True, 4, 3),
+        )
+
+        user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
+        split = user_agent.split(";")
+        self.assertTrue("mw-2|4|3" in split)
 
     @mock.patch("scalyr_agent.scalyr_client.time.time", mock.Mock(return_value=0))
     def test_send_request_body_is_logged_raw_uncompressed(self):


### PR DESCRIPTION
This pull request updates ``User-Agent`` string sent by the agent so it also includes a value which indicates if sharded copy manager functionality is used and total number of workers and unique API keys configured.

Possible values for this header fragment are documented here - https://github.com/scalyr/scalyr-agent-2/compare/user_agent_mpw?expand=1#diff-4cb9befeecb4697d270768d8487b47aa20810c540fa7a9b6c86800735e7927a2R951.

This will provide us with a better insight on usage of this functionality.