### PR TITLE
Add worker log status

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -1674,7 +1674,7 @@ class ScalyrAgent(object):
             "copy_manager_status workers_number=%ld total_scan_iterations=%ld total_read_time=%lf total_compression_time=%lf total_waiting_time=%lf total_blocking_response_time=%lf "
             "total_request_time=%lf total_pipelined_requests=%ld avg_bytes_produced_rate=%lf avg_bytes_copied_rate=%lf"
             % (
-                stats.copying_manager_status.workers_number,
+                stats.num_workers,
                 stats.total_scan_iterations,
                 stats.total_read_time,
                 stats.total_compression_time,
@@ -1817,6 +1817,7 @@ class ScalyrAgent(object):
         result.num_copying_paths = copying_paths
         result.num_running_monitors = running_monitors
         result.num_dead_monitors = dead_monitors
+        result.num_workers = current_status.copying_manager_status.workers_number
 
         (
             result.user_cpu,

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -1671,9 +1671,10 @@ class ScalyrAgent(object):
         stats = overall_stats
 
         log.info(
-            "copy_manager_status total_scan_iterations=%ld total_read_time=%lf total_compression_time=%lf total_waiting_time=%lf total_blocking_response_time=%lf "
+            "copy_manager_status workers_number=%ld total_scan_iterations=%ld total_read_time=%lf total_compression_time=%lf total_waiting_time=%lf total_blocking_response_time=%lf "
             "total_request_time=%lf total_pipelined_requests=%ld avg_bytes_produced_rate=%lf avg_bytes_copied_rate=%lf"
             % (
+                stats.copying_manager_status.workers_number,
                 stats.total_scan_iterations,
                 stats.total_read_time,
                 stats.total_compression_time,

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -1817,7 +1817,8 @@ class ScalyrAgent(object):
         result.num_copying_paths = copying_paths
         result.num_running_monitors = running_monitors
         result.num_dead_monitors = dead_monitors
-        result.num_workers = current_status.copying_manager_status.workers_number
+        if current_status.copying_manager_status is not None:
+            result.num_workers = current_status.copying_manager_status.workers_number
 
         (
             result.user_cpu,

--- a/scalyr_agent/agent_status.py
+++ b/scalyr_agent/agent_status.py
@@ -468,24 +468,22 @@ class CopyingManagerStatus(BaseAgentStatus):
 
         self._verify_workers_health_check()
 
-        # sum up all stats from workers if it is not a default config.
-        if not self.is_single_worker():
-            # sum up some worker stats to overall stats.
-            for worker_status in self._workers():
-                self.total_errors += worker_status.total_errors
-                self.total_bytes_uploaded += worker_status.total_bytes_uploaded
+        # sum up some worker stats to overall stats.
+        for worker_status in self._workers():
+            self.total_errors += worker_status.total_errors
+            self.total_bytes_uploaded += worker_status.total_bytes_uploaded
 
-                self.total_rate_limited_time = worker_status.total_rate_limited_time
-                self.total_read_time = worker_status.total_read_time
-                self.total_waiting_time = worker_status.total_waiting_time
-                self.total_blocking_response_time = (
-                    worker_status.total_blocking_response_time
-                )
-                self.total_request_time = worker_status.total_request_time
-                self.total_pipelined_requests = worker_status.total_pipelined_requests
-                self.rate_limited_time_since_last_status = (
-                    worker_status.rate_limited_time_since_last_status
-                )
+            self.total_rate_limited_time += worker_status.total_rate_limited_time
+            self.total_read_time += worker_status.total_read_time
+            self.total_waiting_time += worker_status.total_waiting_time
+            self.total_blocking_response_time += (
+                worker_status.total_blocking_response_time
+            )
+            self.total_request_time += worker_status.total_request_time
+            self.total_pipelined_requests += worker_status.total_pipelined_requests
+            self.rate_limited_time_since_last_status += (
+                worker_status.rate_limited_time_since_last_status
+            )
 
     def to_dict(self):  # type: () -> dict
         result = super(CopyingManagerStatus, self).to_dict()

--- a/scalyr_agent/agent_status.py
+++ b/scalyr_agent/agent_status.py
@@ -415,6 +415,9 @@ class CopyingManagerStatus(BaseAgentStatus):
         self.total_request_time = 0
         self.total_pipelined_requests = 0
 
+        # the number of all running workers.
+        self.workers_number = 0
+
     def is_single_worker(self):
         # type: () -> bool
         """
@@ -470,6 +473,7 @@ class CopyingManagerStatus(BaseAgentStatus):
 
         # sum up some worker stats to overall stats.
         for worker_status in self._workers():
+            self.workers_number += 1
             self.total_errors += worker_status.total_errors
             self.total_bytes_uploaded += worker_status.total_bytes_uploaded
 

--- a/scalyr_agent/agent_status.py
+++ b/scalyr_agent/agent_status.py
@@ -156,6 +156,8 @@ class OverallStats(AgentStatus):
         self.num_running_monitors = 0
         # The current number of monitors that should be running but are not.
         self.num_dead_monitor = 0
+        # the current number of workers that run by the copying manager.
+        self.num_workers = 0
         # The total amount of user time CPU used by the agent (cpu secs).
         self.user_cpu = 0
         # The total amount of system time CPU used by the agent (cpu secs)

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -586,6 +586,7 @@ class Configuration(object):
             "json_library",
             "use_multiprocess_copying_workers",
             "default_workers_per_api_key",
+            "default_worker_status_message_interval",
             # NOTE: It's important we use sanitzed_ version of this method which masks the API key
             "sanitized_api_key_configs",
         ]
@@ -1585,6 +1586,10 @@ class Configuration(object):
         The default number of workers which should be created for each api key is no value is explicitly set
         """
         return self.__get_config().get_int("default_workers_per_api_key")
+
+    @property
+    def default_worker_status_message_interval(self):
+        return self.__get_config().get_float("default_worker_status_message_interval")
 
     def equivalent(self, other, exclude_debug_level=False):
         """Returns true if other contains the same configuration information as this object.
@@ -2911,6 +2916,15 @@ class Configuration(object):
             apply_defaults,
             env_aware=True,
             min_value=1,
+        )
+
+        self.__verify_or_set_optional_float(
+            config,
+            "default_worker_status_message_interval",
+            600.0,
+            description,
+            apply_defaults,
+            env_aware=True,
         )
 
         # windows does not support copying manager backed with multiprocessing workers.

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -587,6 +587,7 @@ class Configuration(object):
             "use_multiprocess_copying_workers",
             "default_workers_per_api_key",
             "default_worker_status_message_interval",
+            "enable_worker_process_metrics_gather",
             # NOTE: It's important we use sanitzed_ version of this method which masks the API key
             "sanitized_api_key_configs",
         ]
@@ -1590,6 +1591,14 @@ class Configuration(object):
     @property
     def default_worker_status_message_interval(self):
         return self.__get_config().get_float("default_worker_status_message_interval")
+
+    @property
+    def enable_worker_process_metrics_gather(self):
+        """
+        If it True and multi-process workers are used, then the instance of the linux process monitor
+        is created for each worker process.
+        """
+        return self.__get_config().get_bool("enable_worker_process_metrics_gather")
 
     def equivalent(self, other, exclude_debug_level=False):
         """Returns true if other contains the same configuration information as this object.
@@ -2922,6 +2931,15 @@ class Configuration(object):
             config,
             "default_worker_status_message_interval",
             600.0,
+            description,
+            apply_defaults,
+            env_aware=True,
+        )
+
+        self.__verify_or_set_optional_bool(
+            config,
+            "enable_worker_process_metrics_gather",
+            False,
             description,
             apply_defaults,
             env_aware=True,

--- a/scalyr_agent/copying_manager/copying_manager.py
+++ b/scalyr_agent/copying_manager/copying_manager.py
@@ -828,8 +828,11 @@ class CopyingManager(StoppableThread, LogWatcher):
                     # set the workers PID to the monitors.
                     for pool_status in self.generate_status().api_key_worker_pools:
                         for worker_status in pool_status.workers:
-                            monitor = workers_process_monitors[worker_status.worker_id]
-                            monitor.set_pid(worker_status.pid)
+                            monitor = workers_process_monitors.get(
+                                worker_status.worker_id
+                            )
+                            if monitor:
+                                monitor.set_pid(worker_status.pid)
 
                 # Do the initial scan for any log files that match the configured logs we should be copying.  If there
                 # are checkpoints for them, make sure we start copying from the position we left off at.

--- a/scalyr_agent/copying_manager/copying_manager.py
+++ b/scalyr_agent/copying_manager/copying_manager.py
@@ -27,6 +27,8 @@ from six.moves import range
 import signal
 import errno
 
+WORKER_PROCESS_MONITOR_ID_PREFIX = "agent_worker_"
+
 if False:
     from typing import Dict
     from typing import List
@@ -52,6 +54,7 @@ from scalyr_agent.log_watcher import LogWatcher
 from scalyr_agent.configuration import Configuration
 from scalyr_agent.scalyr_client import ScalyrClientSessionStatus
 from scalyr_agent.copying_manager.common import write_checkpoint_state_to_file
+from scalyr_agent.builtin_monitors.linux_process_metrics import ProcessMonitor
 
 
 import six
@@ -60,6 +63,20 @@ log = scalyr_logging.getLogger(__name__)
 
 SCHEDULED_DELETION = "scheduled-deletion"
 CONSOLIDATED_CHECKPOINTS_FILE_NAME = "checkpoints.json"
+
+
+def get_api_key_worker_ids(api_key_config):  # type: (Dict) -> List
+    """
+    Generate the list of IDs of all workers for the specified api key.
+    :param api_key_config: config entry for the api key.
+    :return: List of worker IDs.
+    """
+    result = []
+    for i in range(api_key_config["workers"]):
+        # combine the id of the api key and worker's position in the list to get a workers id.
+        worker_id = "%s_%s" % (api_key_config["id"], i)
+        result.append(worker_id)
+    return result
 
 
 class ApiKeyWorkerPool(object):
@@ -87,10 +104,7 @@ class ApiKeyWorkerPool(object):
         # Those managers allow to communicate with workers if they are in the multiprocessing mode.
         self.__shared_object_managers = dict()
 
-        for i in range(api_key_config["workers"]):
-            # combine the id of the api key and worker's position in the list to get a workers id.
-            worker_id = "%s_%s" % (self.__api_key_id, i)
-
+        for worker_id in get_api_key_worker_ids(api_key_config):
             if not self.__config.use_multiprocess_copying_workers:
                 worker = CopyingManagerThreadedWorker(
                     self.__config, api_key_config, worker_id
@@ -792,6 +806,30 @@ class CopyingManager(StoppableThread, LogWatcher):
                 # start all workers.
                 for worker_pool in self.__api_keys_worker_pools.values():
                     worker_pool.start_workers_and_block_until_copying()
+
+                # if the multi-process workers are enabled, then we have to set the worker PID's for the instances of the
+                # 'linux_process_monitor' that may be set to monitor the worker processes.
+                if self.__config.use_multiprocess_copying_workers:
+                    # create a dict that maps process' monitor id to the worker id.
+                    workers_process_monitors = {}
+                    for m in self.__monitors:
+                        if not isinstance(m, ProcessMonitor):
+                            continue
+
+                        # get the process monitor instance for the worker and fetch the worker id.
+                        if m.process_monitor_id.startswith(
+                            WORKER_PROCESS_MONITOR_ID_PREFIX
+                        ):
+                            worker_id = m.process_monitor_id.replace(
+                                WORKER_PROCESS_MONITOR_ID_PREFIX, ""
+                            )
+                            workers_process_monitors[worker_id] = m
+
+                    # set the workers PID to the monitors.
+                    for pool_status in self.generate_status().api_key_worker_pools:
+                        for worker_status in pool_status.workers:
+                            monitor = workers_process_monitors[worker_status.worker_id]
+                            monitor.set_pid(worker_status.pid)
 
                 # Do the initial scan for any log files that match the configured logs we should be copying.  If there
                 # are checkpoints for them, make sure we start copying from the position we left off at.

--- a/scalyr_agent/platform_linux.py
+++ b/scalyr_agent/platform_linux.py
@@ -122,8 +122,12 @@ class LinuxPlatformController(PosixPlatformController):
                     id="agent",
                 )
             )
-            # if multi-process workers are enabled, then create linux metrics monitor for each worker process.
-            if config.use_multiprocess_copying_workers:
+            # if multi-process workers are enabled and workers process monitoring is enabled,
+            # then create linux metrics monitor for each worker process.
+            if (
+                config.use_multiprocess_copying_workers
+                and config.enable_worker_process_metrics_gather
+            ):
                 for api_key_config in config.api_key_configs:
                     for worker_id in get_api_key_worker_ids(api_key_config):
                         result.append(

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -397,6 +397,10 @@ class ScalyrClientSession(object):
             self.__agent_version, fragments
         )
 
+    @property
+    def session_id(self):  # type: () -> six.text_type
+        return self.__session_id
+
     def ping(self):
         """Ping the Scalyr server by sending a test message to add zero events.
 


### PR DESCRIPTION
This PR adds periodical stats logging for all workers in separate process'. 
The agent's `linux process monitor` also aggregates all metrics from the child worker process'. 

**Things to do/discuss:**

Create a separate app for the `linux process monitor` for each worker process to be able to monitor them separately.
In this case, we need to create a new instance if the `LinuxProcessMonitor` for each worker.