### PR TITLE
Ensure digest on PodInfo is stable and deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ Improvements:
 * Add support for collecting some metrics Kubernetes when running in a CRI runtime.
 
 Bug fixes:
-* Ensure pod digest which we calculate and use to determine if pod info in the Kubernetes
-  monitor has  changed is deterministic and doesn't depend on dictionary item ordering.
+* Ensure pod digest which we calculate and use to determine if pod info in the Kubernetes monitor has  changed is deterministic and doesn't depend on dictionary item ordering.
 
 ## 2.1.19 "StarTram" - March 9, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Packaged by Yan Shnayder <yan@scalyr.com> on Mar 9, 2021 14:00 -0800
 Improvements:
 * Add support for collecting some metrics Kubernetes when running in a CRI runtime.
 
+Bug fixes:
+* Ensure pod digest which we calculate and use to determine if pod info in the Kubernetes
+  monitor has  changed is deterministic and doesn't depend on dictionary item ordering.
+
 ## 2.1.19 "StarTram" - March 9, 2021
 
 <!---

--- a/benchmarks/micro/test_calculate_hash_digest.py
+++ b/benchmarks/micro/test_calculate_hash_digest.py
@@ -1,0 +1,132 @@
+# Copyright 2014-2020 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import hashlib
+
+import six
+import pytest
+import orjson
+
+from scalyr_agent.monitor_utils.k8s import PodInfo
+
+
+MOCK_POD_INFO = PodInfo(
+    name="loggen-58c5486566-fdmzf",
+    namespace="default",
+    uid="5ef12d19-d8e5-4280-9cdf-a80bae251c68",
+    node_name="test-node",
+    labels={
+        "com.docker.compose.config-hash": "d90d71a3d6914cc78ee21692e36ee64f15a09481b13a312b0e04caac881b8b32",
+        "com.docker.compose.container-number": "1",
+        "com.docker.compose.oneoff": "False",
+        "com.docker.compose.project": "stackstorm",
+        "com.docker.compose.project.config_files": "docker-compose.yml",
+        "com.docker.compose.project.working_dir": "/home/user/docker-compose/stackstorm",
+        "com.docker.compose.service": "redis",
+        "com.docker.compose.version": "1.25.0",
+    },
+    container_names=["random-logger"],
+    annotations={
+        "com.docker.compose.config-hash": "d90d71a3d6914cc78ee21692e36ee64f15a09481b13a312b0e04caac881b8b32",
+        "com.docker.compose.container-number": "1",
+        "com.docker.compose.oneoff": "False",
+        "com.docker.compose.project": "stackstorm",
+        "com.docker.compose.project.config_files": "docker-compose.yml",
+        "com.docker.compose.project.working_dir": "/home/user/docker-compose/stackstorm",
+        "com.docker.compose.service": "redis",
+        "com.docker.compose.version": "1.25.0",
+    },
+    controller=None,
+)
+
+
+def _calculate_hash_digest_str_concat():
+    md5 = hashlib.md5()
+    md5.update(MOCK_POD_INFO.name.encode("utf-8"))
+    md5.update(MOCK_POD_INFO.namespace.encode("utf-8"))
+    md5.update(MOCK_POD_INFO.uid.encode("utf-8"))
+    md5.update(MOCK_POD_INFO.node_name.encode("utf-8"))
+
+    # flatten the labels dict in to a single string because update
+    # expects a string arg.  To avoid cases where the 'str' of labels is
+    # just the object id, we explicitly create a flattened string of
+    # key/value pairs
+    keys = sorted(MOCK_POD_INFO.labels.keys())
+    flattened = []
+    for key in keys:
+        flattened.append(key)
+        flattened.append(MOCK_POD_INFO.labels[key])
+    md5.update("".join(flattened).encode("utf-8"))
+
+    # flatten the container names
+    # see previous comment for why flattening is necessary
+    md5.update("".join(sorted(MOCK_POD_INFO.container_names)).encode("utf-8"))
+
+    # flatten the annotations dict in to a single string
+    # see previous comment for why flattening is necessary
+    keys = sorted(MOCK_POD_INFO.annotations.keys())
+    for key in keys:
+        flattened.append(key)
+        flattened.append(six.text_type(MOCK_POD_INFO.annotations[key]))
+
+    md5.update("".join(flattened).encode("utf-8"))
+
+    digest = md5.digest()
+    return digest
+
+
+def _calculate_hash_digest_orjson():
+    md5 = hashlib.md5()
+    md5.update(MOCK_POD_INFO.name.encode("utf-8"))
+    md5.update(MOCK_POD_INFO.namespace.encode("utf-8"))
+    md5.update(MOCK_POD_INFO.uid.encode("utf-8"))
+    md5.update(MOCK_POD_INFO.node_name.encode("utf-8"))
+
+    md5.update(orjson.dumps(MOCK_POD_INFO.labels, option=orjson.OPT_SORT_KEYS))
+
+    # flatten the container names
+    # see previous comment for why flattening is necessary
+    md5.update(orjson.dumps(MOCK_POD_INFO.container_names, option=orjson.OPT_SORT_KEYS))
+
+    md5.update(orjson.dumps(MOCK_POD_INFO.annotations, option=orjson.OPT_SORT_KEYS))
+
+    digest = md5.digest()
+    return digest
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "approach",
+    [
+        "str_concat",
+        "orjson",
+    ],
+    ids=[
+        "str_concat",
+        "orjson",
+    ],
+)
+# fmt: on
+def test_calculate_hash_digest(benchmark, approach):
+    def run_benchmark():
+        if approach == "str_concat":
+            digest = _calculate_hash_digest_str_concat()
+        else:
+            digest = _calculate_hash_digest_orjson()
+        return digest
+
+    result = benchmark.pedantic(run_benchmark, iterations=100, rounds=500)
+    assert isinstance(result, six.binary_type)

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -416,26 +416,34 @@ class PodInfo(object):
         md5.update(uid.encode("utf-8"))
         md5.update(node_name.encode("utf-8"))
 
+        # NOTE: Dictionary ordering is not guaranteed when not using OrderedDict so we need to sort
+        # them to ensure consistent and stable order and digest.
+
         # flatten the labels dict in to a single string because update
         # expects a string arg.  To avoid cases where the 'str' of labels is
         # just the object id, we explicitly create a flattened string of
         # key/value pairs
         flattened = []
-        for k, v in six.iteritems(labels):
-            flattened.append(k)
-            flattened.append(v)
+
+        labels_dict_keys = sorted(labels.keys())
+        for key in labels_dict_keys:
+            flattened.append(key)
+            flattened.append(six.text_type(labels[key]))
+
         md5.update("".join(flattened).encode("utf-8"))
 
         # flatten the container names
         # see previous comment for why flattening is necessary
-        md5.update("".join(container_names).encode("utf-8"))
+        md5.update("".join(sorted(container_names)).encode("utf-8"))
 
         # flatten the annotations dict in to a single string
         # see previous comment for why flattening is necessary
         flattened = []
-        for k, v in six.iteritems(annotations):
-            flattened.append(k)
-            flattened.append(six.text_type(v))
+
+        annotations_dict_keys = sorted(annotations.keys())
+        for key in annotations_dict_keys:
+            flattened.append(key)
+            flattened.append(six.text_type(annotations[key]))
 
         md5.update("".join(flattened).encode("utf-8"))
 


### PR DESCRIPTION
This pull request addresses issue described here - https://github.com/scalyr/scalyr-agent-2/pull/725#discussion_r596725698.

That PodInfo digest code relied on dictionary item ordering which is not guaranteed to be deterministic and stable in Python. 

This mean that in some situations when different dictionary ordering for the same values is used, code would incorrectly assume that the pod information has changed which would have caused unnecessary log config and log watcher churn (but it shouldn't have any other negative implications besides that potential overhead).