### PR TITLE
Add additional safety checks to the ami-tests-stable job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2415,6 +2415,7 @@ workflows:
             - build-linux-packages-and-installer-script
      - ami-tests-stable:
           context: scalyr-agent
+          <<: *master_and_release_only
  benchmarks:
    <<: *skip_release_build_branch_push
    jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2415,7 +2415,6 @@ workflows:
             - build-linux-packages-and-installer-script
      - ami-tests-stable:
           context: scalyr-agent
-          <<: *master_and_release_only
  benchmarks:
    <<: *skip_release_build_branch_push
    jobs:

--- a/tests/ami/scripts/test_deb.sh.j2
+++ b/tests/ami/scripts/test_deb.sh.j2
@@ -93,20 +93,24 @@ sudo DEBIAN_FRONTEND=noninteractive dpkg -i install_package.deb
 sudo sed -i 's/REPLACE_THIS/{{scalyr_api_key}}/' /etc/scalyr-agent-2/agent.json
 export INSTALL_PACKAGE_VERSION=$(dpkg-deb -f "install_package.deb" Version)
 {% else -%}
-# install Scalyr agent by downloading convenience script.
+    {# install Scalyr agent by downloading convenience script. #}
     {% if installer_script_info["type"] == "url" -%}
 wget -O "install-scalyr-agent-2.sh" -q "{{installer_script_info["source"]}}"
-    # If source points to https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh
-    # ensure the script contains correct reference to prod.
-    # In the past, we had a bug where incorrect version of the script which pointed to internal instead
-    # of stable was published
+    {# If source points to https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh #}
+    {# ensure the script contains correct reference to prod. #}
+    {# In the past, we had a bug where incorrect version of the script which pointed to internal instead #}
+    {# of stable was published  #}
     {% if installer_script_info["source"] == "https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" -%}
-echo "ttttest"
+echo_with_date ""
+echo_with_date "Verifying stable installer script content"
+echo_with_date ""
+
 cat install-scalyr-agent-2.sh | grep "REPOSITORY_URL"
 cat install-scalyr-agent-2.sh | grep "baseurl"
 
 cat install-scalyr-agent-2.sh | grep "REPOSITORY_URL" | grep "stable"
 cat install-scalyr-agent-2.sh | grep "baseurl" | grep "stable"
+echo_with_date ""
     {% endif -%}
     {% endif -%}
 sudo bash ./install-scalyr-agent-2.sh --set-api-key "{{scalyr_api_key}}"

--- a/tests/ami/scripts/test_deb.sh.j2
+++ b/tests/ami/scripts/test_deb.sh.j2
@@ -105,11 +105,11 @@ echo_with_date ""
 echo_with_date "Verifying stable installer script content"
 echo_with_date ""
 
-cat install-scalyr-agent-2.sh | grep "REPOSITORY_URL"
-cat install-scalyr-agent-2.sh | grep "baseurl"
+cat -v install-scalyr-agent-2.sh | grep "REPOSITORY_URL"
+cat -v install-scalyr-agent-2.sh | grep "baseurl"
 
-cat install-scalyr-agent-2.sh | grep "REPOSITORY_URL" | grep "stable"
-cat install-scalyr-agent-2.sh | grep "baseurl" | grep "stable"
+cat -v install-scalyr-agent-2.sh | grep "REPOSITORY_URL" | grep "stable"
+cat -v install-scalyr-agent-2.sh | grep "baseurl" | grep "stable"
 echo_with_date ""
     {% endif -%}
     {% endif -%}

--- a/tests/ami/scripts/test_deb.sh.j2
+++ b/tests/ami/scripts/test_deb.sh.j2
@@ -96,6 +96,18 @@ export INSTALL_PACKAGE_VERSION=$(dpkg-deb -f "install_package.deb" Version)
 # install Scalyr agent by downloading convenience script.
     {% if installer_script_info["type"] == "url" -%}
 wget -O "install-scalyr-agent-2.sh" -q "{{installer_script_info["source"]}}"
+    # If source points to https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh
+    # ensure the script contains correct reference to prod.
+    # In the past, we had a bug where incorrect version of the script which pointed to internal instead
+    # of stable was published
+    {% if installer_script_info["source"] == "https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" -%}
+echo "ttttest"
+cat install-scalyr-agent-2.sh | grep "REPOSITORY_URL"
+cat install-scalyr-agent-2.sh | grep "baseurl"
+
+cat install-scalyr-agent-2.sh | grep "REPOSITORY_URL" | grep "stable"
+cat install-scalyr-agent-2.sh | grep "baseurl" | grep "stable"
+    {% endif -%}
     {% endif -%}
 sudo bash ./install-scalyr-agent-2.sh --set-api-key "{{scalyr_api_key}}"
     {% if install_package["source"] == "current" -%}

--- a/tests/ami/scripts/test_deb.sh.j2
+++ b/tests/ami/scripts/test_deb.sh.j2
@@ -67,7 +67,7 @@ sudo apt-get install -y {{additional_packages}}
 {% endif -%}
 
 # Deny the default gpg port to test the install script.
-#sudo iptables -A OUTPUT -p tcp --dport 11371 -j DROP
+sudo iptables -A OUTPUT -p tcp --dport 11371 -j DROP
 
 # Install Sclayr agent.
 echo_with_date ""

--- a/tests/ami/scripts/test_rpm.sh.j2
+++ b/tests/ami/scripts/test_rpm.sh.j2
@@ -66,7 +66,7 @@ sudo yum install -y {{additional_packages}}
 {% endif -%}
 
 # Deny the default gpg port to test the install script.
-#sudo iptables -A OUTPUT -p tcp --dport 11371 -j DROP
+sudo iptables -A OUTPUT -p tcp --dport 11371 -j DROP
 
 # Install Sclayr agent.
 echo_with_date ""

--- a/tests/ami/scripts/test_rpm.sh.j2
+++ b/tests/ami/scripts/test_rpm.sh.j2
@@ -92,9 +92,26 @@ sudo rpm -iv install_package.rpm
 sudo sed -i 's/REPLACE_THIS/{{scalyr_api_key}}/' /etc/scalyr-agent-2/agent.json
 export INSTALL_PACKAGE_VERSION=$(rpm -qp --queryformat '%{VERSION}\n' "install_package.rpm" | sed "s/_.*//g")
 {% else -%}
-# install Scalyr agent by downloading convenience script.
+    {# install Scalyr agent by downloading convenience script. #}
     {% if installer_script_info["type"] == "url" -%}
 wget -O "install-scalyr-agent-2.sh" -q "{{installer_script_info["source"]}}"
+    {# If source points to https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh #}
+    {# ensure the script contains correct reference to prod. #}
+    {# In the past, we had a bug where incorrect version of the script which pointed to internal instead #}
+    {# of stable was published  #}
+    {% if installer_script_info["source"] == "https://www.scalyr.com/scalyr-repo/stable/latest/install-scalyr-agent-2.sh" -%}
+echo_with_date ""
+echo_with_date "Verifying stable installer script content"
+echo_with_date ""
+
+cat -v install-scalyr-agent-2.sh | grep "REPOSITORY_URL"
+cat -v install-scalyr-agent-2.sh | grep "baseurl"
+
+cat -v install-scalyr-agent-2.sh | grep "REPOSITORY_URL" | grep "stable"
+cat -v install-scalyr-agent-2.sh | grep "baseurl" | grep "stable"
+echo_with_date ""
+    {% endif -%}
+
     {% endif -%}
 sudo bash ./install-scalyr-agent-2.sh --set-api-key "{{scalyr_api_key}}"
     {% if install_package["source"] == "current" -%}


### PR DESCRIPTION
This pull request updates ``ami-tests-stable`` job to ensure that the URL in the installer script indeed points to the correct stable repo.

In the past we had a bug when it could incorrectly point to internal instead of stable repo.