### PR TITLE
CT-394, CT-395: Fix repeating and missing logs when get_containers is unstable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Scalyr Agent 2 Changes By Release
 Packaged by Arthur Kamalov <arthur@scalyr.com> on Apr 30, 2021 21:00 -0800
 --->
 
+Bug fixes:
+* Fix an issue where log lines may be duplicated or lost in the Kubernetes monitor when running under CRI with an unstable connection to the K8s API.
+
 Other:
 * Agent now emits a warning if running under Python 2.6 which we will stop supporting in the next release or Python 2.7 which we will stop supporting in the near future.
 

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -2300,6 +2300,7 @@ class CRIEnumerator(ContainerEnumerator):
                 limit_once_per_x_secs=300,
                 limit_key="query-cri-containers",
             )
+            return None
         return result
 
     def _get_containers_from_filesystem(self, k8s_namespaces_to_include):
@@ -3032,7 +3033,7 @@ class ContainerChecker(object):
         for log in docker_logs:
             if self.__log_watcher:
                 log["log_config"] = self.__log_watcher.add_log_config(
-                    self.__module.module_name, log["log_config"]
+                    self.__module.module_name, log["log_config"], force_add=True
                 )
 
             self.raw_logs.append(log)


### PR DESCRIPTION
This PR does two things:
1. Changes the return value of get_containers in the CRIEnumerator on error to `None`, which matches the Docker enumerator and is something we expect for error handling.
2. Enables `force_add` in the k8s monitor when adding new tracked logs. This is needed in case we lose and find logs in rapid succession which may happen with when get_containers fails. (With change #1 I guess it actually won't happen, it would be an extra layer of protection in case there are other routes to reach this scenario.)