### PR TITLE
Update agent status output to include pids, fix / remove warnings logged in status output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Packaged by Arthur Kamalov <arthur@scalyr.com> on Jan 29, 2021 14:00 -0800
 
 Improvements:
 * Add ``Endpoint`` to the default ``event_object_filter`` values for the Kubernetes Event Monitor.
+* Update ``scalyr-agent-2 status -v`` output to also include process id (pid) of the main agent process and children worker processes in scenarios where the agent is configured with multiple worker processes.
+
+Bug fixes:
+* Fix ``scalyr-agent-status -v`` to not emit / print warnings under some edge cases.
 
 ## 2.1.18 "Ravis" - January 29, 2021
 

--- a/scalyr_agent/agent_status.py
+++ b/scalyr_agent/agent_status.py
@@ -610,7 +610,6 @@ def report_status(output, status, current_time):
         "Agent started at:        %s" % scalyr_util.format_time(status.launch_time),
         file=output,
     )
-    print(status)
 
     parent_process_pid = os.getpid()
     print("Main process pid:        %s" % (os.getpid()), file=output)

--- a/scalyr_agent/agent_status.py
+++ b/scalyr_agent/agent_status.py
@@ -370,6 +370,15 @@ class CopyingManagerWorkerStatus(BaseAgentStatus):
         # the status objects from all sessions in the worker.
         self.sessions = []  # type: List[CopyingManagerWorkerSessionStatus]
 
+    def get_pids(self):
+        # type: () -> List[int]
+        worker_pids = []
+        for session in self.sessions:
+            if session.pid:
+                worker_pids.append(session.pid)
+
+        return worker_pids
+
     @property
     def has_files(self):
         # type: () -> bool
@@ -430,6 +439,14 @@ class CopyingManagerStatus(BaseAgentStatus):
             if len(worker.sessions) == 1:
                 return True
         return False
+
+    def get_all_worker_pids(self):
+        all_pids = []
+
+        for worker in self.workers:
+            all_pids.extend(worker.get_pids())
+
+        return all_pids
 
     def _all_worker_sessions(self):
         # type: () -> Generator
@@ -593,6 +610,19 @@ def report_status(output, status, current_time):
         "Agent started at:        %s" % scalyr_util.format_time(status.launch_time),
         file=output,
     )
+    print(status)
+
+    parent_process_pid = os.getpid()
+    print("Main process pid:        %s" % (os.getpid()), file=output)
+
+    # If parent and worker pid is the same, this means we are using a single worker or not using
+    # multi process functionality so we don't report pids for child worker processes
+    worker_processes_pids = status.copying_manager_status.get_all_worker_pids()
+
+    if parent_process_pid not in worker_processes_pids:
+        worker_processes_pids = ", ".join([str(pid) for pid in worker_processes_pids])
+        print("Worker processes pids    %s" % worker_processes_pids, file=output)
+
     print("Version:                 %s" % status.version, file=output)
     print("VCS revision:            %s" % status.revision, file=output)
     print("Python version:          %s" % status.python_version, file=output)

--- a/scalyr_agent/agent_status.py
+++ b/scalyr_agent/agent_status.py
@@ -617,11 +617,17 @@ def report_status(output, status, current_time):
 
     # If parent and worker pid is the same, this means we are using a single worker or not using
     # multi process functionality so we don't report pids for child worker processes
-    worker_processes_pids = status.copying_manager_status.get_all_worker_pids()
+    if status.copying_manager_status:
+        worker_processes_pids = status.copying_manager_status.get_all_worker_pids()
+    else:
+        worker_processes_pids = []
 
-    if parent_process_pid not in worker_processes_pids:
+    if (
+        len(worker_processes_pids) >= 1
+        and parent_process_pid not in worker_processes_pids
+    ):
         worker_processes_pids = ", ".join([str(pid) for pid in worker_processes_pids])
-        print("Worker processes pids    %s" % worker_processes_pids, file=output)
+        print("Worker processes pids:   %s" % worker_processes_pids, file=output)
 
     print("Version:                 %s" % status.version, file=output)
     print("VCS revision:            %s" % status.revision, file=output)

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -521,7 +521,11 @@ class Configuration(object):
         k8s_logs is a top level config option, but it's utilized by Kubernetes monitor which means
         it will have no affect if kubernetes monitor is not configured as well.
         """
-        if self.__k8s_log_configs and not self._is_kubernetes_monitor_configured():
+        if (
+            self.__k8s_log_configs
+            and not self._is_kubernetes_monitor_configured()
+            and self.__log_warnings
+        ):
             self.__logger.warn(
                 '"k8s_logs" config options is defined, but Kubernetes monitor is '
                 "not configured / enabled. That config option applies to "
@@ -3225,7 +3229,7 @@ class Configuration(object):
                 if config_val is not None:
                     config_object.put(param_name, config_val)
                     del config_object[name]
-                    if self.__logger:
+                    if self.__logger and self.__log_warnings:
                         self.__logger.warning(
                             "The configuration option {0} is deprecated, use {1} instead.".format(
                                 name, param_name

--- a/tests/unit/agent_status_test.py
+++ b/tests/unit/agent_status_test.py
@@ -386,6 +386,7 @@ class TestReportStatus(ScalyrTestCase):
 
 Current time:            Fri Sep  5 23:14:13 2014 UTC
 Agent started at:        Thu Sep  4 23:14:13 2014 UTC
+Main process pid:        %s
 Version:                 2.0.0.beta.7
 VCS revision:            git revision
 Python version:          3.6.8
@@ -395,7 +396,7 @@ ServerHost:              test_machine
 Compression algorithm:   deflate
 Compression level:       9
 
-View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%3D%27test_machine%27
+View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%%3D%%27test_machine%%27
 
 
 Agent configuration:
@@ -451,7 +452,9 @@ Running monitors:
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
-"""
+""" % (
+            os.getpid()
+        )
 
         if platform.system() == "Windows":
             # On Windows keys are not case sensitive and get upper cased
@@ -475,6 +478,7 @@ Failed monitors:
 
 Current time:            Fri Sep  5 23:14:13 2014 UTC
 Agent started at:        Thu Sep  4 23:14:13 2014 UTC
+Main process pid:        %s
 Version:                 2.0.0.beta.7
 VCS revision:            git revision
 Python version:          3.6.8
@@ -484,7 +488,7 @@ ServerHost:              test_machine
 Compression algorithm:   deflate
 Compression level:       9
 
-View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%3D%27test_machine%27
+View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%%3D%%27test_machine%%27
 
 
 Agent configuration:
@@ -534,7 +538,10 @@ Running monitors:
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
-"""
+""" % (
+            os.getpid()
+        )
+
         self.assertEquals(expected_output, output.getvalue())
 
     def test_bad_copy_response(self):
@@ -560,6 +567,7 @@ Failed monitors:
 
 Current time:            Fri Sep  5 23:14:13 2014 UTC
 Agent started at:        Thu Sep  4 23:14:13 2014 UTC
+Main process pid:        %s
 Version:                 2.0.0.beta.7
 VCS revision:            git revision
 Python version:          3.6.8
@@ -569,7 +577,7 @@ ServerHost:              test_machine
 Compression algorithm:   deflate
 Compression level:       9
 
-View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%3D%27test_machine%27
+View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%%3D%%27test_machine%%27
 
 
 Agent configuration:
@@ -620,7 +628,10 @@ Running monitors:
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
-"""
+""" % (
+            os.getpid()
+        )
+
         self.assertEquals(expected_output, output.getvalue())
 
     def test_no_health_check(self):
@@ -655,6 +666,7 @@ Failed monitors:
 
 Current time:            Fri Sep  5 23:14:13 2014 UTC
 Agent started at:        Thu Sep  4 23:14:13 2014 UTC
+Main process pid:        %s
 Version:                 2.0.0.beta.7
 VCS revision:            git revision
 Python version:          3.6.8
@@ -664,7 +676,7 @@ ServerHost:              test_machine
 Compression algorithm:   deflate
 Compression level:       9
 
-View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%3D%27test_machine%27
+View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%%3D%%27test_machine%%27
 
 
 Agent configuration:
@@ -719,7 +731,9 @@ Running monitors:
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
-"""
+""" % (
+            os.getpid()
+        )
 
         if platform.system() == "Windows":
             # On Windows keys are not case sensitive and get upper cased
@@ -744,6 +758,7 @@ Failed monitors:
 
 Current time:            Fri Sep  5 23:14:13 2014 UTC
 Agent started at:        Thu Sep  4 23:14:13 2014 UTC
+Main process pid:        %s
 Version:                 2.0.0.beta.7
 VCS revision:            git revision
 Python version:          3.6.8
@@ -753,7 +768,7 @@ ServerHost:              test_machine
 Compression algorithm:   deflate
 Compression level:       9
 
-View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%3D%27test_machine%27
+View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%%3D%%27test_machine%%27
 
 
 Agent configuration:
@@ -804,7 +819,9 @@ Running monitors:
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
-"""
+""" % (
+            os.getpid()
+        )
 
         self.assertEquals(expected_output, output.getvalue())
 
@@ -897,6 +914,7 @@ Failed monitors:
 
 Current time:            Fri Sep  5 23:14:13 2014 UTC
 Agent started at:        Thu Sep  4 23:14:13 2014 UTC
+Main process pid:        %s
 Version:                 2.0.0.beta.7
 VCS revision:            git revision
 Python version:          3.6.8
@@ -906,7 +924,7 @@ ServerHost:              test_machine
 Compression algorithm:   deflate
 Compression level:       9
 
-View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%3D%27test_machine%27
+View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%%3D%%27test_machine%%27
 
 
 Agent configuration:
@@ -1000,7 +1018,10 @@ Running monitors:
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
-"""
+""" % (
+            os.getpid()
+        )
+
         if platform.system() == "Windows":
             # On Windows keys are not case sensitive and get upper cased
             expected_output = expected_output.replace(
@@ -1014,6 +1035,9 @@ Failed monitors:
 
         self.status.copying_manager_status.workers.remove(self.worker2)
 
+        self.status.copying_manager_status.get_all_worker_pids = mock.Mock()
+        self.status.copying_manager_status.get_all_worker_pids.return_value = [3, 4]
+
         self.status.copying_manager_status.calculate_status()
 
         report_status(output, self.status, self.time)
@@ -1022,6 +1046,8 @@ Failed monitors:
 
 Current time:            Fri Sep  5 23:14:13 2014 UTC
 Agent started at:        Thu Sep  4 23:14:13 2014 UTC
+Main process pid:        %s
+Worker processes pids:   3, 4
 Version:                 2.0.0.beta.7
 VCS revision:            git revision
 Python version:          3.6.8
@@ -1031,7 +1057,7 @@ ServerHost:              test_machine
 Compression algorithm:   deflate
 Compression level:       9
 
-View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%3D%27test_machine%27
+View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%%3D%%27test_machine%%27
 
 
 Agent configuration:
@@ -1102,7 +1128,10 @@ Running monitors:
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
-"""
+""" % (
+            os.getpid()
+        )
+
         if platform.system() == "Windows":
             # On Windows keys are not case sensitive and get upper cased
             expected_output = expected_output.replace(
@@ -1116,6 +1145,9 @@ Failed monitors:
 
         self.worker2.sessions.remove(self.session2_2)
 
+        self.status.copying_manager_status.get_all_worker_pids = mock.Mock()
+        self.status.copying_manager_status.get_all_worker_pids.return_value = [3, 4]
+
         self.status.copying_manager_status.calculate_status()
 
         report_status(output, self.status, self.time)
@@ -1124,6 +1156,8 @@ Failed monitors:
 
 Current time:            Fri Sep  5 23:14:13 2014 UTC
 Agent started at:        Thu Sep  4 23:14:13 2014 UTC
+Main process pid:        %s
+Worker processes pids:   3, 4
 Version:                 2.0.0.beta.7
 VCS revision:            git revision
 Python version:          3.6.8
@@ -1133,7 +1167,7 @@ ServerHost:              test_machine
 Compression algorithm:   deflate
 Compression level:       9
 
-View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%3D%27test_machine%27
+View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%%3D%%27test_machine%%27
 
 
 Agent configuration:
@@ -1216,7 +1250,10 @@ Running monitors:
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
-"""
+""" % (
+            os.getpid()
+        )
+
         if platform.system() == "Windows":
             # On Windows keys are not case sensitive and get upper cased
             expected_output = expected_output.replace(
@@ -1242,6 +1279,7 @@ Failed monitors:
 
 Current time:            Fri Sep  5 23:14:13 2014 UTC
 Agent started at:        Thu Sep  4 23:14:13 2014 UTC
+Main process pid:        %s
 Version:                 2.0.0.beta.7
 VCS revision:            git revision
 Python version:          3.6.8
@@ -1251,7 +1289,7 @@ ServerHost:              test_machine
 Compression algorithm:   deflate
 Compression level:       9
 
-View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%3D%27test_machine%27
+View data from this agent at: https://www.scalyr.com/events?filter=$serverHost%%3D%%27test_machine%%27
 
 
 Agent configuration:
@@ -1347,7 +1385,10 @@ Running monitors:
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
-"""
+""" % (
+            os.getpid()
+        )
+
         if platform.system() == "Windows":
             # On Windows keys are not case sensitive and get upper cased
             expected_output = expected_output.replace(


### PR DESCRIPTION
This pull request includes two changes.

## 1. Update agent status to include process id of the main agent process and also children worker processes (when configured with multiple workers)

This should make building various 3rd party monitoring / similar scripts on top of agent status output easier (technically pid file for main process is available via other means, but it's located in /var/log/scalyr-agent-2/agent.pid which is really not a standard location for pid files, pid files should really live in /var/run or similar).

Before:

```bash
Scalyr Agent status.  See https://www.scalyr.com/help/scalyr-agent-2 for help

Current time:            Fri Sep  5 23:14:13 2014 UTC
Agent started at:        Thu Sep  4 23:14:13 2014 UTC
Version:                 2.0.0.beta.7
VCS revision:            git revision
Python version:          3.6.8
....
````

After:

```bash
Scalyr Agent status.  See https://www.scalyr.com/help/scalyr-agent-2 for help

Current time:            Fri Sep  5 23:14:13 2014 UTC
Agent started at:        Thu Sep  4 23:14:13 2014 UTC
Main process pid:        1557010
Worker processes pids:   3, 4
Version:                 2.0.0.beta.7
VCS revision:            git revision
Python version:          3.6.8
```

## 2. Fix a bug and ensure we don't emit warnings in the agent status output

We had similar "regression" many times in the past already. Part of the problem is that the whole logic to determine if warnings should be emitted or not when config is parsed is not the best and it's also hard to add test cases which would catch all those scenarios (since a lot of those warnings are only emitted when specific config options are set).

This pull request fixes that and makes sure two of the recently added warnings are not included in the agent status output (status should be machinable parsable and emitting warnings breaks that - it was also included in the JSON output).

Before:

```bash
2021-02-06 12:53:33.856Z WARNING [core] [configuration.py:3234] The configuration option use_multiprocess_copying_workers is deprecated, use use_multiprocess_workers instead.
2021-02-06 12:53:33.857Z WARNING [core] [configuration.py:531] "k8s_logs" config options is defined, but Kubernetes monitor is not configured / enabled. That config option applies to Kubernetes monitor so for it to have an affect, Kubernetes monitor needs to be enabled and configured
Scalyr Agent status.  See https://www.scalyr.com/help/scalyr-agent-2 for help

Current time:            Sat Feb  6 12:53:33 2021 UTC
Agent started at:        Sat Feb  6 12:53:33 2021 UTC
```

After:

```bash
Scalyr Agent status.  See https://www.scalyr.com/help/scalyr-agent-2 for help

Current time:            Sat Feb  6 12:53:33 2021 UTC
Agent started at:        Sat Feb  6 12:53:33 2021 UTC
```