### PR TITLE
Sort extra field names in log lines for monitor metrics log lines with extra fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Packaged by Arthur Kamalov <arthur@scalyr.com> on Jan 30, 2021 14:00 -0800
 
 Improvements:
 * Add new ``tcp_request_parser`` and ``tcp_message_delimiter`` config option to the ``syslog_monitor``. Valid values for ``tcp_request_parser`` include ``default`` and ``batch``. New TCP recv batch oriented request parser is much more efficient than the default one and should be a preferred choice in most situations.  For backward compatibility reasons, the default parser hasn't been changed yet.
+* Field values in log lines for monitor metrics which contain extra fields are now sorted in alphabetic order. This should have no impact on the end user since server side parsers already support arbitrary ordering, but it's done to ensure consistent ordering and output for for monitor log lines.
 
 Bug fixes:
 * Fix a race condition in ``docker_monitor`` which could cause the monitor to throw exception on start up.

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -419,7 +419,10 @@ class AgentLogger(logging.Logger):
         string_buffer.write("%s %s" % (metric_name, util.json_encode(metric_value)))
 
         if extra_fields is not None:
-            for field_name in extra_fields:
+            # In (C)Python (2) dict keys are not sorted / ordering is not guaranteed so to ensure
+            # the same order of extra fields in each log line, we explicitly sort them here
+            extra_fields_names = sorted(extra_fields.keys())
+            for field_name in extra_fields_names:
                 if not isinstance(field_name, _METRIC_NAME_SUPPORTED_TYPES):
                     raise UnsupportedValueType(field_name=field_name)
 


### PR DESCRIPTION
This pull request updates ``emit_value()`` method so any extra field values are always sorted alphabetically by the field name when being appended to the metric log line.

This ensures consistent and stable ordering for those monitor metrics log lines.


Before:

```bash
2021-01-20 21:53:03.737Z [foo(1)] test_name 5 g=9 a=7 c=5 b=8 
```

(This line is really just given for demonstration, actual order is not guaranteed and could be different for each monitor gather sample run).

After:

```bash
2021-01-20 21:53:03.737Z [foo(1)] test_name 5 a=7 b=8 c=5 g=9
```

## Background, Context

I was verifying / testing agent-metrics parser fixes on the server side. It turns out that issue appeared less frequent on our accounts compared to my personal account.

The reason for that is that I'm using Python 3 where dict ordering is semi-stable (but not guaranteed unless explicitly using OrderedDict + list of tuples) and on our servers we still use Python 2.7 where ordering is not guaranteed / stable which means it's less likely that integer key=value pair will fall at the end of the line aka that parser bug will less likely to manifest itself.

Sorting values should be a good idea in any case since it results in more consistent and stable output (which in theory could also make full text searches over those lines and potentially defined custom parsers easier and faster).