### PR TITLE
CT-77 capture k8s container names

### DIFF
--- a/.circleci/docker_unified_smoke_unit/smoketest/smoketest.py
+++ b/.circleci/docker_unified_smoke_unit/smoketest/smoketest.py
@@ -1026,6 +1026,7 @@ class K8sActor(DockerSmokeTestActor):
                 att.get("stream") in stream_name,
                 att.get("monitor") == "agentKubernetes",
                 process_name in att.get("pod_name"),
+                att.get("container_name") == "scalyr-agent",
             ]
         ):
             return False

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -833,7 +833,7 @@ _CONTROLLER_KEYS = {
 # A regex for splitting a container id and runtime
 _CID_RE = re.compile("^(.+)://(.+)$")
 # A regex to determine whether a string contains template directives
-_TEMPLATE_RE = re.compile("\${[^}]+}")
+_TEMPLATE_RE = re.compile(r"\${[^}]+}")
 
 
 class K8sInitException(Exception):

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -833,7 +833,7 @@ _CONTROLLER_KEYS = {
 # A regex for splitting a container id and runtime
 _CID_RE = re.compile("^(.+)://(.+)$")
 # A regex to determine whether a string contains template directives
-_TEMPLATE_RE = re.compile('\${[^}]+}')
+_TEMPLATE_RE = re.compile("\${[^}]+}")
 
 
 class K8sInitException(Exception):

--- a/tests/unit/builtin_monitors/kubernetes_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_monitor_test.py
@@ -859,9 +859,7 @@ class ContainerCheckerTest(TestConfigurationBase):
             ignore_pod_sandboxes=False,
         )
         cc._ContainerChecker__k8s_config_builder = K8sConfigBuilder(
-            config.k8s_log_configs,
-            mock.Mock(),
-            True,
+            config.k8s_log_configs, mock.Mock(), True,
         )
         cc.get_cluster_name = lambda *_: "the-cluster-name"
 

--- a/tests/unit/builtin_monitors/kubernetes_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_monitor_test.py
@@ -885,7 +885,5 @@ class ContainerCheckerTest(TestConfigurationBase):
             k8s_cache=mock.Mock(pod=_pod),
             base_attributes=cc._ContainerChecker__get_base_attributes(),
         )
-        self.assertIn("zzz_templ_container_name", result["attributes"])
-        self.assertEqual(
-            "xxx_test_container", result["attributes"]["zzz_templ_container_name"]
-        )
+        assert "zzz_templ_container_name" in result["attributes"]
+        assert "xxx_test_container" == result["attributes"]["zzz_templ_container_name"]

--- a/tests/unit/builtin_monitors/kubernetes_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_monitor_test.py
@@ -29,6 +29,7 @@ import sys
 from scalyr_agent.monitor_utils.k8s import (
     KubeletApi,
     KubeletApiException,
+    K8sConfigBuilder,
     K8sNamespaceFilter,
 )
 from scalyr_agent.third_party.requests.packages.urllib3.exceptions import (
@@ -42,6 +43,7 @@ __author__ = "echee@scalyr.com"
 from scalyr_agent.builtin_monitors.kubernetes_monitor import (
     KubernetesMonitor,
     ControlledCacheWarmer,
+    ContainerChecker,
     _ignore_old_dead_container,
 )
 from scalyr_agent.copying_manager import CopyingManager
@@ -50,6 +52,7 @@ from scalyr_agent.test_base import ScalyrTestCase, BaseScalyrLogCaptureTestCase
 from scalyr_agent.test_util import ScalyrTestUtils
 
 from tests.unit.monitor_utils.k8s_test import FakeCache
+from tests.unit.configuration_test import TestConfigurationBase
 from tests.unit.copying_manager_tests.copying_manager_test import FakeMonitor
 from scalyr_agent.test_base import skipIf
 
@@ -811,3 +814,80 @@ class TestKubeletApi(BaseScalyrLogCaptureTestCase):
         created_before = None
         result = _ignore_old_dead_container(container, created_before)
         self.assertFalse(result)
+
+
+class ContainerCheckerTest(TestConfigurationBase):
+    def setUp(self):
+        super(ContainerCheckerTest, self).setUp()
+        self.k8s_info = {
+            "pod_name": "test_pod",
+            "pod_namespace": "test_namespace",
+            "k8s_container_name": "xxx_test_container",
+        }
+
+    def test_variable_container_log_config(self):
+        self._write_file_with_separator_conversion(
+            """ {
+            api_key: "hi there",
+            k8s_logs: [
+              {
+                "k8s_container_glob": "no_match",
+                "test": "no_match",
+              },
+              {
+                "attributes": { "zzz_templ_container_name": "${k8s_container_name}" }
+              }
+            ]
+          }
+        """
+        )
+        config = self._create_test_configuration_instance()
+        config.parse()
+
+        cc = ContainerChecker(
+            config={"k8s_use_v2_attributes": True},
+            global_config=config,
+            logger=mock.Mock(),
+            socket_file=None,
+            docker_api_version=None,
+            agent_pod=None,
+            host_hostname=None,
+            log_path=None,
+            include_all=True,
+            include_controller_info=True,
+            namespaces_to_include=[K8sNamespaceFilter.default_value()],
+            ignore_pod_sandboxes=False,
+        )
+        cc._ContainerChecker__k8s_config_builder = K8sConfigBuilder(
+            config.k8s_log_configs,
+            mock.Mock(),
+            True,
+        )
+        cc.get_cluster_name = lambda *_: "the-cluster-name"
+
+        def _pod(pod_namespace, pod_name, **kwargs):
+            return mock.MagicMock(
+                name=pod_name,
+                namespace=pod_namespace,
+                node_name="asd",
+                uid="lkjsefr",
+                labels={},
+                controller=None,
+                annotations={},
+                container_names=["one", "two"],
+            )
+
+        result = cc._ContainerChecker__get_log_config_for_container(
+            "12345",
+            info={
+                "name": "myname",
+                "k8s_info": self.k8s_info,
+                "log_path": "/var/log/test.log",
+            },
+            k8s_cache=mock.Mock(pod=_pod),
+            base_attributes=cc._ContainerChecker__get_base_attributes(),
+        )
+        self.assertIn("zzz_templ_container_name", result["attributes"])
+        self.assertEqual(
+            "xxx_test_container", result["attributes"]["zzz_templ_container_name"]
+        )


### PR DESCRIPTION
This PR adds support for capturing k8s container names in log event metadata. I implemented Imron's suggestion of providing a generic way to add any k8s data we have. In order to add k8s container names to log event metadata the following config is required:

	"k8s_logs": [
	  {
	    "attributes": { "container_name": "${k8s_container_name}" }
	  }
	]
