### PR TITLE
rename worker checkpoint files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Bug fixes:
 * Fix a config deprecated options bug when they are set to ``false``.
 * Fix agent so it doesn't throw an exception on Windows when trying to escalate permissions on agent start.
 * Make sure we only print the value of ``win32_max_open_fds`` config option on Windows if it has changed.
+* Fix a bug which was produced by the bad naming of the worker session checkpoint files and it might lead to a deletion of the checkpoints of some monitors.
 
 ## 2.1.17 "Xothichi" - January 15, 2021
 

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -3603,6 +3603,19 @@ class Configuration(object):
                 worker_entry, "api_key", self.api_key, description % entry_index
             )
         else:
+
+            # validate the worker id. It should consist only from this set of characters.
+            allowed_worker_id_characters_pattern = "a-zA-Z0-9_"
+            if re.search(
+                r"[^{0}]+".format(allowed_worker_id_characters_pattern), worker_id
+            ):
+                raise BadConfiguration(
+                    "The worker id '{0}' contains an invalid character. Please use only '{1}'".format(
+                        worker_id, allowed_worker_id_characters_pattern
+                    ),
+                    "workers",
+                    "invalidWorkerId",
+                )
             self.__verify_required_string(
                 worker_entry, "api_key", description % entry_index
             )

--- a/scalyr_agent/copying_manager/copying_manager.py
+++ b/scalyr_agent/copying_manager/copying_manager.py
@@ -48,7 +48,7 @@ from scalyr_agent.copying_manager.worker import (
     CopyingManagerWorkerSession,
     create_shared_object_manager,
     CopyingManagerWorkerSessionProxy,
-    WORKER_SESSION_CHECKPOINT_FILENAME_PREFIX,
+    WORKER_SESSION_CHECKPOINT_FILENAME_GLOB,
 )
 from scalyr_agent.log_processing import LogMatcher, LogFileProcessor
 from scalyr_agent.log_watcher import LogWatcher
@@ -75,7 +75,7 @@ def get_worker_session_ids(worker_config):  # type: (Dict) -> List
     result = []
     for i in range(worker_config["sessions"]):
         # combine the id of the worker and session's position in the list to get a session id.
-        worker_session_id = "%s_%s" % (worker_config["id"], i)
+        worker_session_id = "%s-%s" % (worker_config["id"], i)
         result.append(worker_session_id)
     return result
 
@@ -1339,8 +1339,7 @@ class CopyingManager(StoppableThread, LogWatcher):
 
         # clear data folder by removing all worker session checkpoint files.
         checkpoints_glob = os.path.join(
-            self.__config.agent_data_path,
-            "{0}*.json".format(WORKER_SESSION_CHECKPOINT_FILENAME_PREFIX),
+            self.__config.agent_data_path, WORKER_SESSION_CHECKPOINT_FILENAME_GLOB,
         )
 
         for path in scalyr_util.match_glob(checkpoints_glob):
@@ -1372,8 +1371,7 @@ class CopyingManager(StoppableThread, LogWatcher):
 
         # search for all worker session checkpoint files.
         worker_checkpoints_glob = os.path.join(
-            self.__config.agent_data_path,
-            "{0}*.json".format(WORKER_SESSION_CHECKPOINT_FILENAME_PREFIX),
+            self.__config.agent_data_path, WORKER_SESSION_CHECKPOINT_FILENAME_GLOB,
         )
 
         checkpoints_paths = scalyr_util.match_glob(worker_checkpoints_glob)

--- a/scalyr_agent/copying_manager/copying_manager.py
+++ b/scalyr_agent/copying_manager/copying_manager.py
@@ -1350,7 +1350,7 @@ class CopyingManager(StoppableThread, LogWatcher):
             active_checkpoint_path = os.path.join(
                 os.path.dirname(path), "active-{0}".format(checkpoint_file_name),
             )
-            if os.path.exists(active_checkpoint_path):
+            if os.path.isfile(active_checkpoint_path):
                 os.unlink(active_checkpoint_path)
 
     def __find_and_read_checkpoints(self, warn_on_stale=False):

--- a/scalyr_agent/copying_manager/worker.py
+++ b/scalyr_agent/copying_manager/worker.py
@@ -50,6 +50,9 @@ import six
 log = scalyr_logging.getLogger(__name__)
 
 WORKER_SESSION_CHECKPOINT_FILENAME_PREFIX = "checkpoints-worker-"
+WORKER_SESSION_CHECKPOINT_FILENAME_GLOB = "{0}*-*.json".format(
+    WORKER_SESSION_CHECKPOINT_FILENAME_PREFIX
+)
 
 
 class CopyingParameters(object):

--- a/scalyr_agent/copying_manager/worker.py
+++ b/scalyr_agent/copying_manager/worker.py
@@ -49,6 +49,8 @@ import six
 
 log = scalyr_logging.getLogger(__name__)
 
+WORKER_SESSION_CHECKPOINT_FILENAME_PREFIX = "checkpoints-worker-"
+
 
 class CopyingParameters(object):
     """Tracks the copying parameters that should be used for sending requests to Scalyr and adjusts them over time
@@ -1049,7 +1051,7 @@ class CopyingManagerWorkerSession(
         """
         self.__write_checkpoint_state(
             self.__log_processors,
-            "checkpoints-%s.json" % self._id,
+            "%s%s.json" % (WORKER_SESSION_CHECKPOINT_FILENAME_PREFIX, self._id),
             current_time,
             full_checkpoint=True,
         )
@@ -1060,7 +1062,7 @@ class CopyingManagerWorkerSession(
         """
         self.__write_checkpoint_state(
             self.__log_processors,
-            "active-checkpoints-%s.json" % self._id,
+            "active-%s%s.json" % (WORKER_SESSION_CHECKPOINT_FILENAME_PREFIX, self._id),
             current_time,
             full_checkpoint=False,
         )

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -3682,3 +3682,37 @@ class TestWorkersConfiguration(TestConfigurationBase):
         config = self._create_test_configuration_instance()
 
         config.parse()
+
+    def test_invalid_worker_id(self):
+        def recreate(worker_id):
+            self._write_file_with_separator_conversion(
+                """ {{
+                    api_key: "hi there"
+                    workers: [
+                        {{"api_key": "another_key", "id": "{0}"}},
+                    ]
+                  }}
+                """.format(
+                    worker_id
+                )
+            )
+            config = self._create_test_configuration_instance()
+
+            config.parse()
+
+        with pytest.raises(BadConfiguration) as err_info:
+            recreate("Invalid.key /")
+
+        assert "contains an invalid character" in err_info.value.message
+
+        with pytest.raises(BadConfiguration) as err_info:
+            recreate("Invalid.key ")
+
+        assert "contains an invalid character" in err_info.value.message
+
+        with pytest.raises(BadConfiguration) as err_info:
+            recreate("Invalid.key")
+
+        assert "contains an invalid character" in err_info.value.message
+
+        recreate("not_Invalid_key_anymore")

--- a/tests/unit/copying_manager_tests/common.py
+++ b/tests/unit/copying_manager_tests/common.py
@@ -57,7 +57,10 @@ from scalyr_agent.copying_manager import (
     CopyingManagerWorker,
     CopyingManagerWorkerSession,
 )
-from scalyr_agent.copying_manager.worker import WORKER_SESSION_PROXY_EXPOSED_METHODS
+from scalyr_agent.copying_manager.worker import (
+    WORKER_SESSION_PROXY_EXPOSED_METHODS,
+    WORKER_SESSION_CHECKPOINT_FILENAME_PREFIX,
+)
 
 from scalyr_agent.scalyr_client import AddEventsRequest
 from scalyr_agent.log_processing import LogMatcher
@@ -595,16 +598,18 @@ class TestableCopyingManagerWorkerSession(
         )
         self._saved_checkpoints, self.saved_active_checkpoints = self.get_checkpoints()
 
-    # region Utility funtions
+    # region Utility functions
     def get_checkpoints_path(self):
         result = pathlib.Path(
-            self.__config.agent_data_path, "checkpoints-%s.json" % self._id
+            self.__config.agent_data_path,
+            "%s%s.json" % (WORKER_SESSION_CHECKPOINT_FILENAME_PREFIX, self._id),
         )
         return result
 
     def get_active_checkpoints_path(self):
         result = pathlib.Path(
-            self.__config.agent_data_path, "active-checkpoints-%s.json" % self._id
+            self.__config.agent_data_path,
+            "active-%s%s.json" % (WORKER_SESSION_CHECKPOINT_FILENAME_PREFIX, self._id),
         )
         return result
 

--- a/tests/unit/copying_manager_tests/copying_manager_new_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_new_test.py
@@ -239,7 +239,7 @@ class TestBasic(CopyingManagerTest):
         else:
             assert (
                 status.worker_sessions_health_check
-                == "Worker session 'default_0' failed, max time since last copy attempt (60.0 seconds) exceeded"
+                == "Worker session 'default-0' failed, max time since last copy attempt (60.0 seconds) exceeded"
             )
             assert status.health_check_result == "Good"
 
@@ -263,7 +263,7 @@ class TestBasic(CopyingManagerTest):
         else:
             assert (
                 status.worker_sessions_health_check
-                == "Worker session 'default_0' failed, max time since last copy attempt (60.0 seconds) exceeded"
+                == "Worker session 'default-0' failed, max time since last copy attempt (60.0 seconds) exceeded"
             )
             assert (
                 status.health_check_result
@@ -324,6 +324,7 @@ class TestBasic(CopyingManagerTest):
         # make sure that all worker session checkpoint files are consolidated and removed.
         for worker_session in manager.worker_sessions:
             assert not worker_session.get_checkpoints_path().exists()
+            assert not worker_session.get_active_checkpoints_path().exists()
 
         assert manager.consolidated_checkpoints_path.exists()
         manager.consolidated_checkpoints_path.unlink()

--- a/tests/unit/copying_manager_tests/copying_manager_new_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_new_test.py
@@ -273,6 +273,26 @@ class TestBasic(CopyingManagerTest):
     def test_checkpoints(self):
         (test_file, test_file2), manager = self._init_manager(2)
 
+        # also add non-copying manager related checkpoints files, to be sure that the copying manager does not
+        # touch them. This emulates the case where some agent monitors also store their own state in checkpoint files
+        # and we must not consolidate them with the worker checkpoints.
+        monitor_checkpoint_file_names = [
+            "windows-event-checkpoints.json",
+            "docker-checkpoints.json",
+            "journald-checkpoints.json",
+        ]
+
+        monitors_checkpoint_paths = {}
+
+        for name in monitor_checkpoint_file_names:
+            monitor_checkpoint_path = pathlib.Path(
+                self._env_builder.config.agent_data_path, name
+            )
+            check_text = "{0}. Do not delete me, please.".format(name)
+            # write some text to the monitor checkpoint files, just to verify that it is not changed later.
+            monitors_checkpoint_paths[monitor_checkpoint_path] = check_text
+            monitor_checkpoint_path.write_text(check_text)
+
         test_file.append_lines("line1")
         test_file2.append_lines("line2")
 
@@ -301,10 +321,12 @@ class TestBasic(CopyingManagerTest):
         test_file.append_lines("Line7")
         test_file.append_lines("Line8")
 
-        for checkpoint_path in pathlib.Path(
-            self._env_builder.config.agent_data_path
-        ).glob("*checkpoints*.json"):
-            checkpoint_path.unlink()
+        # make sure that all worker session checkpoint files are consolidated and removed.
+        for worker_session in manager.worker_sessions:
+            assert not worker_session.get_checkpoints_path().exists()
+
+        assert manager.consolidated_checkpoints_path.exists()
+        manager.consolidated_checkpoints_path.unlink()
 
         self._instance = manager = TestableCopyingManager(self._env_builder.config, [])
 
@@ -317,7 +339,12 @@ class TestBasic(CopyingManagerTest):
 
         assert set(self._wait_for_rpc_and_respond()) == set(["Line9", "Line10"])
 
-    def test_checkpoints_master_checkpoints(self):
+        # verify if monitor checkpoint file is remaining untouched.
+        for monitor_checkpoint_path, check_text in monitors_checkpoint_paths.items():
+            assert monitor_checkpoint_path.exists()
+            assert monitor_checkpoint_path.read_text() == check_text
+
+    def test_checkpoints_consolidated_checkpoints(self):
         if self.worker_sessions_count == 1 and self.workers_count == 1:
             pytest.skip("This test is only for multi-worker copying manager.")
 

--- a/tests/unit/copying_manager_tests/test_environment.py
+++ b/tests/unit/copying_manager_tests/test_environment.py
@@ -29,6 +29,9 @@ from scalyr_agent.configuration import Configuration
 from scalyr_agent.platform_controller import DefaultPaths
 
 from scalyr_agent import scalyr_logging
+from scalyr_agent.copying_manager.worker import (
+    WORKER_SESSION_CHECKPOINT_FILENAME_PREFIX,
+)
 
 
 import six
@@ -241,12 +244,20 @@ class TestEnvironBuilder(object):
         return self.test_logs_dir / "non-glob-logs"
 
     def get_checkpoints_path(self, worker_id):  # type: (six.text_type) -> pathlib.Path
-        return self.agent_data_path / ("checkpoints-%s.json" % worker_id)
+        checkpoint_file_name = "%s%s.json" % (
+            WORKER_SESSION_CHECKPOINT_FILENAME_PREFIX,
+            worker_id,
+        )
+        return self.agent_data_path / checkpoint_file_name
 
     def get_active_checkpoints_path(
         self, worker_id
     ):  # type: (six.text_type) -> pathlib.Path
-        return self.agent_data_path / "active-checkpoints-%s.json" % worker_id
+        checkpoint_file_name = "active-%s%s.json" % (
+            WORKER_SESSION_CHECKPOINT_FILENAME_PREFIX,
+            worker_id,
+        )
+        return self.agent_data_path / checkpoint_file_name
 
     def get_checkpoints(self, worker_id):
         return json.loads(self.get_checkpoints_path(worker_id).read_text())


### PR DESCRIPTION
This PR fixes worker session checkpoints consolidation bug, where the copying manager also was deleting the monitor checkpoint files.

The worker session checkpoint files now have the format - `checkpoints-worker-<worker_id>`. 
THe consolidation logic is also changed to use the glob that only matches the checkpoint files from the worker sessions.