### PR TITLE
Fix debian change log build and small fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2246,6 +2246,8 @@ jobs:
       - run:
           name: Build deb and rpm packages
           command: |
+            set -e
+
             mkdir artifacts
             mkdir package
 
@@ -2255,9 +2257,19 @@ jobs:
             python ../build_package.py rpm
 
             dpkg -X "$(ls *.deb)" /tmp/deb_package
-            warnings=$(dpkg-parsechangelog --file /tmp/deb_package/usr/share/doc/scalyr-agent-2/changelog.gz 2>&1 1>/dev/null | grep warning || true)
+
+            set +e
+            stderr=$(dpkg-parsechangelog --file /tmp/deb_package/usr/share/doc/scalyr-agent-2/changelog.gz 2>&1 1>/dev/null)
+            if [[ "$?" -ne 0 ]]; then
+              >&2 echo "$stderr"
+              exit 1
+            fi
+            set -e
+            warnings=$(grep warning \<<< "$stderr" || true)
+
             if [[ -n "${warnings}" ]]; then
-              echo "The debian package changelog is built with warnings."
+              >&2 echo "The debian package changelog is built with warnings. This may be caused by splitting the text across miltiple lines."
+              >&2 echo "$warnings"
               exit 1
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2254,6 +2254,13 @@ jobs:
             python ../build_package.py deb
             python ../build_package.py rpm
 
+            dpkg -X "$(ls *.deb)" /tmp/deb_package
+            warnings=$(dpkg-parsechangelog --file /tmp/deb_package/usr/share/doc/scalyr-agent-2/changelog.gz 2>&1 1>/dev/null | grep warning || true)
+            if [[ -n "${warnings}" ]]; then
+              echo "The debian package changelog is built with warnings."
+              exit 1
+            fi
+
             popd
 
             # NOTE: We preserve two versions of the package as the build artifact. One with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,10 @@ Packaged by Arthur Kamalov <arthur@scalyr.com> on Jan 13, 2021 14:00 -0800
 --->
 
 Features:
-* Add copy truncate log rotation support.  This is enabled by default.  It does not support copy truncate with
-compression unless the `delaycompress` option is used.  This feature can be disabled by setting `enable_copy_truncate_log_rotation_support` to false.
+* Add copy truncate log rotation support. This is enabled by default.  It does not support copy truncate with compression unless the `delaycompress` option is used.  This feature can be disabled by setting `enable_copy_truncate_log_rotation_support` to false.
 
 Improvements:
-* Add new ``tcp_request_parser`` and ``tcp_message_delimiter`` config option. Valid values for ``tcp_request_parser``
-include ``default`` and ``batch``. New TCP recv batch oriented request parser is much more efficient than the default
-one and should be a preferred choice in most situations.  For backward compatibility reasons, the default parser hasn't
-been changed yet.
+* Add new ``tcp_request_parser`` and ``tcp_message_delimiter`` config option. Valid values for ``tcp_request_parser`` include ``default`` and ``batch``. New TCP recv batch oriented request parser is much more efficient than the default one and should be a preferred choice in most situations.  For backward compatibility reasons, the default parser hasn't been changed yet.
 
 Misc:
 * On startup and when parsing a config file, agent now emits a warning if the config file is readable by others.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,14 +19,9 @@ been changed yet.
 
 Misc:
 * On startup and when parsing a config file, agent now emits a warning if the config file is readable by others.
-* Add the config option ``enable_worker_process_metrics_gather`` to enable 'linux_process_metrics' monitor for each
-multiprocess worker.
-* Each session, which runs in a separate process, periodically writes its stats in the log file.
-The interval between writes can be changed by using the ``default_worker_session_status_message_interval``
-* Rename some of the configuration parameters: ``use_miltiprocess_copying_workers``  to ``use_multiprocess_workers``,
-``default_workers_per_api_key`` to ``default_sessions_per_api_key``. Previous option names are preserved for the
-backward compatibility but they are marked as deprecated.
-NOTE: The appropriate [environment variable names](https://app.scalyr.com/help/scalyr-agent-env-aware) are changed too.
+* Add the config option ``enable_worker_process_metrics_gather`` to enable 'linux_process_metrics' monitor for each multiprocess worker.
+* Each session, which runs in a separate process, periodically writes its stats in the log file. The interval between writes can be changed by using the ``default_worker_session_status_message_interval``
+* Rename some of the configuration parameters: ``use_miltiprocess_copying_workers``  to ``use_multiprocess_workers``, ``default_workers_per_api_key`` to ``default_sessions_per_api_key``. Previous option names are preserved for the backward compatibility but they are marked as deprecated. NOTE: The appropriate [environment variable names](https://app.scalyr.com/help/scalyr-agent-env-aware) are changed too.
 * Update docker monitor so we don't log some non-fatal errors under warning log level when consuming logs using Docker API.
 * Add support for ``compression_type: none`` config option which completely disables compression for outgoing requests. Right now one of the main bottle necks in the high volume scenarios in the agent is compression operation. Disabling it can, in some scenarios, lead to large increase to the overall throughput (up to 2x). Disabling the compression will in most cases result in larger data egress traffic which may incur additional charges on your infrastructure provider so this option should never be set to ``none`` unless explicitly advised by the technical support.
 * Linux system metrics monitor has been updated to also ignore ``/var/lib/docker/*`` and ``/snap/*`` mount points by default. Capturing metrics for those mount points usually offers no additional insight to the end user. For information on how to change the ignore list via configuration option, please see [RELEASE_NOTES](https://github.com/scalyr/scalyr-agent-2/blob/master/RELEASE_NOTES.md).

--- a/build_package.py
+++ b/build_package.py
@@ -1501,9 +1501,9 @@ def create_change_logs():
             )
             # Include release notes with an indented first level (using asterisk, then a dash for the next level,
             # finally a plus sign.
-            print_release_notes(fp, release["notes"], [" * ", "   - ", "     + "])
+            print_release_notes(fp, release["notes"], ["  * ", "   - ", "     + "])
             print(
-                "-- %s <%s>  %s"
+                " -- %s <%s>  %s"
                 % (release["packager"], release["packager_email"], date_str,),
                 file=fp,
             )

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -1820,7 +1820,7 @@ class ScalyrAgent(object):
         result.num_running_monitors = running_monitors
         result.num_dead_monitors = dead_monitors
         if current_status.copying_manager_status is not None:
-            result.num_workers = (
+            result.num_worker_sessions = (
                 current_status.copying_manager_status.num_worker_sessions
             )
 

--- a/scalyr_agent/copying_manager/worker.py
+++ b/scalyr_agent/copying_manager/worker.py
@@ -1175,7 +1175,7 @@ class CopyingManagerWorkerSession(
         ) / self.__config.default_worker_session_status_message_interval
 
         log.info(
-            "worker_session_requests worker_session_id=%s scalyr_client_session_id=%s session requests_sent=%ld requests_failed=%ld "
+            "worker_session_requests worker_session_id=%s scalyr_client_session_id=%s requests_sent=%ld requests_failed=%ld "
             "bytes_sent=%ld compressed_bytes_sent=%ld bytes_received=%ld request_latency_secs=%lf connections_"
             "created=%ld total_copy_iterations=%ld total_read_time=%lf total_compression_time=%lf total_"
             "waiting_time=%lf total_blocking_response_time=%lf total_request_time=%lf total_pipelined_requests=%ld "


### PR DESCRIPTION
This PR fixes the changelog build warnings for the debian. It seems like those warnings were there for  a long time (the `dpkg-parsechangelog` throws them since agent version 2.0.1)
First issue: The first level entries(e.g. Features, Improvements) begin with only one space character. Because of that, those entries are not shown.
Second issue:  the release author entry also does not have extra space.

The changelog before the PR:
```
Source: scalyr-agent-2
Version: 2.1.16
Distribution: stable
Urgency: low
Changes:
 scalyr-agent-2 (2.1.16) stable; urgency=low
 .
    - Add copy truncate log rotation support. This is enabled by default.  It does not support copy truncate with compression unless the `delaycompress` option is used.  This feature can be disabled by setting `enable_copy_truncate_log_rotation_support` to false.
 .
    - Add new ``tcp_request_parser`` and ``tcp_message_delimiter`` config option. Valid values for ``tcp_request_parser`` include ``default`` and ``batch``. New TCP recv batch oriented request parser is much more efficient than the default one and should be a preferred choice in most situations.  For backward compatibility reasons, the default parser hasn't been changed yet.

```

after:
```
Source: scalyr-agent-2
Version: 2.1.16
Distribution: stable
Urgency: low
Maintainer: Arthur Kamalov <arthur@scalyr.com>
Timestamp: 1610575200
Date: Thu, 14 Jan 2021 01:00:00 +0300
Changes:
 scalyr-agent-2 (2.1.16) stable; urgency=low
 .
   * Features:
    - Add copy truncate log rotation support. This is enabled by default.  It does not support copy truncate with compression unless the `delaycompress` option is used.  This feature can be disabled by setting `enable_copy_truncate_log_rotation_support` to false.
 .
   * Improvements:
    - Add new ``tcp_request_parser`` and ``tcp_message_delimiter`` config option. Valid values for ``tcp_request_parser`` include ``default`` and ``batch``. New TCP recv batch oriented request parser is much more efficient than the default one and should be a preferred choice in most situations.  For backward compatibility reasons, the default parser hasn't been changed yet.

```
 