### PR TITLE
Add sample systemd service config file for the agent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -745,6 +745,13 @@ commands:
             i=0
             until [ "$i" -ge ${max_attempts} ]; do
                 echo "Running tests command"
+
+                # On subsequent runs we enable VERBOSE flag to perhaps make
+                # troubleshooting easier
+                if [ "${i}" -ge 1 ]; then
+                    export VERBOSE="true"
+                fi
+
                 ./scripts/circleci/run-ami-tests-in-bg.sh << parameters.test_type >>
                 exit_code=$?
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Packaged by Arthur Kamalov <arthur@scalyr.com> on Jan 29, 2021 14:00 -0800
 Improvements:
 * Add ``Endpoint`` to the default ``event_object_filter`` values for the Kubernetes Event Monitor.
 * Update ``scalyr-agent-2 status -v`` output to also include process id (pid) of the main agent process and children worker processes in scenarios where the agent is configured with multiple worker processes.
+* Add a new experimental ``--systemd-managed`` flag to the ``scalyr-agent-2-config`` tool which converts existing scalyr agent installation to be managed by systemd instead of init.d.
 
 Bug fixes:
 * Fix ``scalyr-agent-status -v`` to not emit / print warnings under some edge cases.

--- a/examples/systemd/scalyr-agent-2.service
+++ b/examples/systemd/scalyr-agent-2.service
@@ -1,0 +1,60 @@
+# This file contains sample systemd config file for the scalyr agent.
+#
+# It can be used / installed with the following commands:
+#
+# sudo touch /etc/systemd/system/scalyr-agent-2.service
+# sudo chmod 664 /etc/systemd/system/scalyr-agent-2.service
+#
+# Add the content bellow to /etc/systemd/system/scalyr-agent-2.service file
+#
+# reload systemd configs:
+#
+# sudo systemctl daemon-reload
+#
+# You can then use standard systemd commands to control the agent service.
+#
+# 1. sudo systemctl enable scalyr-agent-2 - make sure agent starts on boot
+# 2. sudo systemctl start scalyr-agent-2 - start the service
+# 3. sudo systemctl restart scalyr-agent-2 - restart the service
+# 4. sudo journalctl -f -u scalyr-agent-2 - view service logs
+#
+# All the agent info level logs will also be managed via journald (in addition to being it available
+# in the usual location at /var/log/scalyr-agent-2/agent.json) which means you can use journalctl
+# comamnd to view / tail main agent.info log file
+#
+# sudo journalctl -f -u scalyr-agent-2
+#
+# You also need to remove symlinks which are used by init.d to start the service on boot.
+#
+# On Debian systems with update-rc.d:
+#
+# sudo update-rc.d -f scalyr-agent-2 remove
+#
+# On RHEL systems with chkconfig:
+#
+# sudo chkconfig --del scalyr-agent-2
+#
+# On other systems without chkconfig or update-rc.d:
+#
+# sudo rm /etc/rc{0,1,6}/K02scalyr-agent-2
+# sudo rm /etc/rc{2,3,4,5}/S98scalyr-agent-2
+#
+# Keep in mind that you will need to run those steps each time agent is upgraded since our
+# post install script creates that symlink.
+#
+# In the future we plan to ship distribution specific packages when systemd will be configured
+# out of the box on supported distros and those manual commands won't be needed.
+#
+
+[Unit]
+Description=Scalyr Monitoring Agent
+
+[Service]
+# NOTE: Type=forking doesn't seem to be working correctly, bit usually "don't fork" behavior is more common since
+# it means logs also go to journald, etc. and it behaves more like a proper systemd service
+Type=simple
+ExecStart=/usr/share/scalyr-agent-2/bin/scalyr-agent-2 start --no-fork
+ExecStop=/usr/share/scalyr-agent-2/bin/scalyr-agent-2 stop
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/systemd/scalyr-agent-2.service
+++ b/examples/systemd/scalyr-agent-2.service
@@ -45,7 +45,6 @@
 # In the future we plan to ship distribution specific packages when systemd will be configured
 # out of the box on supported distros and those manual commands won't be needed.
 #
-
 [Unit]
 Description=Scalyr Monitoring Agent
 

--- a/scalyr_agent/config_main.py
+++ b/scalyr_agent/config_main.py
@@ -37,6 +37,7 @@ import tarfile
 import tempfile
 import traceback
 import errno
+import itertools
 from io import open
 
 from optparse import OptionParser
@@ -80,9 +81,25 @@ from scalyr_agent.scalyr_client import ScalyrClientSession
 from scalyr_agent.configuration import Configuration
 from scalyr_agent.platform_controller import PlatformController
 from scalyr_agent import compat
+from scalyr_agent.util import run_command_popen
 
 from scalyr_agent.util import win_remove_user_file_path_permissions
 import scalyr_agent.util as scalyr_util
+
+SYSTEMD_SERVICE_CONFGI = """
+[Unit]
+Description=Scalyr Monitoring Agent
+
+[Service]
+# NOTE: Type=forking doesn't seem to be working correctly, bit usually "don't fork" behavior is more common since
+# it means logs also go to journald, etc. and it behaves more like a proper systemd service
+Type=simple
+ExecStart=/usr/share/scalyr-agent-2/bin/scalyr-agent-2 start --no-fork
+ExecStop=/usr/share/scalyr-agent-2/bin/scalyr-agent-2 stop
+
+[Install]
+WantedBy=multi-user.target
+""".strip()
 
 
 def set_api_key(config, config_file_path, new_api_key):
@@ -1233,6 +1250,119 @@ def set_python_version(version):
     )
 
 
+def configure_agent_service_for_systemd_management():
+    """
+    Configure this Linux agent installation to be managed by systemd instead of init.d which is the
+    default.
+
+    This method performs the following:
+
+        - Copies over systemd service files
+        - Removes any rc.d symlinks (if any exist)
+        - Writes a special file which tells the installer that the installation is systemd managed
+    """
+    if os.getuid() != 0:
+        raise ValueError("This commands needs to run as root")
+
+    # 1. Copy over systemd service file
+    # NOTE: We use the file content in line to avoid potential issue with different type of
+    # installations and file maybe not already be present in /usr/share or similar
+
+    systemd_service_config_file_path = "/etc/systemd/system/scalyr-agent-2.service"
+
+    with open(systemd_service_config_file_path, "w") as fp:
+        fp.write(SYSTEMD_SERVICE_CONFGI)
+
+    os.chmod(systemd_service_config_file_path, int("664", 8))
+
+    # 2. Remove any existing rc.d symlinks via chkconfig, update-rc.d and in the end regular
+    # symlinks (if any of those are available)
+    chkconfig_binary_path = compat.which("chkconfig")
+    update_rcd_binary_path = compat.which("update-rc.d")
+
+    if chkconfig_binary_path:
+        print("Removing rc.d symlinks using chkconfig")
+        exit_code, stdout, stderr = run_command_popen(
+            "chkconfig --del scalyr-agent-2", shell=True
+        )
+
+        if exit_code != 0:
+            print("Failed to remove symlinks via chkconfig")
+            print("stdout: %s" % (stdout))
+            print("stderr: %s" % (stderr))
+    elif update_rcd_binary_path:
+        print("Removing rc.d symlinks using update-rc.d")
+
+        exit_code, stdout, stderr = run_command_popen(
+            "update-rc.d -f scalyr-agent-2 remove", shell=True
+        )
+
+        if exit_code != 0:
+            print("Failed to remove symlinks via update-rc.d")
+            print("stdout: %s" % (stdout))
+            print("stderr: %s" % (stderr))
+
+    rc_d_paths_1 = [
+        "/etc/rc0.d/K02scalyr-agent-2"
+        "/etc/rc1.d/K02scalyr-agent-2"
+        "/etc/rc6.d/K02scalyr-agent-2"
+    ]
+
+    rc_d_paths_2 = [
+        "/etc/rc2.d/S98scalyr-agent-2"
+        "/etc/rc3.d/S98scalyr-agent-2"
+        "/etc/rc4.d/S98scalyr-agent-2"
+        "/etc/rc5.d/S98scalyr-agent-2"
+    ]
+
+    # 2. Remove any existing init.d symlinks to ensure service is not managed twice (once by init.d
+    # aod once by systemd)
+    for file_path in itertools.chain(rc_d_paths_1, rc_d_paths_2):
+        if os.path.isfile(file_path):
+            print('Removing rc.d file "%s"' % (file_path))
+            os.unlink(file_path)
+
+    # 3. Create a file which tells agent post install that this installation is systemd managed so
+    # post install script won't create any init symlinks
+    # If user wants to move back to init.d service management, they simply need to remove this file
+    # and re-install or upgrade the agent package
+    systemd_managed_file_path = "/etc/scalyr-agent-2/systemd_managed"
+
+    with open(systemd_managed_file_path, "w") as _:
+        pass
+
+    # 4. Reload systemd configs
+    systemctl_binary = compat.which("systemctl")
+
+    if systemctl_binary:
+        run_command_popen("systemctl daemon-reload", shell=True)
+
+    print(
+        "This agent installation has been configured to be managed by systemd and systemd "
+        'service config installed to "%s". ' % (systemd_service_config_file_path)
+    )
+    print("")
+    print(
+        "You can now use standard systemd commands to manage the service. For example:"
+    )
+    print("")
+    print("sudo systemctl status scalyr-agent-2 - view the service status")
+    print(
+        "sudo systemctl enable scalyr-agent-2 - enable the service so it starts on boot"
+    )
+    print("sudo systemctl start scalyr-agent-2 - start the service")
+    print("sudo systemctl stop scalyr-agent-2 - stop the service")
+    print("sudo systemctl restart scalyr-agent-2 - restart the service")
+    print("sudo journalctl -f -u scalyr-agent-2 - tail the service logs via journald")
+    print("")
+    print(
+        "If you wish to revert back to init.d approach, you need to delete %s and %s file, "
+        "reload systemd configs and re-install scalyr-agent-2 package which will cause init.d "
+        "symlinks to be created again."
+        % (systemd_service_config_file_path, systemd_managed_file_path)
+    )
+
+
 if __name__ == "__main__":
     parser = OptionParser(usage="Usage: scalyr-agent-2-config [options]")
     parser.add_option(
@@ -1432,23 +1562,34 @@ if __name__ == "__main__":
             help="Starts the agent if the conditional restart file marker exists.",
         )
 
-        if sys.platform.startswith("win"):
-            # Special flag which is used by the Windows installer. We use it to indicate to this binary
-            # to fix up permissions for agent.json file and agent.d/ directory. This file is also used
-            # to create initial config by the install which means we can't correctly set those
-            # permissions inside the .wxs wix spec file.
-            # Right now it can only be used with "--init-config" flag on Windows.
-            parser.add_option(
-                "",
-                "--fix-config-permissions",
-                dest="fix_config_permissions",
-                action="store_true",
-                default=False,
-                help=(
-                    "Fix permissions for agent.json file and agent.d/ directory and make sure it's. "
-                    "not readable by others. Applies to Windows only."
-                ),
-            )
+        # Special flag which is used by the Windows installer. We use it to indicate to this binary
+        # to fix up permissions for agent.json file and agent.d/ directory. This file is also used
+        # to create initial config by the install which means we can't correctly set those
+        # permissions inside the .wxs wix spec file.
+        # Right now it can only be used with "--init-config" flag on Windows.
+        parser.add_option(
+            "",
+            "--fix-config-permissions",
+            dest="fix_config_permissions",
+            action="store_true",
+            default=False,
+            help=(
+                "Fix permissions for agent.json file and agent.d/ directory and make sure it's. "
+                "not readable by others. Applies to Windows only."
+            ),
+        )
+
+    # Add Linux specific options
+    if sys.platform.startswith("linux"):
+        parser.add_option(
+            "",
+            "--systemd-managed",
+            dest="systemd_managed",
+            action="store_true",
+            default=False,
+            help="Configure the agent to be managed by systemd instead of init.d which is a default",
+        )
+
     (options, args) = parser.parse_args()
     if len(args) > 1:
         print("Could not parse commandline arguments.", file=sys.stderr)
@@ -1469,6 +1610,10 @@ if __name__ == "__main__":
     # NOTE: This option is also intentionally at the top for the same reasons as `set_python`.
     if options.report_python_version:
         print("The Scalyr Agent is using Python %s" % platform.python_version())
+        sys.exit(0)
+
+    if options.systemd_managed:
+        configure_agent_service_for_systemd_management()
         sys.exit(0)
 
     if options.config_filename is None:

--- a/scalyr_agent/config_main.py
+++ b/scalyr_agent/config_main.py
@@ -1264,6 +1264,14 @@ def configure_agent_service_for_systemd_management():
     if os.getuid() != 0:
         raise ValueError("This commands needs to run as root")
 
+    systemctl_binary = compat.which("systemctl")
+
+    if not systemctl_binary:
+        raise ValueError(
+            "Unable to find systemctl binary, this likely indicates systemd is not "
+            "installed"
+        )
+
     # 1. Copy over systemd service file
     # NOTE: We use the file content in line to avoid potential issue with different type of
     # installations and file maybe not already be present in /usr/share or similar

--- a/scalyr_agent/config_main.py
+++ b/scalyr_agent/config_main.py
@@ -1612,7 +1612,7 @@ if __name__ == "__main__":
         print("The Scalyr Agent is using Python %s" % platform.python_version())
         sys.exit(0)
 
-    if options.systemd_managed:
+    if sys.platform.startswith("linux") and options.systemd_managed:
         configure_agent_service_for_systemd_management()
         sys.exit(0)
 

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -434,6 +434,7 @@ def main(
 
     rendered_template = render_script_template(
         script_template=script_content,
+        distro_name=distro,
         distro_details=distro_details,
         python_package=python_package,
         test_type=test_type,
@@ -568,6 +569,7 @@ def main(
 
 def render_script_template(
     script_template,
+    distro_name,
     distro_details,
     python_package,
     test_type,
@@ -577,14 +579,14 @@ def render_script_template(
     additional_packages=None,
     verbose=False,
 ):
-    # type: (str, dict, str, str, Optional[Dict], Optional[Dict], Optional[Dict], Optional[str], bool) -> str
+    # type: (str, str, dict, str, str, Optional[Dict], Optional[Dict], Optional[Dict], Optional[str], bool) -> str
     """
     Render the provided script template with common context.
     """
     # from_version = from_version or ""
     # to_version = to_version or ""
-
     template_context = distro_details.copy()
+    template_context["distro_name"] = distro_name
 
     template_context["test_type"] = test_type
 

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -227,6 +227,8 @@ SECURITY_GROUPS = SECURITY_GROUPS_STR.split(",")  # type: List[str]
 
 SCALYR_API_KEY = get_env_throw_if_not_set("SCALYR_API_KEY")
 
+VERBOSE = compat.os_environ_unicode.get("VERBOSE", "false").lower() == "true"
+
 # All the instances created by this script will use this string in the name.
 INSTANCE_NAME_STRING = "-automated-agent-tests-"
 assert "-tests-" in INSTANCE_NAME_STRING
@@ -750,7 +752,7 @@ if __name__ == "__main__":
             "True to enable verbose mode where every executed shell command is logged."
         ),
         action="store_true",
-        default=False,
+        default=VERBOSE,
     )
     parser.add_argument(
         "--no-destroy-node",

--- a/tests/ami/scripts/partial/ssl_checks.sh.j2
+++ b/tests/ami/scripts/partial/ssl_checks.sh.j2
@@ -162,6 +162,7 @@ sudo curl -o /tmp/ca_certs.crt https://raw.githubusercontent.com/scalyr/scalyr-a
 echo_with_date ""
 echo_with_date "Verifying agent status output"
 echo_with_date ""
+sleep 5
 STATUS_OUTPUT=$(sudo scalyr-agent-2 status -v)
 echo -e "${STATUS_OUTPUT}"
 echo_with_date ""

--- a/tests/ami/scripts/test_deb.sh.j2
+++ b/tests/ami/scripts/test_deb.sh.j2
@@ -239,3 +239,41 @@ echo_with_date ""
 {% endif -%}
 
 {% include "partial/ssl_checks.sh.j2" %}
+
+# Verify --systemd-managed flag
+# TODO: Also test on stable once v2.1.19 is out
+{% if test_type == "upgrade" and distro_name == "debian1003" -%}
+sudo cp agent.json /etc/scalyr-agent-2/agent.json
+
+{% include "partial/restart_agent_and_remove_logs.sh.j2" %}
+
+echo_with_date ""
+echo_with_date "Verifying --systemd-managed flag"
+echo_with_date ""
+
+sudo scalyr-agent-2-config --systemd-managed
+
+# Verify rc*.d symlinks have been removed
+echo_with_date ""
+echo_with_date "Verifying rc.d symlinks have been removed"
+echo_with_date ""
+
+ls -la /etc/rc*.d/
+echo_with_date ""
+ls -la /etc/rc*.d/ | grep scalyr-agent | wc -l | grep 0
+
+# Verify systemd service config file is present
+echo_with_date ""
+echo_with_date "Verifying .service file is in place"
+echo_with_date ""
+
+ls -la /etc/systemd/system/scalyr-agent-2.service
+cat /etc/systemd/system/scalyr-agent-2.service
+
+echo_with_date ""
+echo_with_date "Verifying service has been installed"
+echo_with_date ""
+
+sudo systemctl status scalyr-agent-2 || true
+sudo systemctl status scalyr-agent-2 | grep "loaded"
+{% endif -%}

--- a/tests/ami/scripts/test_rpm.sh.j2
+++ b/tests/ami/scripts/test_rpm.sh.j2
@@ -275,5 +275,6 @@ echo_with_date ""
 echo_with_date "Verifying service has been installed"
 echo_with_date ""
 
-sudo systemctl status scalyr-agent-2
+sudo systemctl status scalyr-agent-2 || true
+sudo systemctl status scalyr-agent-2 | grep "loaded"
 {% endif -%}

--- a/tests/ami/scripts/test_rpm.sh.j2
+++ b/tests/ami/scripts/test_rpm.sh.j2
@@ -244,6 +244,10 @@ echo_with_date ""
 # Verify --systemd-managed flag
 # TODO: Also test on stable once v2.1.19 is out
 {% if test_type == "upgrade" and distro_name == "centos8" -%}
+sudo cp agent.json /etc/scalyr-agent-2/agent.json
+
+{% include "partial/restart_agent_and_remove_logs.sh.j2" %}
+
 echo_with_date ""
 echo_with_date "Verifying --systemd-managed flag"
 echo_with_date ""

--- a/tests/ami/scripts/test_rpm.sh.j2
+++ b/tests/ami/scripts/test_rpm.sh.j2
@@ -240,3 +240,36 @@ echo_with_date ""
 {% endif -%}
 
 {% include "partial/ssl_checks.sh.j2" %}
+
+# Verify --systemd-managed flag
+# TODO: Also test on stable once v2.1.19 is out
+{% if test_type == "upgrade" and distro_name == "centos8" -%}
+echo_with_date ""
+echo_with_date "Verifying --systemd-managed flag"
+echo_with_date ""
+
+sudo scalyr-agent-2-config --systemd-managed
+
+# Verify rc*.d symlinks have been removed
+echo_with_date ""
+echo_with_date "Verifying rc.d symlinks have been removed"
+echo_with_date ""
+
+ls -la /etc/rc*.d/ | grep scalyr-agent
+echo_with_date ""
+ls -la /etc/rc*.d/ | grep scalyr-agent | wc -l | grep 0
+
+# Verify systemd service config file is present
+echo_with_date ""
+echo_with_date "Verifying .service file is in place"
+echo_with_date ""
+
+ls -la /etc/systemd/system/scalyr-agent-2.service
+cat /etc/systemd/system/scalyr-agent-2.service
+
+echo_with_date ""
+echo_with_date "Verifying service has been installed"
+echo_with_date ""
+
+sudo systemctl status scalyr-agent-2
+{% endif -%}

--- a/tests/ami/scripts/test_rpm.sh.j2
+++ b/tests/ami/scripts/test_rpm.sh.j2
@@ -259,7 +259,7 @@ echo_with_date ""
 echo_with_date "Verifying rc.d symlinks have been removed"
 echo_with_date ""
 
-ls -la /etc/rc*.d/ | grep scalyr-agent
+ls -la /etc/rc*.d/
 echo_with_date ""
 ls -la /etc/rc*.d/ | grep scalyr-agent | wc -l | grep 0
 


### PR DESCRIPTION
This pull request adds a sample systemd service config file for the agent with information on how to install / use it.

The "setup process" does include some additional steps which need to be taken care of after agent install and upgrade (aka rc.d symlinks need to be manually removed on install / upgrade because they are created automatically in ``postinst`` script).

We do plan to work on distribution specific packages in the future, but that will take a while and this example config is to service as a stop gap in the mean time.

I tested various situations, including multiple worker processes and verified it works correctly.

## Proposal for a small improvement for manual init.d rc.d symlink removal on install / upgrade

As mentioned above, we do plan to ship packages which will utilize distro specific service managers such as systemd in the future, but this will take a while.

To remove burden on the end user of needing to manually clean up ``init.d`` symlinks so service is not managed twice (once by init.d and once by systemd), I propose a small change to the ``postinstall`` script - only create init.d boot symlinks if ``/etc/scalyr-agent-2/systemd_managed`` file is not present (we would then document this behavior and tell users how to use systemd if they wish to).

That change would be easy to implement and I think would serve as a good enough workaround to reduce post install cleanup burden on the end user until proper distro specific stuff is in place.