### PR TITLE
Upgrade orjson to latest stable version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,7 +22,7 @@ docker==4.1.0
 # NOTE: We can't use requests >= 2.22.0 since we still need to support Python 2.6
 requests==2.15.1
 ujson==1.35
-orjson==3.4.7; python_version >= '3.6'
+orjson==3.5.1; python_version >= '3.6'
 orjson==2.0.11; python_version == '3.5'
 # Needed by MockHTTPServer class and related tests
 flask==1.1.1

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,6 +1,6 @@
 # dependencies for docker images.
 ujson==1.35
-orjson==3.4.7; python_version >= '3.6'
+orjson==3.5.1; python_version >= '3.6'
 orjson==2.0.11; python_version == '3.5'
 yappi==1.2.3
 # the version of 'requests' library that 'docker' uses as a dependency is higher than we use in agent,

--- a/win32/windows-build-requirements.txt
+++ b/win32/windows-build-requirements.txt
@@ -1,4 +1,4 @@
 psutil==5.7.0
 pyinstaller==4.2
 pywin32==300
-orjson==3.4.7
+orjson==3.5.1

--- a/windows-unit-tests-requirements.txt
+++ b/windows-unit-tests-requirements.txt
@@ -18,7 +18,7 @@ docker==4.1.0
 # NOTE: We can't use requests >= 2.22.0 since we still need to support Python 2.6
 requests==2.15.1
 ujson==1.35
-orjson==3.4.7; python_version >= '3.6'
+orjson==3.5.1; python_version >= '3.6'
 orjson==2.0.11; python_version == '3.5'
 # Needed by MockHTTPServer class and related tests
 flask==1.1.1


### PR DESCRIPTION
This pull request updates orjson to latest stable version (https://github.com/ijl/orjson/blob/master/CHANGELOG.md).

That version includes pre-built wheels for more platforms so hopefully this will make it easier to run various tox targets locally which depend on Python libraries with C extensions (since we will be able to use wheels in more situations instead of needing to compile extensions locally).