### PR TITLE
Add CodeQL static analysis CI check

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,34 @@
+name: "CodeQL Analysis"
+
+on:
+  push:
+    branches: [ master, add_codeql ]
+  pull_request:
+    branches: [ master, add_codeql ]
+  schedule:
+    - cron: '23 15 * * 3'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,11 +2,11 @@ name: "CodeQL Analysis"
 
 on:
   push:
-    branches: [ master, add_codeql ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, add_codeql ]
+    branches: [ master ]
   schedule:
-    - cron: '23 15 * * 3'
+    - cron: '0 4 * * *'
 
 jobs:
   analyze:


### PR DESCRIPTION
This pull request adds a CI check which runs CodeQL static security analysis on the code once a day.

It utilizes Github workflow since it's a bit PITA to hook it up all the way using Circle CI.