### PR TITLE
Update docker monitor to log labels + container info when starting a logger for a new container

### DIFF
--- a/docker/Dockerfile.docker_monitor_testing_config
+++ b/docker/Dockerfile.docker_monitor_testing_config
@@ -21,7 +21,7 @@
 #
 # To run in:
 #
-# docker run -it --rm -d --name std-printer std-printer --env SLEEP_DELAY=5
+# docker run -it --rm -d --name std-printer std-printer -l my-label-1 -l my-label-2 --env SLEEP_DELAY=5
 #
 # To kill / restart it to test various scenarios:
 #


### PR DESCRIPTION
This pull request updates Docker monitor to log some container + logger related information for newly started containers.

I had some problems with using labels as configs and having some log statements like that would make troubleshooting easier.

It's worth noting that this code only runs when a new container is found so it shouldn't add tons of overhead. I'm debating if I should use info log level with rate limit key being a container name (or perhaps log path / similar) or using debug level 1.

We probably can't just use straight up INFO without any rate limit since it would cause havoc in scenarios where a lot of short lived containers are started.