### PR TITLE
Warn if "k8s_logs" config option is configured, but Kubernetes monitor is not configured / enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1608,7 +1608,7 @@ jobs:
     docker:
       - image: circleci/python:3.6-jessie
     environment:
-      VERSION: "4.1.0.1829"
+      VERSION: "4.6.0.2311"
       SCANNER_DIRECTORY: "/tmp/cache/scanner"
       SONAR_USER_HOME: "/tmp/cache/scanner/.sonar"
       OS: "linux"
@@ -1621,7 +1621,7 @@ jobs:
           name: Create cache directory if it doesn't exist
           command: mkdir -p /tmp/cache/scanner
       - restore_cache:
-          key: v2-sonarcloud-scanner-4.1.0.1829
+          key: v2-sonarcloud-scanner-4.6.0.2311
       - run:
           name: Download Sonar Scanner
           command: |
@@ -1635,7 +1635,7 @@ jobs:
             chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner
             chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/jre/bin/java
       - save_cache:
-          key: v2sonarcloud-scanner-4.1.0.1829
+          key: v2sonarcloud-scanner-4.6.0.2311
           paths:
             - /tmp/cache/scanner
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2256,14 +2256,13 @@ jobs:
           command: |
             sudo apt-key update
             sudo apt update
-            sudo apt install -y ruby ruby-dev rubygems rpm build-essential --force-yes
+            sudo apt install -y ruby2.3 ruby2.3-dev rubygems rpm build-essential --force-yes
             # Needed to validate rpm package
             sudo apt install -y rpm
 
             # TODO: looks like fpm upgraded its 'ffi' dependency version, which is now requres newer version of ruby.
             # as a temporaty solution explicitly specify ffi version.
             sudo gem install --no-document ffi:1.12.2 fpm
-
 
       - when:
           condition: << pipeline.parameters.agent_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2324,8 +2324,16 @@ jobs:
             gpg --update-trustdb
 
             # import remote sign machine public keys from files in the Scalyr agent repo.
-            GPG_SIGNING_KEYID=`gpg --with-fingerprint scripts/circleci/release/public_keys/main.asc | grep "Key fingerprint" | awk '{print $10$11$12$13}'`
-            GPG_ALT_SIGNING_KEYID=`gpg --with-fingerprint scripts/circleci/release/public_keys/alt.asc | grep "Key fingerprint" | awk '{print $10$11$12$13}'`
+            # gnupg < 2.1
+            #GPG_SIGNING_KEYID=`gpg --with-fingerprint scripts/circleci/release/public_keys/main.asc | grep "Key fingerprint" | awk '{print $10$11$12$13}'`
+            #GPG_ALT_SIGNING_KEYID=`gpg --with-fingerprint scripts/circleci/release/public_keys/alt.asc | grep "Key fingerprint" | awk '{print $10$11$12$13}'`
+
+            # gnupg > 2.1
+            GPG_SIGNING_KEYID=$(cat scripts/circleci/release/public_keys/main.asc | gpg --with-fingerprint --with-colons --import-options show-only --import | grep "fpr:" | head -1 | awk -F ":" '{print $10}')
+            GPG_ALT_SIGNING_KEYID=$(cat scripts/circleci/release/public_keys/alt.asc | gpg --with-fingerprint --with-colons --import-options show-only --import | grep "fpr:" | head -1 | awk -F ":" '{print $10}')
+
+            echo "Using GPG_SIGNING_KEYID=${GPG_SIGNING_KEYID}"
+            echo "Using GPG_ALT_SIGNING_KEYID=${GPG_ALT_SIGNING_KEYID}"
 
             # import gpg public keys.
             gpg --import scripts/circleci/release/public_keys/main.asc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2242,7 +2242,10 @@ jobs:
     description: "Build deb and rpm packages."
     working_directory: ~/scalyr-agent-2
     docker:
-        - image: circleci/python:3.6-jessie
+        # NOTE: fpm and git gem depend on Ruby >= 2.3 so we need to use Debian
+        # 10 which ships with Ruby 2.5. Jessie (Debian 8) ships with 2.1 which
+        # doesn't work anymore with those gems.
+        - image: circleci/python:3.6-buster
     environment:
       AGENT_REPO_BRANCH: "<< pipeline.parameters.agent_repo_branch >>"
       REPO_BASE_URL: "<< pipeline.parameters.repo_base_url >>"
@@ -2256,13 +2259,13 @@ jobs:
           command: |
             sudo apt-key update
             sudo apt update
-            sudo apt install -y ruby2.3 ruby2.3-dev rubygems rpm build-essential --force-yes
+            sudo apt install -y ruby ruby-dev rubygems rpm build-essential --force-yes
             # Needed to validate rpm package
             sudo apt install -y rpm
 
             # TODO: looks like fpm upgraded its 'ffi' dependency version, which is now requres newer version of ruby.
             # as a temporaty solution explicitly specify ffi version.
-            sudo gem install --no-document ffi:1.12.2 fpm
+            sudo gem install --no-document ffi:1.14.2 fpm:1.12.0
 
       - when:
           condition: << pipeline.parameters.agent_version >>

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -13,7 +13,7 @@ sonar.language=python
 sonar.sources=scalyr_agent/
 
 # Path to tests
-sonar.tests=tests/
+sonar.tests=tests/unit,tests/smoke_tests,tests/distribution,tests/ami
 
 # Exclude bundled third party libs from analysis
 sonar.exclusions=scalyr_agent/third_party/**,scalyr_agent/third_party_tls/**,scalyr_agent/third_party_python2/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Packaged by Arthur Kamalov <arthur@scalyr.com> on Jan 30, 2021 14:00 -0800
 
 Improvements:
 * Add new ``tcp_request_parser`` and ``tcp_message_delimiter`` config option to the ``syslog_monitor``. Valid values for ``tcp_request_parser`` include ``default`` and ``batch``. New TCP recv batch oriented request parser is much more efficient than the default one and should be a preferred choice in most situations.  For backward compatibility reasons, the default parser hasn't been changed yet.
+* Update agent to emit a warning if ``k8s_logs`` config option is defined, but Kubernetes monitor is not enabled / configured.
+* Update Kubernetes and Docker monitor to not propagate and show some non-fatal errors.
 
 Bug fixes:
 * Fix a race condition in ``docker_monitor`` which could cause the monitor to throw exception on start up.

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -392,6 +392,9 @@ class Configuration(object):
 
             self.__monitor_configs = list(self.__config.get_json_array("monitors"))
 
+            # Perform validation for k8s_logs option
+            self._check_k8s_logs_config_option_and_warn()
+
             # NOTE do this verifications only after all config fragments were added into configurations.
             self.__verify_workers()
             self.__verify_and_match_workers_in_logs()
@@ -503,6 +506,40 @@ class Configuration(object):
                 limit_once_per_x_secs=86400,
                 limit_key=limit_key,
             )
+
+    def _check_k8s_logs_config_option_and_warn(self):
+        # type: () -> None
+        """
+        Check if k8s_logs attribute is configured, but kubernetes monitor is not and warn.
+
+        k8s_logs is a top level config option, but it's utilized by Kubernetes monitor which means
+        it will have no affect if kubernetes monitor is not configured as well.
+        """
+        if self.__k8s_log_configs and not self._is_kubernetes_monitor_configured():
+            self.__logger.warn(
+                '"k8s_logs" config options is defined, but Kubernetes monitor is '
+                "not configured / enabled. That config option applies to "
+                "Kubernetes monitor so for it to have an affect, Kubernetes "
+                "monitor needs to be enabled and configured",
+                limit_once_per_x_secs=86400,
+                limit_key="k8s_logs_k8s_monitor_not_enabled",
+            )
+
+    def _is_kubernetes_monitor_configured(self):
+        # type: () -> bool
+        """
+        Return true if Kubernetes monitor is configured, false otherwise.
+        """
+        monitor_configs = self.monitor_configs or []
+
+        for monitor_config in monitor_configs:
+            if (
+                monitor_config.get("module", "")
+                == "scalyr_agent.builtin_monitors.kubernetes_monitor"
+            ):
+                return True
+
+        return False
 
     def _warn_of_override_due_to_rate_enforcement(self, config_option, default):
         if self.__log_warnings and self.__config[config_option] != default:

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -1316,7 +1316,12 @@ class StoppableThread(threading.Thread):
             indefinitely.
         @type timeout: float|None
         """
-        threading.Thread.join(self, timeout)
+        try:
+            threading.Thread.join(self, timeout)
+        except RuntimeError:
+            # Calling .join() on thread which is not started should not be considered fatal
+            pass
+
         if not self.isAlive() and self.__exception_info is not None:
             six.reraise(
                 self.__exception_info[0],

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -1349,6 +1349,73 @@ class TestConfiguration(TestConfigurationBase):
             limit_key="config-permissions-warn-%s" % (self._config_file),
         )
 
+    def test_k8s_logs_config_option_is_configured_but_k8s_monitor_is_not(self):
+        # kubernetes_monitor is not configured
+        self._write_file_with_separator_conversion(
+            """ {
+            api_key: "foo",
+            k8s_logs: [
+                { "rename_logfile": "foobar.log" }
+            ]
+          }
+        """
+        )
+        mock_logger = Mock()
+        config = self._create_test_configuration_instance(logger=mock_logger)
+
+        mock_logger.warn.assert_not_called()
+
+        config.parse()
+
+        expected_msg = (
+            '"k8s_logs" config options is defined, but Kubernetes monitor is not configured / '
+            "enabled. That config option applies to Kubernetes monitor so for it to have an "
+            "affect, Kubernetes monitor needs to be enabled and configured"
+        )
+        mock_logger.warn.assert_called_with(
+            expected_msg,
+            limit_once_per_x_secs=86400,
+            limit_key="k8s_logs_k8s_monitor_not_enabled",
+        )
+
+        # kubernetes_monitor is configured
+        self._write_file_with_separator_conversion(
+            """ {
+            api_key: "foo",
+            k8s_logs: [
+                { "rename_logfile": "foobar.log" }
+            ],
+            monitors: [
+                {
+                    "module": "scalyr_agent.builtin_monitors.kubernetes_monitor",
+                }
+            ]
+          }
+        """
+        )
+        mock_logger = Mock()
+        config = self._create_test_configuration_instance(logger=mock_logger)
+
+        mock_logger.warn.assert_not_called()
+
+        config.parse()
+        mock_logger.warn.assert_not_called()
+
+        # By default option is not configured so no warning should be emitted
+        self._write_file_with_separator_conversion(
+            """ {
+            api_key: "foo",
+          }
+        """
+        )
+        mock_logger = Mock()
+        config = self._create_test_configuration_instance(logger=mock_logger)
+
+        mock_logger.warn.assert_not_called()
+
+        config.parse()
+        mock_logger.warn.assert_not_called()
+
     def test_api_key_use_env(self):
         self._write_file_with_separator_conversion(
             """ {

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -1349,6 +1349,7 @@ class TestConfiguration(TestConfigurationBase):
             limit_key="config-permissions-warn-%s" % (self._config_file),
         )
 
+    @skipIf(platform.system() == "Windows", "Skipping tests under Windows")
     def test_k8s_logs_config_option_is_configured_but_k8s_monitor_is_not(self):
         # kubernetes_monitor is not configured
         self._write_file_with_separator_conversion(


### PR DESCRIPTION
This pull request updates config parsing code to warn user if ``k8s_logs`` config option is configured, but Kubernetes monitor is not enabled / configured.

## Background, Context

This "issue" was originally reported by Wei Liu. I believe he configured ``k8s_logs`` config option, but not the Kubernetes monitor itself so the ``k8s_logs`` config option had no affect.

I do think this config option is somewhat confusing - it's a top level config option, but (afaik, please correct me if I'm wrong), it's used by Kubernetes monitor so it has no affect without that monitor being configured. I assume we made it a top-level option for "simplicity" reasons, but dunno.

In other cases we don't have such issues since monitor-specific config options go under that monitor config entry.

I also asked @weilliu to confirm this and if that's indeed an issue also update documentation to make that very explicit and obvious to the end users.