### PR TITLE
Also validate changelog syntax / formatting in the RPM package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2246,7 +2246,7 @@ jobs:
                   echo "$(cat VERSION).dev1-$(git rev-parse --short HEAD)" > VERSION
 
       - run:
-          name: Build deb and rpm packages
+          name: Build and validate deb and rpm packages
           command: |
             set -e
 
@@ -2276,7 +2276,7 @@ jobs:
             cp artifacts/scalyr-agent-2*.rpm package/scalyr-agent-2.rpm
 
       - run:
-          name: Build deb and rpm packages
+          name: Build deb and rpm packages for installer
           command: |
 
             gpg --update-trustdb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2217,6 +2217,8 @@ jobs:
             sudo apt-key update
             sudo apt update
             sudo apt install -y ruby ruby-dev rubygems rpm build-essential --force-yes
+            # Needed to validate rpm package
+            sudo apt install -y rpm
 
             # TODO: looks like fpm upgraded its 'ffi' dependency version, which is now requres newer version of ruby.
             # as a temporaty solution explicitly specify ffi version.
@@ -2256,22 +2258,12 @@ jobs:
             python ../build_package.py deb
             python ../build_package.py rpm
 
-            dpkg -X "$(ls *.deb)" /tmp/deb_package
+            # Validate that changelog files in the package artifacts are valid
+            DEB_PACKAGE_PATH="$(pwd)/$(ls --color=none *.deb)"
+            RPM_PACKAGE_PATH="$(pwd)/$(ls --color=none *.rpm)"
 
-            set +e
-            stderr=$(dpkg-parsechangelog --file /tmp/deb_package/usr/share/doc/scalyr-agent-2/changelog.gz 2>&1 1>/dev/null)
-            if [[ "$?" -ne 0 ]]; then
-              >&2 echo "$stderr"
-              exit 1
-            fi
-            set -e
-            warnings=$(grep warning \<<< "$stderr" || true)
-
-            if [[ -n "${warnings}" ]]; then
-              >&2 echo "The debian package changelog is built with warnings. This may be caused by splitting the text across miltiple lines."
-              >&2 echo "$warnings"
-              exit 1
-            fi
+            ./../scripts/circleci/validate-deb-changelog.sh "${DEB_PACKAGE_PATH}"
+            ./../scripts/circleci/validate-rpm-changelog.sh "${RPM_PACKAGE_PATH}"
 
             popd
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
+## 2.1.17 "Xothichi" - January 15, 2021
+
+<!---
+Packaged by Arthur Kamalov <arthur@scalyr.com> on Jan 15, 2021 14:00 -0800
+--->
+
+Bug fixes:
+* Fix syslog monitor default TCP message parser bug which was inadvertently introduced in 2.1.16 which may sometimes cause for a delayed ingest of some syslog data. This would only affect installations utilizing syslog monitor in TCP mode using the default message parser.
+
 ## 2.1.16 "Lasso" - January 13, 2021
 
 <!---

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -712,8 +712,8 @@ class SyslogBatchedRequestParser(SyslogRequestParser):
 
         while self._offset < size:
             # 2->TODO use slicing to get bytes in both python versions.
-            # TODO: This is not really robust, we should make it an explicit config option if the
-            # we should try to parse messages as framed or new line delimited one
+            # TODO: This is not really robust, we should make it an explicit config option if
+            # we should try to parse messages as framed or new line delimited one.
             c = self._remaining[self._offset : self._offset + 1]
             framed = b"0" <= c <= b"9"
 

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -712,6 +712,8 @@ class SyslogBatchedRequestParser(SyslogRequestParser):
 
         while self._offset < size:
             # 2->TODO use slicing to get bytes in both python versions.
+            # TODO: This is not really robust, we should make it an explicit config option if the
+            # we should try to parse messages as framed or new line delimited one
             c = self._remaining[self._offset : self._offset + 1]
             framed = b"0" <= c <= b"9"
 

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -628,6 +628,7 @@ class SyslogRequestParser(object):
             )
 
         self._remaining = self._remaining[self._offset :]
+        self._offset = 0
 
 
 class SyslogRawRequestParser(SyslogRequestParser):

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -627,6 +627,8 @@ class SyslogRequestParser(object):
                 limit_key="syslog-no-frames",
             )
 
+        self._remaining = self._remaining[self._offset :]
+
 
 class SyslogRawRequestParser(SyslogRequestParser):
     """

--- a/scripts/circleci/validate-deb-changelog.sh
+++ b/scripts/circleci/validate-deb-changelog.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Script which verifies that the changelog formatting in the provided debian package is valid
+set -e
+
+DEB_FILE_PATH=$1
+
+if [ ! -f "${DEB_FILE_PATH}" ]; then
+  echo "File ${DEB_FILE_PATH} doesn't exist"
+  exit 1
+fi
+
+echo "Using file ${DEB_FILE_PATH}"
+
+dpkg -X "${DEB_FILE_PATH}" /tmp/deb_package > /dev/null
+
+set +e
+
+stderr=$(dpkg-parsechangelog --file /tmp/deb_package/usr/share/doc/scalyr-agent-2/changelog.gz 2>&1 1> /dev/null)
+
+if [[ "$?" -ne 0 ]]; then
+  >&2 echo "$stderr"
+  exit 1
+fi
+
+set -e
+
+warnings=$(grep warning <<< "$stderr" || true)
+
+if [[ -n "${warnings}" ]]; then
+  >&2 echo "The debian package changelog is built with warnings. This may be caused by splitting the text across miltiple lines."
+  >&2 echo -e "$warnings"
+  >&2 echo -e "$stderr"
+  exit 1
+fi
+
+echo "Changelog in ${DEB_FILE_PATH} file is valid"
+exit 0

--- a/scripts/circleci/validate-rpm-changelog.sh
+++ b/scripts/circleci/validate-rpm-changelog.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Script which verifies that the changelog formatting in the provided rpm package is valid
+set -e
+
+RPM_FILE_PATH=$1
+
+if [ ! -f "${RPM_FILE_PATH}" ]; then
+  echo "File ${RPM_FILE_PATH} doesn't exist"
+  exit 1
+fi
+
+echo "Using file ${RPM_FILE_PATH}"
+
+set +e
+
+OUTPUT=$(rpm -qp --changelog "${RPM_FILE_PATH}")
+EXIT_CODE=$?
+
+set -e
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+    echo "Changelog in the provided rpm package is not valid"
+    echo -e "${OUTPUT}"
+    rpm -qip "${RPM_FILE_PATH}"
+    exit 2
+fi
+
+echo "Changelog in ${RPM_FILE_PATH} file is valid"
+exit 0

--- a/tests/unit/syslog_monitor_test.py
+++ b/tests/unit/syslog_monitor_test.py
@@ -869,14 +869,10 @@ class SyslogDefaultRequestParserTestCase(SyslogMonitorTestCase):
         parser.process(None, mock_handle_frame)
         self.assertEqual(mock_handle_frame.call_count, 0)
         self.assertEqual(mock_global_log.warning.call_count, 1)
-
-        # Verify internal state is correctly reset
         self.assertEqual(parser._remaining, None)
 
         parser.process(b"", mock_handle_frame)
         self.assertEqual(mock_handle_frame.call_count, 0)
-
-        # Verify internal state is correctly reset
         self.assertEqual(parser._remaining, None)
 
     def test_internal_buffer_and_offset_is_reset_on_handler_method_call_single_complete_message(
@@ -899,6 +895,8 @@ class SyslogDefaultRequestParserTestCase(SyslogMonitorTestCase):
             six.ensure_binary(mock_handle_frame.call_args_list[0][0][0]),
             mock_msg_1[:-1],
         )
+
+        # Verify internal state is correctly reset
         self.assertEqual(parser._remaining, bytearray())
         self.assertEqual(parser._offset, 0)
 
@@ -922,6 +920,8 @@ class SyslogDefaultRequestParserTestCase(SyslogMonitorTestCase):
         self.assertEqual(
             six.ensure_binary(mock_handle_frame.call_args_list[0][0][0]), mock_data[:-1]
         )
+
+        # Verify internal state is correctly reset
         self.assertEqual(parser._remaining, bytearray())
         self.assertEqual(parser._offset, 0)
 


### PR DESCRIPTION
This pull request adds small change on top of #692 so we also validate syntax / conformance of changelog file / content which is embedded into the builtrpm package.

RPM seems to be much less strict with changelog formatting than deb, but it also doesn't hurt to have this validation.

In addition to that change, I also moved validation logic into a standalone script file.