### PR TITLE
Test a fix for tests failure

### DIFF
--- a/tests/image_builder/distributions/amazonlinux2/Dockerfile.base
+++ b/tests/image_builder/distributions/amazonlinux2/Dockerfile.base
@@ -5,4 +5,7 @@ RUN yum install -y python2-pip python2-devel python3-pip python3-devel
 COPY dev-requirements.txt dev-requirements.txt
 
 RUN python -m pip install -r dev-requirements.txt
+# We need newer version of pip since old version don't support manylinux wheels
+RUN python3 -m pip install --upgrade "pip==21.0"
+RUN python3 -m pip --version
 RUN python3 -m pip install -r dev-requirements.txt

--- a/tests/image_builder/distributions/centos6/Dockerfile.base
+++ b/tests/image_builder/distributions/centos6/Dockerfile.base
@@ -24,4 +24,8 @@ COPY py26-unit-tests-requirements.txt py26-unit-tests-requirements.txt
 COPY dev-requirements.txt dev-requirements.txt
 
 RUN pip install -r py26-unit-tests-requirements.txt
+
+# We need newer version of pip since old version don't support manylinux wheels
+RUN python3 -m pip install --upgrade "pip==21.0"
+RUN python3 -m pip --version
 RUN python3 -m pip install -r dev-requirements.txt

--- a/tests/image_builder/distributions/centos7/Dockerfile.base
+++ b/tests/image_builder/distributions/centos7/Dockerfile.base
@@ -12,6 +12,9 @@ RUN yum install -y python3 python3-devel python3-pip
 COPY dev-requirements.txt dev-requirements.txt
 
 RUN python2 -m pip install -r dev-requirements.txt
+# We need newer version of pip since old version don't support manylinux wheels
+RUN python3 -m pip install --upgrade "pip==21.0"
+RUN python3 -m pip --version
 RUN python3 -m pip install -r dev-requirements.txt
 
 # we create symlink to python3.6 with different name only to run tests.

--- a/tests/image_builder/distributions/centos8/Dockerfile.base
+++ b/tests/image_builder/distributions/centos8/Dockerfile.base
@@ -6,4 +6,7 @@ RUN yum install -y python2-devel python2-pip python3-devel python3-pip
 COPY dev-requirements.txt dev-requirements.txt
 
 RUN python2 -m pip install -r dev-requirements.txt
+# We need newer version of pip since old version don't support manylinux wheels
+RUN python3 -m pip install --upgrade "pip==21.0"
+RUN python3 -m pip --version
 RUN python3 -m pip install -r dev-requirements.txt

--- a/tests/image_builder/distributions/ubuntu1604/Dockerfile.base
+++ b/tests/image_builder/distributions/ubuntu1604/Dockerfile.base
@@ -10,5 +10,9 @@ COPY dev-requirements.txt dev-requirements.txt
 RUN python2 -m pip install -r dev-requirements.txt
 
 # so we create symlink to python3.5 with different name only to run tests.
+# We need newer version of pip since old version don't support manylinux wheels
+RUN python3 -m pip install --upgrade "pip==21.0"
+RUN python3 -m pip --version
 RUN python3 -m pip install -r dev-requirements.txt
+
 RUN ln -sf /usr/bin/python3.5 /usr/bin/python_for_tests

--- a/tests/image_builder/distributions/ubuntu1804/Dockerfile.base
+++ b/tests/image_builder/distributions/ubuntu1804/Dockerfile.base
@@ -11,5 +11,9 @@ COPY dev-requirements.txt dev-requirements.txt
 RUN python2 -m pip install -r dev-requirements.txt
 
 # so we create symlink to python3.5 with different name only to run tests.
+# We need newer version of pip since old version don't support manylinux wheels
+RUN python3 -m pip install --upgrade "pip==21.0"
+RUN python3 -m pip --version
 RUN python3 -m pip install -r dev-requirements.txt
+
 RUN ln -sf /usr/bin/python3.6 /usr/bin/python_for_tests


### PR DESCRIPTION
Fix for CI tests failure.

Old versions of pip don't support more recent manylinux2014 wheel format so the tests fail when trying to compile ``orjson`` dependency instead of using the pre-built wheel.