### PR TITLE
CT-298 Add Endpoint kind to event_object_filter default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
+## 2.1.19 "TBD" - TBD
+
+<!---
+Packaged by Arthur Kamalov <arthur@scalyr.com> on Jan 29, 2021 14:00 -0800
+--->
+
+Improvements:
+* Add ``Endpoint`` to the default ``event_object_filter`` values.
+
 ## 2.1.18 "Ravis" - January 29, 2021
 
 <!---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Packaged by Arthur Kamalov <arthur@scalyr.com> on Jan 29, 2021 14:00 -0800
 --->
 
 Improvements:
-* Add ``Endpoint`` to the default ``event_object_filter`` values.
+* Add ``Endpoint`` to the default ``event_object_filter`` values for the Kubernetes Event Monitor.
 
 ## 2.1.18 "Ravis" - January 29, 2021
 

--- a/docs/monitors/kubernetes_events_monitor.md
+++ b/docs/monitors/kubernetes_events_monitor.md
@@ -117,9 +117,10 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
                                   which event messages are stored. The file will be placed in the default Scalyr log \
                                   directory, unless it is an absolute path
 |||# ``event_object_filter``  ||| Optional (defaults to ['CronJob', 'DaemonSet', 'Deployment', 'Job', 'Node', 'Pod', \
-                                  'ReplicaSet', 'ReplicationController', 'StatefulSet']). A list of event object types \
-                                  to filter on. If set, only events whose `involvedObject` `kind` is on this list will \
-                                  be included.
+                                  'ReplicaSet', 'ReplicationController', 'StatefulSet', 'Endpoint']). A list of event \
+                                  object types to filter on. Only events whose ``involvedObject`` ``kind`` is on this \
+                                  list will be included.  To not perform filtering and to send all event kinds, set \
+                                  the environment variable ``SCALYR_K8S_EVENT_OBJECT_FILTER=null``.
 |||# ``leader_check_interval``||| Optional (defaults to 60). The number of seconds to wait between checks to see if we \
                                   are still the leader.
 |||# ``leader_node``          ||| Optional (defaults to None). Force the `leader` to be the scalyr-agent that runs on \

--- a/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
@@ -132,7 +132,9 @@ define_config_option(
     __monitor__,
     "event_object_filter",
     "Optional (defaults to %s). A list of event object types to filter on. "
-    "If set, only events whose `involvedObject` `kind` is on this list will be included."
+    "Only events whose ``involvedObject`` ``kind`` is on this list will be included.  "
+    "To not perform filtering and to send all event kinds, set the environment variable "
+    "``SCALYR_K8S_EVENT_OBJECT_FILTER=null``."
     % six.text_type(EVENT_OBJECT_FILTER_DEFAULTS),
     convert_to=ArrayOfStrings,
     default=EVENT_OBJECT_FILTER_DEFAULTS,

--- a/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
@@ -126,6 +126,7 @@ EVENT_OBJECT_FILTER_DEFAULTS = [
     "ReplicaSet",
     "ReplicationController",
     "StatefulSet",
+    "Endpoint",
 ]
 define_config_option(
     __monitor__,
@@ -350,6 +351,7 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
                 "ReplicaSet",
                 "ReplicationController",
                 "StatefulSet",
+                "Endpoint",
             ],
         )
 


### PR DESCRIPTION
A customer reported that `Endpoint` event `involvedObject` `kind` was not sent by default.  Add `Endpoint` kind to event_object_filter default.