### PR TITLE
Add support for disabling compression for outgoing requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
+## 2.1.17 "TBD" - December 31, 2020
+
+<!---
+Packaged by Tomaz Muraus <tomaz@scalyr.com> on Dec 31, 2020 14:00 -0800
+--->
+
+Misc:
+* Add support for ``compression_type: none`` config option which completely disables compression for outgoing requests. Right now one of the main bottle necks in the high volume scenarios in the agent is compression operation. Disabling it can, in some scenarios, lead to large increase to the overall throughput (up to 2x). Disabling the compression will in most cases result in larger data egress traffic which may incur additional charges on your infrastructure provider so this option should never be set to ``none`` unless explicitly advised by the technical support.
+
 ## 2.1.16 "Lasso" - December 23, 2020
 
 <!---

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -2950,7 +2950,7 @@ class Configuration(object):
             self.__logger.warn(
                 "No compression will be used for outgoing requests. In most scenarios this will "
                 "result in larger data egress traffic which may incur additional charges on your "
-                "side (depending on your location, provider, etc.).",
+                "side (depending on your infrastructure provider, location, pricing model, etc.).",
                 limit_once_per_x_secs=86400,
                 limit_key="compression_type_none",
             )

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -2946,6 +2946,15 @@ class Configuration(object):
             )
             raise BadConfiguration(msg, "compression_type", "invalidCompressionType")
 
+        if compression_type == "none":
+            self.__logger.warn(
+                "No compression will be used for outgoing requests. In most scenarios this will "
+                "result in larger data egress traffic which may incur additional charges on your "
+                "side (depending on your location, provider, etc.).",
+                limit_once_per_x_secs=86400,
+                limit_key="compression_type_none",
+            )
+
     def __verify_compression_level(self, compression_level):
         """
         Verify that the provided compression level is valid for the configured compression type.

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -329,7 +329,7 @@ class ScalyrClientSession(object):
                     % (compression_type, compression_type)
                 )
 
-        if encoding:
+        if encoding and encoding != "none":
             self.__standard_headers["Content-Encoding"] = encoding
 
         # Configure compression level

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -2086,7 +2086,11 @@ class TestConfiguration(TestConfigurationBase):
 
             config = self._create_test_configuration_instance()
             config.parse()
-            self.assertEqual(config.compression_level, 5)
+
+            if config.compression_type == "none":
+                self.assertEqual(config.compression_level, 0)
+            else:
+                self.assertEqual(config.compression_level, 5)
 
     def test_parse_compression_algorithm_invalid_compression_level(self):
         # If invalid compression level is used, we should use a default value for that particular

--- a/tests/unit/scalyr_client_test.py
+++ b/tests/unit/scalyr_client_test.py
@@ -1299,16 +1299,25 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
             )
 
             self.assertEqual(path[0], "/addEvents")
-            self.assertEqual(
-                session._ScalyrClientSession__standard_headers["Content-Encoding"],
-                compression_type,
-            )
 
-            # Verify decompressed data matches the raw body
-            self.assertTrue(b"test message 1" not in request["body"])
-            self.assertTrue(b"test message 2" not in request["body"])
-            self.assertFalse(serialized_data == request["body"])
-            self.assertEqual(serialized_data, decompress_func(request["body"]))
+            if compression_type == "none":
+                self.assertTrue(
+                    "Content-Encoding"
+                    not in session._ScalyrClientSession__standard_headers
+                )
+                self.assertTrue(b"test message 1" in request["body"])
+                self.assertTrue(b"test message 2" in request["body"])
+            else:
+                self.assertEqual(
+                    session._ScalyrClientSession__standard_headers["Content-Encoding"],
+                    compression_type,
+                )
+
+                # Verify decompressed data matches the raw body
+                self.assertTrue(b"test message 1" not in request["body"])
+                self.assertTrue(b"test message 2" not in request["body"])
+                self.assertFalse(serialized_data == request["body"])
+                self.assertEqual(serialized_data, decompress_func(request["body"]))
 
         # Compression is disabled
         session = ScalyrClientSession(

--- a/tests/unit/util/util_test.py
+++ b/tests/unit/util/util_test.py
@@ -55,6 +55,7 @@ from scalyr_agent.util import (
     RedirectorError,
 )
 from scalyr_agent.util import verify_and_get_compress_func
+from scalyr_agent.util import get_compress_and_decompress_func
 from scalyr_agent.json_lib import JsonObject
 
 
@@ -68,6 +69,21 @@ class TestUtilCompression(ScalyrTestCase):
     def setUp(self):
         super(TestUtilCompression, self).setUp()
         self._data = b"The rain in spain. " * 1000
+
+    def test_compression_none(self):
+        data = self._data
+        compress = verify_and_get_compress_func("none")
+        self.assertIsNotNone(compress)
+
+        self.assertEqual(data, compress(data))
+
+        compress_func, decompress_func = get_compress_and_decompress_func("none")
+        self.assertIsNotNone(compress_func)
+        self.assertIsNotNone(decompress_func)
+
+        self.assertEqual(data, compress_func(data))
+        self.assertEqual(data, decompress_func(data))
+        self.assertEqual(data, decompress_func(compress_func(data)))
 
     def test_zlib(self):
         """Successful zlib compression"""


### PR DESCRIPTION
This pull request adds support for fully disabling compression for outgoing requests by setting ``compression_type: none`` config option.

## Background, Context

As profiled many times in the past already, currently one of the main bottlenecks in the agent when dealing with high volume / throughput scenarios is the compression operation itself.

As benchmarked yesterday, disabling compression can increase to large increase in overall throughput (e.g. yesterday with 4 workers and medium line size we've seen around ~50 MB/s with deflate level 6 aka default and ~80 MB/s with compression disabled).

As they say - there is no such thing as free lunch and the same thing applies here as well. Disabling compression will in most cases result in larger egress traffic on the servers where the agent is running and this may incur additional chargers on the user and our side depending on various factors (where users infra is located, etc.).

As documented, this option should only be set by the user if they are explicitly instructed to do so by the technical support team.

Situations where disabling compression all together may make sense are very high volume customers which are running the agents in the same AWS region / AZ as we do, have fast enough NIC (as seen yesterday, we can easily saturate 1 Gbit NIC with compression disabled and 8 workers) and are aware of other things associated with that change.