### PR TITLE
Fix run_monitor.py so it works when -c flag is provided

### DIFF
--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -278,6 +278,11 @@ class ScalyrMonitor(StoppableThread):
         This way we spread a potential short load spike during sample gathering across a longer time
         frame.
         """
+        # NOTE: self._global_config will be None when using scalyr_agent/run_monitor.py script with
+        # -c flag
+        if not self._global_config:
+            return 0
+
         if not self._global_config.global_monitor_sample_interval_enable_jitter:
             return 0
 


### PR DESCRIPTION
This pull request fixes ``run_monitor.py`` script so it doesn't throw an exception when ``-c`` argument is used.

## Background, Context

#660 inadvertently broke that script when ``-c`` flag is used aka when config is provided as JSON string on the command line.