### PR TITLE
CT-384: Downgrade missing pod exception to a debug log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Improvements:
 Bug fixes:
 * Ensure pod digest which we calculate and use to determine if pod info in the Kubernetes monitor has  changed is deterministic and doesn't depend on dictionary item ordering.
 
+Other:
+* Changed the logging level of "not found" errors while querying pods from the Kubernetes API from ERROR to DEBUG, as these errors are always transient and result in no data loss.
+
 ## 2.1.19 "StarTram" - March 9, 2021
 
 <!---

--- a/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
@@ -830,7 +830,11 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
                                         global_log.log(
                                             scalyr_logging.DEBUG_LEVEL_1,
                                             "Failed to process single k8s event line due to following exception: %s, %s, %s"
-                                            % (repr(e), six.text_type(e), traceback.format_exc()),
+                                            % (
+                                                repr(e),
+                                                six.text_type(e),
+                                                traceback.format_exc(),
+                                            ),
                                         )
                                         continue
                                     if pod and pod.controller:

--- a/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
@@ -819,12 +819,20 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
                                 if kind == "Pod":
                                     extra_fields["pod_name"] = name
                                     extra_fields["pod_namespace"] = namespace
-                                    pod = k8s_cache.pod(
-                                        namespace,
-                                        name,
-                                        current_time,
-                                        query_options=k8s_events_query_options,
-                                    )
+                                    try:
+                                        pod = k8s_cache.pod(
+                                            namespace,
+                                            name,
+                                            current_time,
+                                            query_options=k8s_events_query_options,
+                                        )
+                                    except k8s_utils.K8sApiNotFoundException as e:
+                                        global_log.log(
+                                            scalyr_logging.DEBUG_LEVEL_1,
+                                            "Failed to process single k8s event line due to following exception: %s, %s, %s"
+                                            % (repr(e), six.text_type(e), traceback.format_exc()),
+                                        )
+                                        continue
                                     if pod and pod.controller:
                                         extra_fields[
                                             "k8s-controller"


### PR DESCRIPTION
This error occurs if the Kubernetes events API returns an event for a pod that is already gone, common if the agent is restarted, this does not affect us in any meaningful way and goes away on its own but makes a big red error for the user. This PR will make that error only get logged as a debug log to not spook anybody.