### PR TITLE
Don't emit EOL warning under Python 2.7 yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Bug fixes:
 * Fix an issue where log lines may be duplicated or lost in the Kubernetes monitor when running under CRI with an unstable connection to the K8s API.
 
 Other:
-* Agent now emits a warning if running under Python 2.6 which we will stop supporting in the next release or Python 2.7 which we will stop supporting in the near future.
+* Agent now emits a warning if running under Python 2.6 which we will stop supporting in the next release.
 
 ## 2.1.20 "Tabeisshi" - April 19, 2021
 

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -75,7 +75,6 @@ from scalyr_agent.json_lib import JsonParseException
 from scalyr_agent.platform_controller import CannotExecuteAsUser
 from scalyr_agent.build_info import get_build_revision
 from scalyr_agent.compat import PY26
-from scalyr_agent.compat import PY27
 
 
 # Use sha1 from hashlib (Python 2.5 or greater) otherwise fallback to the old sha module.
@@ -214,10 +213,11 @@ def warn_on_old_or_unsupported_python_version():
 
         scalyr_agent.scalyr_logging.getLogger(__name__).warn(PYTHON26_EOL_WARNING)
 
-    if PY27:
-        import scalyr_agent.scalyr_logging
 
-        scalyr_agent.scalyr_logging.getLogger(__name__).warn(PYTHON27_EOL_WARNING)
+# if PY27:
+#     import scalyr_agent.scalyr_logging
+#
+#     scalyr_agent.scalyr_logging.getLogger(__name__).warn(PYTHON27_EOL_WARNING)
 
 
 def get_json_implementation(lib_name):


### PR DESCRIPTION
As discussed, we don't want to emit an EOL warning when running agent under Python 2.7 just yet.