### PR TITLE
Update Linux System metrics monitor to also ignore /var/lib/docker/* and /snap/* mount points by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ Scalyr Agent 2 Changes By Release
 Packaged by Tomaz Muraus <tomaz@scalyr.com> on Dec 31, 2020 14:00 -0800
 --->
 
-Misc:
 Improvements:
 * Add new ``tcp_request_parser`` and ``tcp_message_delimiter`` config option. Valid values for ``tcp_request_parser`` include ``default`` and ``batch``. New TCP recv batch oriented request parser is much more efficient than the default one and should be a preferred choice in most situations. For backward compatibility reasons, the default parsed hasn't been changed yet.
 
 Misc:
 * Update docker monitor so we don't log some non-fatal errors under warning log level when consuming logs using Docker API.
 * Add support for ``compression_type: none`` config option which completely disables compression for outgoing requests. Right now one of the main bottle necks in the high volume scenarios in the agent is compression operation. Disabling it can, in some scenarios, lead to large increase to the overall throughput (up to 2x). Disabling the compression will in most cases result in larger data egress traffic which may incur additional charges on your infrastructure provider so this option should never be set to ``none`` unless explicitly advised by the technical support.
+* Linux system metrics monitor has been updated to also ignore ``/var/lib/docker/*`` and ``/snap/*`` mount points by default. Capturing metrics for those mount points usually offers no additional insight to the end user. For information on how to change the ignore list via configuration option, please see [RELEASE_NOTES](https://github.com/scalyr/scalyr-agent-2/blob/master/RELEASE_NOTES.md).
 
 ## 2.1.16 "Lasso" - December 23, 2020
 

--- a/scalyr_agent/builtin_monitors/linux_system_metrics.py
+++ b/scalyr_agent/builtin_monitors/linux_system_metrics.py
@@ -557,7 +557,7 @@ define_config_option(
     "ignore_mounts",
     "List of glob patterns for mounts to ignore",
     convert_to=ArrayOfStrings,
-    default=["/sys/*", "/dev*", "/run*"],
+    default=["/sys/*", "/dev*", "/run*", "/var/lib/docker/*", "/snap/*"],
 )
 
 


### PR DESCRIPTION
This pull request updates Linux system metrics monitor to ignore two additional mount point globs by default - ``/var/lib/docker/*`` and ``/snap/*``.

First one represents Docker overlay volume mounts which size and other values will always match the values of the mount point where ``/var/lib/docker`` lives on and the second one represents read-only mount points for snap packages.

Metrics for those mount points provide no additional insight to the end user and just result in unnecessary network traffic and storage usage (albeit very small one).

Keep in mind that this change will only affect deployments where the agent is running on the host where docker containers run and deployments which utilize snap packages.