### PR TITLE
Don't log non-fatal errors in the Docker monitor under warning log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Packaged by Tomaz Muraus <tomaz@scalyr.com> on Dec 31, 2020 14:00 -0800
 Improvements:
 * Add new ``tcp_request_parser`` and ``tcp_message_delimiter`` config option. Valid values for ``tcp_request_parser`` include ``default`` and ``batch``. New TCP recv batch oriented request parser is much more efficient than the default one and should be a preferred choice in most situations. For backward compatibility reasons, the default parsed hasn't been changed yet.
 
+Misc:
+* Update docker monitor so we don't log some non-fatal errors under warning log level when consuming logs using Docker API.
+
 ## 2.1.16 "Lasso" - December 23, 2020
 
 <!---

--- a/scalyr_agent/builtin_monitors/docker_monitor.py
+++ b/scalyr_agent/builtin_monitors/docker_monitor.py
@@ -1687,6 +1687,19 @@ class DockerLogger(object):
                 % (self.cid, self.name, str(e))
             )
         except Exception as e:
+            # Those errors are not fatal so we simply ignore dont dont log them under warning.
+            # They usually appear on agent restart when using log consumption via API since
+            # long running streaming API connection will be closed.
+            if "readinto of closed file" in str(e) or "operation on closed file" in str(
+                e
+            ):
+                global_log.log(
+                    scalyr_logging.DEBUG_LEVEL_1,
+                    "Unhandled non-fatal exception in DockerLogger.process_request for %s:\n\t%s.\n\n%s"
+                    % (self.name, six.text_type(e), traceback.format_exc()),
+                )
+                return
+
             global_log.warn(
                 "Unhandled exception in DockerLogger.process_request for %s:\n\t%s.\n\n%s"
                 % (self.name, six.text_type(e), traceback.format_exc())


### PR DESCRIPTION
This pull request updates Docker monitor to not-log some non fatal errors under warning log level.

## Background, Context

When using Docker container monitor and consuming logs from the Docker streaming HTTP API, you will often see errors like this in the agent log when restarting / upgrading the agent:

```bash
  File "/usr/share/scalyr-agent-2/py/scalyr_agent/third_party/requests/packages/urllib3/response.py", line 333, in _error_catcher
    self._original_response.close()
  File "/usr/lib/python3.8/http/client.py", line 416, in close
    super().close() # set "closed" flag
  File "/usr/lib/python3.8/http/client.py", line 429, in flush
    self.fp.flush()
ValueError: I/O operation on closed file.

2020-12-27 19:55:09.098Z INFO [core] [connection.py:218] HttpConnection uses native os ssl
2020-12-27 19:55:09.099Z INFO [core] [connection.py:108] Using ScalyrHttpConnection/Httplib for HTTP(S) connections
2020-12-27 19:55:10.176Z WARNING [monitor:docker_monitor] [docker_monitor.py:1690] Unhandled exception in DockerLogger.process_request for foo:
        I/O operation on closed file..

Traceback (most recent call last):
  File "/usr/share/scalyr-agent-2/py/scalyr_agent/third_party/requests/packages/urllib3/response.py", line 302, in _error_catcher
    yield
  File "/usr/share/scalyr-agent-2/py/scalyr_agent/third_party/requests/packages/urllib3/response.py", line 384, in read
    data = self._fp.read(amt)
  File "/usr/lib/python3.8/http/client.py", line 458, in read
    n = self.readinto(b)
  File "/usr/lib/python3.8/http/client.py", line 492, in readinto
    return self._readinto_chunked(b)
  File "/usr/lib/python3.8/http/client.py", line 592, in _readinto_chunked
    n = self._safe_readinto(mvb)
  File "/usr/lib/python3.8/http/client.py", line 620, in _safe_readinto
    n = self.fp.readinto(b)
ValueError: readinto of closed file
```

Those errors are non-fatal and simply mean the underlying long-running streaming HTTP connection socket has been closed. Agent will simply re-connect and continue consuming logs in such scenarios.

Because of that, I think it makes more sense to log this under DEBUG and not WARNING Log level.