### PR TITLE
Various Windows fixes and improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -963,7 +963,7 @@ jobs:
       - run:
           name: Run Unit Tests under Python 3.5
           command: |
-           # NOTE: If we don't redirect the output, Windows this step doesn't correctly exit even
+            # NOTE: If we don't redirect the output, Windows this step doesn't correctly exit even
             # after the tox commands finishes. That's why we use the redirect workaround. Sadly
             # this means we don't see output immediately as it produced (using redirect + tee also
             # results in the job not exiting when tox command finishes).
@@ -975,14 +975,17 @@ jobs:
               exit ${EXIT_CODE}
             fi
 
-            # There is a weird issue on Circle ci when tests will fail with
+            # There is a weird issue on Circle CIwhen tests will fail with
             # ImportError: DLL load failed: The specified module could not be found.
             # so we need to reinstall the library for it to work :/
+            # Likely something to do with pywin32 post install step not running
+            # for some reason (Scripts\pywin32_postinstall.py -install)
             tox.exe -epy3.5-windows-unit-tests-windows-platform --notest > output 2>&1
             cat output
 
             .tox/py3.5-windows-unit-tests-windows-platform/scripts/pip.exe uninstall --yes pywin32
             .tox/py3.5-windows-unit-tests-windows-platform/scripts/pip.exe install "pywin32==300"
+
             tox.exe -epy3.5-windows-unit-tests-windows-platform > output 2>&1
             EXIT_CODE=$?
             cat output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -944,7 +944,7 @@ jobs:
             choco install python --version "${PYTHON}" --yes --limit-output --no-progress
 
             # Add Python we installed to PATH and make sure it has precedence over system Python
-            echo "export PATH=\"/c/Python35:/c/Python35/Scripts:/c/Users/circleci/AppData/Roaming/Python/Python35/Scripts:$PATH\"" >> $BASH_ENV
+            echo "export PATH=\"/c/Python38:/c/Python38/Scripts:/c/Users/circleci/AppData/Roaming/Python/Python38/Scripts:$PATH\"" >> $BASH_ENV
       - save_cache:
           name: Save Chocolatey Cache
           key: deps-v4-<< pipeline.parameters.cache_version_py_dependencies >>-choco-{{ .Branch }}-3.8-windows-{{ checksum "dev-requirements.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -969,7 +969,7 @@ jobs:
             tox.exe -epy3.5-windows-unit-tests --notest > output 2>&1
             cat output
 
-            .tox/py3.5-windows-unit-tests/scripts/pip.exe uninstall pywin32
+            .tox/py3.5-windows-unit-tests/scripts/pip.exe uninstall --yes pywin32
             .tox/py3.5-windows-unit-tests/scripts/pip.exe install "pywin32==300"
 
             # NOTE: If we don't redirect the output, Windows this step doesn't correctly exit even

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -853,7 +853,7 @@ jobs:
           fail_only: true
           only_for_branches: master
 
-  unittest-35-windows:
+  unittest-38-windows:
     # TODO: That's a temporary in-line definition from slack orb. We can remove it once
     # https://github.com/CircleCI-Public/slack-orb/pull/152 is merged
     parameters:
@@ -928,12 +928,13 @@ jobs:
       size: medium
       shell: bash
     environment:
-      PYTHON: 3.5.4
+      # NOTE: This should be the same version as we use for pre-built Windows binaries
+      PYTHON: 3.8.7
     steps:
       - checkout
       - restore_cache:
           name: Restore Chocolatey Cache
-          key: deps-v4-<< pipeline.parameters.cache_version_py_dependencies >>-choco-{{ .Branch }}-3.5-windows-{{ checksum "dev-requirements.txt" }}
+          key: deps-v4-<< pipeline.parameters.cache_version_py_dependencies >>-choco-{{ .Branch }}-3.8-windows-{{ checksum "dev-requirements.txt" }}
       - run:
           name: Install Python
           command: |
@@ -946,14 +947,14 @@ jobs:
             echo "export PATH=\"/c/Python35:/c/Python35/Scripts:/c/Users/circleci/AppData/Roaming/Python/Python35/Scripts:$PATH\"" >> $BASH_ENV
       - save_cache:
           name: Save Chocolatey Cache
-          key: deps-v4-<< pipeline.parameters.cache_version_py_dependencies >>-choco-{{ .Branch }}-3.5-windows-{{ checksum "dev-requirements.txt" }}
+          key: deps-v4-<< pipeline.parameters.cache_version_py_dependencies >>-choco-{{ .Branch }}-3.8-windows-{{ checksum "dev-requirements.txt" }}
           paths:
             - ~/choco-cache
             # Actual package files are stored in NuGet cache
             - C:\Users\circleci\AppData\Local\NuGet\Cache
       - restore_cache:
           name: Restore Python Dependencies Cache
-          key: deps-v3-<< pipeline.parameters.cache_version_py_dependencies >>-tox-{{ .Branch }}-3.5-windows-{{ checksum "dev-requirements.txt" }}
+          key: deps-v3-<< pipeline.parameters.cache_version_py_dependencies >>-tox-{{ .Branch }}-3.8-windows-{{ checksum "dev-requirements.txt" }}
       - run:
           name: Install Python Dependencies
           command: |
@@ -961,13 +962,13 @@ jobs:
             python.exe -m pip install --user --upgrade "tox==<< pipeline.parameters.default_tox_version >>"
             python.exe -m pip install --user --upgrade "pip==<< pipeline.parameters.default_pip_version >>"
       - run:
-          name: Run Unit Tests under Python 3.5
+          name: Run Unit Tests under Python 3.8
           command: |
             # NOTE: If we don't redirect the output, Windows this step doesn't correctly exit even
             # after the tox commands finishes. That's why we use the redirect workaround. Sadly
             # this means we don't see output immediately as it produced (using redirect + tee also
             # results in the job not exiting when tox command finishes).
-            tox.exe -epy3.5-windows-unit-tests > output 2>&1
+            tox.exe -epy3.8-windows-unit-tests > output 2>&1
             EXIT_CODE=$?
             cat output
 
@@ -980,13 +981,13 @@ jobs:
             # so we need to reinstall the library for it to work :/
             # Likely something to do with pywin32 post install step not running
             # for some reason (Scripts\pywin32_postinstall.py -install)
-            tox.exe -epy3.5-windows-unit-tests-windows-platform --notest > output 2>&1
+            tox.exe -epy3.8-windows-unit-tests-windows-platform --notest > output 2>&1
             cat output
 
-            .tox/py3.5-windows-unit-tests-windows-platform/scripts/pip.exe uninstall --yes pywin32
-            .tox/py3.5-windows-unit-tests-windows-platform/scripts/pip.exe install "pywin32==300"
+            .tox/py3.8-windows-unit-tests-windows-platform/scripts/pip.exe uninstall --yes pywin32
+            .tox/py3.8-windows-unit-tests-windows-platform/scripts/pip.exe install "pywin32==300"
 
-            tox.exe -epy3.5-windows-unit-tests-windows-platform > output 2>&1
+            tox.exe -epy3.8-windows-unit-tests-windows-platform > output 2>&1
             EXIT_CODE=$?
             cat output
 
@@ -994,7 +995,7 @@ jobs:
           no_output_timeout: 4m
       - save_cache:
           name: Save Python Dependencies Cache
-          key: deps-v3-<< pipeline.parameters.cache_version_py_dependencies >>-tox-{{ .Branch }}-3.5-windows-{{ checksum "dev-requirements.txt" }}
+          key: deps-v3-<< pipeline.parameters.cache_version_py_dependencies >>-tox-{{ .Branch }}-3.8-windows-{{ checksum "dev-requirements.txt" }}
           paths:
             - C:\Users\circleci\AppData\Local\pip\Cache
       - store_test_results:
@@ -2432,7 +2433,7 @@ workflows:
          context: scalyr-agent
      - unittest-35-osx:
          context: scalyr-agent
-     - unittest-35-windows:
+     - unittest-38-windows:
          context: scalyr-agent
  smoke-tests:
    <<: *skip_release_build_branch_push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -963,6 +963,15 @@ jobs:
       - run:
           name: Run Unit Tests under Python 3.5
           command: |
+            # There is a weird issue on Circle ci when tests will fail with
+            # ImportError: DLL load failed: The specified module could not be found.
+            # so we need to reinstall the library for it to work :/
+            tox.exe -epy3.5-windows-unit-tests --notest > output 2>&1
+            cat output
+
+            .tox/py3.5-windows-unit-tests/scripts/pip.exe uninstall pywin32
+            .tox/py3.5-windows-unit-tests/scripts/pip.exe install "pywin32==300"
+
             # NOTE: If we don't redirect the output, Windows this step doesn't correctly exit even
             # after the tox commands finishes. That's why we use the redirect workaround. Sadly
             # this means we don't see output immediately as it produced (using redirect + tee also

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -963,22 +963,30 @@ jobs:
       - run:
           name: Run Unit Tests under Python 3.5
           command: |
-            # There is a weird issue on Circle ci when tests will fail with
-            # ImportError: DLL load failed: The specified module could not be found.
-            # so we need to reinstall the library for it to work :/
-            tox.exe -epy3.5-windows-unit-tests --notest > output 2>&1
-            cat output
-
-            .tox/py3.5-windows-unit-tests/scripts/pip.exe uninstall --yes pywin32
-            .tox/py3.5-windows-unit-tests/scripts/pip.exe install "pywin32==300"
-
-            # NOTE: If we don't redirect the output, Windows this step doesn't correctly exit even
+           # NOTE: If we don't redirect the output, Windows this step doesn't correctly exit even
             # after the tox commands finishes. That's why we use the redirect workaround. Sadly
             # this means we don't see output immediately as it produced (using redirect + tee also
             # results in the job not exiting when tox command finishes).
             tox.exe -epy3.5-windows-unit-tests > output 2>&1
             EXIT_CODE=$?
             cat output
+
+            if [ "${EXIT_CODE}" -ne 0 ]; then
+              exit ${EXIT_CODE}
+            fi
+
+            # There is a weird issue on Circle ci when tests will fail with
+            # ImportError: DLL load failed: The specified module could not be found.
+            # so we need to reinstall the library for it to work :/
+            tox.exe -epy3.5-windows-unit-tests-windows-platform --notest > output 2>&1
+            cat output
+
+            .tox/py3.5-windows-unit-tests-windows-platform/scripts/pip.exe uninstall --yes pywin32
+            .tox/py3.5-windows-unit-tests-windows-platform/scripts/pip.exe install "pywin32==300"
+            tox.exe -epy3.5-windows-unit-tests-windows-platform > output 2>&1
+            EXIT_CODE=$?
+            cat output
+
             exit ${EXIT_CODE}
           no_output_timeout: 4m
       - save_cache:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,8 +3,6 @@ name: "CodeQL Analysis"
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
   schedule:
     - cron: '0 4 * * *'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Improvements:
 * Add new ``tcp_request_parser`` and ``tcp_message_delimiter`` config option to the ``syslog_monitor``. Valid values for ``tcp_request_parser`` include ``default`` and ``batch``. New TCP recv batch oriented request parser is much more efficient than the default one and should be a preferred choice in most situations.  For backward compatibility reasons, the default parser hasn't been changed yet.
 * Field values in log lines for monitor metrics which contain extra fields are now sorted in alphabetic order. This should have no impact on the end user since server side parsers already support arbitrary ordering, but it's done to ensure consistent ordering and output for for monitor log lines.
 * Update agent to throw more user-friendly exceptions on Windows when the agent doesn't have access to the agent config file and Windows registry.
+* Update code which periodically prints out useful configuration settings to also include actual value of the json library used in case the config option is set to "auto".
 
 Bug fixes:
 * Fix a race condition in ``docker_monitor`` which could cause the monitor to throw exception on start up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ Packaged by Arthur Kamalov <arthur@scalyr.com> on Jan 30, 2021 14:00 -0800
 
 Improvements:
 * Add new ``tcp_request_parser`` and ``tcp_message_delimiter`` config option to the ``syslog_monitor``. Valid values for ``tcp_request_parser`` include ``default`` and ``batch``. New TCP recv batch oriented request parser is much more efficient than the default one and should be a preferred choice in most situations.  For backward compatibility reasons, the default parser hasn't been changed yet.
+* Update agent to throw more user-friendly exceptions on Windows when the agent doesn't have access to the agent config file and Windows registry.
 
 Bug fixes:
 * Fix a race condition in ``docker_monitor`` which could cause the monitor to throw exception on start up.
+* Fix agent so it doesn't throw an exception on Windows when trying to escalate permissions on agent start.
 
 ## 2.1.17 "Xothichi" - January 15, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Bug fixes:
 * Fix a race condition in ``docker_monitor`` which could cause the monitor to throw exception on start up.
 * Fix a config deprecated options bug when they are set to ``false``.
 * Fix agent so it doesn't throw an exception on Windows when trying to escalate permissions on agent start.
+* Make sure we only print the value of ``win32_max_open_fds`` config option on Windows if it has changed.
 
 ## 2.1.17 "Xothichi" - January 15, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ Packaged by Arthur Kamalov <arthur@scalyr.com> on Jan 30, 2021 14:00 -0800
 
 Improvements:
 * Add new ``tcp_request_parser`` and ``tcp_message_delimiter`` config option to the ``syslog_monitor``. Valid values for ``tcp_request_parser`` include ``default`` and ``batch``. New TCP recv batch oriented request parser is much more efficient than the default one and should be a preferred choice in most situations.  For backward compatibility reasons, the default parser hasn't been changed yet.
+* Field values in log lines for monitor metrics which contain extra fields are now sorted in alphabetic order. This should have no impact on the end user since server side parsers already support arbitrary ordering, but it's done to ensure consistent ordering and output for for monitor log lines.
 * Update agent to throw more user-friendly exceptions on Windows when the agent doesn't have access to the agent config file and Windows registry.
 
 Bug fixes:
 * Fix a race condition in ``docker_monitor`` which could cause the monitor to throw exception on start up.
 * Fix a config deprecated options bug when they are set to ``false``.
-* Field values in log lines for monitor metrics which contain extra fields are now sorted in alphabetic order. This should have no impact on the end user since server side parsers already support arbitrary ordering, but it's done to ensure consistent ordering and output for for monitor log lines.
 * Fix agent so it doesn't throw an exception on Windows when trying to escalate permissions on agent start.
 
 ## 2.1.17 "Xothichi" - January 15, 2021

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,12 +22,12 @@ docker==4.1.0
 # NOTE: We can't use requests >= 2.22.0 since we still need to support Python 2.6
 requests==2.15.1
 ujson==1.35
-orjson==2.6.1; python_version >= '3.6'
+orjson==3.4.7; python_version >= '3.6'
 orjson==2.0.11; python_version == '3.5'
 # Needed by MockHTTPServer class and related tests
 flask==1.1.1
 pathlib2==2.3.5; python_version <= '2.7'
-# Used for performanice optimized versions of rfc3339_to_* functions
+# Used for performance optimized versions of rfc3339_to_* functions
 # NOTE: Not supported on windows
 udatetime==0.0.16
 futures==3.3.0; python_version <= '2.7'

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,6 +1,6 @@
 # dependencies for docker images.
 ujson==1.35
-orjson==2.6.1; python_version >= '3.6'
+orjson==3.4.7; python_version >= '3.6'
 orjson==2.0.11; python_version == '3.5'
 yappi==1.2.3
 # the version of 'requests' library that 'docker' uses as a dependency is higher than we use in agent,

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -310,8 +310,11 @@ class ScalyrAgent(object):
                 config_file_path, log_warnings=log_warnings
             )
 
-            # check if not a tty and override the no check remote variable
-            if not sys.stdout.isatty():
+            # NOTE: isatty won't be available on Redirector object on Windows when doing permission
+            # escalation so we need to handle this scenario as well
+            isatty_func = getattr(getattr(sys, "stdout", None), "isatty", None)
+            if isatty_func is not None and isatty_func():
+                # check if not a tty and override the no check remote variable
                 no_check_remote = not self.__config.check_remote_if_no_tty
         except Exception as e:
             # We ignore a bad configuration file for 'stop' and 'status' because sometimes you do just accidentally

--- a/scalyr_agent/compat.py
+++ b/scalyr_agent/compat.py
@@ -30,6 +30,7 @@ PY26 = sys.version_info[0] == 2 and sys.version_info[1] == 6
 PY2_pre_279 = PY2 and sys.version_info < (2, 7, 9)
 PY_post_equal_279 = sys.version_info >= (2, 7, 9)
 PY3_pre_32 = PY3 and sys.version_info < (3, 2)
+PY3_post_equal_37 = PY3 and sys.version_info >= (3, 7)
 
 # NOTE: ssl.match_hostname was added in Python 2.7.9 so for earlier versions, we need to use
 # version from backports package

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -634,6 +634,12 @@ class Configuration(object):
             ):
                 print_value = True
 
+            # For json_library config option, we also print actual library which is being used in
+            # case the value is set to "auto"
+            if option == "json_library" and value == "auto":
+                json_lib = scalyr_util.get_json_lib()
+                value = "%s (%s)" % (value, json_lib)
+
             if print_value:
                 # if this is the first option we are printing, output a header
                 if first:

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -55,7 +55,6 @@ from scalyr_agent.json_lib.objects import (
     SpaceAndCommaSeparatedArrayOfStrings,
 )
 from scalyr_agent.monitor_utils.blocking_rate_limiter import BlockingRateLimiter
-from scalyr_agent.util import JsonReadFileException
 from scalyr_agent.config_util import BadConfiguration, get_config_from_env
 
 from scalyr_agent.__scalyr__ import get_install_root
@@ -63,7 +62,7 @@ from scalyr_agent.compat import os_environ_unicode
 from scalyr_agent import compat
 
 FILE_WRONG_OWNER_ERROR_MSG = """
-File \"%s\" is not readable the current user (%s).
+File \"%s\" is not readable by the current user (%s).
 
 You need to make sure that the file is owned by the same account which is used to run the agent.
 
@@ -156,7 +155,7 @@ class Configuration(object):
                 self.__config = scalyr_util.read_config_file_as_json(self.__file_path)
 
                 # What implicit entries do we need to add?  metric monitor, agent.log, and then logs from all monitors.
-            except JsonReadFileException as e:
+            except Exception as e:
                 # Special case - file is not readable, likely means a permission issue so return a
                 # more user-friendly error
                 msg = str(e).lower()

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -605,7 +605,7 @@ class Configuration(object):
             "use_multiprocess_workers",
             "default_sessions_per_worker",
             "default_worker_session_status_message_interval",
-            "enable_worker_process_metrics_gather",
+            "enable_worker_session_process_metrics_gather",
             # NOTE: It's important we use sanitzed_ version of this method which masks the API key
             "sanitized_worker_configs",
         ]

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -159,7 +159,12 @@ class Configuration(object):
             except JsonReadFileException as e:
                 # Special case - file is not readable, likely means a permission issue so return a
                 # more user-friendly error
-                if "file is not readable" in str(e).lower():
+                msg = str(e).lower()
+                if (
+                    "file is not readable" in msg
+                    or "error reading" in msg
+                    or "failed while reading"
+                ):
                     from scalyr_agent.platform_controller import PlatformController
 
                     platform_controller = PlatformController.new_platform()

--- a/scalyr_agent/connection.py
+++ b/scalyr_agent/connection.py
@@ -31,6 +31,7 @@ import scalyr_agent.scalyr_logging as scalyr_logging
 from scalyr_agent.compat import ssl_match_hostname
 from scalyr_agent.compat import CertificateError
 from scalyr_agent.compat import PY_post_equal_279
+from scalyr_agent.compat import PY3_post_equal_37
 
 
 log = scalyr_logging.getLogger(__name__)
@@ -237,8 +238,37 @@ class ScalyrHttpConnection(Connection):
                 errno = None
 
             error_code = "client/connectionFailed"
+            error_msg = str(error).lower()
 
-            if isinstance(error, CertificateError):
+            if PY3_post_equal_37 and "hostname mismatch" in error_msg:
+                # On Windows under Python >= 3.7 this error is returned instead:
+                #   ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate
+                # verify failed: Hostname mismatch, certificate is not valid for ...
+                error_code = "client/connectionFailedCertHostnameValidationFailed"
+                log.exception(
+                    'Failed to connect to "%s" because of server certificate validation error: "%s". '
+                    "This likely indicates a MITM attack.",
+                    self._full_address,
+                    getattr(error, "message", str(error)),
+                    error_code=error_code,
+                )
+            elif PY3_post_equal_37 and "certificate verify failed" in error_msg:
+                # Special case for Windows under Python >= 3.7 where
+                # ssl.SSLCertVerificationError is thrown
+                error_code = "client/connectionFailedSSLError"
+                log.exception(
+                    'Failed to connect to "%s" due to some SSL error.  Possibly the configured certificate '
+                    "for the root Certificate Authority could not be parsed, or we attempted to connect to "
+                    "a server whose certificate could not be trusted (if so, maybe Scalyr's SSL cert has "
+                    "changed and you should update your agent to get the new certificate).  The returned "
+                    "errno was %d and the full exception was '%s'.  Closing connection, will re-attempt",
+                    self._full_address,
+                    errno,
+                    six.text_type(error),
+                    error_code=error_code,
+                )
+            elif isinstance(error, CertificateError):
+                # So we need to handle this scenario as well.
                 error_code = "client/connectionFailedCertHostnameValidationFailed"
                 log.exception(
                     'Failed to connect to "%s" because of server certificate validation error: "%s". '

--- a/scalyr_agent/platform_windows.py
+++ b/scalyr_agent/platform_windows.py
@@ -926,7 +926,11 @@ class PipeRedirectorClient(RedirectorClient):
                 self.__pipe_handle = None
 
 
-if __name__ == "__main__":
+# Workaround to make sure we don't run this as part of tests on import since it breaks
+# things
+if __name__ == "__main__" and not not compat.os_environ_unicode.get(
+    "INSIDE_WINDOWS_TESTS_PYTEST", False
+):
     if len(sys.argv) == 1:
         servicemanager.Initialize()
         servicemanager.PrepareToHostSingle(ScalyrAgentService)

--- a/scalyr_agent/platform_windows.py
+++ b/scalyr_agent/platform_windows.py
@@ -928,7 +928,7 @@ class PipeRedirectorClient(RedirectorClient):
 
 # Workaround to make sure we don't run this as part of tests on import since it breaks
 # things
-if __name__ == "__main__" and not not compat.os_environ_unicode.get(
+if __name__ == "__main__" and not compat.os_environ_unicode.get(
     "INSIDE_WINDOWS_TESTS_PYTEST", False
 ):
     if len(sys.argv) == 1:

--- a/scalyr_agent/platform_windows.py
+++ b/scalyr_agent/platform_windows.py
@@ -136,6 +136,16 @@ registry entries.
 Original error: %s
 """.strip()
 
+AGENT_STOP_ACCESS_DENIED_ERROR_MSG = """
+Unable to stop agent process due to access denied error. This likely indicates that the agent was
+started by a different user and / or the current user doesn't have correct permissions to stop the
+agent.
+
+You should run this script as an Administrator / user who started the agent.
+
+Original error: %s
+""".strip()
+
 
 def _set_config_path_registry_entry(value):
     """Updates the Windows registry entry for the configuration file path.
@@ -626,6 +636,8 @@ class WindowsPlatformController(PlatformController):
                     "The operating system indicates the Scalyr Agent Service is not installed.  "
                     "This indicates a failed installation.  Try reinstalling the agent."
                 )
+            elif "access is denied" in str(e).lower():
+                raise Exception(AGENT_STOP_ACCESS_DENIED_ERROR_MSG % (str(e)))
             else:
                 raise e
 

--- a/scalyr_agent/platform_windows.py
+++ b/scalyr_agent/platform_windows.py
@@ -927,11 +927,7 @@ class PipeRedirectorClient(RedirectorClient):
                 self.__pipe_handle = None
 
 
-# Workaround to make sure we don't run this as part of tests on import since it breaks
-# things
-if __name__ == "__main__" and not compat.os_environ_unicode.get(
-    "INSIDE_WINDOWS_TESTS_PYTEST", False
-):
+if __name__ == "__main__":
     if len(sys.argv) == 1:
         servicemanager.Initialize()
         servicemanager.PrepareToHostSingle(ScalyrAgentService)

--- a/scalyr_agent/platform_windows.py
+++ b/scalyr_agent/platform_windows.py
@@ -636,10 +636,11 @@ class WindowsPlatformController(PlatformController):
                     "The operating system indicates the Scalyr Agent Service is not installed.  "
                     "This indicates a failed installation.  Try reinstalling the agent."
                 )
-            elif "access is denied" in str(e).lower():
-                raise Exception(AGENT_STOP_ACCESS_DENIED_ERROR_MSG % (str(e)))
             else:
                 raise e
+        except Exception as e:
+            if "access is denied" in str(e).lower():
+                raise Exception(AGENT_STOP_ACCESS_DENIED_ERROR_MSG % (str(e)))
 
     def get_usage_info(self):
         """Returns CPU and memory usage information.

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,4 @@ filterwarnings =
 markers =
     memory_leak: marks tests which test memory leaks and should be run in isolation
     json_lib: mark tests which mock json libs and need to run isolated from other tests
+    windows_platform: Windows platform tests which need to run isolated and on Windows only

--- a/tests/image_builder/monitors/base/Dockerfile
+++ b/tests/image_builder/monitors/base/Dockerfile
@@ -21,6 +21,9 @@ RUN apt install -y nginx
 COPY dev-requirements.txt dev-requirements.txt
 
 RUN python2 -m pip install -r dev-requirements.txt
+# We need newer version of pip since old version don't support manylinux wheels
+RUN python3 -m pip install --upgrade "pip==21.0"
+RUN python3 -m pip --version
 RUN python3 -m pip install -r dev-requirements.txt
 
 WORKDIR /

--- a/tests/unit/builtin_monitors/docker_monitor_test.py
+++ b/tests/unit/builtin_monitors/docker_monitor_test.py
@@ -261,14 +261,21 @@ class DockerMonitorTest(ScalyrTestCase):
                 fake_clock=fake_clock,
             )
 
+            counter_lock = threading.Lock()
+
             fragment_polls = FakeClockCounter(fake_clock, num_waiters=2)
             counter = {"callback_invocations": 0}
             detected_fragment_changes = []
 
             # Mock the callback (that would normally be invoked on ScalyrClientSession
             def augment_user_agent(fragments):
-                counter["callback_invocations"] += 1
-                detected_fragment_changes.append(fragments[0])
+                counter_lock.acquire()
+
+                try:
+                    counter["callback_invocations"] += 1
+                    detected_fragment_changes.append(fragments[0])
+                finally:
+                    counter_lock.release()
 
             # Decorate the get_user_agent_fragment() function as follows:
             # Each invocation increments the FakeClockCounter

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -1980,6 +1980,13 @@ class TestConfiguration(TestConfigurationBase):
         mock_logger = Mock()
         maxstdio = win32file._getmaxstdio()
 
+        self._write_file_with_separator_conversion(
+            """{
+            api_key: "hi there",
+            }
+        """
+        )
+
         config = self._create_test_configuration_instance(logger=mock_logger)
         config.parse()
         config.print_useful_settings()

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -57,6 +57,8 @@ from scalyr_agent.util import JsonReadFileException
 import scalyr_agent.util as scalyr_util
 from scalyr_agent.compat import os_environ_unicode
 
+import scalyr_agent.configuration
+
 import six
 from six.moves import range
 from mock import patch, Mock
@@ -78,10 +80,17 @@ class TestConfigurationBase(ScalyrTestCase):
             if "scalyr" in key.lower():
                 del os.environ[key]
 
+        self._original_win32_file = scalyr_agent.configuration.win32file
+
+        # Patch it so tests pass on Windows
+        scalyr_agent.configuration.win32file = None
+
     def tearDown(self):
         """Restore the pre-test os environment"""
         os.environ.clear()
         os.environ.update(self.original_os_env)
+
+        scalyr_agent.configuration.win32file = self._original_win32_file
 
     def __convert_separators(self, contents):
         """Recursively converts all path values for fields in a JsonObject that end in 'path'.

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -1977,6 +1977,8 @@ class TestConfiguration(TestConfigurationBase):
     def test_print_config_windows(self):
         import win32file  # pylint: disable=import-error
 
+        scalyr_agent.configuration.win32file = win32file
+
         mock_logger = Mock()
         maxstdio = win32file._getmaxstdio()
 

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -1964,6 +1964,7 @@ class TestConfiguration(TestConfigurationBase):
         self.assertEquals(config.server_attributes["webServer"], "true")
         self.assertEquals(config.server_attributes["serverHost"], "foo.com")
 
+    @skipIf(platform.system() == "Windows", "Skipping tests on Windows")
     @mock.patch("scalyr_agent.util.read_config_file_as_json")
     def test_parse_invalid_config_file_permissions(self, mock_read_config_file_as_json):
         # User-friendly exception should be thrown on some config permission related errors

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -1991,11 +1991,20 @@ class TestConfiguration(TestConfigurationBase):
 
         config = self._create_test_configuration_instance(logger=mock_logger)
         config.parse()
+        self.assertEqual(mock_logger.info.call_count, 0)
+
         config.print_useful_settings()
         mock_logger.info.assert_any_call("Configuration settings")
         mock_logger.info.assert_any_call(
             "\twin32_max_open_fds(maxstdio): %s" % (maxstdio)
         )
+
+        mock_logger.reset_mock()
+        self.assertEqual(mock_logger.info.call_count, 0)
+
+        # If the value has not changed, the line should not be printed
+        config.print_useful_settings(other_config=config)
+        self.assertEqual(mock_logger.info.call_count, 0)
 
     @skipIf(platform.system() == "Windows", "Skipping tests on Windows")
     @mock.patch("scalyr_agent.util.read_config_file_as_json")

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -1973,6 +1973,21 @@ class TestConfiguration(TestConfigurationBase):
         self.assertEquals(config.server_attributes["webServer"], "true")
         self.assertEquals(config.server_attributes["serverHost"], "foo.com")
 
+    @skipIf(platform.system() != "Windows", "Skipping tests on non-Windows platform")
+    def test_print_config_windows(self):
+        import win32file  # pylint: disable=import-error
+
+        mock_logger = Mock()
+        maxstdio = win32file._getmaxstdio()
+
+        config = self._create_test_configuration_instance(logger=mock_logger)
+        config.parse()
+        config.print_useful_settings()
+        mock_logger.info.assert_any_call("Configuration settings")
+        mock_logger.info.assert_any_call(
+            "\twin32_max_open_fds(maxstdio): %s" % (maxstdio)
+        )
+
     @skipIf(platform.system() == "Windows", "Skipping tests on Windows")
     @mock.patch("scalyr_agent.util.read_config_file_as_json")
     def test_parse_invalid_config_file_permissions(self, mock_read_config_file_as_json):

--- a/tests/unit/connection_test.py
+++ b/tests/unit/connection_test.py
@@ -21,6 +21,7 @@ from scalyr_agent import scalyr_init
 scalyr_init()
 
 import os
+import sys
 import ssl
 import socket
 
@@ -77,10 +78,14 @@ class ScalyrNativeHttpConnectionTestCase(ScalyrTestCase):
         socket.create_connection = mock_create_connection
 
         try:
-            expected_msg = (
-                r"Original error: hostname 'agent.invalid.scalyr.com' doesn't match either "
-                "of '\*.scalyr.com', 'scalyr.com'"
-            )  # NOQA
+            if sys.version_info >= (3, 7, 0):
+                expected_msg = r"Original error: .*Hostname mismatch.*"  # NOQA
+            else:
+                expected_msg = (
+                    r"Original error: hostname 'agent.invalid.scalyr.com' doesn't match either "
+                    "of '\*.scalyr.com', 'scalyr.com'"
+                )  # NOQA
+
             self.assertRaisesRegexp(
                 Exception,
                 expected_msg,

--- a/tests/unit/test_platform_windows.py
+++ b/tests/unit/test_platform_windows.py
@@ -18,6 +18,7 @@ import os
 import platform
 
 import mock
+import pytest
 
 from scalyr_agent.test_base import ScalyrTestCase
 from scalyr_agent.test_base import skipIf
@@ -28,6 +29,7 @@ else:
     WINDOWS = False
 
 
+@pytest.mark.windows_platform
 class WindowsPlatformControllerTestCase(ScalyrTestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/unit/test_platform_windows.py
+++ b/tests/unit/test_platform_windows.py
@@ -22,10 +22,7 @@ from scalyr_agent.test_base import ScalyrTestCase
 from scalyr_agent.test_base import skipIf
 
 if platform.system() == "Windows":
-    # TODO: Test is failing on Circle CI with
-    # ImportError: DLL load failed: The specified module could not be found.
-    # from scalyr_agent.platform_windows import WindowsPlatformController
-    WindowsPlatformController = None  # type: ignore
+    from scalyr_agent.platform_windows import WindowsPlatformController
 else:
     WindowsPlatformController = None  # type: ignore
 

--- a/tests/unit/test_platform_windows.py
+++ b/tests/unit/test_platform_windows.py
@@ -1,0 +1,52 @@
+# Copyright 2021 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import platform
+
+import mock
+
+from scalyr_agent.test_base import ScalyrTestCase
+from scalyr_agent.test_base import skipIf
+
+if platform.system() == "Windows":
+    from scalyr_agent.platform_windows import WindowsPlatformController
+else:
+    WindowsPlatformController = None  # type: ignore
+
+
+class WindowsPlatformControllerTestCase(ScalyrTestCase):
+    @skipIf(not WindowsPlatformController, "Skipping tests under non-Windows platform")
+    @mock.patch("scalyr_agent.platform_windows._set_config_path_registry_entry")
+    def test_start_agent_service_friendly_error_on_insufficient_permissions(
+        self, mock_set_config_path_registry_entry
+    ):
+        mock_set_config_path_registry_entry.side_effect = Exception("Access is denied")
+
+        controller = WindowsPlatformController()
+        expected_msg = r".*Unable to set registry entry.*"
+        self.assertRaisesRegexp(Exception, expected_msg, controller.start_agent_service)
+
+    @skipIf(not WindowsPlatformController, "Skipping tests under non-Windows platform")
+    @mock.patch("win32serviceutil.StopService")
+    def test_stop_agent_service_friendly_error_on_insufficient_permissions(
+        self, mock_StopService
+    ):
+        mock_StopService.side_effect = Exception("Access is denied")
+        controller = WindowsPlatformController()
+        expected_msg = r".*Unable to stop agent process.*"
+        self.assertRaisesRegexp(
+            Exception, expected_msg, controller.stop_agent_service, False
+        )

--- a/tests/unit/test_platform_windows.py
+++ b/tests/unit/test_platform_windows.py
@@ -38,7 +38,7 @@ class WindowsPlatformControllerTestCase(ScalyrTestCase):
         if "INSIDE_WINDOWS_TESTS_PYTEST" in os.environ:
             del os.environ["INSIDE_WINDOWS_TESTS_PYTEST"]
 
-    @skipIf(not WINDOWS, "Skipping tests under non-Windows platform")
+    @skipIf(not WINDOWS or False, "Skipping tests under non-Windows platform")
     @mock.patch("scalyr_agent.platform_windows._set_config_path_registry_entry")
     def test_start_agent_service_friendly_error_on_insufficient_permissions(
         self, mock_set_config_path_registry_entry
@@ -51,7 +51,7 @@ class WindowsPlatformControllerTestCase(ScalyrTestCase):
         expected_msg = r".*Unable to set registry entry.*"
         self.assertRaisesRegexp(Exception, expected_msg, controller.start_agent_service)
 
-    @skipIf(not WINDOWS, "Skipping tests under non-Windows platform")
+    @skipIf(not WINDOWS or False, "Skipping tests under non-Windows platform")
     @mock.patch("win32serviceutil.StopService")
     def test_stop_agent_service_friendly_error_on_insufficient_permissions(
         self, mock_StopService

--- a/tests/unit/test_platform_windows.py
+++ b/tests/unit/test_platform_windows.py
@@ -22,6 +22,8 @@ from scalyr_agent.test_base import ScalyrTestCase
 from scalyr_agent.test_base import skipIf
 
 if platform.system() == "Windows":
+    # TODO: Test is failing on Circle CI with
+    # ImportError: DLL load failed: The specified module could not be found.
     from scalyr_agent.platform_windows import WindowsPlatformController
 else:
     WindowsPlatformController = None  # type: ignore

--- a/tests/unit/test_platform_windows.py
+++ b/tests/unit/test_platform_windows.py
@@ -49,9 +49,14 @@ class WindowsPlatformControllerTestCase(ScalyrTestCase):
 
         mock_set_config_path_registry_entry.side_effect = Exception("Access is denied")
 
+        def noop():
+            pass
+
         controller = WindowsPlatformController()
         expected_msg = r".*Unable to set registry entry.*"
-        self.assertRaisesRegexp(Exception, expected_msg, controller.start_agent_service)
+        self.assertRaisesRegexp(
+            Exception, expected_msg, controller.start_agent_service, noop, None
+        )
 
     @skipIf(not WINDOWS or False, "Skipping tests under non-Windows platform")
     @mock.patch("win32serviceutil.StopService")

--- a/tests/unit/test_platform_windows.py
+++ b/tests/unit/test_platform_windows.py
@@ -23,11 +23,8 @@ from scalyr_agent.test_base import ScalyrTestCase
 from scalyr_agent.test_base import skipIf
 
 if platform.system() == "Windows":
-    from scalyr_agent.platform_windows import WindowsPlatformController
-
     WINDOWS = True
 else:
-    WindowsPlatformController = None  # type: ignore
     WINDOWS = False
 
 
@@ -46,6 +43,8 @@ class WindowsPlatformControllerTestCase(ScalyrTestCase):
     def test_start_agent_service_friendly_error_on_insufficient_permissions(
         self, mock_set_config_path_registry_entry
     ):
+        from scalyr_agent.platform_windows import WindowsPlatformController
+
         mock_set_config_path_registry_entry.side_effect = Exception("Access is denied")
 
         controller = WindowsPlatformController()
@@ -57,6 +56,8 @@ class WindowsPlatformControllerTestCase(ScalyrTestCase):
     def test_stop_agent_service_friendly_error_on_insufficient_permissions(
         self, mock_StopService
     ):
+        from scalyr_agent.platform_windows import WindowsPlatformController
+
         mock_StopService.side_effect = Exception("Access is denied")
         controller = WindowsPlatformController()
         expected_msg = r".*Unable to stop agent process.*"

--- a/tests/unit/test_platform_windows.py
+++ b/tests/unit/test_platform_windows.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import
 
-import os
 import platform
 
 import mock
@@ -31,15 +30,6 @@ else:
 
 @pytest.mark.windows_platform
 class WindowsPlatformControllerTestCase(ScalyrTestCase):
-    @classmethod
-    def setUpClass(cls):
-        os.environ["INSIDE_WINDOWS_TESTS_PYTEST"] = "true"
-
-    @classmethod
-    def tearDownClass(cls):
-        if "INSIDE_WINDOWS_TESTS_PYTEST" in os.environ:
-            del os.environ["INSIDE_WINDOWS_TESTS_PYTEST"]
-
     @skipIf(not WINDOWS or False, "Skipping tests under non-Windows platform")
     @mock.patch("scalyr_agent.platform_windows._set_config_path_registry_entry")
     def test_start_agent_service_friendly_error_on_insufficient_permissions(

--- a/tests/unit/test_platform_windows.py
+++ b/tests/unit/test_platform_windows.py
@@ -22,28 +22,32 @@ from scalyr_agent.test_base import ScalyrTestCase
 from scalyr_agent.test_base import skipIf
 
 if platform.system() == "Windows":
-    from scalyr_agent.platform_windows import WindowsPlatformController
+    WINDOWS = True
 else:
-    WindowsPlatformController = None  # type: ignore
+    WINDOWS = False
 
 
 class WindowsPlatformControllerTestCase(ScalyrTestCase):
-    @skipIf(not WindowsPlatformController, "Skipping tests under non-Windows platform")
+    @skipIf(not WINDOWS, "Skipping tests under non-Windows platform")
     @mock.patch("scalyr_agent.platform_windows._set_config_path_registry_entry")
     def test_start_agent_service_friendly_error_on_insufficient_permissions(
         self, mock_set_config_path_registry_entry
     ):
+        from scalyr_agent.platform_windows import WindowsPlatformController
+
         mock_set_config_path_registry_entry.side_effect = Exception("Access is denied")
 
         controller = WindowsPlatformController()
         expected_msg = r".*Unable to set registry entry.*"
         self.assertRaisesRegexp(Exception, expected_msg, controller.start_agent_service)
 
-    @skipIf(not WindowsPlatformController, "Skipping tests under non-Windows platform")
+    @skipIf(not WINDOWS, "Skipping tests under non-Windows platform")
     @mock.patch("win32serviceutil.StopService")
     def test_stop_agent_service_friendly_error_on_insufficient_permissions(
         self, mock_StopService
     ):
+        from scalyr_agent.platform_windows import WindowsPlatformController
+
         mock_StopService.side_effect = Exception("Access is denied")
         controller = WindowsPlatformController()
         expected_msg = r".*Unable to stop agent process.*"

--- a/tests/unit/test_platform_windows.py
+++ b/tests/unit/test_platform_windows.py
@@ -24,7 +24,8 @@ from scalyr_agent.test_base import skipIf
 if platform.system() == "Windows":
     # TODO: Test is failing on Circle CI with
     # ImportError: DLL load failed: The specified module could not be found.
-    from scalyr_agent.platform_windows import WindowsPlatformController
+    # from scalyr_agent.platform_windows import WindowsPlatformController
+    WindowsPlatformController = None  # type: ignore
 else:
     WindowsPlatformController = None  # type: ignore
 

--- a/tests/unit/util/json_util_test.py
+++ b/tests/unit/util/json_util_test.py
@@ -83,10 +83,14 @@ class EncodeDecodeTest(ScalyrTestCase):
         self.__test_encode_decode(r"-1234567890123456789", -1234567890123456789)
 
     def test_64_bit_int(self):
-        # NOTE: latest version of orjson available for Python >= 3.6 can also serialize large
-        # igned and unsigned 64 bit ints now
-        if six.PY3 and sys.version_info >= (3, 6, 0):
-            orjson.dumps(18446744073709551615)
+        # NOTE: Latest version of orjson available for Python >= 3.6 can also serialize large
+        # siigned and unsigned 64 bit ints
+        if six.PY3:
+            if sys.version_info >= (3, 6, 0):
+                orjson.dumps(18446744073709551615)
+            else:
+                with self.assertRaises(orjson.JSONEncodeError):
+                    orjson.dumps(18446744073709551615)
 
         # here we do the regular json tests to be sure that
         # we fall back to native json library in case of too bit integer.

--- a/tests/unit/util/json_util_test.py
+++ b/tests/unit/util/json_util_test.py
@@ -83,10 +83,10 @@ class EncodeDecodeTest(ScalyrTestCase):
         self.__test_encode_decode(r"-1234567890123456789", -1234567890123456789)
 
     def test_64_bit_int(self):
-        if six.PY3:
-            # this should throw an error because orjson can not serialize more than signed 64 integer.
-            with self.assertRaises(orjson.JSONEncodeError):
-                orjson.dumps(18446744073709551615)
+        # NOTE: latest version of orjson available for Python >= 3.6 can also serialize large
+        # igned and unsigned 64 bit ints now
+        if six.PY3 and sys.version_info >= (3, 6, 0):
+            orjson.dumps(18446744073709551615)
 
         # here we do the regular json tests to be sure that
         # we fall back to native json library in case of too bit integer.

--- a/tox.ini
+++ b/tox.ini
@@ -79,9 +79,11 @@ deps =
     -r benchmarks/micro/requirements-compression-algorithms.txt
 commands =
     # NOTE: We disable capturing ouf output (-s flag) since it doesn't play along nicely with Windows
-    py.test tests/unit/ -s -vv --durations=5 -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/ --junitxml=test-results/junit-1.xml
-    py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
-    py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-3.xml
+    py.test tests/unit/ -s -vv --durations=5 -m "not memory_leak and not json_lib and not windows_platform" --cov=scalyr_agent --cov=tests/ --junitxml=test-results/junit-1.xml
+    # We run this test separately to avoid weird import related failures in other tests
+    py.test tests/unit/tests/unit/test_platform_windows.py -s -vv --durations=5 -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/ --junitxml=test-results/junit-2.xml
+    py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-3.xml
+    py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-4.xml
 
 # Lint target which runs all the linting tools such as black, modernize, pylint, flake8, mypy, etc.
 # NOTE: We use bash -c since we don't want tox to quote all the arguments, we want globs to

--- a/tox.ini
+++ b/tox.ini
@@ -75,15 +75,27 @@ commands =
 basepython = python3.5
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps =
+    # NOTE: Do not install pywin32 here since it will cause weird test failures
     -r windows-unit-tests-requirements.txt
     -r benchmarks/micro/requirements-compression-algorithms.txt
 commands =
     # NOTE: We disable capturing ouf output (-s flag) since it doesn't play along nicely with Windows
     py.test tests/unit/ -s -vv --durations=5 -m "not memory_leak and not json_lib and not windows_platform" --cov=scalyr_agent --cov=tests/ --junitxml=test-results/junit-1.xml
-    # We run this test separately to avoid weird import related failures in other tests
-    py.test tests/unit/tests/unit/test_platform_windows.py -s -vv --durations=5 -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/ --junitxml=test-results/junit-2.xml
-    py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-3.xml
-    py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-4.xml
+    py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
+    py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-3.xml
+
+[testenv:py3.5-windows-unit-tests-windows-platform]
+basepython = python3.5
+install_command = pip install -U --force-reinstall {opts} {packages}
+deps =
+    -r windows-unit-tests-requirements.txt
+    -r benchmarks/micro/requirements-compression-algorithms.txt
+    psutil==5.7.0
+    pywin32==300
+commands =
+    # NOTE 1: We disable capturing ouf output (-s flag) since it doesn't play along nicely with Windows
+    # NOTE 2: We run Windows platform tests separately since they cause issues when running them with other unit tests
+    py.test tests/unit/test_platform_windows.py -s -vv --durations=5 -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-4.xml
 
 # Lint target which runs all the linting tools such as black, modernize, pylint, flake8, mypy, etc.
 # NOTE: We use bash -c since we don't want tox to quote all the arguments, we want globs to

--- a/tox.ini
+++ b/tox.ini
@@ -71,8 +71,8 @@ commands =
     py.test tests/unit/util/json_util_test.py -vv --durations=5 -m "json_lib" --junitxml=test-results/junit-2.xml
 
 # Custom target for running unit tests on Windows where some of the C extension based libraries are not available
-[testenv:py3.5-windows-unit-tests]
-basepython = python3.5
+[testenv:py3.8-windows-unit-tests]
+basepython = python3.8
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps =
     # NOTE: Do not install pywin32 here since it will cause weird test failures
@@ -84,8 +84,8 @@ commands =
     py.test tests/unit/test_memory_leaks.py -s -vv --durations=5 --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-2.xml
     py.test tests/unit/util/json_util_test.py -s -vv --durations=5 -m "json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-3.xml
 
-[testenv:py3.5-windows-unit-tests-windows-platform]
-basepython = python3.5
+[testenv:py3.8-windows-unit-tests-windows-platform]
+basepython = python3.8
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps =
     -r windows-unit-tests-requirements.txt

--- a/windows-unit-tests-requirements.txt
+++ b/windows-unit-tests-requirements.txt
@@ -2,6 +2,7 @@
 # Testing tools and libraries
 mock==3.0.5
 psutil==5.7.0
+pyinstaller==3.6
 pywin32==224
 pytest==4.6.9; python_version < '3.0'
 pytest==5.4.3; python_version >= '3.5'

--- a/windows-unit-tests-requirements.txt
+++ b/windows-unit-tests-requirements.txt
@@ -1,9 +1,7 @@
 # Python requirements file which is used for running unit Tests on Windows
 # Testing tools and libraries
 mock==3.0.5
-psutil==5.7.0
 # NOTE: For Python 3 we need newer version of pywin32
-pywin32==300
 pytest==4.6.9; python_version < '3.0'
 pytest==5.4.3; python_version >= '3.5'
 pytest-cov==2.10.0

--- a/windows-unit-tests-requirements.txt
+++ b/windows-unit-tests-requirements.txt
@@ -18,7 +18,7 @@ docker==4.1.0
 # NOTE: We can't use requests >= 2.22.0 since we still need to support Python 2.6
 requests==2.15.1
 ujson==1.35
-orjson==2.6.1; python_version >= '3.6'
+orjson==3.4.7; python_version >= '3.6'
 orjson==2.0.11; python_version == '3.5'
 # Needed by MockHTTPServer class and related tests
 flask==1.1.1

--- a/windows-unit-tests-requirements.txt
+++ b/windows-unit-tests-requirements.txt
@@ -2,6 +2,7 @@
 # Testing tools and libraries
 mock==3.0.5
 psutil==5.7.0
+pywin32==224
 pytest==4.6.9; python_version < '3.0'
 pytest==5.4.3; python_version >= '3.5'
 pytest-cov==2.10.0

--- a/windows-unit-tests-requirements.txt
+++ b/windows-unit-tests-requirements.txt
@@ -1,7 +1,6 @@
 # Python requirements file which is used for running unit Tests on Windows
 # Testing tools and libraries
 mock==3.0.5
-# NOTE: For Python 3 we need newer version of pywin32
 pytest==4.6.9; python_version < '3.0'
 pytest==5.4.3; python_version >= '3.5'
 pytest-cov==2.10.0

--- a/windows-unit-tests-requirements.txt
+++ b/windows-unit-tests-requirements.txt
@@ -2,8 +2,8 @@
 # Testing tools and libraries
 mock==3.0.5
 psutil==5.7.0
-pyinstaller==3.6
-pywin32==224
+# NOTE: For Python 3 we need newer version of pywin32
+pywin32==300
 pytest==4.6.9; python_version < '3.0'
 pytest==5.4.3; python_version >= '3.5'
 pytest-cov==2.10.0


### PR DESCRIPTION
This pull request fixes a bug which would result in an exception being thrown if user tried to start agent on Windows with a non-admin user.

An exception would be thrown during permissions escalation phase due to the code not handling that scenario correctly.

While troubleshooting this issue, I also encountered various other scenarios related to incorrect permissions which result in non-user friendly exceptions being thrown.

I tried to update all of those places to throw more explicit and user-friendly error messages.

## Notes on tests

I already mentioned this in YT issue - our current AMI based Windows end to end tests run in shell / non-gui mode which means there is no easy way to write automated test which would have caught the permission escalation issue since that code path depends on GUI.

Technically It's possible to write some kind of GUI based tests for that, but we have no existing framework and code in place for that which means that it would likely be multiple weeks long effort.