### PR TITLE
Improve throughput of TCP syslog monitor with the new experimental config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
+## 2.1.17 "TBD" - December 31, 2020
+
+<!---
+Packaged by Tomaz Muraus <tomaz@scalyr.com> on Dec 31, 2020 14:00 -0800
+--->
+
+Improvements:
+* Add new ``tcp_request_parser`` and ``tcp_message_delimiter`` config option. Valid values for ``tcp_request_parser`` include ``default`` and ``batch``. New TCP recv batch oriented request parser is much more efficient than the default one and should be a preferred choice in most situations. For backward compatibility reasons, the default parsed hasn't been changed yet.
+
 ## 2.1.16 "Lasso" - December 23, 2020
 
 <!---

--- a/docs/monitors/syslog_monitor.md
+++ b/docs/monitors/syslog_monitor.md
@@ -179,3 +179,15 @@ Note:  You need to map the host's \
                                                the log deletion configuration options. If False, only the file \
                                                modification time of the main log file is checked, and the rotated \
                                                files will only be deleted when the main log file is deleted.
+|||# ``tcp_request_parser``                ||| Optional (defaults to default). Which TCP packet data request parser to \
+                                               use. Most users should leave this as is.
+|||# ``tcp_incomplete_frame_timeout``      ||| How long we wait (in seconds) for a complete frame / syslog message \
+                                               when running in TCP mode with batch request parser before giving up and \
+                                               flushing what has accumulated in the buffer.
+|||# ``tcp_message_delimiter``             ||| Which character sequence to use for a message delimiter / suffix \
+                                               (defaults to \ n). Some implementations such as Python syslog handler \
+                                               one utilize null character (\ 000) which allows messages to contain new \
+                                               lines without using framing. If that is the case for you, set this \
+                                               option to \ 000. Keep in mind that this value needs to be escaped when \
+                                               specified in the config option which means you need to use two \
+                                               backslashes instead of one.

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -331,7 +331,7 @@ define_config_option(
     __monitor__,
     "tcp_incomplete_frame_timeout",
     "How long we wait (in seconds) for a complete frame / syslog message when running in TCP mode "
-    "with batched request parser before giving up and flushing what has accumulated in the buffer.",
+    "with batch request parser before giving up and flushing what has accumulated in the buffer.",
     default=5,
     min_value=0,
     max_value=600,
@@ -818,7 +818,7 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
                 max_buffer_size=self.server.tcp_buffer_size,
                 message_size_can_exceed_tcp_buffer=self.server.message_size_can_exceed_tcp_buffer,
             )
-        elif self.request_parser == "batched":
+        elif self.request_parser == "batch":
             request_stream = SyslogBatchedRequestParser(
                 socket=self.request,
                 max_buffer_size=self.server.tcp_buffer_size,
@@ -1493,7 +1493,7 @@ class SyslogServer(object):
                 )
                 request_parser = config.get("tcp_request_parser")
 
-                if request_parser not in ["default", "batched", "raw"]:
+                if request_parser not in ["default", "batch", "raw"]:
                     raise ValueError(
                         "Invalid tcp_request_parser value: %s" % (request_parser)
                     )

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1510,10 +1510,12 @@ class SyslogServer(object):
 
                 global_log.log(
                     scalyr_logging.DEBUG_LEVEL_0,
-                    "Starting TCP Server (tcp_buffer_size=%s, "
-                    "message_size_can_exceed_tcp_buffer=%s, tcp_request_parser=%s,"
+                    "Starting TCP Server (host=%s, port=%s, tcp_buffer_size=%s, "
+                    "message_size_can_exceed_tcp_buffer=%s, tcp_request_parser=%s, "
                     "message_delimiter=%s)"
                     % (
+                        bind_address,
+                        port,
                         tcp_buffer_size,
                         message_size_can_exceed_tcp_buffer,
                         request_parser,
@@ -1533,7 +1535,10 @@ class SyslogServer(object):
                     message_delimiter=message_delimiter,
                 )
             elif protocol == "udp":
-                global_log.log(scalyr_logging.DEBUG_LEVEL_2, "Starting UDP Server")
+                global_log.log(
+                    scalyr_logging.DEBUG_LEVEL_0,
+                    "Starting UDP Server (host=%s, port=%s)" % (bind_address, port),
+                )
                 server = SyslogUDPServer(
                     port, bind_address=bind_address, verifier=verifier
                 )

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -598,7 +598,7 @@ class SyslogRequestParser(object):
                     )
 
                     # skip invalid bytes which can appear because of the buffer overflow.
-                    frame_data = six.ensure_text(self._remaining, "ignore")
+                    frame_data = six.ensure_text(self._remaining, errors="ignore")
                     handle_frame(frame_data)
 
                     frames_handled += 1

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -586,7 +586,7 @@ class SyslogRequestParser(object):
                     )
 
                     # skip invalid bytes which can appear because of the buffer overflow.
-                    frame_data = six.ensure_text(self._remaining, errors="ignore")
+                    frame_data = six.ensure_text(self._remaining, "ignore")
 
                     handle_frame(frame_data)
                     frames_handled += 1
@@ -732,9 +732,7 @@ class SyslogBatchedRequestParser(SyslogRequestParser):
                         limit_key="syslog-incomplete-message-flush",
                     )
 
-                    handle_frame(
-                        self._remaining.decode("utf-8", errors="ignore").strip()
-                    )
+                    handle_frame(self._remaining.decode("utf-8", "ignore").strip())
                     frames_handled += 1
 
                     self._last_handle_frame_call_time = int(time.time())
@@ -764,7 +762,7 @@ class SyslogBatchedRequestParser(SyslogRequestParser):
 
         # All the currently available data has been processed, output it and reset the buffer
         if data_to_write:
-            handle_frame(data_to_write.decode("utf-8", errors="ignore").strip())
+            handle_frame(data_to_write.decode("utf-8", "ignore").strip())
             data_to_write = bytearray()
 
             self._last_handle_frame_call_time = int(time.time())

--- a/scripts/print_monitor_doc.py
+++ b/scripts/print_monitor_doc.py
@@ -161,6 +161,7 @@ def print_options(option_list, column_size):
             "|||%s%s||| "
             % (row[0], space_filler(first_column_length - len(row[0]) - 3))
         )
+        row[1] = row[1].replace("\\n", "\\ n").replace("\\000", "\\ 000")
         write_wrapped_line(
             row[1],
             column_size - first_column_length - 4,

--- a/tests/unit/syslog_monitor_test.py
+++ b/tests/unit/syslog_monitor_test.py
@@ -690,12 +690,12 @@ class SyslogMonitorConnectTest(SyslogMonitorTestCase):
         "scalyr_agent.builtin_monitors.syslog_monitor.SyslogHandler", TestSyslogHandler
     )
     @skipIf(platform.system() == "Windows", "Skipping Linux only tests on Windows")
-    def test_run_tcp_server_batched_request_parser(self):
+    def test_run_tcp_server_batch_request_parser(self):
         config = {
             "module": "scalyr_agent.builtin_monitors.syslog_monitor",
             "protocols": "tcp:8514",
             "log_flush_delay": 0.0,
-            "tcp_request_parser": "batched",
+            "tcp_request_parser": "batch",
         }
 
         self.monitor = TestSyslogMonitor(config, self.logger)
@@ -849,7 +849,7 @@ class SyslogMonitorConnectTest(SyslogMonitorTestCase):
         )
 
 
-class SyslogBatchedRequestParserTestCase(SyslogMonitorTestCase):
+class SyslogBatchRequestParserTestCase(SyslogMonitorTestCase):
     @mock.patch("scalyr_agent.builtin_monitors.syslog_monitor.global_log")
     def test_process_success_no_data(self, mock_global_log):
         mock_socket = mock.Mock()

--- a/tests/unit/syslog_monitor_test.py
+++ b/tests/unit/syslog_monitor_test.py
@@ -39,6 +39,7 @@ import platform
 from scalyr_agent.builtin_monitors import syslog_monitor
 from scalyr_agent.builtin_monitors.syslog_monitor import SyslogMonitor
 from scalyr_agent.builtin_monitors.syslog_monitor import SyslogFrameParser
+from scalyr_agent.builtin_monitors.syslog_monitor import SyslogBatchedRequestParser
 from scalyr_agent.monitor_utils.server_processors import RequestSizeExceeded
 from scalyr_agent.scalyr_monitor import MonitorInformation
 from scalyr_agent.test_base import ScalyrTestCase
@@ -689,6 +690,60 @@ class SyslogMonitorConnectTest(SyslogMonitorTestCase):
         "scalyr_agent.builtin_monitors.syslog_monitor.SyslogHandler", TestSyslogHandler
     )
     @skipIf(platform.system() == "Windows", "Skipping Linux only tests on Windows")
+    def test_run_tcp_server_batched_request_parser(self):
+        config = {
+            "module": "scalyr_agent.builtin_monitors.syslog_monitor",
+            "protocols": "tcp:8514",
+            "log_flush_delay": 0.0,
+            "tcp_request_parser": "batched",
+        }
+
+        self.monitor = TestSyslogMonitor(config, self.logger)
+        self.monitor.open_metric_log()
+
+        self.monitor.start()
+        time.sleep(0.05)
+
+        s = socket.socket(socket.AF_INET)
+        self.sockets.append(s)
+
+        self.connect(s, ("localhost", 8514))
+
+        expected_line1 = "TCP TestXX"
+        self.send_and_wait_for_lines(s, expected_line1 + "\n")
+
+        expected_line2 = "Line2"
+        expected_line3 = "Line3"
+        self.send_and_wait_for_lines(
+            s, expected_line2 + "\n" + expected_line3 + "\n", expected_line_count=2
+        )
+
+        # without close, the logger will interfere with other test cases.
+        self.monitor.close_metric_log()
+
+        self.monitor.stop(wait_on_join=False)
+        self.monitor = None
+
+        f = open("agent_syslog.log", "r")
+        actual = f.read().strip()
+
+        self.assertTrue(
+            expected_line1 in actual,
+            "Unable to find '%s' in output:\n\t %s" % (expected_line1, actual),
+        )
+        self.assertTrue(
+            expected_line2 in actual,
+            "Unable to find '%s' in output:\n\t %s" % (expected_line2, actual),
+        )
+        self.assertTrue(
+            expected_line2 in actual,
+            "Unable to find '%s' in output:\n\t %s" % (expected_line2, actual),
+        )
+
+    @mock.patch(
+        "scalyr_agent.builtin_monitors.syslog_monitor.SyslogHandler", TestSyslogHandler
+    )
+    @skipIf(platform.system() == "Windows", "Skipping Linux only tests on Windows")
     def test_run_udp_server(self):
         config = {
             "module": "scalyr_agent.builtin_monitors.syslog_monitor",
@@ -792,3 +847,97 @@ class SyslogMonitorConnectTest(SyslogMonitorTestCase):
             expected_tcp2 in actual,
             "Unable to find '%s' in output:\n\t %s" % (expected_tcp2, actual),
         )
+
+
+class SyslogBatchedRequestParserTestCase(SyslogMonitorTestCase):
+    def test_process_success_no_data(self):
+        mock_socket = mock.Mock()
+        mock_handle_frame = mock.Mock()
+        max_buffer_size = 1024
+
+        parser = SyslogBatchedRequestParser(
+            socket=mock_socket, max_buffer_size=max_buffer_size
+        )
+
+        parser.process(None, mock_handle_frame)
+        self.assertEqual(mock_handle_frame.call_count, 0)
+
+        parser.process(b"", mock_handle_frame)
+        self.assertEqual(mock_handle_frame.call_count, 0)
+
+    def test_process_success_no_existing_buffer_recv_single_complete_message(self):
+        # Here we emulate receving a single message in a single recv call (which is quite unlikely
+        # to happen often in real life)
+        mock_socket = mock.Mock()
+        mock_handle_frame = mock.Mock()
+        max_buffer_size = 1024
+
+        mock_msg_1 = b"<14>Dec 24 16:12:48 hosttest.example.com tag-0-0-17[2593]: Hey diddle diddle, The Cat and the Fiddle, The Cow jump'd over the Spoon\n"
+
+        parser = SyslogBatchedRequestParser(
+            socket=mock_socket, max_buffer_size=max_buffer_size
+        )
+        parser.process(mock_msg_1, mock_handle_frame)
+        self.assertEqual(mock_handle_frame.call_count, 1)
+        self.assertEqual(mock_handle_frame.call_args_list[0][0][0], mock_msg_1[:-1])
+        self.assertEqual(parser._remaining, bytearray())
+
+    def test_process_success_no_existing_buffer_recv_multiple_complete_messages(self):
+        # 2. Here we emulate multiple complete messages returned in a single recv call
+        mock_socket = mock.Mock()
+        mock_handle_frame = mock.Mock()
+        max_buffer_size = 1024
+
+        mock_msg_1 = b"<14>Dec 24 16:12:48 hosttest.example.com tag-1-0-17[2593]: Hey diddle diddle, The Cat and the Fiddle, The Cow jump'd over the Spoon\n"
+        mock_msg_2 = b"<14>Dec 24 16:12:48 hosttest.example.com tag-2-0-17[2593]: Hey diddle diddle, The Cat and the Fiddle, The Cow jump'd over the Spoon\n"
+        mock_msg_3 = b"<14>Dec 24 16:12:48 hosttest.example.com tag-3-0-17[2593]: Hey diddle diddle, The Cat and the Fiddle, The Cow jump'd over the Spoon\n"
+        mock_data = mock_msg_1 + mock_msg_2 + mock_msg_3
+
+        parser = SyslogBatchedRequestParser(
+            socket=mock_socket, max_buffer_size=max_buffer_size
+        )
+        parser.process(mock_data, mock_handle_frame)
+
+        # Ensure we only call handle_frame once with all the data
+        self.assertEqual(mock_handle_frame.call_count, 1)
+        self.assertEqual(mock_handle_frame.call_args_list[0][0][0], mock_data[:-1])
+        self.assertEqual(parser._remaining, bytearray())
+
+    def test_process_no_frame_data_timeout_reached_flush_partial(self):
+        # Here we emulate recv returning partial data and ensuring it's handled correctly
+        mock_socket = mock.Mock()
+        mock_handle_frame = mock.Mock()
+        max_buffer_size = 1024
+
+        mock_msg_1 = b"<14>Dec 24 16:12:48 hosttest.example.com tag-1-0-17[2593]: Hey diddle diddle, The Cat and the Fiddle, The Cow jump'd over the Spoon\n"
+        mock_msg_2 = b"<14>Dec 24 16:12:48 hosttest.example.com tag-2-0-17[2593]: Hey diddle diddle, The Cat and the Fiddle, The Cow jump'd over the Spoon\n"
+        mock_msg_3 = b"<14>Dec 24 16:12:48 hosttest.example.com tag-3-0-17[2593]: Hey diddle diddle, The Cat and the Fiddle, The Cow jump'd over the Spoon\n"
+        mock_msg_4 = b"<14>Dec 24 16:12:48 hosttest.example.com tag-3-0-17[2593]: Hey diddle diddle, The Cat and the Fiddle, The Cow jump'd over the Spoon\n"
+
+        mock_data = mock_msg_1 + mock_msg_2 + mock_msg_3[: len(mock_msg_3) / 2]
+
+        parser = SyslogBatchedRequestParser(
+            socket=mock_socket, max_buffer_size=max_buffer_size
+        )
+        parser.process(mock_data, mock_handle_frame)
+
+        # Ensure we only call handle_frame. Since last message was incomplete, only first two
+        # messages should have been flushed and part of the 3rd one should still be in internal
+        # buffer
+        self.assertEqual(mock_handle_frame.call_count, 1)
+        self.assertEqual(
+            mock_handle_frame.call_args_list[0][0][0], mock_msg_1 + mock_msg_2[:-1]
+        )
+
+        self.assertEqual(parser._remaining, mock_msg_3[: len(mock_msg_3) / 2])
+
+        # Now emulate rest of the message 3 + complete message 4 arriving
+        mock_data = mock_msg_3[len(mock_msg_3) / 2 :] + mock_msg_4
+
+        parser.process(mock_data, mock_handle_frame)
+        self.assertEqual(mock_handle_frame.call_count, 2)
+        self.assertEqual(
+            mock_handle_frame.call_args_list[1][0][0], mock_msg_3 + mock_msg_4[:-1]
+        )
+
+        self.assertEqual(parser._remaining, bytearray())


### PR DESCRIPTION
This pull requests adds support for two new experimental syslog request parsers for syslog TCP monitor.

Both of those parsers should offer much better throughput than the current default parser which supports framed and line delimited syslog messages.

## Background, Context

We've done some benchmarking in the past and currently syslog monitor in TCP mode can only handle ~3 MB/s of data before it saturates all the CPU available to the syslog monitor thread.

I wanted to find the root cause for this poor performance so I've done some more profiling.

Based on the profiling results, the main bottleneck is calling ``handle_frame()`` function for each processed syslog message (frame / line).

Basically what that function does is calls scalyr logger method which writes data to a file on disk.

## Proposed Change

To be able to work around this poor performance, I introduced two new syslog TCP request parsers.

### 1) SyslogRawRequestParser

This parser doesn't handle framed or new line delimited messages, but it simply writes any data it reads from the socket directly to a file.

This one isn't really meant to be used in production, but it's mostly used for benchmarking purposes since in a sense it represents "best case" scenario where no processing is performed on read data.

Technically, it could still work in some scenarios where messages are line delimited and not framed with a caveat / limitation that we could potentially be writing partial line data to a file when logger method is called (depending on data we read from the socket).

This could perhaps be worked around with server-side parser definition, but it involve overhead on the server.

### 2) SyslogBatchedRequestParser

This parser works very similar to the current default parser. It can handle frame and line delimited data, only difference is that it doesn't call ``handle_frame()`` for each processed / parsed line / frame, but only after it has exhausted current buffer.

This results in much less calls to scalyr logger method which results in better efficiency and improved throughput.

As part of this parser, I also got rid of the ``message_size_can_exceed_tcp_buffer`` config option and made that the default behavior. Having said that, we may still potentially want to add a guard  which causes the handler to flush currently accumulated buffer if we haven't seen a complete frame / syslog message for X seconds.

With that change, I can easily get ~30 MB/s locally with our load gen (5 workers, 200 bytes message size, count 1000).

This basically means that the bottleneck will rarely be the syslog monitor itself, but actual agent code which is responsible for ingesting lines which are written to disk by syslog monitor up to Scalyr (and that's a familiar beast and we have many ways to mitigate that such as using multiple workers, etc.).

## Open Questions

I'm 95% this approach should work (aka we can write multiple lines at once to a log file on disk / call scalyr logger with multiple lines at once and file will be correctly ingested since it's no different than some other software writing arbitrary number of bytes to a file), but it would still be good if @czerwingithub can confirm that.

## TODO

- [x] Agree on the approach
- [x] Clean up and finish the code (remove duplicated code, etc).
- [x] Add tests