### PR TITLE
Reformat code with latest version of black

### DIFF
--- a/.circleci/circleci_cli.py
+++ b/.circleci/circleci_cli.py
@@ -82,7 +82,9 @@ def set_env_variables_from_config():
     This function gets those settings and add them as "-e <VAR_NAME>=<VAR_VALUE> to the current circleci command."
     """
     test_config_path = os.path.join(
-        os.path.dirname(os.path.dirname(_script_abs_path)), "tests", "config.yml",
+        os.path.dirname(os.path.dirname(_script_abs_path)),
+        "tests",
+        "config.yml",
     )
 
     if not os.path.exists(test_config_path):

--- a/.circleci/modernize/custom_fixers/fix_os_getenv_unicode.py
+++ b/.circleci/modernize/custom_fixers/fix_os_getenv_unicode.py
@@ -4,10 +4,10 @@ import libmodernize
 
 class FixOsGetenvUnicode(BaseFix):
     """
-        This fixer searches for places where we calling os.getenv,
-        and replaces them with 'scalyr_agent.compat.os_getenv_unicode'.
-        This is needed because os.getenv returns 'str' in python2 and we need unicode.
-        """
+    This fixer searches for places where we calling os.getenv,
+    and replaces them with 'scalyr_agent.compat.os_getenv_unicode'.
+    This is needed because os.getenv returns 'str' in python2 and we need unicode.
+    """
 
     BM_compatible = True
     PATTERN = """

--- a/.circleci/modernize/custom_fixers/fix_struct_unicode.py
+++ b/.circleci/modernize/custom_fixers/fix_struct_unicode.py
@@ -4,10 +4,10 @@ import libmodernize
 
 class FixStructUnicode(BaseFix):
     """
-        This fixer searches for places where we are calling struct.pack or struct.unpack,
-        and replaces them with 'scalyr_agent.compat.struct_pack' or struct_unpack.
-        This is needed because struct library does not allow unicode format strings.
-        """
+    This fixer searches for places where we are calling struct.pack or struct.unpack,
+    and replaces them with 'scalyr_agent.compat.struct_pack' or struct_unpack.
+    This is needed because struct library does not allow unicode format strings.
+    """
 
     BM_compatible = True
     PATTERN = """

--- a/build_package.py
+++ b/build_package.py
@@ -252,7 +252,8 @@ def build_win32_installer_package(variant, version):
     shutil.copy(convert_path("scalyr_agent/__scalyr__.py"), "__scalyr__.py")
     shutil.copy(make_path(agent_source_root, "VERSION"), "VERSION")
     shutil.copy(
-        make_path(agent_source_root, "VERSION"), convert_path("scalyr_agent/VERSION"),
+        make_path(agent_source_root, "VERSION"),
+        convert_path("scalyr_agent/VERSION"),
     )
 
     shutil.copytree(make_path(agent_source_root, "monitors"), "monitors")
@@ -297,7 +298,9 @@ def build_win32_installer_package(variant, version):
     # Copy the config file.
     agent_json_path = make_path(agent_source_root, "config/agent.json")
     cat_files(
-        [agent_json_path], "agent_config.tmpl", convert_newlines=True,
+        [agent_json_path],
+        "agent_config.tmpl",
+        convert_newlines=True,
     )
     # NOTE: We in intentionally set this permission bit for agent.json to make sure it's not
     # readable by others.
@@ -1387,7 +1390,10 @@ def run_command(command_str, exit_on_fail=True, fail_quietly=False, command_name
             if command_name is not None:
                 print(
                     "Executing %s failed and returned a non-zero result of %d"
-                    % (command_name, return_code,),
+                    % (
+                        command_name,
+                        return_code,
+                    ),
                     file=sys.stderr,
                 )
             else:
@@ -1504,7 +1510,11 @@ def create_change_logs():
             print_release_notes(fp, release["notes"], ["  * ", "   - ", "     + "])
             print(
                 " -- %s <%s>  %s"
-                % (release["packager"], release["packager_email"], date_str,),
+                % (
+                    release["packager"],
+                    release["packager_email"],
+                    date_str,
+                ),
                 file=fp,
             )
     finally:
@@ -1874,7 +1884,10 @@ if __name__ == "__main__":
         set_build_info(options.build_info)
 
     artifact = build_package(
-        args[0], options.variant, options.no_versioned_file_name, options.coverage,
+        args[0],
+        options.variant,
+        options.no_versioned_file_name,
+        options.coverage,
     )
     print("Built %s" % artifact)
     sys.exit(0)

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,5 +1,5 @@
 # This file contains requirements which are needed by the lint test targets
-black==19.10b0
+black==21.4b2
 modernize==0.7
 flake8==3.7.9
 pylint==2.4.4

--- a/scalyr_agent/__scalyr__.py
+++ b/scalyr_agent/__scalyr__.py
@@ -194,8 +194,7 @@ def __add_scalyr_package_to_path():
 
 
 def __determine_version():
-    """Returns the agent version number, read from the VERSION file.
-    """
+    """Returns the agent version number, read from the VERSION file."""
 
     file_names = ["VERSION"]
 

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -179,8 +179,7 @@ def _check_disabled(current_time, other_time, message):
 
 
 class ScalyrAgent(object):
-    """Encapsulates the entire Scalyr Agent 2 application.
-    """
+    """Encapsulates the entire Scalyr Agent 2 application."""
 
     def __init__(self, platform_controller):
         """Initialize the object.
@@ -1201,13 +1200,17 @@ class ScalyrAgent(object):
                 disable_config_reload_until = _update_disabled_until(
                     self.__config.disable_config_reload, current_time
                 )
-                disable_verify_config_create_monitors_manager_until = _update_disabled_until(
-                    self.__config.disable_verify_config_create_monitors_manager,
-                    current_time,
+                disable_verify_config_create_monitors_manager_until = (
+                    _update_disabled_until(
+                        self.__config.disable_verify_config_create_monitors_manager,
+                        current_time,
+                    )
                 )
-                disable_verify_config_create_copying_manager_until = _update_disabled_until(
-                    self.__config.disable_verify_config_create_copying_manager,
-                    current_time,
+                disable_verify_config_create_copying_manager_until = (
+                    _update_disabled_until(
+                        self.__config.disable_verify_config_create_copying_manager,
+                        current_time,
+                    )
                 )
 
                 config_change_check_interval = (
@@ -1275,7 +1278,8 @@ class ScalyrAgent(object):
                             > last_copy_manager_stats_report_time + log_stats_delta
                         ):
                             self.__overall_stats = self.__calculate_overall_stats(
-                                base_overall_stats, copy_manager_warnings=True,
+                                base_overall_stats,
+                                copy_manager_warnings=True,
                             )
                             self.__log_copy_manager_stats(self.__overall_stats)
                             last_copy_manager_stats_report_time = current_time
@@ -1479,13 +1483,17 @@ class ScalyrAgent(object):
                     disable_config_reload_until = _update_disabled_until(
                         self.__config.disable_config_reload, current_time
                     )
-                    disable_verify_config_create_monitors_manager_until = _update_disabled_until(
-                        self.__config.disable_verify_config_create_monitors_manager,
-                        current_time,
+                    disable_verify_config_create_monitors_manager_until = (
+                        _update_disabled_until(
+                            self.__config.disable_verify_config_create_monitors_manager,
+                            current_time,
+                        )
                     )
-                    disable_verify_config_create_copying_manager_until = _update_disabled_until(
-                        self.__config.disable_verify_config_create_copying_manager,
-                        current_time,
+                    disable_verify_config_create_copying_manager_until = (
+                        _update_disabled_until(
+                            self.__config.disable_verify_config_create_copying_manager,
+                            current_time,
+                        )
                     )
 
                 # Log the stats one more time before we terminate.
@@ -1510,8 +1518,7 @@ class ScalyrAgent(object):
             scalyr_logging.close_handlers()
 
     def __fail_if_already_running(self):
-        """If the agent is already running, prints an appropriate error message and exits the process.
-        """
+        """If the agent is already running, prints an appropriate error message and exits the process."""
         try:
             self.__controller.is_agent_running(fail_if_running=True)
         except AgentAlreadyRunning as e:
@@ -2062,8 +2069,7 @@ class ScalyrAgent(object):
 
 
 class WorkerThread(object):
-    """A thread used to run the log copier and the monitor manager.
-    """
+    """A thread used to run the log copier and the monitor manager."""
 
     def __init__(self, configuration, copying_manager, monitors):
         self.config = configuration

--- a/scalyr_agent/agent_status.py
+++ b/scalyr_agent/agent_status.py
@@ -88,8 +88,7 @@ class BaseAgentStatus(object):
 
 
 class AgentStatus(BaseAgentStatus):
-    """The main status container object, holding references to all other status elements.
-    """
+    """The main status container object, holding references to all other status elements."""
 
     def __init__(self):
         # The time (in seconds past epoch) when the agent process was launched.
@@ -140,8 +139,7 @@ class GCStatus(BaseAgentStatus):
 
 
 class OverallStats(AgentStatus):
-    """Used to track stats that are calculated over the lifetime of the agent.
-    """
+    """Used to track stats that are calculated over the lifetime of the agent."""
 
     def __init__(self):
         # The time in seconds past epoch when the agent was started.
@@ -643,7 +641,10 @@ def report_status(output, status, current_time):
     # the url.  Same goes for https://log.scalyr.com  -- it is really is just https://www.scalyr.com
     print(
         "View data from this agent at: %s/events?filter=$serverHost%%3D%%27%s%%27"
-        % (server, quote_plus(status.server_host),),
+        % (
+            server,
+            quote_plus(status.server_host),
+        ),
         file=output,
     )
     print("", file=output)
@@ -850,7 +851,10 @@ def _report_worker_session(
     if worker_session.total_errors > 0:
         _indent_print(
             "Total responses with errors:               %d (see '%s' for details)"
-            % (worker_session.total_errors, agent_log_file_path,),
+            % (
+                worker_session.total_errors,
+                agent_log_file_path,
+            ),
             file=output,
             indent=indent,
         )
@@ -1073,7 +1077,12 @@ def __report_monitor_manager(output, manager_status, read_time):
         if entry.is_alive:
             print(
                 "%s%s: %d lines emitted, %d errors"
-                % (padding, entry.monitor_name, entry.reported_lines, entry.errors,),
+                % (
+                    padding,
+                    entry.monitor_name,
+                    entry.reported_lines,
+                    entry.errors,
+                ),
                 file=output,
             )
 
@@ -1087,6 +1096,10 @@ def __report_monitor_manager(output, manager_status, read_time):
             if not entry.is_alive:
                 print(
                     "  %s %d lines emitted, %d errors"
-                    % (entry.monitor_name, entry.reported_lines, entry.errors,),
+                    % (
+                        entry.monitor_name,
+                        entry.reported_lines,
+                        entry.errors,
+                    ),
                     file=output,
                 )

--- a/scalyr_agent/builtin_monitors/apache_monitor.py
+++ b/scalyr_agent/builtin_monitors/apache_monitor.py
@@ -150,6 +150,7 @@ class BindableHTTPHandler(six.moves.urllib.request.HTTPHandler):
 
 
 class ApacheMonitor(ScalyrMonitor):
+    # fmt: off
     """
 # Apache Monitor
 
@@ -253,6 +254,7 @@ running the Apache plugin. Use the {{menuRef:ServerHost}} dropdown to show data 
 
 See [Analyze Access Logs](/solutions/analyze-access-logs) for more information about working with web access logs.
     """
+    # fmt: on
 
     def _initialize(self):
         global httpSourceAddress

--- a/scalyr_agent/builtin_monitors/docker_monitor.py
+++ b/scalyr_agent/builtin_monitors/docker_monitor.py
@@ -2067,6 +2067,7 @@ class DockerOptions(object):
 
 
 class DockerMonitor(ScalyrMonitor):  # pylint: disable=monitor-not-included-for-win32
+    # fmt: off
     """
 # Docker Monitor
 
@@ -2196,6 +2197,7 @@ If you wish to use labels and label configuration when using the syslog monitor 
 
 TODO:  Back fill the instructions here.
     """
+    # fmt: on
 
     def __get_socket_file(self):
         """Gets the Docker API socket file and validates that it is a UNIX socket

--- a/scalyr_agent/builtin_monitors/docker_monitor.py
+++ b/scalyr_agent/builtin_monitors/docker_monitor.py
@@ -624,9 +624,9 @@ define_metric(
 
 
 class WrappedStreamResponse(CancellableStream):
-    """ Wrapper for generator returned by docker.Client._stream_helper
-        that gives us access to the response, and therefore the socket, so that
-        we can shutdown the socket from another thread if needed
+    """Wrapper for generator returned by docker.Client._stream_helper
+    that gives us access to the response, and therefore the socket, so that
+    we can shutdown the socket from another thread if needed
     """
 
     def __init__(self, client, response, decode):
@@ -642,9 +642,9 @@ class WrappedStreamResponse(CancellableStream):
 
 
 class WrappedRawResponse(CancellableStream):
-    """ Wrapper for generator returned by docker.Client._stream_raw_result
-        that gives us access to the response, and therefore the socket, so that
-        we can shutdown the socket from another thread if needed
+    """Wrapper for generator returned by docker.Client._stream_raw_result
+    that gives us access to the response, and therefore the socket, so that
+    we can shutdown the socket from another thread if needed
     """
 
     def __init__(self, client, response, chunk_size=8096):
@@ -660,9 +660,9 @@ class WrappedRawResponse(CancellableStream):
 
 
 class WrappedMultiplexedStreamResponse(CancellableStream):
-    """ Wrapper for generator returned by docker.Client._multiplexed_response_stream_helper
-        that gives us access to the response, and therefore the socket, so that
-        we can shutdown the socket from another thread if needed
+    """Wrapper for generator returned by docker.Client._multiplexed_response_stream_helper
+    that gives us access to the response, and therefore the socket, so that
+    we can shutdown the socket from another thread if needed
     """
 
     def __init__(self, client, response):
@@ -679,10 +679,10 @@ class WrappedMultiplexedStreamResponse(CancellableStream):
 
 
 class DockerClient(docker.APIClient):  # pylint: disable=no-member
-    """ Wrapper for docker.Client to return 'wrapped' versions of streamed responses
-        so that we can have access to the response object, which allows us to get the
-        socket in use, and shutdown the blocked socket from another thread (e.g. upon
-        shutdown
+    """Wrapper for docker.Client to return 'wrapped' versions of streamed responses
+    so that we can have access to the response object, which allows us to get the
+    socket in use, and shutdown the blocked socket from another thread (e.g. upon
+    shutdown
     """
 
     def _stream_helper(self, response, decode=False):
@@ -725,8 +725,7 @@ def _get_containers(
     include_log_path=False,
     get_labels=False,
 ):
-    """Gets a dict of running containers that maps container id to container name
-    """
+    """Gets a dict of running containers that maps container id to container name"""
     if logger is None:
         logger = global_log
 
@@ -830,15 +829,15 @@ def _get_containers(
 
 def get_attributes_and_config_from_labels(labels, docker_options):
     """
-        Takes a dict of labels and splits it in to two separate attributes and config dicts.
+    Takes a dict of labels and splits it in to two separate attributes and config dicts.
 
-        @param labels: All the Docker labels for a container
-        @param docker_options: Options for determining which labels to use for the attributes and config items
-        @type labels: dict
-        @type docker_options: DockerOptions
+    @param labels: All the Docker labels for a container
+    @param docker_options: Options for determining which labels to use for the attributes and config items
+    @type labels: dict
+    @type docker_options: DockerOptions
 
-        @return: A tuple with the first element containing a dict of attributes and the second element containing a JsonObject of config items
-        @rtype: (dict, JsonObject)
+    @return: A tuple with the first element containing a dict of attributes and the second element containing a JsonObject of config items
+    @rtype: (dict, JsonObject)
 
     """
     config = JsonObject({})
@@ -910,7 +909,7 @@ def get_parser_from_config(base_config, attributes, default_parser):
 
 class ContainerChecker(StoppableThread):
     """
-        Monitors containers to check when they start and stop running.
+    Monitors containers to check when they start and stop running.
     """
 
     def __init__(
@@ -1918,8 +1917,7 @@ class ContainerIdResolver:
             self.__lock.release()
 
     class Entry:
-        """Helper abstraction representing a single cache entry mapping a container id to its name.
-        """
+        """Helper abstraction representing a single cache entry mapping a container id to its name."""
 
         def __init__(self, container_id, container_name, labels, last_access_time):
             """
@@ -2020,15 +2018,12 @@ class DockerOptions(object):
         """
         String representation of a DockerOption
         """
-        return (
-            "\n\tLabels as Attributes:%s\n\tLabel Prefix: '%s'\n\tLabel Include Globs: %s\n\tLabel Exclude Globs: %s\n\tUse Labels for Log Config: %s"
-            % (
-                six.text_type(self.labels_as_attributes),
-                self.label_prefix,
-                six.text_type(self.label_include_globs),
-                six.text_type(self.label_exclude_globs),
-                six.text_type(self.use_labels_for_log_config),
-            )
+        return "\n\tLabels as Attributes:%s\n\tLabel Prefix: '%s'\n\tLabel Include Globs: %s\n\tLabel Exclude Globs: %s\n\tUse Labels for Log Config: %s" % (
+            six.text_type(self.labels_as_attributes),
+            self.label_prefix,
+            six.text_type(self.label_include_globs),
+            six.text_type(self.label_exclude_globs),
+            six.text_type(self.use_labels_for_log_config),
         )
 
     def configure_from_monitor(self, monitor):
@@ -2200,8 +2195,7 @@ TODO:  Back fill the instructions here.
     # fmt: on
 
     def __get_socket_file(self):
-        """Gets the Docker API socket file and validates that it is a UNIX socket
-        """
+        """Gets the Docker API socket file and validates that it is a UNIX socket"""
         # make sure the API socket exists and is a valid socket
         api_socket = self._config.get("api_socket")
         try:
@@ -2354,8 +2348,7 @@ TODO:  Back fill the instructions here.
         self.__version_lock = threading.RLock()
 
     def set_log_watcher(self, log_watcher):
-        """Provides a log_watcher object that monitors can use to add/remove log files
-        """
+        """Provides a log_watcher object that monitors can use to add/remove log files"""
         if self.__container_checker:
             self.__container_checker.set_log_watcher(log_watcher, self)
 

--- a/scalyr_agent/builtin_monitors/garbage_monitor.py
+++ b/scalyr_agent/builtin_monitors/garbage_monitor.py
@@ -106,6 +106,7 @@ define_config_option(
 
 # TODO: Probably we should include this monitor for Windows builds, but currently we do not.
 class GarbageMonitor(ScalyrMonitor):  # pylint: disable=monitor-not-included-for-win32
+    # fmt: off
     """
 # GarbageMonitor
 
@@ -143,6 +144,7 @@ along with dumping up to 20 objects of the types 'list' and 'dict'.
       }
     ]
     """
+    # fmt: on
 
     def _initialize(self):
 

--- a/scalyr_agent/builtin_monitors/graphite_monitor.py
+++ b/scalyr_agent/builtin_monitors/graphite_monitor.py
@@ -138,6 +138,7 @@ define_log_field(__monitor__, "orig_time", "The Graphite timestamp.")
 
 
 class GraphiteMonitor(ScalyrMonitor):
+    # fmt: off
     """
 # Graphite Monitor
 
@@ -178,6 +179,7 @@ The [View Logs](/help/view) page describes the tools you can use to view and ana
 [Query Language](/help/query-language) lists the operators you can use to select specific metrics and values.
 You can also use this data in [Dashboards](/help/dashboards) and [Alerts](/help/alerts).
     """
+    # fmt: on
 
     def _initialize(self):
         """Performs monitor-specific initialization.

--- a/scalyr_agent/builtin_monitors/graphite_monitor.py
+++ b/scalyr_agent/builtin_monitors/graphite_monitor.py
@@ -182,8 +182,7 @@ You can also use this data in [Dashboards](/help/dashboards) and [Alerts](/help/
     # fmt: on
 
     def _initialize(self):
-        """Performs monitor-specific initialization.
-        """
+        """Performs monitor-specific initialization."""
         self.__only_accept_local = self._config.get("only_accept_local")
         self.__accept_plaintext = self._config.get("accept_plaintext")
         self.__accept_pickle = self._config.get("accept_pickle")

--- a/scalyr_agent/builtin_monitors/journald_monitor.py
+++ b/scalyr_agent/builtin_monitors/journald_monitor.py
@@ -363,8 +363,10 @@ seconds and then polls again.
         self._extra_fields = self._config.get("journal_fields")
         if self._extra_fields is not None:
             for field_name in self._extra_fields:
-                fixed_field_name = scalyr_logging.AgentLogger.force_valid_metric_or_field_name(
-                    field_name, is_metric=False
+                fixed_field_name = (
+                    scalyr_logging.AgentLogger.force_valid_metric_or_field_name(
+                        field_name, is_metric=False
+                    )
                 )
                 if field_name != fixed_field_name:
                     self._extra_fields[fixed_field_name] = self._extra_fields[
@@ -557,7 +559,10 @@ seconds and then polls again.
                 )
 
     def format_msg(
-        self, message, log_config, extra_fields=None,
+        self,
+        message,
+        log_config,
+        extra_fields=None,
     ):
         string_buffer = six.StringIO()
 

--- a/scalyr_agent/builtin_monitors/journald_monitor.py
+++ b/scalyr_agent/builtin_monitors/journald_monitor.py
@@ -257,6 +257,7 @@ class Checkpoint(object):
 
 
 class JournaldMonitor(ScalyrMonitor):  # pylint: disable=monitor-not-included-for-win32
+    # fmt: off
     """
 # Journald Monitor
 
@@ -320,6 +321,7 @@ of that object.  The ``poll`` method is called with a 0 second timeout so it nev
 After processing any new events, or if there are no events to process, the monitor thread sleeps for ``journal_poll_interval``
 seconds and then polls again.
     """
+    # fmt: on
 
     def _initialize(self):
         verify_systemd_library_is_available()

--- a/scalyr_agent/builtin_monitors/journald_utils.py
+++ b/scalyr_agent/builtin_monitors/journald_utils.py
@@ -64,8 +64,7 @@ class LogConfigManager:
         self.__log_config_creators = self.initialize()
 
     def initialize(self):
-        """ Generate the config matchers for this manager from the global config
-        """
+        """Generate the config matchers for this manager from the global config"""
         config_matchers = []
         for config in self._global_config.journald_log_configs:
             config_matcher = self.create_config_matcher(config)
@@ -76,7 +75,7 @@ class LogConfigManager:
         return config_matchers
 
     def create_config_matcher(self, conf):
-        """ Create a function that will return a log configuration when passed in data that matches that config.
+        """Create a function that will return a log configuration when passed in data that matches that config.
         Intended to be overwritten by users of LogConfigManager to match their own use case.
         If passed an empty dictionary in `conf` this should create a catchall matcher with default configuration.
 
@@ -165,7 +164,7 @@ class LogConfigManager:
         return regex_matcher
 
     def get_config(self, fields):
-        """ Get a log configuration that matches the passed in data based on the configured config matchers.
+        """Get a log configuration that matches the passed in data based on the configured config matchers.
 
         @param fields: Fields that the configured config matchers will attempt to match against
         @return: Logger configuration if a config matcher matched on `fields`, None otherwise
@@ -177,7 +176,7 @@ class LogConfigManager:
         return None
 
     def get_logger(self, fields):
-        """ Get a logger that matches the passed in data based on the configured config matchers. This will create
+        """Get a logger that matches the passed in data based on the configured config matchers. This will create
         a logger if the configuration gets matched but no logger exists yet
 
         @param fields: Fields that the configured config matchers will attempt to match against
@@ -199,7 +198,7 @@ class LogConfigManager:
         self.log_watcher = log_watcher
 
     def create_logger(self, log_config):
-        """ Create a logger with the given configuration.
+        """Create a logger with the given configuration.
 
         @param log_config: Configuration for this logger
         """
@@ -224,8 +223,7 @@ class LogConfigManager:
         self._loggers[log_config["path"]]["config"] = log_config
 
     def close(self):
-        """Close all log handlers currently managed by this LogConfigManager.
-        """
+        """Close all log handlers currently managed by this LogConfigManager."""
         for logger in self._loggers.values():
             logger["logger"].removeHandler(logger["handler"])
             logger["handler"].close()

--- a/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
@@ -197,6 +197,7 @@ class EventLogFormatter(BaseFormatter):
 class KubernetesEventsMonitor(
     ScalyrMonitor
 ):  # pylint: disable=monitor-not-included-for-win32
+    # fmt: off
     """
 # Kubernetes Events Monitor
 
@@ -295,6 +296,7 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
     kubectl create -f https://raw.githubusercontent.com/scalyr/scalyr-agent-2/release/k8s/scalyr-agent-2.yaml
     ```
     """
+    # fmt: on
 
     def _initialize(self):
 

--- a/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
@@ -182,9 +182,7 @@ define_config_option(
 
 
 class EventLogFormatter(BaseFormatter):
-    """Formatter used for the logs produced by the event monitor.
-
-    """
+    """Formatter used for the logs produced by the event monitor."""
 
     def __init__(self):
         # TODO: It seems on Python 2.4 the filename and line number do not work correctly.  I think we need to
@@ -428,7 +426,7 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
 
     def _check_if_alive(self, k8s, node):
         """
-            Checks to see if the node specified by `node` is alive
+        Checks to see if the node specified by `node` is alive
         """
         if node is None:
             return False
@@ -451,11 +449,11 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
 
     def _get_oldest_node(self, nodes, ignore_master):
         """
-            Takes a list of nodes returned from querying the k8s api, and returns the name
-            of the node with the oldest creationTimestamp or None if nodes is empty or doesn't
-            contain Node objects.
+        Takes a list of nodes returned from querying the k8s api, and returns the name
+        of the node with the oldest creationTimestamp or None if nodes is empty or doesn't
+        contain Node objects.
 
-            if `ignore_master` is true, then any nodes with the label `node-role.kubernetes.io/master` are ignored.
+        if `ignore_master` is true, then any nodes with the label `node-role.kubernetes.io/master` are ignored.
         """
 
         oldest_time = datetime.datetime.utcnow()
@@ -489,11 +487,11 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
 
     def _check_nodes_for_leader(self, k8s, query_fields=""):
         """
-            Checks all nodes on the cluster to see which one has the oldest creationTime
-            If `self._ignore_master` is True then any node with the label `node-role.kubernetes.io/master`
-            is ignored.
-            @param k8s: a KubernetesApi object for querying the k8s api
-            @query_fields - optional query string appended to the node endpoint to allow for filtering
+        Checks all nodes on the cluster to see which one has the oldest creationTime
+        If `self._ignore_master` is True then any node with the label `node-role.kubernetes.io/master`
+        is ignored.
+        @param k8s: a KubernetesApi object for querying the k8s api
+        @query_fields - optional query string appended to the node endpoint to allow for filtering
         """
         response = k8s.query_api_with_retries(
             "/api/v1/nodes%s" % query_fields,
@@ -520,15 +518,15 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
 
     def _get_current_leader(self, k8s):
         """
-            Queries the kubernetes api to see which node is the current leader node.
+        Queries the kubernetes api to see which node is the current leader node.
 
-            If there is currently a leader node, then only that node is polled to see if it still
-            exists.
+        If there is currently a leader node, then only that node is polled to see if it still
+        exists.
 
-            Check to see if the leader is specified as a node label.
-            If not, then if there is not a current leader node, or if the current leader node no longer exists
-            then query all nodes for the leader
-            @param k8s: a KubernetesApi object for querying the k8s api
+        Check to see if the leader is specified as a node label.
+        If not, then if there is not a current leader node, or if the current leader node no longer exists
+        then query all nodes for the leader
+        @param k8s: a KubernetesApi object for querying the k8s api
         """
 
         try:
@@ -615,8 +613,8 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
 
     def _is_resource_expired(self, response):
         """
-            Checks to see if the resource identified in `response` is expired or not.
-            @param response: a response from querying the k8s api for a resource
+        Checks to see if the resource identified in `response` is expired or not.
+        @param response: a response from querying the k8s api for a resource
         """
         obj = response.get("object", dict())
 
@@ -629,10 +627,10 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
 
     def _get_involved_object(self, obj):
         """
-            Processes an object returned from querying the k8s api, and determines whether the object
-            has an `involvedObject` and if so returns a tuple containing the kind, namespace and name of the involved object.
-            Otherwise returns (None, None, None)
-            @param obj: an object returned from querying th k8s api
+        Processes an object returned from querying the k8s api, and determines whether the object
+        has an `involvedObject` and if so returns a tuple containing the kind, namespace and name of the involved object.
+        Otherwise returns (None, None, None)
+        @param obj: an object returned from querying th k8s api
         """
         involved = obj.get("involvedObject", dict())
         kind = involved.get("kind", None)
@@ -646,8 +644,7 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
         return (kind, namespace, name)
 
     def run(self):
-        """Begins executing the monitor, writing metric output to logger.
-        """
+        """Begins executing the monitor, writing metric output to logger."""
         if self.__disable_monitor:
             global_log.info(
                 "kubernetes_events_monitor exiting because it has been disabled."

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -3354,6 +3354,7 @@ class ContainerChecker(object):
 class KubernetesMonitor(
     ScalyrMonitor
 ):  # pylint: disable=monitor-not-included-for-win32
+    # fmt: off
     """
 # Kubernetes Monitor
 
@@ -3478,6 +3479,7 @@ container is still running, there is currently no way to dynamically start/stop 
 container using annotations without updating the config yaml, and applying the updated config to the
 cluster.
     """
+    # fmt: on
 
     @staticmethod
     def __build_metric_dict(prefix, names):

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -837,21 +837,21 @@ _TEMPLATE_RE = re.compile(r"\${[^}]+}")
 
 
 class K8sInitException(Exception):
-    """ Wrapper exception to indicate when the monitor failed to start due to
-        a problem with initializing the k8s cache
+    """Wrapper exception to indicate when the monitor failed to start due to
+    a problem with initializing the k8s cache
     """
 
 
 class DockerSocketException(Exception):
-    """ Wrapper exception to indicate when the monitor failed to start due to
-        a problem with docker socket
+    """Wrapper exception to indicate when the monitor failed to start due to
+    a problem with docker socket
     """
 
 
 class WrappedStreamResponse(object):
-    """ Wrapper for generator returned by docker.Client._stream_helper
-        that gives us access to the response, and therefore the socket, so that
-        we can shutdown the socket from another thread if needed
+    """Wrapper for generator returned by docker.Client._stream_helper
+    that gives us access to the response, and therefore the socket, so that
+    we can shutdown the socket from another thread if needed
     """
 
     def __init__(self, client, response, decode):
@@ -868,9 +868,9 @@ class WrappedStreamResponse(object):
 
 
 class WrappedRawResponse(object):
-    """ Wrapper for generator returned by docker.Client._stream_raw_result
-        that gives us access to the response, and therefore the socket, so that
-        we can shutdown the socket from another thread if needed
+    """Wrapper for generator returned by docker.Client._stream_raw_result
+    that gives us access to the response, and therefore the socket, so that
+    we can shutdown the socket from another thread if needed
     """
 
     def __init__(self, client, response):
@@ -884,9 +884,9 @@ class WrappedRawResponse(object):
 
 
 class WrappedMultiplexedStreamResponse(object):
-    """ Wrapper for generator returned by docker.Client._multiplexed_response_stream_helper
-        that gives us access to the response, and therefore the socket, so that
-        we can shutdown the socket from another thread if needed
+    """Wrapper for generator returned by docker.Client._multiplexed_response_stream_helper
+    that gives us access to the response, and therefore the socket, so that
+    we can shutdown the socket from another thread if needed
     """
 
     def __init__(self, client, response):
@@ -901,10 +901,10 @@ class WrappedMultiplexedStreamResponse(object):
 
 
 class DockerClient(docker.APIClient):  # pylint: disable=no-member
-    """ Wrapper for docker.Client to return 'wrapped' versions of streamed responses
-        so that we can have access to the response object, which allows us to get the
-        socket in use, and shutdown the blocked socket from another thread (e.g. upon
-        shutdown
+    """Wrapper for docker.Client to return 'wrapped' versions of streamed responses
+    so that we can have access to the response object, which allows us to get the
+    socket in use, and shutdown the blocked socket from another thread (e.g. upon
+    shutdown
     """
 
     def _stream_helper(self, response, decode=False):
@@ -939,12 +939,12 @@ def _split_datetime_from_line(line):
 
 def _get_short_cid(container_id):
     """returns a shortened container id.  Useful for logging, where using a full length container id
-       is not necessary and would just add noise to the log.
-       The shortened container id will contain enough information to uniquely
-       identify the container for most situations.  Note:  the returned value
-       should never be used as a key in a dict for containers because there is
-       always the remote possibility of a conflict (given a large enough number
-       of containers).
+    is not necessary and would just add noise to the log.
+    The shortened container id will contain enough information to uniquely
+    identify the container for most situations.  Note:  the returned value
+    should never be used as a key in a dict for containers because there is
+    always the remote possibility of a conflict (given a large enough number
+    of containers).
     """
     # return the first 8 chars of the container id.
     # we don't need to check for length because even if len( container_id ) < 8
@@ -955,14 +955,14 @@ def _get_short_cid(container_id):
 
 def _ignore_old_dead_container(container, created_before=None):
     """
-        Returns True or False to determine whether we should ignore the
-        logs for a dead container, depending on whether the create time
-        of the container is before a certain threshold time (specified in
-        seconds since the epoch).
+    Returns True or False to determine whether we should ignore the
+    logs for a dead container, depending on whether the create time
+    of the container is before a certain threshold time (specified in
+    seconds since the epoch).
 
-        If the container was created before the threshold time, then the
-          container logs will be ignored.
-        Otherwise the logs of the dead container will be uploaded.
+    If the container was created before the threshold time, then the
+      container logs will be ignored.
+    Otherwise the logs of the dead container will be uploaded.
     """
 
     # check for recently finished containers
@@ -980,7 +980,7 @@ def _ignore_old_dead_container(container, created_before=None):
 
 def construct_metrics_container_name(cname, pod_name, pod_namespace, pod_uid):
     """
-        Returns a string in the same format as container names in Docker runtime Kubernetes.
+    Returns a string in the same format as container names in Docker runtime Kubernetes.
     """
     return "k8s_%s_%s_%s_%s_0" % (cname, pod_name, pod_namespace, pod_uid)
 
@@ -1079,8 +1079,7 @@ class ControlledCacheWarmer(StoppableThread):
         self.__k8s_cache = k8s_cache
 
     def _prepare_to_stop(self):
-        """Invoked when the stop has been requested to be stopped.
-        """
+        """Invoked when the stop has been requested to be stopped."""
         # Since our background thread may be waiting in `__pick_next_pod`, we poke the condition variable to
         # get it to wake up and notice the thread has stopped.
         self.__condition_var.acquire()
@@ -1596,8 +1595,7 @@ class ControlledCacheWarmer(StoppableThread):
         return time.time()
 
     def run_and_propagate(self):
-        """Runs the background thread that is responsible for actually warming the active pod's information.
-        """
+        """Runs the background thread that is responsible for actually warming the active pod's information."""
         assert self.__k8s_cache is not None
 
         consecutive_warm_pods = 0
@@ -1652,8 +1650,7 @@ class ControlledCacheWarmer(StoppableThread):
                 global_log.exception("cacher warmer uncaught exception")
 
     class WarmingEntry(object):
-        """Used to represent an active container whose pod information should be warmed in the cache.
-        """
+        """Used to represent an active container whose pod information should be warmed in the cache."""
 
         def __init__(self, pod_namespace, pod_name):
             # The associated pod's namespace.
@@ -1710,25 +1707,25 @@ def _get_containers(
     controlled_warmer=None,
 ):
     """Queries the Docker API and returns a dict of running containers that maps container id to container name, and other info
-        @param client: A docker.Client object
-        @param ignore_container: String, a single container id to exclude from the results (useful for ignoring the scalyr_agent container)
-        @param ignored_pod: QualifiedPod, a pod name and namespace to exclude from results (useful for ignoring the scalyr_agent container)
-        @param restrict_to_container: String, a single continer id that will be the only returned result
-        @param logger: scalyr_logging.Logger.  Allows the caller to write logging output to a specific logger.  If None the default agent.log
-            logger is used.
-        @param only_running_containers: Boolean.  If true, will only return currently running containers
-        @param running_or_created_after: Unix timestamp.  If specified, the results will include any currently running containers *and* any
-            dead containers that were created after the specified time.  Used to pick up short-lived containers.
-        @param glob_list: List of strings.  A glob string limits results to containers whose container names match the glob
-        @param include_log_path: Boolean.  If true include the path to the raw log file on disk as part of the extra info mapped to the container id.
-        @param k8s_cache: KubernetesCache.  If not None, k8s information (if it exists) for the container will be added as part of the extra info mapped to the container id
-        @param k8s_include_by_default: Boolean.  If True, then all k8s containers are included by default, unless an include/exclude annotation excludes them.
-            If False, then all k8s containers are excluded by default, unless an include/exclude annotation includes them.
-        @param k8s_namespaces_to_include: K8sNamespaceFilter  The filter for namespaces whose containers should be included.  If None, all will be included.
-        @param ignore_pod_sandboxes: Boolean.  If True then any k8s pod sandbox containers are ignored from the list of monitored containers
-        @param current_time: Timestamp since the epoch
-        @param controlled_warmer:  If the pod cache should be proactively warmed using the controlled warmer
-            strategy, then the warmer instance to use.
+    @param client: A docker.Client object
+    @param ignore_container: String, a single container id to exclude from the results (useful for ignoring the scalyr_agent container)
+    @param ignored_pod: QualifiedPod, a pod name and namespace to exclude from results (useful for ignoring the scalyr_agent container)
+    @param restrict_to_container: String, a single continer id that will be the only returned result
+    @param logger: scalyr_logging.Logger.  Allows the caller to write logging output to a specific logger.  If None the default agent.log
+        logger is used.
+    @param only_running_containers: Boolean.  If true, will only return currently running containers
+    @param running_or_created_after: Unix timestamp.  If specified, the results will include any currently running containers *and* any
+        dead containers that were created after the specified time.  Used to pick up short-lived containers.
+    @param glob_list: List of strings.  A glob string limits results to containers whose container names match the glob
+    @param include_log_path: Boolean.  If true include the path to the raw log file on disk as part of the extra info mapped to the container id.
+    @param k8s_cache: KubernetesCache.  If not None, k8s information (if it exists) for the container will be added as part of the extra info mapped to the container id
+    @param k8s_include_by_default: Boolean.  If True, then all k8s containers are included by default, unless an include/exclude annotation excludes them.
+        If False, then all k8s containers are excluded by default, unless an include/exclude annotation includes them.
+    @param k8s_namespaces_to_include: K8sNamespaceFilter  The filter for namespaces whose containers should be included.  If None, all will be included.
+    @param ignore_pod_sandboxes: Boolean.  If True then any k8s pod sandbox containers are ignored from the list of monitored containers
+    @param current_time: Timestamp since the epoch
+    @param controlled_warmer:  If the pod cache should be proactively warmed using the controlled warmer
+        strategy, then the warmer instance to use.
     """
     if logger is None:
         logger = global_log
@@ -2458,7 +2455,7 @@ class CRIEnumerator(ContainerEnumerator):
 
 class ContainerChecker(object):
     """
-        Monitors containers to check when they start and stop running.
+    Monitors containers to check when they start and stop running.
     """
 
     def __init__(
@@ -2588,8 +2585,7 @@ class ContainerChecker(object):
         self.__stopped = False
 
     def _validate_socket_file(self):
-        """Gets the Docker API socket file and validates that it is a UNIX socket
-        """
+        """Gets the Docker API socket file and validates that it is a UNIX socket"""
         # make sure the API socket exists and is a valid socket
         api_socket = self.__socket_file
         try:
@@ -2611,7 +2607,7 @@ class ContainerChecker(object):
         return os.path.exists("/.dockerenv")
 
     def get_cluster_name(self, k8s_cache):
-        """ Gets the cluster name that the agent is running on """
+        """Gets the cluster name that the agent is running on"""
         cluster_name = compat.os_environ_unicode.get("SCALYR_K8S_CLUSTER_NAME")
         if cluster_name is not None:
             # 2->TODO in python2 os.getenv returns 'str' type. Convert it to unicode.
@@ -2621,7 +2617,7 @@ class ContainerChecker(object):
         return (k8s_cache and k8s_cache.get_cluster_name()) or None
 
     def _get_node_name(self):
-        """ Gets the node name of the node running the agent from downward API """
+        """Gets the node name of the node running the agent from downward API"""
         # 2->TODO in python2 os.getenv returns 'str' type. Convert it to unicode.
         node_name = compat.os_environ_unicode.get("SCALYR_K8S_NODE_NAME")
         if node_name is not None:
@@ -2629,7 +2625,7 @@ class ContainerChecker(object):
         return node_name
 
     def _get_pod_name(self):
-        """ Gets the pod name of the pod running the agent from downward API"""
+        """Gets the pod name of the pod running the agent from downward API"""
         # 2->TODO in python2 os.getenv returns 'str' type. Convert it to unicode.
         pod_name = compat.os_environ_unicode.get("SCALYR_K8S_POD_NAME")
         if pod_name is not None:
@@ -2637,7 +2633,7 @@ class ContainerChecker(object):
         return pod_name
 
     def _get_container_runtime(self):
-        """ Gets the container runtime currently in use """
+        """Gets the container runtime currently in use"""
         if not self.k8s_cache:
             global_log.warning(
                 "Coud not determine K8s CRI because no k8 cache.",
@@ -2822,12 +2818,12 @@ class ContainerChecker(object):
         self.raw_logs = []
 
     def get_k8s_data(self):
-        """ Convenience wrapper to query and process all pods
-            and pods retreived by the k8s API.
-            A filter is used to limit pods returned to those that
-            are running on the current node
+        """Convenience wrapper to query and process all pods
+        and pods retreived by the k8s API.
+        A filter is used to limit pods returned to those that
+        are running on the current node
 
-            @return: a dict keyed by namespace, whose values are a dict of pods inside that namespace, keyed by pod name
+        @return: a dict keyed by namespace, whose values are a dict of pods inside that namespace, keyed by pod name
         """
         result = {}
         try:
@@ -2842,8 +2838,7 @@ class ContainerChecker(object):
         return result
 
     def check_containers(self, run_state):
-        """Update thread for monitoring docker containers and the k8s info such as labels
-        """
+        """Update thread for monitoring docker containers and the k8s info such as labels"""
 
         # Assert that the cache has been initialized
         if not self.k8s_cache.is_initialized():
@@ -3223,7 +3218,9 @@ class ContainerChecker(object):
             )
 
         result = self.__k8s_config_builder.get_log_config(
-            info=info, k8s_info=k8s_info, parser=parser,
+            info=info,
+            k8s_info=k8s_info,
+            parser=parser,
         )
 
         if result is None:
@@ -3714,8 +3711,7 @@ cluster.
             )
 
     def set_log_watcher(self, log_watcher):
-        """Provides a log_watcher object that monitors can use to add/remove log files
-        """
+        """Provides a log_watcher object that monitors can use to add/remove log files"""
         if self.__container_checker:
             self.__container_checker.set_log_watcher(log_watcher, self)
 
@@ -3763,12 +3759,12 @@ cluster.
     def __log_network_interface_metrics(
         self, container, metrics, interface=None, k8s_extra={}
     ):
-        """ Logs network interface metrics
+        """Logs network interface metrics
 
-            @param container:  name of the container the log originated from
-            @param metrics: a dict of metrics keys/values to emit
-            @param interface: an optional interface value to associate with each metric value emitted
-            @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
+        @param container:  name of the container the log originated from
+        @param metrics: a dict of metrics keys/values to emit
+        @param interface: an optional interface value to associate with each metric value emitted
+        @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
         """
         extra = None
         if interface:
@@ -3782,11 +3778,11 @@ cluster.
         self.__log_metrics(container, self.__network_metrics, metrics, extra)
 
     def __log_memory_stats_metrics(self, container, metrics, k8s_extra):
-        """ Logs memory stats metrics
+        """Logs memory stats metrics
 
-            @param container: name of the container the log originated from
-            @param metrics: a dict of metrics keys/values to emit
-            @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
+        @param container: name of the container the log originated from
+        @param metrics: a dict of metrics keys/values to emit
+        @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
         """
         if "stats" in metrics:
             self.__log_metrics(
@@ -3796,11 +3792,11 @@ cluster.
         self.__log_metrics(container, self.__mem_metrics, metrics, k8s_extra)
 
     def __log_cpu_stats_metrics(self, container, metrics, k8s_extra):
-        """ Logs cpu stats metrics
+        """Logs cpu stats metrics
 
-            @param container: name of the container the log originated from
-            @param metrics: a dict of metrics keys/values to emit
-            @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
+        @param container: name of the container the log originated from
+        @param metrics: a dict of metrics keys/values to emit
+        @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
         """
         if "cpu_usage" in metrics:
             cpu_usage = metrics["cpu_usage"]
@@ -3840,13 +3836,13 @@ cluster.
             )
 
     def __log_memory_stats_cri_metrics(self, container, metrics, k8s_extra):
-        """ Logs memory stats metrics
-            This method expects the metrics to come from the `stats/summary` kubelet endpoint and so has a translation
-            to the metric names we expect from the docker client
+        """Logs memory stats metrics
+        This method expects the metrics to come from the `stats/summary` kubelet endpoint and so has a translation
+        to the metric names we expect from the docker client
 
-            @param container: name of the container the log originated from
-            @param metrics: a dict of metrics keys/values to emit
-            @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
+        @param container: name of the container the log originated from
+        @param metrics: a dict of metrics keys/values to emit
+        @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
         """
         self.__log_metrics(
             container,
@@ -3864,13 +3860,13 @@ cluster.
         )
 
     def __log_cpu_stats_cri_metrics(self, container, metrics, k8s_extra):
-        """ Logs cpu stats metrics
-            This method expects the metrics to come from the `stats/summary` kubelet endpoint and so has a translation
-            to the metric names we expect from the docker client
+        """Logs cpu stats metrics
+        This method expects the metrics to come from the `stats/summary` kubelet endpoint and so has a translation
+        to the metric names we expect from the docker client
 
-            @param container: name of the container the log originated from
-            @param metrics: a dict of metrics keys/values to emit
-            @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
+        @param container: name of the container the log originated from
+        @param metrics: a dict of metrics keys/values to emit
+        @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
         """
         self.__log_metrics(
             container,
@@ -3881,11 +3877,11 @@ cluster.
         )
 
     def __log_json_metrics(self, container, metrics, k8s_extra):
-        """ Log docker metrics based on the JSON response returned from querying the Docker API
+        """Log docker metrics based on the JSON response returned from querying the Docker API
 
-            @param container: name of the container the log originated from
-            @param metrics: a dict of metrics keys/values to emit
-            @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
+        @param container: name of the container the log originated from
+        @param metrics: a dict of metrics keys/values to emit
+        @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
         """
         for key, value in six.iteritems(metrics):
             if value is None:
@@ -3904,11 +3900,11 @@ cluster.
                 self.__log_cpu_stats_metrics(container, value, k8s_extra)
 
     def __log_cri_container_metrics(self, container, metrics, k8s_extra):
-        """ Log docker metrics based on the JSON response returned from querying the Docker API
+        """Log docker metrics based on the JSON response returned from querying the Docker API
 
-            @param container: name of the container the log originated from
-            @param metrics: a dict of metrics keys/values to emit
-            @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
+        @param container: name of the container the log originated from
+        @param metrics: a dict of metrics keys/values to emit
+        @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
         """
         for key, value in six.iteritems(metrics):
             if value is None:
@@ -3920,10 +3916,10 @@ cluster.
                 self.__log_cpu_stats_cri_metrics(container, value, k8s_extra)
 
     def __gather_metrics_from_api_for_container(self, container, k8s_extra):
-        """ Query the Docker API for container metrics
+        """Query the Docker API for container metrics
 
-            @param container: name of the container to query
-            @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
+        @param container: name of the container to query
+        @param k8s_extra: extra k8s specific key/value pairs to associate with each metric value emitted
         """
         result = self.__metric_fetcher.get_metrics(container)
         if result is not None:
@@ -3931,12 +3927,12 @@ cluster.
 
     def __build_k8s_controller_info(self, pod):
         """
-            Builds a dict containing information about the controller settings for a given pod
+        Builds a dict containing information about the controller settings for a given pod
 
-            @param pod: a PodInfo object containing basic information (namespace/name) about the pod to query
+        @param pod: a PodInfo object containing basic information (namespace/name) about the pod to query
 
-            @return: a dict containing the controller name for the controller running
-                     the specified pod, or an empty dict if the pod is not part of a controller
+        @return: a dict containing the controller name for the controller running
+                 the specified pod, or an empty dict if the pod is not part of a controller
         """
         k8s_extra = {}
         if pod is not None:
@@ -3960,8 +3956,8 @@ cluster.
 
     def __get_k8s_controller_info(self, container):
         """
-            Gets information about the kubernetes controller of a given container
-            @param container: a dict containing information about a container, returned by _get_containers
+        Gets information about the kubernetes controller of a given container
+        @param container: a dict containing information about a container, returned by _get_containers
         """
         k8s_info = container.get("k8s_info", {})
         pod = k8s_info.get("pod_info", None)
@@ -3970,7 +3966,7 @@ cluster.
         return self.__build_k8s_controller_info(pod)
 
     def __get_cluster_info(self, cluster_name):
-        """ returns a dict of values about the cluster """
+        """returns a dict of values about the cluster"""
         cluster_info = {}
         if self.__include_controller_info and cluster_name is not None:
             cluster_info["k8s-cluster"] = cluster_name
@@ -4061,10 +4057,10 @@ cluster.
 
     def __gather_k8s_metrics_for_node(self, node, extra):
         """
-            Gathers metrics from a Kubelet API response for a specific pod
+        Gathers metrics from a Kubelet API response for a specific pod
 
-            @param node_metrics: A JSON Object from a response to a Kubelet API query
-            @param extra: Extra fields to append to each metric
+        @param node_metrics: A JSON Object from a response to a Kubelet API query
+        @param extra: Extra fields to append to each metric
         """
 
         name = node.get("nodeName", None)
@@ -4082,11 +4078,11 @@ cluster.
 
     def __gather_k8s_metrics_for_pod(self, pod_metrics, pod_info, k8s_extra):
         """
-            Gathers metrics from a Kubelet API response for a specific pod
+        Gathers metrics from a Kubelet API response for a specific pod
 
-            @param pod_metrics: A JSON Object from a response to a Kubelet API query
-            @param pod_info: A PodInfo structure regarding the pod in question
-            @param k8s_extra: Extra k8s specific fields to append to each metric
+        @param pod_metrics: A JSON Object from a response to a Kubelet API query
+        @param pod_info: A PodInfo structure regarding the pod in question
+        @param k8s_extra: Extra k8s specific fields to append to each metric
         """
 
         extra = {"pod_uid": pod_info.uid}
@@ -4103,11 +4099,11 @@ cluster.
         self, containers, kubelet_api, cluster_name, stats=None
     ):
         """
-            Gathers k8s metrics from a response to a stats query of the Kubelet API
+        Gathers k8s metrics from a response to a stats query of the Kubelet API
 
-            @param containers: a dict returned by _get_containers with info for all containers we are interested in
-            @param kubelet_api: a KubeletApi object for querying the KubeletApi
-            @param cluster_name: the name of the k8s cluster
+        @param containers: a dict returned by _get_containers with info for all containers we are interested in
+        @param kubelet_api: a KubeletApi object for querying the KubeletApi
+        @param cluster_name: the name of the k8s cluster
 
         """
 
@@ -4267,10 +4263,12 @@ cluster.
         if self.__gather_k8s_pod_info:
             cluster_info = self.__get_cluster_info(cluster_name)
 
-            containers = self._container_enumerator.get_containers(  # pylint: disable=no-member
-                k8s_cache=k8s_cache,
-                k8s_include_by_default=self.__include_all,
-                k8s_namespaces_to_include=self.__namespaces_to_include,
+            containers = (
+                self._container_enumerator.get_containers(  # pylint: disable=no-member
+                    k8s_cache=k8s_cache,
+                    k8s_include_by_default=self.__include_all,
+                    k8s_namespaces_to_include=self.__namespaces_to_include,
+                )
             )
             for cid, info in six.iteritems(containers):
                 try:

--- a/scalyr_agent/builtin_monitors/linux_process_metrics.py
+++ b/scalyr_agent/builtin_monitors/linux_process_metrics.py
@@ -265,8 +265,7 @@ class Metric(object):
 
 
 class MetricPrinter:
-    """Helper class that emits metrics for the specified monitor.
-    """
+    """Helper class that emits metrics for the specified monitor."""
 
     def __init__(self, logger, monitor_id):
         """Initializes the class.

--- a/scalyr_agent/builtin_monitors/linux_process_metrics.py
+++ b/scalyr_agent/builtin_monitors/linux_process_metrics.py
@@ -1011,6 +1011,7 @@ class ProcessList(object):
 
 
 class ProcessMonitor(ScalyrMonitor):  # pylint: disable=monitor-not-included-for-win32
+    # fmt: off
     """
 # Linux Process Metrics
 
@@ -1060,6 +1061,7 @@ The "agent" ID is used to report metrics for the Scalyr Agent itself.
 You can now return to the dashboard. Use the dropdowns near the top of the page to select the host and process
 you'd like to view.
     """
+    # fmt: on
 
     def _initialize(self):
         """Performs monitor-specific initialization."""

--- a/scalyr_agent/builtin_monitors/linux_system_metrics.py
+++ b/scalyr_agent/builtin_monitors/linux_system_metrics.py
@@ -678,6 +678,7 @@ class WriterThread(StoppableThread):
 class SystemMetricsMonitor(
     ScalyrMonitor
 ):  # pylint: disable=monitor-not-included-for-win32
+    # fmt: off
     """
 # Linux System Metrics
 
@@ -698,6 +699,7 @@ this plugin in your configuration file.
 You can see an overview of this data in the System dashboard. Click the {{menuRef:Dashboards}} menu and select
 {{menuRef:System}}. Use the dropdown near the top of the page to select the host whose data you'd like to view.
     """
+    # fmt: on
 
     def _initialize(self):
         """Performs monitor-specific initialization."""

--- a/scalyr_agent/builtin_monitors/mysql_monitor.py
+++ b/scalyr_agent/builtin_monitors/mysql_monitor.py
@@ -956,6 +956,7 @@ class MysqlDB(object):
 
 
 class MysqlMonitor(ScalyrMonitor):
+    # fmt: off
     """
 # MySQL Monitor
 
@@ -1009,6 +1010,7 @@ The [View Logs](/help/view) page describes the tools you can use to view and ana
 [Query Language](/help/query-language) lists the operators you can use to select specific metrics and values.
 You can also use this data in [Dashboards](/help/dashboards) and [Alerts](/help/alerts).
 """
+    # fmt: on
 
     def _initialize(self):
         """Performs monitor-specific initialization.

--- a/scalyr_agent/builtin_monitors/mysql_monitor.py
+++ b/scalyr_agent/builtin_monitors/mysql_monitor.py
@@ -359,8 +359,7 @@ __coms_to_report__ = (
 
 
 class MysqlDB(object):
-    """ Represents a MySQL database
-    """
+    """Represents a MySQL database"""
 
     def _connect(self):
         try:
@@ -706,7 +705,7 @@ class MysqlDB(object):
 
     def _derived_stat_connections_used_percentage(self, globalVars, globalStatusMap):
         """Calculate what percentage of the configured connections are used.  A high percentage can
-           indicate a an app is using more than the expected number / configured number of connections.
+        indicate a an app is using more than the expected number / configured number of connections.
         """
         pct = 100.0 * (
             float(globalStatusMap["global.max_used_connections"])
@@ -799,7 +798,7 @@ class MysqlDB(object):
 
     def _derived_stat_open_file_percentage(self, globalVars, globalStatusMap):
         """Calculate the percentage of files that are open compared to the allowed limit.
-           If no open file limit is configured, the value will be 0.
+        If no open file limit is configured, the value will be 0.
         """
         pct = 0.0
         if globalVars["vars.open_files_limit"] > 0:
@@ -846,8 +845,7 @@ class MysqlDB(object):
         return pct
 
     def gather_derived_stats(self, globalVars, globalStatusMap):
-        """Gather derived stats based on global variables and global status.
-        """
+        """Gather derived stats based on global variables and global status."""
         if not globalVars or not globalStatusMap:
             return None
         stats = [
@@ -1013,8 +1011,7 @@ You can also use this data in [Dashboards](/help/dashboards) and [Alerts](/help/
     # fmt: on
 
     def _initialize(self):
-        """Performs monitor-specific initialization.
-        """
+        """Performs monitor-specific initialization."""
 
         # Useful instance variables:
         #   _sample_interval_secs:  The number of seconds between calls to gather_sample.
@@ -1124,8 +1121,7 @@ You can also use this data in [Dashboards](/help/dashboards) and [Alerts](/help/
             )
 
     def gather_sample(self):
-        """Invoked once per sample interval to gather a statistic.
-        """
+        """Invoked once per sample interval to gather a statistic."""
 
         # make sure we have a database connection
         if self._db is None:
@@ -1137,13 +1133,11 @@ You can also use this data in [Dashboards](/help/dashboards) and [Alerts](/help/
             return
 
         def print_status_line(key, value, extra_fields):
-            """ Emit a status line.
-            """
+            """Emit a status line."""
             self._logger.emit_value("mysql.%s" % key, value, extra_fields=extra_fields)
 
         def print_status(status):
-            """print a status object, assumed to be a dictionary of key/values (and possibly extra fields).
-            """
+            """print a status object, assumed to be a dictionary of key/values (and possibly extra fields)."""
             if status is not None:
                 for entry in status:
                     field = entry["field"]

--- a/scalyr_agent/builtin_monitors/nginx_monitor.py
+++ b/scalyr_agent/builtin_monitors/nginx_monitor.py
@@ -135,6 +135,7 @@ class BindableHTTPHandler(six.moves.urllib.request.HTTPHandler):
 
 
 class NginxMonitor(ScalyrMonitor):
+    # fmt: off
     """
 # Nginx Monitor
 
@@ -243,6 +244,7 @@ running the nginx plugin. Use the {{menuRef:ServerHost}} dropdown to show data f
 See [Analyze Access Logs](/solutions/analyze-access-logs) for more information about working with web access logs.
 
     """
+    # fmt: on
 
     def _initialize(self):
         global httpSourceAddress

--- a/scalyr_agent/builtin_monitors/postgres_monitor.py
+++ b/scalyr_agent/builtin_monitors/postgres_monitor.py
@@ -246,8 +246,7 @@ define_log_field(__monitor__, "value", "The metric value.")
 
 
 class PostgreSQLDb(object):
-    """ Represents a PopstgreSQL database
-    """
+    """Represents a PopstgreSQL database"""
 
     _database_stats = {
         "pg_stat_database": {
@@ -468,8 +467,7 @@ instance."""
     # fmt: on
 
     def _initialize(self):
-        """Performs monitor-specific initialization.
-        """
+        """Performs monitor-specific initialization."""
 
         # Useful instance variables:
         #   _sample_interval_secs:  The number of seconds between calls to gather_sample.
@@ -513,8 +511,7 @@ instance."""
         )
 
     def gather_sample(self):
-        """Invoked once per sample interval to gather a statistic.
-        """
+        """Invoked once per sample interval to gather a statistic."""
 
         def timestamp_ms(dt):
             epoch = datetime(1970, 1, 1, 0, 0, 0, 0)

--- a/scalyr_agent/builtin_monitors/postgres_monitor.py
+++ b/scalyr_agent/builtin_monitors/postgres_monitor.py
@@ -422,6 +422,7 @@ class PostgreSQLDb(object):
 
 
 class PostgresMonitor(ScalyrMonitor):  # pylint: disable=monitor-not-included-for-win32
+    # fmt: off
     """
 # PostgreSQL Monitor
 
@@ -464,6 +465,7 @@ A basic PostgreSQL monitor configuration entry might resemble:
 Note the ``id`` field in the configurations.  This is an optional field that allows you to specify an identifier
 specific to a particular instance of PostgreSQL and will make it easier to filter on metrics specific to that
 instance."""
+    # fmt: on
 
     def _initialize(self):
         """Performs monitor-specific initialization.

--- a/scalyr_agent/builtin_monitors/redis_monitor.py
+++ b/scalyr_agent/builtin_monitors/redis_monitor.py
@@ -49,8 +49,7 @@ define_config_option(
 
 
 class RedisHost(object):
-    """Class that holds various information about a specific redis connection
-    """
+    """Class that holds various information about a specific redis connection"""
 
     def __init__(self, host, port, password, connection_timeout):
         # redis instance information

--- a/scalyr_agent/builtin_monitors/redis_monitor.py
+++ b/scalyr_agent/builtin_monitors/redis_monitor.py
@@ -342,6 +342,7 @@ class RedisHost(object):
 
 
 class RedisMonitor(ScalyrMonitor):  # pylint: disable=monitor-not-included-for-win32
+    # fmt: off
     """
 # Redis Monitor
 
@@ -417,6 +418,7 @@ Here is an example with two hosts with passwords:
     some log lines will be dropped.
 
     """
+    # fmt: on
 
     def _initialize(self):
         """Performs monitor-specific initialization."""

--- a/scalyr_agent/builtin_monitors/shell_monitor.py
+++ b/scalyr_agent/builtin_monitors/shell_monitor.py
@@ -93,6 +93,7 @@ __first_line_pattern__ = re.compile("[^\r\n]+")
 
 # ShellMonitor implementation
 class ShellMonitor(ScalyrMonitor):
+    # fmt: off
     """
 # Shell Monitor
 
@@ -130,6 +131,7 @@ The [View Logs](/help/view) page describes the tools you can use to view and ana
 [Query Language](/help/query-language) lists the operators you can use to select specific metrics and values.
 You can also use this data in [Dashboards](/help/dashboards) and [Alerts](/help/alerts).
     """
+    # fmt: on
 
     def _initialize(self):
         # Fetch and validate our configuration options.

--- a/scalyr_agent/builtin_monitors/snmp_monitor.py
+++ b/scalyr_agent/builtin_monitors/snmp_monitor.py
@@ -77,6 +77,7 @@ define_log_field(__monitor__, "value", "The value reported by the device.")
 
 
 class SNMPMonitor(ScalyrMonitor):  # pylint: disable=monitor-not-included-for-win32
+    # fmt: off
     """
 # SNMP Monitor
 The SNMP Monitor polls SNMP-enabled devices on the network to collect values specified in the configuration
@@ -204,6 +205,7 @@ well as a list of OID groups to query. e.g.
 
         }
     """
+    # fmt: on
 
     def _initialize(self):
 

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1620,6 +1620,7 @@ class SyslogServer(object):
 
 
 class SyslogMonitor(ScalyrMonitor):
+    # fmt: off
     """
 # Syslog Monitor
 
@@ -1691,6 +1692,7 @@ specifies TCP.
 Messages uploaded by the Syslog Monitor will appear as an independent log file on the host where the agent is
 running. You can find this log file in the [Overview](/logStart) page. By default, the file is named "agentSyslog.log".
     """
+    # fmt: on
 
     def _initialize(self):
         if self._config.get("mode") == "docker" and not docker_module_available:

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -496,7 +496,10 @@ class SyslogRequestParser(object):
     """
 
     def __init__(
-        self, socket, max_buffer_size, message_size_can_exceed_tcp_buffer=False,
+        self,
+        socket,
+        max_buffer_size,
+        message_size_can_exceed_tcp_buffer=False,
     ):
         self._socket = socket
 
@@ -832,7 +835,8 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
             )
         elif self.request_parser == "raw":
             request_stream = SyslogRawRequestParser(
-                socket=self.request, max_buffer_size=self.server.tcp_buffer_size,
+                socket=self.request,
+                max_buffer_size=self.server.tcp_buffer_size,
             )
         else:
             raise ValueError("Invalid request parser: %s" % (self.request_parser))
@@ -882,8 +886,7 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
 class SyslogUDPServer(
     six.moves.socketserver.ThreadingMixIn, six.moves.socketserver.UDPServer
 ):
-    """Class that creates a UDP SocketServer on a specified port
-    """
+    """Class that creates a UDP SocketServer on a specified port"""
 
     def __init__(self, port, bind_address, verifier):
 
@@ -908,8 +911,7 @@ class SyslogUDPServer(
 class SyslogTCPServer(
     six.moves.socketserver.ThreadingMixIn, six.moves.socketserver.TCPServer
 ):
-    """Class that creates a TCP SocketServer on a specified port
-    """
+    """Class that creates a TCP SocketServer on a specified port"""
 
     def __init__(
         self,
@@ -1201,8 +1203,7 @@ class SyslogHandler(object):
         return attributes
 
     def __create_log_file(self, cname, cid, log_config):
-        """create our own rotating logger which will log raw messages out to disk.
-        """
+        """create our own rotating logger which will log raw messages out to disk."""
         result = None
         try:
             result = AutoFlushingRotatingFile(
@@ -1422,7 +1423,7 @@ class SyslogHandler(object):
 
 class RequestVerifier(object):
     """Determines whether or not a request should be processed
-       based on the state of various config options
+    based on the state of various config options
     """
 
     def __init__(self, accept_remote, accept_ips, docker_logging):

--- a/scalyr_agent/builtin_monitors/test_monitor.py
+++ b/scalyr_agent/builtin_monitors/test_monitor.py
@@ -30,8 +30,7 @@ from scalyr_agent import ScalyrMonitor
 
 
 class RandomMonitor(ScalyrMonitor):
-    """A Scalyr agent monitor that records random numbers.
-    """
+    """A Scalyr agent monitor that records random numbers."""
 
     def _initialize(self):
         """Performs monitor-specific initialization."""

--- a/scalyr_agent/builtin_monitors/tomcat_monitor.py
+++ b/scalyr_agent/builtin_monitors/tomcat_monitor.py
@@ -320,6 +320,7 @@ def _convert_to_milliseconds(value):
 
 
 class TomcatMonitor(ScalyrMonitor):  # pylint: disable=monitor-not-included-for-win32
+    # fmt: off
     """
 # Tomcat Monitor
 
@@ -382,6 +383,7 @@ file.  A typical fragment resembles:
 Note the ``id`` field in the configurations.  This is an optional field that allows you to specify an identifier
 specific to a particular instance of Nginx and will make it easier to filter on metrics specific to that
 instance."""
+    # fmt: on
 
     def _initialize(self):
         """Performs monitor-specific initialization.
@@ -720,3 +722,4 @@ instance."""
                     self._logger.emit_value(
                         "tomcat.memory_pools.%s" % heap[key][0], heap[key][1], extra
                     )
+

--- a/scalyr_agent/builtin_monitors/tomcat_monitor.py
+++ b/scalyr_agent/builtin_monitors/tomcat_monitor.py
@@ -386,8 +386,7 @@ instance."""
     # fmt: on
 
     def _initialize(self):
-        """Performs monitor-specific initialization.
-        """
+        """Performs monitor-specific initialization."""
         global httpSourceAddress
 
         # Useful instance variables:
@@ -699,8 +698,7 @@ instance."""
         return result
 
     def gather_sample(self):
-        """Invoked once per sample interval to gather a statistic.
-        """
+        """Invoked once per sample interval to gather a statistic."""
 
         status = self._get_status(self._monitor_url)
         if status is not None:
@@ -722,4 +720,3 @@ instance."""
                     self._logger.emit_value(
                         "tomcat.memory_pools.%s" % heap[key][0], heap[key][1], extra
                     )
-

--- a/scalyr_agent/builtin_monitors/url_monitor.py
+++ b/scalyr_agent/builtin_monitors/url_monitor.py
@@ -149,8 +149,7 @@ class NoRedirection(six.moves.urllib.request.HTTPErrorProcessor):
 
 # UrlMonitor implementation
 class UrlMonitor(ScalyrMonitor):
-    """A Scalyr agent monitor which retrieves a specified URL, and records the response status and body.
-    """
+    """A Scalyr agent monitor which retrieves a specified URL, and records the response status and body."""
 
     def _initialize(self):
         # Fetch and validate our configuration options.

--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -639,6 +639,7 @@ class NewApi(Api):
 
 
 class WindowEventLogMonitor(ScalyrMonitor):
+    # fmt: off
     """
 # Window Event Log Monitor
 
@@ -706,6 +707,7 @@ and System sources:
       }
     ]
     """
+    # fmt: on
 
     def _initialize(self):
         # get the checkpoint file

--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -262,8 +262,7 @@ class OldApi(Api):
             self._checkpoints[source] = event.RecordNumber
 
     def __log_event(self, source, event):
-        """ Emits information about an event to the logfile for this monintor
-        """
+        """Emits information about an event to the logfile for this monintor"""
         event_type = self.__event_types[event.EventType]
 
         # we need to get the root source e.g. Application in Application/MyApplication
@@ -322,10 +321,10 @@ class NewApi(Api):
 
     def _open_remote_session_if_necessary(self, server, config):
         """
-            Opens a session to a remote server if `server` is not localhost or None
-            @param server: string containing the server to connect to (can be None)
-            @param config: a log config object
-            @return: a valid session to a remote machine, or None if no remote session was needed
+        Opens a session to a remote server if `server` is not localhost or None
+        @param server: string containing the server to connect to (can be None)
+        @param config: a log config object
+        @return: a valid session to a remote machine, or None if no remote session was needed
         """
         session = None
 
@@ -363,9 +362,9 @@ class NewApi(Api):
 
     def _subscribe_to_events(self):
         """
-            Go through all channels, and create an event subscription to that channel.
-            If a bookmark exists for a given channel, start the events from that bookmark, otherwise subscribe
-            to future events only.
+        Go through all channels, and create an event subscription to that channel.
+        If a bookmark exists for a given channel, start the events from that bookmark, otherwise subscribe
+        to future events only.
         """
 
         for info in self.__channels:

--- a/scalyr_agent/builtin_monitors/windows_process_metrics.py
+++ b/scalyr_agent/builtin_monitors/windows_process_metrics.py
@@ -504,11 +504,14 @@ def commandline_matcher(regex, flags=re.IGNORECASE):
 
 
 class ProcessMonitor(ScalyrMonitor):
-    """This agent monitor plugin records CPU consumption, memory usage, and other metrics for a specified process on
+    # fmt: off
+    """
+    This agent monitor plugin records CPU consumption, memory usage, and other metrics for a specified process on
     Windows system.
 
     You can use this plugin to record resource usage for a web server, database, or other application.
     """
+    # fmt: on
 
     def __init__(self, monitor_config, logger, **kw):
         """TODO: Function documentation

--- a/scalyr_agent/builtin_monitors/windows_process_metrics.py
+++ b/scalyr_agent/builtin_monitors/windows_process_metrics.py
@@ -158,7 +158,7 @@ def _gather_metric(method, attribute=None, transform=None):
         )
 
     def gather_metric(process):
-        """Dynamically Generated """
+        """Dynamically Generated"""
         errmsg = (
             "Only the 'psutil.Process' interface is supported currently; not {}".format
         )
@@ -514,8 +514,7 @@ class ProcessMonitor(ScalyrMonitor):
     # fmt: on
 
     def __init__(self, monitor_config, logger, **kw):
-        """TODO: Function documentation
-        """
+        """TODO: Function documentation"""
         if psutil is None:
             raise UnsupportedSystem(
                 "windows_process_metrics",
@@ -537,8 +536,7 @@ class ProcessMonitor(ScalyrMonitor):
         )
 
     def _select_target_process(self):
-        """TODO: Function documentation
-        """
+        """TODO: Function documentation"""
         process = None
         if "commandline" in self._config:
             matcher = commandline_matcher(self._config["commandline"])
@@ -553,8 +551,7 @@ class ProcessMonitor(ScalyrMonitor):
         self.__process = process
 
     def gather_sample(self):
-        """TODO: Function documentation
-        """
+        """TODO: Function documentation"""
         try:
             self._select_target_process()
             for idx, metric in enumerate(METRICS):

--- a/scalyr_agent/builtin_monitors/windows_system_metrics.py
+++ b/scalyr_agent/builtin_monitors/windows_system_metrics.py
@@ -105,7 +105,7 @@ def _gather_metric(method, attribute=None, transform=None):
         doc = "Extract the {}().{} attribute from the given process object".format
 
     def gather_metric():
-        """Dynamically Generated """
+        """Dynamically Generated"""
         no_diskperf = False
         is_diskio_counters_method = method == "disk_io_counters"
 
@@ -603,8 +603,7 @@ class SystemMonitor(ScalyrMonitor):
     # fmt: on
 
     def __init__(self, config, logger, **kwargs):
-        """TODO: Fucntion documentation
-        """
+        """TODO: Fucntion documentation"""
         if psutil is None:
             raise UnsupportedSystem(
                 "windows_system_metrics",
@@ -619,8 +618,7 @@ class SystemMonitor(ScalyrMonitor):
         )
 
     def gather_sample(self):
-        """TODO: Fucntion documentation
-        """
+        """TODO: Fucntion documentation"""
         try:
             for idx, metric in enumerate(METRICS):
                 metric_name = metric.config["metric_name"]

--- a/scalyr_agent/builtin_monitors/windows_system_metrics.py
+++ b/scalyr_agent/builtin_monitors/windows_system_metrics.py
@@ -591,13 +591,16 @@ define_log_field(__monitor__, "value", "The metric value.")
 
 
 class SystemMonitor(ScalyrMonitor):
-    """A Scalyr agent monitor that records system metrics for Windows platforms.
+    # fmt: off
+    """
+    A Scalyr agent monitor that records system metrics for Windows platforms.
 
     This agent monitor plugin records CPU consumption, memory usage, and other metrics for the server on which
     the agent is running.
 
     There is no required configuration for this monitor and is generally automatically run by the agent.
     """
+    # fmt: on
 
     def __init__(self, config, logger, **kwargs):
         """TODO: Fucntion documentation

--- a/scalyr_agent/config_main.py
+++ b/scalyr_agent/config_main.py
@@ -280,7 +280,10 @@ def write_config_fragment(config, file_name, field_description, config_json):
             else:
                 print(
                     "Error attempting to update the %s: %s"
-                    % (field_description, six.text_type(error),),
+                    % (
+                        field_description,
+                        six.text_type(error),
+                    ),
                     file=sys.stderr,
                 )
                 print(traceback.format_exc(), file=sys.stderr)
@@ -288,7 +291,10 @@ def write_config_fragment(config, file_name, field_description, config_json):
         except Exception as err:
             print(
                 "Error attempting to update the %s: %s"
-                % (field_description, six.text_type(err),),
+                % (
+                    field_description,
+                    six.text_type(err),
+                ),
                 file=sys.stderr,
             )
             print(traceback.format_exc(), file=sys.stderr)
@@ -310,7 +316,10 @@ def update_user_id(file_path, new_uid):
     except Exception as err:
         print(
             'Error attempting to update permission on file "%s": %s'
-            % (file_path, six.text_type(err),),
+            % (
+                file_path,
+                six.text_type(err),
+            ),
             file=sys.stderr,
         )
         print(traceback.format_exc(), file=sys.stderr)
@@ -334,7 +343,10 @@ def update_user_id_recursively(path, new_uid):
     except Exception as err:
         print(
             'Error attempting to update permissions on files in dir "%s": %s'
-            % (path, six.text_type(err),),
+            % (
+                path,
+                six.text_type(err),
+            ),
             file=sys.stderr,
         )
         print(traceback.format_exc(), file=sys.stderr)
@@ -684,7 +696,10 @@ def upgrade_windows_install(
 
         print(
             "Attempting to upgrade agent from version %s to version %s."
-            % (SCALYR_VERSION, data_payload["current_version"],)
+            % (
+                SCALYR_VERSION,
+                data_payload["current_version"],
+            )
         )
         url_path = data_payload["urls"]["win32"]
 
@@ -837,7 +852,10 @@ def run_command(command_str, exit_on_fail=True, command_name=None, grep_for=None
             if command_name is not None:
                 print(
                     "Executing %s failed and returned a non-zero result of %d"
-                    % (command_name, return_code,),
+                    % (
+                        command_name,
+                        return_code,
+                    ),
                     file=sys.stderr,
                 )
             else:
@@ -889,8 +907,7 @@ def copy_dir_to_new_agent(old_install_dir, new_install_dir, directory):
 
 
 class UpgradeFailure(Exception):
-    """Raised when a failure occurs in the tarball upgrade process.
-    """
+    """Raised when a failure occurs in the tarball upgrade process."""
 
     pass
 

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -367,7 +367,10 @@ class Configuration(object):
             worker_session_agent_logs = None
             if self.implicit_agent_log_collection:
                 # set path as glob to handle log files from the multiprocess worker sessions.
-                config = JsonObject(path="agent.log", parser="scalyrAgentLog",)
+                config = JsonObject(
+                    path="agent.log",
+                    parser="scalyrAgentLog",
+                )
 
                 # add log config for the worker session agent log files.
                 worker_session_logs_config = JsonObject(
@@ -787,9 +790,9 @@ class Configuration(object):
     @staticmethod
     def get_session_ids_of_the_worker(worker_config):  # type: (Dict) -> List
         """
-            Generate the list of IDs of all sessions for the specified worker.
-            :param worker_config: config entry for the worker.
-            :return: List of worker session IDs.
+        Generate the list of IDs of all sessions for the specified worker.
+        :param worker_config: config entry for the worker.
+        :return: List of worker session IDs.
         """
         result = []
         for i in range(worker_config["sessions"]):
@@ -2016,7 +2019,11 @@ class Configuration(object):
         self.__verify_compression_level(self.compression_level)
 
         self.__verify_or_set_optional_attributes(
-            config, "server_attributes", description, apply_defaults, env_aware=True,
+            config,
+            "server_attributes",
+            description,
+            apply_defaults,
+            env_aware=True,
         )
         self.__verify_or_set_optional_string(
             config,
@@ -2951,7 +2958,11 @@ class Configuration(object):
             config, "disable_leak_bandwidth_stats", False, description, apply_defaults
         )
         self.__verify_or_set_optional_bool(
-            config, "disable_copy_manager_stats", False, description, apply_defaults,
+            config,
+            "disable_copy_manager_stats",
+            False,
+            description,
+            apply_defaults,
         )
         self.__verify_or_set_optional_bool(
             config,
@@ -3362,7 +3373,9 @@ class Configuration(object):
         i = 0
         for log_entry in config.get_json_array("k8s_logs"):
             self.__verify_k8s_log_entry_and_set_defaults(
-                log_entry, config_file_path=file_path, entry_index=i,
+                log_entry,
+                config_file_path=file_path,
+                entry_index=i,
             )
             i += 1
 
@@ -3374,7 +3387,11 @@ class Configuration(object):
             i += 1
 
     def __verify_k8s_log_entry_and_set_defaults(
-        self, log_entry, description=None, config_file_path=None, entry_index=None,
+        self,
+        log_entry,
+        description=None,
+        config_file_path=None,
+        entry_index=None,
     ):
         """Verifies that the configuration for the specified k8s log entry.
 
@@ -3452,7 +3469,10 @@ class Configuration(object):
 
         # set default worker if it is not specified.
         self.__verify_or_set_optional_string(
-            log_entry, "worker_id", "default", description,
+            log_entry,
+            "worker_id",
+            "default",
+            description,
         )
 
     def __verify_log_entry_with_key_and_set_defaults(
@@ -3508,7 +3528,11 @@ class Configuration(object):
             )
 
         self.__verify_or_set_optional_array_of_strings(
-            log_entry, "exclude", [], description, apply_defaults=apply_defaults,
+            log_entry,
+            "exclude",
+            [],
+            description,
+            apply_defaults=apply_defaults,
         )
 
         # If a parser was specified, make sure it is a string.
@@ -4250,7 +4274,10 @@ class Configuration(object):
             )
 
     def __verify_required_attributes(
-        self, config_object, field, config_description,
+        self,
+        config_object,
+        field,
+        config_description,
     ):
         """Verifies that the specified field in config_object is a json object if present, otherwise sets to empty
         object.

--- a/scalyr_agent/connection.py
+++ b/scalyr_agent/connection.py
@@ -38,7 +38,7 @@ log = scalyr_logging.getLogger(__name__)
 
 
 class ConnectionFactory:
-    """ Factory class for creating connection objects using either Httplib or Requests
+    """Factory class for creating connection objects using either Httplib or Requests
     to handle the connection.
     """
 
@@ -53,7 +53,7 @@ class ConnectionFactory:
         quiet=False,
         proxies=None,
     ):
-        """ Create a new connection, with either Requests or Httplib, depending on the
+        """Create a new connection, with either Requests or Httplib, depending on the
         use_requests parameter.  If Requests is not available, fallback to to Httplib
 
         @param server: the server to connect to (scheme://domain:port)
@@ -94,12 +94,20 @@ class ConnectionFactory:
                     % six.text_type(e)
                 )
                 result = ScalyrHttpConnection(
-                    server, request_deadline, ca_file, intermediate_certs_file, headers,
+                    server,
+                    request_deadline,
+                    ca_file,
+                    intermediate_certs_file,
+                    headers,
                 )
                 use_requests = False
         else:
             result = ScalyrHttpConnection(
-                server, request_deadline, ca_file, intermediate_certs_file, headers,
+                server,
+                request_deadline,
+                ca_file,
+                intermediate_certs_file,
+                headers,
             )
 
         if not quiet:
@@ -112,7 +120,7 @@ class ConnectionFactory:
 
 
 class Connection(object):
-    """ Connection class
+    """Connection class
     An abstraction for dealing with different connection types Httplib or Requests
     """
 
@@ -150,7 +158,7 @@ class Connection(object):
         self.__connection = None
 
     def __check_ssl(self):
-        """ Helper function to check if ssl is available and enabled """
+        """Helper function to check if ssl is available and enabled"""
         if self._use_ssl and not self._ca_file:
             log.warn(
                 "Server certificate validation has been disabled while communicating with Scalyr. "
@@ -172,11 +180,11 @@ class Connection(object):
         self._get(request_path)
 
     def _post(self, request_path, body):
-        """Subclasses override to handle specifics of post requests """
+        """Subclasses override to handle specifics of post requests"""
         pass
 
     def _get(self, request_path):
-        """Subclasses override to handle specifics of get requests """
+        """Subclasses override to handle specifics of get requests"""
         pass
 
     def response(self):
@@ -206,7 +214,12 @@ class Connection(object):
 
 class ScalyrHttpConnection(Connection):
     def __init__(
-        self, server, request_deadline, ca_file, intermediate_certs_file, headers,
+        self,
+        server,
+        request_deadline,
+        ca_file,
+        intermediate_certs_file,
+        headers,
     ):
         super(ScalyrHttpConnection, self).__init__(
             server, request_deadline, ca_file, headers
@@ -222,7 +235,10 @@ class ScalyrHttpConnection(Connection):
         try:
             if self._use_ssl:
                 self.__connection = HTTPSConnectionWithTimeoutAndVerification(
-                    self._host, self._port, self._request_deadline, self._ca_file,
+                    self._host,
+                    self._port,
+                    self._request_deadline,
+                    self._ca_file,
                 )
                 self.__connection.connect()
             else:

--- a/scalyr_agent/copying_manager/copying_manager.py
+++ b/scalyr_agent/copying_manager/copying_manager.py
@@ -846,13 +846,10 @@ class CopyingManager(StoppableThread, LogWatcher):
 
                 # For multi processing mode we also include pids of all the spawned processes
                 if self.__config.use_multiprocess_workers:
-                    msg = (
-                        "Copying manager started. Total worker sessions: %s, Agent Pid: %s, Worker Session Processes Pids: %s"
-                        % (
-                            worker_sessions_count,
-                            os.getpid(),
-                            ", ".join([str(pid) for pid in worker_session_process_ids]),
-                        )
+                    msg = "Copying manager started. Total worker sessions: %s, Agent Pid: %s, Worker Session Processes Pids: %s" % (
+                        worker_sessions_count,
+                        os.getpid(),
+                        ", ".join([str(pid) for pid in worker_session_process_ids]),
                     )
                 else:
                     msg = (
@@ -1397,7 +1394,8 @@ class CopyingManager(StoppableThread, LogWatcher):
         Path for the current main checkpoint file.
         """
         return os.path.join(
-            self.__config.agent_data_path, CONSOLIDATED_CHECKPOINTS_FILE_NAME,
+            self.__config.agent_data_path,
+            CONSOLIDATED_CHECKPOINTS_FILE_NAME,
         )
 
     def __consolidate_checkpoints(self, checkpoints):
@@ -1408,7 +1406,8 @@ class CopyingManager(StoppableThread, LogWatcher):
         """
 
         consolidated_checkpoints_path = os.path.join(
-            self.__config.agent_data_path, CONSOLIDATED_CHECKPOINTS_FILE_NAME,
+            self.__config.agent_data_path,
+            CONSOLIDATED_CHECKPOINTS_FILE_NAME,
         )
 
         update_checkpoint_state_in_file(
@@ -1417,7 +1416,8 @@ class CopyingManager(StoppableThread, LogWatcher):
 
         # clear data folder by removing all worker session checkpoint files.
         checkpoints_glob = os.path.join(
-            self.__config.agent_data_path, WORKER_SESSION_CHECKPOINT_FILENAME_GLOB,
+            self.__config.agent_data_path,
+            WORKER_SESSION_CHECKPOINT_FILENAME_GLOB,
         )
 
         for path in scalyr_util.match_glob(checkpoints_glob):
@@ -1426,7 +1426,8 @@ class CopyingManager(StoppableThread, LogWatcher):
             # also delete active checkpoint file.
             checkpoint_file_name = os.path.basename(path)
             active_checkpoint_path = os.path.join(
-                os.path.dirname(path), "active-{0}".format(checkpoint_file_name),
+                os.path.dirname(path),
+                "active-{0}".format(checkpoint_file_name),
             )
             if os.path.isfile(active_checkpoint_path):
                 os.unlink(active_checkpoint_path)
@@ -1449,7 +1450,8 @@ class CopyingManager(StoppableThread, LogWatcher):
 
         # search for all worker session checkpoint files.
         worker_checkpoints_glob = os.path.join(
-            self.__config.agent_data_path, WORKER_SESSION_CHECKPOINT_FILENAME_GLOB,
+            self.__config.agent_data_path,
+            WORKER_SESSION_CHECKPOINT_FILENAME_GLOB,
         )
 
         checkpoints_paths = scalyr_util.match_glob(worker_checkpoints_glob)

--- a/scalyr_agent/copying_manager/worker.py
+++ b/scalyr_agent/copying_manager/worker.py
@@ -507,8 +507,10 @@ class CopyingManagerWorkerSession(
 
                         # Collect log lines to send if we don't have one already.
                         if self.__pending_add_events_task is None:
-                            self.__pending_add_events_task = self.__get_next_add_events_task(
-                                copying_params.current_bytes_allowed_to_send
+                            self.__pending_add_events_task = (
+                                self.__get_next_add_events_task(
+                                    copying_params.current_bytes_allowed_to_send
+                                )
                             )
                         else:
                             log.log(
@@ -559,9 +561,11 @@ class CopyingManagerWorkerSession(
                                 # have to wait before we send the next request.
                                 pipeline_time = time.time()
                                 self.total_pipelined_requests += 1
-                                self.__pending_add_events_task.next_pipelined_task = self.__get_next_add_events_task(
-                                    copying_params.current_bytes_allowed_to_send,
-                                    for_pipelining=True,
+                                self.__pending_add_events_task.next_pipelined_task = (
+                                    self.__get_next_add_events_task(
+                                        copying_params.current_bytes_allowed_to_send,
+                                        for_pipelining=True,
+                                    )
                                 )
                             else:
                                 pipeline_time = 0.0
@@ -644,8 +648,10 @@ class CopyingManagerWorkerSession(
 
                             # Rate limit based on amount of copied log bytes in a successful request
                             if self.__rate_limiter:
-                                time_slept = self.__rate_limiter.block_until_charge_succeeds(
-                                    log_bytes_sent
+                                time_slept = (
+                                    self.__rate_limiter.block_until_charge_succeeds(
+                                        log_bytes_sent
+                                    )
                                 )
                                 self.__total_rate_limited_time += time_slept
                                 self.__rate_limited_time_since_last_status += time_slept
@@ -800,12 +806,9 @@ class CopyingManagerWorkerSession(
                     > self._last_attempt_time
                     + self.__config.healthy_max_time_since_last_copy_attempt
                 ):
-                    result.health_check_result = (
-                        "Worker session '%s' failed, max time since last copy attempt (%s seconds) exceeded"
-                        % (
-                            self._id,
-                            self.__config.healthy_max_time_since_last_copy_attempt,
-                        )
+                    result.health_check_result = "Worker session '%s' failed, max time since last copy attempt (%s seconds) exceeded" % (
+                        self._id,
+                        self.__config.healthy_max_time_since_last_copy_attempt,
                     )
 
         finally:

--- a/scalyr_agent/line_matcher.py
+++ b/scalyr_agent/line_matcher.py
@@ -30,7 +30,7 @@ import six
 
 
 class LineMatcher(object):
-    """ An abstraction for a Line Matcher.
+    """An abstraction for a Line Matcher.
     Reads an entire 'line' from a file like object (e.g. anything implementing Python's
     file interface such as StringIO).  By default it reads just a single line terminated
     by a newline, however subclasses can override the _readline method to provide their
@@ -143,7 +143,7 @@ class LineMatcher(object):
         return line
 
     def _readline(self, file_like, max_length=0):
-        """ Takes a file_like object (e.g. anything conforming to python's file interface
+        """Takes a file_like object (e.g. anything conforming to python's file interface
         and returns either a full line, or a partial line.
         @param file_like: a file like object (e.g. StringIO)
         @param max_length: the maximum length to read from the file_like object
@@ -164,7 +164,7 @@ class LineMatcher(object):
 
 
 class LineMatcherCollection(LineMatcher):
-    """ A group of line matchers.
+    """A group of line matchers.
     Returns the line from the first line matcher that returns a non-empty line,
     or a single newline terminated line if no matches are found.
     """
@@ -177,7 +177,7 @@ class LineMatcherCollection(LineMatcher):
         self.__matchers.append(matcher)
 
     def _readline(self, file_like, max_length=0):
-        """ Takes a file_like object (e.g. anything conforming to python's file interface
+        """Takes a file_like object (e.g. anything conforming to python's file interface
         and checks all self.__matchers to see if any of them match.  If so then return the
         first matching line, otherwise return a single newline terminated line from the input.
 
@@ -213,7 +213,7 @@ class LineMatcherCollection(LineMatcher):
 
 
 class LineGrouper(LineMatcher):
-    """ An abstraction for a LineMatcher that groups multiple lines as a single line.
+    """An abstraction for a LineMatcher that groups multiple lines as a single line.
     Most of the complexity of multiline matching is handled by this class, and subclasses
     are expected to override methods determining when a multiline begins, and whether the
     multiline should continue.
@@ -235,7 +235,7 @@ class LineGrouper(LineMatcher):
         self._continuation_pattern = re.compile(continuation_pattern)
 
     def _readline(self, file_like, max_length=0):
-        """ Takes a file_like object (e.g. anything conforming to python's file interface
+        """Takes a file_like object (e.g. anything conforming to python's file interface
         and returns either a full line, or a partial line.
         @param file_like: a file like object (e.g. StringIO)
         @param max_length: the maximum length to read from the file_like object
@@ -342,19 +342,19 @@ class LineGrouper(LineMatcher):
         return line, partial
 
     def _match_single_line(self):
-        """ Returns whether or not the grouper can match a single line based on the start_pattern.
+        """Returns whether or not the grouper can match a single line based on the start_pattern.
         Defaults to false
         """
         return False
 
     def _continue_line(self, line):
-        """ Returns whether or not the grouper should continue matching a multiline.  Defaults to false
+        """Returns whether or not the grouper should continue matching a multiline.  Defaults to false
         @param line - the next line of input
         """
         return False
 
     def _start_line(self, line):
-        """ Returns whether or not the grouper should start matching a multiline.
+        """Returns whether or not the grouper should start matching a multiline.
         @param line - the next line of input
         @return bool - whether or not the start pattern finds a match in the input line
         """
@@ -362,7 +362,7 @@ class LineGrouper(LineMatcher):
 
 
 class ContinueThrough(LineGrouper):
-    """  A ContinueThrough multiline grouper.
+    """A ContinueThrough multiline grouper.
     If the start_pattern matches, then all consecutive lines matching the continuation pattern are included in the line.
     This is useful in cases such as a Java stack trace, where some indicator in the line (such as leading whitespace)
     indicates that it is an extension of the preceeding line.
@@ -380,7 +380,7 @@ class ContinueThrough(LineGrouper):
 
 
 class ContinuePast(LineGrouper):
-    """ A ContinuePast multiline grouper.
+    """A ContinuePast multiline grouper.
     If the start pattern matches, then all consecutive lines matching the contuation pattern, plus one additional line,
     are included in the line.
     This is useful in cases where a log message ends with a continuation marker, such as a backslash, indicating
@@ -437,7 +437,7 @@ class ContinuePast(LineGrouper):
 
 
 class HaltBefore(LineGrouper):
-    """ A HaltBefore line grouper.
+    """A HaltBefore line grouper.
     If the start pattern matches, then all consecutive lines not matching the contuation pattern are included in the line.
     This is useful where a log line contains a marker indicating that it begins a new message.
     """
@@ -471,7 +471,7 @@ class HaltBefore(LineGrouper):
 
 
 class HaltWith(LineGrouper):
-    """ A HaltWith line grouper.
+    """A HaltWith line grouper.
     If the start pattern matches, all consecutive lines, up to and including the first line matching the contuation pattern,
     are included in the line. This is useful where a log line ends with a termination marker, such as a semicolon.
     """

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -326,8 +326,8 @@ class LogFileIterator(object):
 
                 if "position" in checkpoint:
                     self.__position = checkpoint["position"]
-                    self.__extended_line_position = LogFileIterator.ExtendedLinePosition.from_checkpoint(
-                        checkpoint
+                    self.__extended_line_position = (
+                        LogFileIterator.ExtendedLinePosition.from_checkpoint(checkpoint)
                     )
                     for state in checkpoint["pending_files"]:
                         if not state["is_log_file"] or self.__file_system.trust_inodes:
@@ -642,8 +642,8 @@ class LogFileIterator(object):
         # Do we need more bytes to have at least max_line_bytes in available in the buffer.
         need_more_bytes_for_max_line = available_buffer_bytes < self.__max_line_length
         # If we are on an extended line, do we need more bytes in buffer to read the next fragment
-        need_more_bytes_for_fragment_position = not self.__have_buffer_for_fragment_position(
-            available_buffer_bytes
+        need_more_bytes_for_fragment_position = (
+            not self.__have_buffer_for_fragment_position(available_buffer_bytes)
         )
 
         if more_file_bytes_available and (
@@ -1278,9 +1278,12 @@ class LogFileIterator(object):
             tmp = self.__buffer.read()
             new_buffer.write(tmp)
             if expected_bytes != new_buffer.tell():
-                assert expected_bytes == new_buffer.tell(), (
-                    'Failed to get the right number of left over bytes %d %d "%s"'
-                    % (expected_bytes, new_buffer.tell(), tmp,)
+                assert (
+                    expected_bytes == new_buffer.tell()
+                ), 'Failed to get the right number of left over bytes %d %d "%s"' % (
+                    expected_bytes,
+                    new_buffer.tell(),
+                    tmp,
                 )
 
         self.__buffer = new_buffer
@@ -2596,8 +2599,10 @@ class LogFileProcessor(object):
                     # If it was a success, then we update the counters and advance the iterator.
                     if result == LogFileProcessor.SUCCESS:
                         self.__total_bytes_copied += bytes_copied
-                        bytes_between_positions = self.__log_file_iterator.bytes_between_positions(
-                            original_position, final_position
+                        bytes_between_positions = (
+                            self.__log_file_iterator.bytes_between_positions(
+                                original_position, final_position
+                            )
                         )
                         self.__total_bytes_skipped += (
                             bytes_between_positions - bytes_read
@@ -2738,7 +2743,11 @@ class LogFileProcessor(object):
         self.__lock.release()
 
         log.warning(
-            msg, skipped_bytes, self.__path, message, error_code=error_code,
+            msg,
+            skipped_bytes,
+            self.__path,
+            message,
+            error_code=error_code,
         )
 
     def add_sampler(self, match_expression, sampling_rate):

--- a/scalyr_agent/log_watcher.py
+++ b/scalyr_agent/log_watcher.py
@@ -41,13 +41,13 @@ class LogWatcher(object):
 
     def update_log_config(self, monitor_name, log_config):
         """Update the config of any logs that match the
-           path of the log_config param
+        path of the log_config param
         """
         pass
 
     def schedule_log_path_for_removal(self, monitor_name, log_path):
         """
-            Schedules a log path for removal.  The logger will only
-            be removed once the number of pending bytes for that log reaches 0
+        Schedules a log path for removal.  The logger will only
+        be removed once the number of pending bytes for that log reaches 0
         """
         pass

--- a/scalyr_agent/monitor_utils/annotation_config.py
+++ b/scalyr_agent/monitor_utils/annotation_config.py
@@ -168,8 +168,7 @@ def _is_int(string):
 
 
 def _process_annotation_items(items, hyphens_as_underscores):
-    """ Process annotation items after the scalyr config prefix has been stripped
-    """
+    """Process annotation items after the scalyr config prefix has been stripped"""
 
     def sort_annotation(pair):
         (key, value) = pair

--- a/scalyr_agent/monitor_utils/blocking_rate_limiter.py
+++ b/scalyr_agent/monitor_utils/blocking_rate_limiter.py
@@ -256,8 +256,7 @@ class BlockingRateLimiter(object):
             self._cluster_rate_lock.release()
 
     def _get_actual_cluster_rate(self):
-        """Calculate actual rate based on recorded actions.  If fewer than 2 actions, returns None
-        """
+        """Calculate actual rate based on recorded actions.  If fewer than 2 actions, returns None"""
         self._cluster_rate_lock.acquire()
         try:
             if self._num_actions < 2:
@@ -272,8 +271,7 @@ class BlockingRateLimiter(object):
             self._cluster_rate_lock.release()
 
     def _record_actual_rate(self):
-        """Record a completed action in order to keep track of actual rate
-        """
+        """Record a completed action in order to keep track of actual rate"""
         self._cluster_rate_lock.acquire()
         try:
             t = self._time()

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -108,9 +108,9 @@ FALLBACK_KUBELET_URL_TEMPLATE = Template("http://${host_ip}:10255")
 
 def cache(global_config):
     """
-        Returns the global k8s cache, configured using the options in `config`
-        @param config: The configuration
-        @type config: A Scalyr Configuration object
+    Returns the global k8s cache, configured using the options in `config`
+    @param config: The configuration
+    @type config: A Scalyr Configuration object
     """
     cache_config = _CacheConfig(
         api_url=global_config.k8s_api_url,
@@ -383,7 +383,7 @@ class QualifiedName(object):
 
 class PodInfo(object):
     """
-        A collection class that stores label and other information about a kubernetes pod
+    A collection class that stores label and other information about a kubernetes pod
     """
 
     def __init__(
@@ -451,19 +451,19 @@ class PodInfo(object):
 
     def exclude_pod(self, container_name=None, default=False):
         """
-            Returns whether or not this pod should be excluded based
-            on include/exclude annotations.  If an annotation 'exclude' exists
-            then this will be returned.  If an annotation 'include' exists, then
-            the boolean opposite of 'include' will be returned.  'include' will
-            always override 'exclude' if it exists.
+        Returns whether or not this pod should be excluded based
+        on include/exclude annotations.  If an annotation 'exclude' exists
+        then this will be returned.  If an annotation 'include' exists, then
+        the boolean opposite of 'include' will be returned.  'include' will
+        always override 'exclude' if it exists.
 
-            param: container_name - if specified, and container_name exists in
-              the pod annotations, then the container specific annotations will
-              also be checked.  These will supercede the pod level include/exclude
-              annotations
-            param: default - Boolean the default value if no annotations are found
+        param: container_name - if specified, and container_name exists in
+          the pod annotations, then the container specific annotations will
+          also be checked.  These will supercede the pod level include/exclude
+          annotations
+        param: default - Boolean the default value if no annotations are found
 
-            return Boolean - whether or not to exclude this pod
+        return Boolean - whether or not to exclude this pod
         """
 
         def exclude_status(annotations, default):
@@ -484,7 +484,7 @@ class PodInfo(object):
 
 class Controller(object):
     """
-        General class for all cached Controller objects
+    General class for all cached Controller objects
     """
 
     def __init__(
@@ -510,8 +510,7 @@ class Controller(object):
 
 
 class ApiQueryOptions(object):
-    """Options to use when querying the K8s Api server.
-    """
+    """Options to use when querying the K8s Api server."""
 
     def __init__(self, max_retries=3, return_temp_errors=True, rate_limiter=None):
         """
@@ -532,20 +531,20 @@ class ApiQueryOptions(object):
 
 class _K8sCache(object):
     """
-        A cached store of objects from a k8s api query
+    A cached store of objects from a k8s api query
 
-        This is a private class to this module.  See KubernetesCache which instantiates
-        instances of _K8sCache for querying different k8s API objects.
+    This is a private class to this module.  See KubernetesCache which instantiates
+    instances of _K8sCache for querying different k8s API objects.
 
-        This abstraction is thread-safe-ish, assuming objects returned
-        from querying the cache are never written to.
+    This abstraction is thread-safe-ish, assuming objects returned
+    from querying the cache are never written to.
     """
 
     def __init__(self, processor, object_type):
         """
-            Initialises a Kubernetes Cache
-            @param processor: a _K8sProcessor object for querying/processing the k8s api
-            @param object_type: a string containing a textual name of the objects being cached, for use in log messages
+        Initialises a Kubernetes Cache
+        @param processor: a _K8sProcessor object for querying/processing the k8s api
+        @param object_type: a string containing a textual name of the objects being cached, for use in log messages
         """
         # protects self._objects and self._objects_expired
         self._lock = threading.Lock()
@@ -664,7 +663,7 @@ class _K8sCache(object):
     def _lookup_object(
         self, namespace, name, current_time, allow_expired=True, query_options=None
     ):
-        """ Look to see if the object specified by the namespace and name exists within the cached data.
+        """Look to see if the object specified by the namespace and name exists within the cached data.
 
         Note: current_time should be provided (otherwise, access_time-based revalidation of cache won't work correctly,
         for example, manifesting as unnecessary re-queries of controller metadata)
@@ -789,19 +788,19 @@ class _K8sCache(object):
 
 class _K8sProcessor(object):
     """
-        An abstract interface used by _K8sCache for querying a specific type of
-        object from the k8s api, and generating python objects from the queried result JSON.
+    An abstract interface used by _K8sCache for querying a specific type of
+    object from the k8s api, and generating python objects from the queried result JSON.
     """
 
     def _get_managing_controller(self, items):
         """
-            Processes a list of items, searching to see if one of them
-            is a 'managing controller', which is determined by the 'controller' field
+        Processes a list of items, searching to see if one of them
+        is a 'managing controller', which is determined by the 'controller' field
 
-            @param items: an array containing 'ownerReferences' metadata for an object
-                            returned from the k8s api
+        @param items: an array containing 'ownerReferences' metadata for an object
+                        returned from the k8s api
 
-            @return: A dict containing the managing controller of type `kind` or None if no such controller exists
+        @return: A dict containing the managing controller of type `kind` or None if no such controller exists
         """
         for i in items:
             controller = i.get("controller", False)
@@ -828,10 +827,10 @@ class PodProcessor(_K8sProcessor):
 
     def _get_controller_from_owners(self, k8s, owners, namespace, query_options=None):
         """
-            Processes a list of owner references returned from a Pod's metadata to see
-            if it is eventually owned by a Controller, and if so, returns the Controller object
+        Processes a list of owner references returned from a Pod's metadata to see
+        if it is eventually owned by a Controller, and if so, returns the Controller object
 
-            @return Controller - a Controller object
+        @return Controller - a Controller object
         """
         controller = None
 
@@ -897,7 +896,7 @@ class PodProcessor(_K8sProcessor):
         return controller
 
     def process_object(self, k8s, obj, query_options=None):
-        """ Generate a PodInfo object from a JSON object
+        """Generate a PodInfo object from a JSON object
         @param k8s: a KubernetesApi object
         @param pod: The JSON object returned as a response to querying
             a specific pod from the k8s API
@@ -957,7 +956,7 @@ class PodProcessor(_K8sProcessor):
 
 class ControllerProcessor(_K8sProcessor):
     def process_object(self, k8s, obj, query_options=None):
-        """ Generate a Controller object from a JSON object
+        """Generate a Controller object from a JSON object
         @param k8s: a KubernetesApi object
         @param obj: The JSON object returned as a response to querying
             a specific controller from the k8s API
@@ -1030,7 +1029,7 @@ class _CacheConfig(object):
         self.global_config = global_config
 
     def __eq__(self, other):
-        """Equivalence method for _CacheConfig objects so == testing works """
+        """Equivalence method for _CacheConfig objects so == testing works"""
         for key, val in self.__dict__.items():
             if val != getattr(other, key):
                 return False
@@ -1260,7 +1259,7 @@ class KubernetesCache(object):
 
     def start(self):
         """
-            Starts the background thread that reads from the k8s cache
+        Starts the background thread that reads from the k8s cache
         """
         if self._thread is None:
             self._thread = StoppableThread(target=self.update_cache, name="K8S Cache")
@@ -1408,7 +1407,7 @@ class KubernetesCache(object):
 
     def update_cache(self, run_state):
         """
-            Main thread for updating the k8s cache
+        Main thread for updating the k8s cache
         """
 
         start_time = time.time()
@@ -1675,8 +1674,7 @@ class KubernetesCache(object):
 
 
 class KubernetesApi(object):
-    """Simple wrapper class for querying the k8s api
-    """
+    """Simple wrapper class for querying the k8s api"""
 
     @staticmethod
     def create_instance(
@@ -1815,28 +1813,26 @@ class KubernetesApi(object):
         )
 
     def _verify_connection(self):
-        """ Return whether or not to use SSL verification
-        """
+        """Return whether or not to use SSL verification"""
         if self._ca_file:
             return self._ca_file
         return False
 
     def _ensure_session(self):
-        """Create the session if it doesn't exist, otherwise do nothing
-        """
+        """Create the session if it doesn't exist, otherwise do nothing"""
         if not self._session:
             self._session = requests.Session()
             self._session.headers.update(self._standard_headers)
 
     def get_pod_name(self):
-        """ Gets the pod name of the pod running the scalyr-agent """
+        """Gets the pod name of the pod running the scalyr-agent"""
         # 2->TODO in python2 os.environ returns 'str' type. Convert it to unicode.
         return os_environ_unicode.get("SCALYR_K8S_POD_NAME") or os_environ_unicode.get(
             "HOSTNAME"
         )
 
     def get_node_name(self, pod_name):
-        """ Gets the node name of the node running the agent """
+        """Gets the node name of the node running the agent"""
         # 2->TODO in python2 os.environ returns 'str' type. Convert it to unicode.
         node = os_environ_unicode.get("SCALYR_K8S_NODE_NAME")
         if not node:
@@ -1859,7 +1855,7 @@ class KubernetesApi(object):
         return version_map.get("gitVersion")
 
     def get_cluster_name(self):
-        """ Returns the name of the cluster running this agent.
+        """Returns the name of the cluster running this agent.
 
         There is no way to get this from the k8s API so we check the following:
 
@@ -2038,8 +2034,7 @@ class KubernetesApi(object):
                 raise K8sApiTemporaryError("Fake %s" % fake_response_code)
 
     def query_api(self, path, pretty=0, return_temp_errors=False, rate_limited=False):
-        """ Queries the k8s API at 'path', and converts OK responses to JSON objects
-        """
+        """Queries the k8s API at 'path', and converts OK responses to JSON objects"""
         self._ensure_session()
         pretty = "pretty=%d" % pretty
         if "?" in path:
@@ -2152,13 +2147,13 @@ class KubernetesApi(object):
                         )
 
     def query_object(self, kind, namespace, name, query_options=None):
-        """ Queries a single object from the k8s api based on an object kind, a namespace and a name
-            An empty dict is returned if the object kind is unknown, or if there is an error generating
-            an appropriate query string
-            @param kind: the kind of the object
-            @param namespace: the namespace to query in
-            @param name: the name of the object
-            @return - a dict returned by the query
+        """Queries a single object from the k8s api based on an object kind, a namespace and a name
+        An empty dict is returned if the object kind is unknown, or if there is an error generating
+        an appropriate query string
+        @param kind: the kind of the object
+        @param namespace: the namespace to query in
+        @param name: the name of the object
+        @return - a dict returned by the query
         """
         if kind not in _OBJECT_ENDPOINTS:
             global_log.warn(
@@ -2194,10 +2189,10 @@ class KubernetesApi(object):
         )
 
     def query_objects(self, kind, namespace=None, filter=None):
-        """ Queries a list of objects from the k8s api based on an object kind, optionally limited by
-            a namespace and a filter
-            A dict containing an empty 'items' array is returned if the object kind is unknown, or if there is an error generating
-            an appropriate query string
+        """Queries a list of objects from the k8s api based on an object kind, optionally limited by
+        a namespace and a filter
+        A dict containing an empty 'items' array is returned if the object kind is unknown, or if there is an error generating
+        an appropriate query string
         """
         if kind not in _OBJECT_ENDPOINTS:
             global_log.warn(
@@ -2289,7 +2284,7 @@ class KubernetesApi(object):
 
 class KubeletApi(object):
     """
-        A class for querying the kubelet API
+    A class for querying the kubelet API
     """
 
     def __init__(
@@ -2346,8 +2341,7 @@ class KubeletApi(object):
         self._kubelet_url = self._fallback_kubelet_url
 
     def _verify_connection(self):
-        """ Return whether or not to use SSL verification
-        """
+        """Return whether or not to use SSL verification"""
         if self._verify_https and self._ca_file:
             return self._ca_file
         return False
@@ -2356,8 +2350,7 @@ class KubeletApi(object):
         return self._session.get(url, timeout=self._timeout, verify=verify)
 
     def query_api(self, path):
-        """ Queries the kubelet API at 'path', and converts OK responses to JSON objects
-        """
+        """Queries the kubelet API at 'path', and converts OK responses to JSON objects"""
         while True:
             url = self._kubelet_url + path
             # We suppress warnings here to avoid spam about an unverified connection going to stderr.
@@ -2385,16 +2378,12 @@ class KubeletApi(object):
                     response.status_code == 403
                     and self._kubelet_url != self._fallback_kubelet_url
                 ):
-                    msg = (
-                        "Invalid response while querying the Kubelet API on %s. Falling back "
-                        "to older endpoint (%s).\n\nurl: %s\nstatus: %s\nresponse: %s\n"
-                        % (
-                            url,
-                            self._fallback_kubelet_url,
-                            url,
-                            response.status_code,
-                            response.text,
-                        )
+                    msg = "Invalid response while querying the Kubelet API on %s. Falling back " "to older endpoint (%s).\n\nurl: %s\nstatus: %s\nresponse: %s\n" % (
+                        url,
+                        self._fallback_kubelet_url,
+                        url,
+                        response.status_code,
+                        response.text,
                     )
 
                     global_log.warn(
@@ -2477,7 +2466,12 @@ class K8sConfigBuilder(object):
                 self._logger.log(
                     scalyr_logging.DEBUG_LEVEL_2,
                     "Ignoring k8s_log item %d because %s '%s' doesn't match '%s'"
-                    % (element, name, value, glob,),
+                    % (
+                        element,
+                        name,
+                        value,
+                        glob,
+                    ),
                 )
         return result
 
@@ -2734,8 +2728,7 @@ class DockerMetricFetcher(object):
             self.__idle_workers_count += 1
 
     def __worker(self):
-        """The body for the worker threads.
-        """
+        """The body for the worker threads."""
         while True:
             # Get the next container to fetch if there is one.
             container_id, is_stopped = self._get_fetch_task()
@@ -2805,7 +2798,7 @@ class DockerMetricFetcher(object):
 
 def _create_k8s_cache():
     """
-        creates a new k8s cache object
+    creates a new k8s cache object
     """
 
     return KubernetesCache(start_caching=False)

--- a/scalyr_agent/monitor_utils/server_processors.py
+++ b/scalyr_agent/monitor_utils/server_processors.py
@@ -285,8 +285,7 @@ class ConnectionIdleTooLong(Exception):
 
 
 class RequestSizeExceeded(Exception):
-    """Raised when an incoming request has exceeded the maximum allowed request size.
-    """
+    """Raised when an incoming request has exceeded the maximum allowed request size."""
 
     def __init__(self, request_size, max_request_size):
         Exception.__init__(
@@ -344,7 +343,7 @@ class ConnectionProcessor(object):
 
         @param current_time: If provided, uses the specified time as the current time. Used for testing.
 
-        @return: """
+        @return:"""
         if current_time is None:
             current_time = time.time()
 
@@ -365,8 +364,7 @@ class ConnectionProcessor(object):
 
 
 class ConnectionHandler(six.moves.socketserver.BaseRequestHandler):
-    """The handler class that is used by ServerProcess to handle incoming connections.
-    """
+    """The handler class that is used by ServerProcess to handle incoming connections."""
 
     # The bulk of the work for this class is actually implemented in ConnectionProcess to allow for
     # easier testing.
@@ -565,8 +563,7 @@ class RequestStream(object):
                 self.__quick_compaction()
 
     def at_end(self):
-        """Returns True if the underlying socket has been closed.
-        """
+        """Returns True if the underlying socket has been closed."""
         return self.__at_end
 
     def is_closed(self):
@@ -631,8 +628,7 @@ class RequestStream(object):
             return True
 
     def __full_compaction(self):
-        """Compacts the memory buffer by remove all bytes that have already been read.
-        """
+        """Compacts the memory buffer by remove all bytes that have already been read."""
         # Read the leftover data and write it into a new buffer.
         remaining_data = self.__buffer.read()
         self.__buffer.close()

--- a/scalyr_agent/monitors_manager.py
+++ b/scalyr_agent/monitors_manager.py
@@ -76,8 +76,8 @@ class MonitorsManager(StoppableThread):
 
     def find_monitor(self, module_name):
         """Finds a monitor with a specific name
-           @param module_name: the module name of the monitor to find
-           @return: a monitor object if a monitor matches `module_name`, or None
+        @param module_name: the module name of the monitor to find
+        @return: a monitor object if a monitor matches `module_name`, or None
         """
         for monitor in self.__monitors:
             if monitor.module_name == module_name:

--- a/scalyr_agent/platform_controller.py
+++ b/scalyr_agent/platform_controller.py
@@ -36,8 +36,7 @@ PLATFORM_INSTANCE = None
 
 class PlatformController(object):
     def __init__(self):
-        """Initializes a platform instance.
-        """
+        """Initializes a platform instance."""
         self._install_type = INSTALL_TYPE
 
     # A list of PlatformController classes that have been registered for use.
@@ -47,7 +46,7 @@ class PlatformController(object):
     @staticmethod
     def __register_supported_platforms():
         """Adds all available platforms to the '__platforms_registered__' array.
-         a new platform class that could be instantiated during the 'new_platform' method.
+        a new platform class that could be instantiated during the 'new_platform' method.
         """
         if sys.platform == "win32":
             from scalyr_agent.platform_windows import WindowsPlatformController
@@ -377,15 +376,13 @@ class DefaultPaths(object):
 
 
 class AgentAlreadyRunning(Exception):
-    """Raised to signal the agent is already running.
-    """
+    """Raised to signal the agent is already running."""
 
     pass
 
 
 class AgentNotRunning(Exception):
-    """Raised to signal the agent is not running.
-    """
+    """Raised to signal the agent is not running."""
 
     pass
 
@@ -400,7 +397,6 @@ class CannotExecuteAsUser(Exception):
 
 
 class ChangeUserNotSupported(Exception):
-    """Raised to signal that this platform has not implemented the operation of changing its executing user.
-    """
+    """Raised to signal that this platform has not implemented the operation of changing its executing user."""
 
     pass

--- a/scalyr_agent/platform_linux.py
+++ b/scalyr_agent/platform_linux.py
@@ -49,8 +49,7 @@ class LinuxPlatformController(PosixPlatformController):
     """
 
     def __init__(self, stdin="/dev/null", stdout="/dev/null", stderr="/dev/null"):
-        """Initializes the POSIX platform instance.
-        """
+        """Initializes the POSIX platform instance."""
         PosixPlatformController.__init__(
             self, stdin=stdin, stdout=stdout, stderr=stderr
         )
@@ -110,7 +109,9 @@ class LinuxPlatformController(PosixPlatformController):
 
         if config.implicit_metric_monitor:
             result.append(
-                JsonObject(module="scalyr_agent.builtin_monitors.linux_system_metrics",)
+                JsonObject(
+                    module="scalyr_agent.builtin_monitors.linux_system_metrics",
+                )
             )
 
         if config.implicit_agent_process_metrics_monitor:

--- a/scalyr_agent/platform_posix.py
+++ b/scalyr_agent/platform_posix.py
@@ -67,8 +67,7 @@ class PosixPlatformController(PlatformController):
     """
 
     def __init__(self, stdin="/dev/null", stdout="/dev/null", stderr="/dev/null"):
-        """Initializes the POSIX platform instance.
-        """
+        """Initializes the POSIX platform instance."""
         self.__stdin = stdin
         self.__stdout = stdout
         self.__stderr = stderr
@@ -1237,8 +1236,7 @@ class StatusReporter(object):
             assert self.__fp.fileno() != source_fp.fileno()
 
     def close(self):
-        """Closes the status reporter.  This must be invoked by all processes.
-        """
+        """Closes the status reporter.  This must be invoked by all processes."""
         self.__fp.close()
 
     def report_status(self, message):

--- a/scalyr_agent/platform_tests/run_platform_test.py
+++ b/scalyr_agent/platform_tests/run_platform_test.py
@@ -42,8 +42,7 @@ from scalyr_agent import compat
 
 
 class WorkingDirectory:
-    """Simple abstraction with the context manager for changing the current working directory
-    """
+    """Simple abstraction with the context manager for changing the current working directory"""
 
     def __init__(self, new_path):
         """

--- a/scalyr_agent/platform_windows.py
+++ b/scalyr_agent/platform_windows.py
@@ -190,8 +190,7 @@ def _get_config_path_registry_entry(default_config_path):
 
 # noinspection PyPep8Naming
 class ScalyrAgentService(win32serviceutil.ServiceFramework):
-    """Implements the Windows service interface and exports the Scalyr Agent as a service.
-    """
+    """Implements the Windows service interface and exports the Scalyr Agent as a service."""
 
     # The following fields must be present for PyInstaller to detect this as a service implementation.
     _svc_name_ = _SCALYR_AGENT_SERVICE_
@@ -261,12 +260,10 @@ class ScalyrAgentService(win32serviceutil.ServiceFramework):
 
 
 class WindowsPlatformController(PlatformController):
-    """A controller instance for Microsoft's Windows platforms
-    """
+    """A controller instance for Microsoft's Windows platforms"""
 
     def __init__(self):
-        """Initializes the Windows platform instance.
-        """
+        """Initializes the Windows platform instance."""
         # The method to invoke when termination is requested.
         self.__termination_handler = None
         # The method to invoke when status is requested by another process.
@@ -773,8 +770,7 @@ class PipeRedirectorServer(RedirectorServer):
         )
 
     class ServerChannel(RedirectorServer.ServerChannel):
-        """Provides the channel implementation for receiving client connections over a named pipe.
-        """
+        """Provides the channel implementation for receiving client connections over a named pipe."""
 
         def __init__(self, name):
             self.__full_pipe_name = name
@@ -817,8 +813,7 @@ class PipeRedirectorServer(RedirectorServer):
             win32file.WriteFile(self.__pipe_handle, content)
 
         def close(self):
-            """Closes the channel to the client.
-            """
+            """Closes the channel to the client."""
             try:
                 # 2->TODO struct.pack|unpack in python < 2.7.7 does not allow unicode format string.
                 win32file.WriteFile(
@@ -858,8 +853,7 @@ class PipeRedirectorClient(RedirectorClient):
         return self.__pipe_name
 
     class ClientChannel(object):
-        """Implements the client channel that connects to a named pipe and can receive data from it.
-        """
+        """Implements the client channel that connects to a named pipe and can receive data from it."""
 
         def __init__(self, full_pipe_name):
             self.__full_pipe_name = full_pipe_name
@@ -923,8 +917,7 @@ class PipeRedirectorClient(RedirectorClient):
                 )
 
         def close(self):
-            """Closes the channel to the server.
-            """
+            """Closes the channel to the server."""
             if self.__pipe_handle is not None:
                 win32file.CloseHandle(self.__pipe_handle)
                 self.__pipe_handle = None

--- a/scalyr_agent/profiler.py
+++ b/scalyr_agent/profiler.py
@@ -213,8 +213,8 @@ class CPUProfiler(BaseProfiler):
 
     def _get_clock_type(self, clock_type, allowed, default_value):
         """
-            gets the clock type.  If clock type is `random` then
-            randomly choose from the first 2 elements of the `allowed` array.
+        gets the clock type.  If clock type is `random` then
+        randomly choose from the first 2 elements of the `allowed` array.
         """
         result = default_value
         if clock_type in allowed:

--- a/scalyr_agent/remote_shell.py
+++ b/scalyr_agent/remote_shell.py
@@ -175,8 +175,7 @@ class DebugServer(StoppableThread):
         return None
 
     def __setup_server_socket(self):
-        """Create the server socket, binding to the appropriate address.
-        """
+        """Create the server socket, binding to the appropriate address."""
         if self.__server_socket is not None:
             return
 
@@ -195,8 +194,7 @@ class DebugServer(StoppableThread):
             self.__close_socket()
 
     def __close_socket(self):
-        """Close the underlying server socket.
-        """
+        """Close the underlying server socket."""
         if self.__server_socket is not None:
             try:
                 self.__server_socket.shutdown(socket.SHUT_RDWR)

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -806,7 +806,9 @@ class ScalyrClientSession(object):
             return add_events_request.get_payload()
 
         return self.__send_request(
-            "/addEvents", body_func=generate_body, block_on_response=block_on_response,
+            "/addEvents",
+            body_func=generate_body,
+            block_on_response=block_on_response,
         )
 
     def close(self, current_time=None):
@@ -964,7 +966,11 @@ class ScalyrClientSession(object):
             and len(sessions_api_keys_tuple) == 3
             and sessions_api_keys_tuple[1] > 1
         ):
-            (worker_type, workers_count, api_keys_count,) = sessions_api_keys_tuple
+            (
+                worker_type,
+                workers_count,
+                api_keys_count,
+            ) = sessions_api_keys_tuple
 
             if worker_type == "multiprocess":
                 sharded_copy_manager_string = "mw-2|"
@@ -1000,8 +1006,7 @@ class ScalyrClientSession(object):
         return ";".join(map(six.text_type, parts))
 
     def perform_agent_version_check(self, track="stable"):
-        """Query the Scalyr API to determine if a newer version is available
-        """
+        """Query the Scalyr API to determine if a newer version is available"""
         url_path = (
             "/ajax?method=performAgentVersionCheck&installedVersion=%s&track=%s"
             % (self.__agent_version, track)
@@ -1435,8 +1440,7 @@ class AddEventsRequest(object):
         self.__event_sequencer.reset()
 
     class Position(object):
-        """Represents a position in the added events.
-        """
+        """Represents a position in the added events."""
 
         def __init__(self, events_added, buffer_size, postfix_buffer_position):
             self.events_added = events_added
@@ -1843,8 +1847,7 @@ class Event(object):
         self.__num_optimal_fields = 0
 
     def __set_attributes(self, thread_id, attributes):
-        """ Set the attributes and thread id of an Event.
-        """
+        """Set the attributes and thread id of an Event."""
         self.__thread_id = thread_id
         self.__attrs = attributes
         attributes_to_serialize = self.__get_attributes_to_serialize()
@@ -1900,7 +1903,7 @@ class Event(object):
         return result
 
     def add_attributes(self, attributes, overwrite_existing=False):
-        """ Adds items attributes to __attrs if the __parent_event doesn't
+        """Adds items attributes to __attrs if the __parent_event doesn't
         already have those attributes set.
 
         If overwrite_existing is False an attribute will not be added if the key already exists in __attrs.

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -861,13 +861,10 @@ class BaseFormatter(logging.Formatter):
 
         # Otherwise, build the format.  Prepend a warning if we had to skip lines.
         if getattr(record, "rate_limited_dropped_records", 0) > 0:
-            result = (
-                ".... Warning, skipped writing %ld log lines due to limit set by `%s` option...\n%s"
-                % (
-                    record.rate_limited_dropped_records,
-                    "monitor_log_write_rate",
-                    logging.Formatter.format(self, record),
-                )
+            result = ".... Warning, skipped writing %ld log lines due to limit set by `%s` option...\n%s" % (
+                record.rate_limited_dropped_records,
+                "monitor_log_write_rate",
+                logging.Formatter.format(self, record),
             )
         else:
             result = logging.Formatter.format(self, record)
@@ -1007,7 +1004,7 @@ class RateLimiterLogFilter(object):
         @param log_write_rate: The average number of bytes per second to allow to be written to the log. This is the
             bucket fill rate in the "leaky bucket" algorithm.
 
-        @return: """
+        @return:"""
         self.__rate_limiter = RateLimiter(
             bucket_size=max_write_burst, bucket_fill_rate=log_write_rate
         )
@@ -1047,8 +1044,7 @@ class StdoutFilter(object):
     """
 
     def __init__(self, no_fork, stdout_severity):
-        """Initializes the filter.
-        """
+        """Initializes the filter."""
         self.__no_fork = no_fork
 
         self.__stdout_severity = logging.getLevelName(stdout_severity.upper())
@@ -1082,12 +1078,10 @@ class StdoutFilter(object):
 
 
 class StderrFilter(object):
-    """A filter that includes any record if it has `force_stderr` as True
-    """
+    """A filter that includes any record if it has `force_stderr` as True"""
 
     def __init__(self):
-        """Initializes the filter.
-        """
+        """Initializes the filter."""
 
     def filter(self, record):
         """Performs the filtering.
@@ -1831,14 +1825,10 @@ class UnsupportedValueType(Exception):
                 % (six.text_type(type(field_name)), six.text_type(field_name))
             )
         elif metric_name is not __NOT_GIVEN__ and metric_value is not __NOT_GIVEN__:
-            message = (
-                'Unsupported metric value type of "%s" with value "%s" for metric="%s". '
-                "Only int, long, float, and str are supported."
-                % (
-                    six.text_type(type(metric_value)),
-                    six.text_type(metric_value),
-                    metric_name,
-                )
+            message = 'Unsupported metric value type of "%s" with value "%s" for metric="%s". ' "Only int, long, float, and str are supported." % (
+                six.text_type(type(metric_value)),
+                six.text_type(metric_value),
+                metric_name,
             )
         elif field_name is not __NOT_GIVEN__ and field_value is not __NOT_GIVEN__:
             message = (

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -213,8 +213,7 @@ class ScalyrMonitor(StoppableThread):
 
     @property
     def module_name(self):
-        """Returns the name of the module that will run this monitor.
-        """
+        """Returns the name of the module that will run this monitor."""
         return self._config["module"]
 
     def reported_lines(self):
@@ -242,8 +241,7 @@ class ScalyrMonitor(StoppableThread):
         return result
 
     def increment_counter(self, reported_lines=0, errors=0):
-        """Increment some of the counters pertaining to the performance of this monitor.
-        """
+        """Increment some of the counters pertaining to the performance of this monitor."""
         self.__lock.acquire()
         self.__reported_lines += reported_lines
         self.__errors += errors
@@ -406,8 +404,7 @@ class ScalyrMonitor(StoppableThread):
         self._sample_interval_secs = secs
 
     def set_log_watcher(self, log_watcher):
-        """Provides a log_watcher object that monitors can use to add/remove log files
-        """
+        """Provides a log_watcher object that monitors can use to add/remove log files"""
         pass
 
     def _get_log_rotation_configuration(self):
@@ -815,8 +812,7 @@ class MonitorInformation(object):
 
 
 class ConfigOption(object):
-    """Simple object to hold the fields for a single configuration option.
-    """
+    """Simple object to hold the fields for a single configuration option."""
 
     def __init__(self):
         # The name of the option.

--- a/scalyr_agent/test_base.py
+++ b/scalyr_agent/test_base.py
@@ -134,8 +134,7 @@ def _thread_watcher():
 
 
 def _start_thread_watcher_if_necessary():
-    """Starts the thread watcher if it hasn't already been started.
-    """
+    """Starts the thread watcher if it hasn't already been started."""
     global __thread_watcher_started
 
     if not __thread_watcher_started:

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -419,8 +419,7 @@ def json_encode(obj, output=None, binary=False):
 
 
 def json_decode(text):
-    """Decodes text containing json and returns either a dict
-    """
+    """Decodes text containing json and returns either a dict"""
     return _json_decode(text)
 
 
@@ -996,8 +995,7 @@ class RunState(object):
 
 
 class FakeRunState(RunState):
-    """A RunState subclass that does not actually sleep when sleep_but_awaken_if_stopped that can be used for tests.
-    """
+    """A RunState subclass that does not actually sleep when sleep_but_awaken_if_stopped that can be used for tests."""
 
     def __init__(self):
         # The number of times this instance would have slept.
@@ -1014,12 +1012,10 @@ class FakeRunState(RunState):
 
 
 class FakeClock(object):
-    """Used to simulate time and control threads waking up for sleep for tests.
-    """
+    """Used to simulate time and control threads waking up for sleep for tests."""
 
     def __init__(self):
-        """Constructs a new instance.
-        """
+        """Constructs a new instance."""
         # A lock/condition to protected _time.  It is notified whenever _time is changed.
         self._time_condition = threading.Condition()
         # The current time in seconds past epoch.
@@ -1109,8 +1105,7 @@ class FakeClock(object):
         self._waiting_condition.release()
 
     def wake_all_threads(self):
-        """Invoked to wake all threads currently blocked in `simulate_waiting`.
-        """
+        """Invoked to wake all threads currently blocked in `simulate_waiting`."""
         self.advance_time(increment_by=0.0)
 
     def _increment_waiting_count(self, increment):
@@ -1294,8 +1289,7 @@ class StoppableThread(threading.Thread):
         return self.__run_impl()
 
     def __run_impl(self):
-        """Internal run implementation.
-        """
+        """Internal run implementation."""
         # noinspection PyBroadException
         try:
             if self.__target is not None:
@@ -1414,12 +1408,12 @@ class RateLimiter(object):
     def __init__(self, bucket_size, bucket_fill_rate, current_time=None):
         """Creates a new bucket.
 
-          @param bucket_size: The bucket size, which should be the maximum number of bytes that can be consumed
-              in a burst.
-          @param bucket_fill_rate: The fill rate, expressed as bytes per second.  This should correspond to the
-              maximum desired steady state rate limit.
-          @param current_time:   If not none, the value to use as the current time, expressed in seconds past epoch.
-              This is used in testing.
+        @param bucket_size: The bucket size, which should be the maximum number of bytes that can be consumed
+            in a burst.
+        @param bucket_fill_rate: The fill rate, expressed as bytes per second.  This should correspond to the
+            maximum desired steady state rate limit.
+        @param current_time:   If not none, the value to use as the current time, expressed in seconds past epoch.
+            This is used in testing.
         """
         self.__bucket_contents = bucket_size
         self.__bucket_size = bucket_size
@@ -1754,8 +1748,7 @@ class RedirectorServer(object):
             pass
 
         def close(self):
-            """Closes the channel to the client.
-            """
+            """Closes the channel to the client."""
             pass
 
     class Redirector(object):
@@ -1789,8 +1782,7 @@ class RedirectorServer(object):
 
 
 class RedirectorError(Exception):
-    """Raised when an exception occurs with the RedirectionClient or RedirectionServer.
-    """
+    """Raised when an exception occurs with the RedirectionClient or RedirectionServer."""
 
     pass
 
@@ -1827,8 +1819,7 @@ class RedirectorClient(StoppableThread):
     CLIENT_CONNECT_TIMEOUT = 60.0
 
     def run_and_propagate(self):
-        """Invoked when the thread begins and performs the bulk of the work.
-        """
+        """Invoked when the thread begins and performs the bulk of the work."""
         # The timeline by which we must connect to the server and receiving all bytes.
         overall_deadline = self.__time() + RedirectorClient.CLIENT_CONNECT_TIMEOUT
 
@@ -2035,8 +2026,7 @@ class RedirectorClient(StoppableThread):
             pass
 
         def close(self):
-            """Closes the channel to the server.
-            """
+            """Closes the channel to the server."""
             pass
 
 
@@ -2200,21 +2190,21 @@ def get_agent_start_up_message():
     # easier for us to troubleshoot invalid locale related issues
     lang_env_var = compat.os_environ_unicode.get("LANG", "notset")
 
-    (language_code, encoding, used_locale,) = get_language_code_coding_and_locale()
+    (
+        language_code,
+        encoding,
+        used_locale,
+    ) = get_language_code_coding_and_locale()
 
-    msg = (
-        "Starting scalyr agent... (version=%s) (revision=%s) %s (Python version: %s) "
-        "(OpenSSL version: %s) (default fs encoding: %s) (locale: %s) (LANG env variable: %s)"
-        % (
-            SCALYR_VERSION,
-            build_revision,
-            get_pid_tid(),
-            python_version_str,
-            openssl_version,
-            sys.getfilesystemencoding(),
-            used_locale,
-            lang_env_var,
-        )
+    msg = "Starting scalyr agent... (version=%s) (revision=%s) %s (Python version: %s) " "(OpenSSL version: %s) (default fs encoding: %s) (locale: %s) (LANG env variable: %s)" % (
+        SCALYR_VERSION,
+        build_revision,
+        get_pid_tid(),
+        python_version_str,
+        openssl_version,
+        sys.getfilesystemencoding(),
+        used_locale,
+        lang_env_var,
     )
 
     return msg
@@ -2456,8 +2446,7 @@ class HistogramTracker(object):
         return self.__max
 
     def reset(self):
-        """Resets all the instance, discarding all information about all previously added samples.
-        """
+        """Resets all the instance, discarding all information about all previously added samples."""
         for i in range(0, len(self.__counts)):
             self.__counts[i] = 0
         self.__overflow = 0
@@ -2547,7 +2536,7 @@ class ProcessWatchDog(threading.Thread):
         :param on_stop_callback: Function that will be invoked by this
         abstraction once the parent is no longer running.
         out.
-         """
+        """
         self._on_stop_callback = on_stop_callback
         super(ProcessWatchDog, self).start()
 
@@ -2611,12 +2600,17 @@ class ParentProcessAwareSyncManager(multiprocessing.managers.SyncManager):
 
         # create and start a watchdog for  a parent process.
         self._watchdog = ProcessWatchDog(
-            parent_pid, poll_interval=parent_process_poll_interval,
+            parent_pid,
+            poll_interval=parent_process_poll_interval,
         )
         self._watchdog.start_watchdog(on_stop_callback=self._terminate)
 
     def start_shared_object_manager(
-        self, parent_pid, parent_process_poll_interval=5, initializer=None, initargs=(),
+        self,
+        parent_pid,
+        parent_process_poll_interval=5,
+        initializer=None,
+        initargs=(),
     ):
         # type: (int, int, Callable, Tuple) -> None
         """

--- a/scripts/circleci/upload_circleci_artifacts.py
+++ b/scripts/circleci/upload_circleci_artifacts.py
@@ -148,7 +148,8 @@ def download_artifact_file(artifact_info, output_path):
     :return:
     """
     artifact_output_path = os.path.join(
-        output_path, os.path.basename(artifact_info["path"]),
+        output_path,
+        os.path.basename(artifact_info["path"]),
     )
 
     resp = _do_request(
@@ -233,7 +234,9 @@ def discard_outdated_workflows(workflow_infos):
     return result
 
 
-def wait_for_pipeline(pipeline_number,):
+def wait_for_pipeline(
+    pipeline_number,
+):
     # type: (int) -> Dict
     """
     Wait for all workflows are finishedin the pipeline specified by 'pipeline number'.

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -486,7 +486,13 @@ def main(
     driver = get_libcloud_driver()
 
     size = NodeSize(
-        distro_details["size_id"], distro_details["size_id"], 0, 0, 0, 0, driver,
+        distro_details["size_id"],
+        distro_details["size_id"],
+        0,
+        0,
+        0,
+        0,
+        driver,
     )
     image = NodeImage(
         distro_details["image_id"], distro_details["image_name"], driver, None

--- a/tests/distribution/basic_sanity_deb.py
+++ b/tests/distribution/basic_sanity_deb.py
@@ -34,7 +34,8 @@ from tests.image_builder.distributions.ubuntu1804 import UbuntuBuilder
 
 @pytest.mark.usefixtures("agent_environment")
 @dockerized_case(
-    UbuntuBuilder, __file__,
+    UbuntuBuilder,
+    __file__,
 )
 def test_default_compression_algorithm(request):
     runner = AgentRunner(PACKAGE_INSTALL, send_to_server=False)

--- a/tests/distribution/basic_sanity_rpm.py
+++ b/tests/distribution/basic_sanity_rpm.py
@@ -34,7 +34,8 @@ from tests.image_builder.distributions.amazonlinux2 import AmazonlinuxBuilder
 
 @pytest.mark.usefixtures("agent_environment")
 @dockerized_case(
-    AmazonlinuxBuilder, __file__,
+    AmazonlinuxBuilder,
+    __file__,
 )
 def test_default_compression_algorithm(request):
     runner = AgentRunner(PACKAGE_INSTALL, send_to_server=False)

--- a/tests/distribution/python_version_change_tests/common.py
+++ b/tests/distribution/python_version_change_tests/common.py
@@ -97,7 +97,8 @@ def _mock_python_binary_version(python_binary_name, version):
     # this function was used previously delete old backup.
     if binary_path_backup_path.exists():
         shutil.copy(
-            six.text_type(binary_path_backup_path), six.text_type(binary_path),
+            six.text_type(binary_path_backup_path),
+            six.text_type(binary_path),
         )
         os.remove(six.text_type(binary_path_backup_path))
 

--- a/tests/smoke_tests/standalone_test/basic_test.py
+++ b/tests/smoke_tests/standalone_test/basic_test.py
@@ -71,7 +71,9 @@ def _perform_workers_check(runner):
 def _stop_and_perform_checks(runner):
     # type: (AgentRunner) -> None
 
-    process, worker_pids, children, workers_processes = _perform_workers_check(runner,)
+    process, worker_pids, children, workers_processes = _perform_workers_check(
+        runner,
+    )
 
     logging.info("Stopping agent.")
 

--- a/tests/smoke_tests/verifier.py
+++ b/tests/smoke_tests/verifier.py
@@ -98,7 +98,7 @@ class AgentVerifier(object):
 
     def verify(self, timeout=2 * 60):
         # type: (int) -> bool
-        """"
+        """ "
         :param timeout: How to long to wait (in seconds) before timing out if no successful response is found.
         """
         self.prepare()

--- a/tests/unit/builtin_monitors/docker_monitor_test.py
+++ b/tests/unit/builtin_monitors/docker_monitor_test.py
@@ -156,7 +156,7 @@ class DockerMonitorTest(ScalyrTestCase):
         return client
 
     def test_get_containers_no_include_no_exclude(self):
-        """ Test get containers when no glob filters are applied """
+        """Test get containers when no glob filters are applied"""
 
         expected_ids = [
             "87d533137e70601d17a4bf9d563b11d528ba81e31e2299eb8d4ab2ef5a54f0c0",
@@ -178,7 +178,7 @@ class DockerMonitorTest(ScalyrTestCase):
             self.assertTrue(cid in containers)
 
     def test_get_containers_include_no_exclude(self):
-        """ Test get_containers when an include filter but no exclude filter is applied """
+        """Test get_containers when an include filter but no exclude filter is applied"""
         expected_ids = [
             "e511aaf76add81d41c1536b2a93a17448d9f9d3c6a3f8a5abab1d9a582c397fc",
             "cfcb7f7d1481c805f91fd6c8c120300a586978fa2541a58026bd930eeeda3e36",
@@ -197,7 +197,7 @@ class DockerMonitorTest(ScalyrTestCase):
             self.assertTrue(cid in containers)
 
     def test_get_containers_no_include_exclude(self):
-        """ Test get_containers when no include filter is applied but an exclude filter is"""
+        """Test get_containers when no include filter is applied but an exclude filter is"""
         expected_ids = [
             "87d533137e70601d17a4bf9d563b11d528ba81e31e2299eb8d4ab2ef5a54f0c0",
             "84afc8ee4d726544e77dcfe22c6f5be04f36b115ea99c0510d612666f83da1ce",
@@ -218,7 +218,7 @@ class DockerMonitorTest(ScalyrTestCase):
             self.assertTrue(cid in containers)
 
     def test_get_containers_include_exclude(self):
-        """ Test get_containers when both an include and an exclude filter are applied"""
+        """Test get_containers when both an include and an exclude filter are applied"""
         expected_ids = [
             "b8757266fd6a9efcb40a2881215d8d3642e6f8a0cfdcbb941382d002f31dcca4",
             "343c05b55c1b0cebca6df0309a4892974c5ed3013731433461ffe7442223659a",

--- a/tests/unit/builtin_monitors/kubernetes_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_monitor_test.py
@@ -741,7 +741,9 @@ class TestKubeletApi(BaseScalyrLogCaptureTestCase):
 
         with mock.patch.object(KubeletApi, "_get", fake_get):
             api = KubeletApi(
-                FakeKubernetesApi(), host_ip="127.0.0.1", node_name="FakeNode",
+                FakeKubernetesApi(),
+                host_ip="127.0.0.1",
+                node_name="FakeNode",
             )
 
             self.assertEqual(mock_global_log.error.call_count, 0)
@@ -775,7 +777,9 @@ class TestKubeletApi(BaseScalyrLogCaptureTestCase):
 
         with mock.patch.object(KubeletApi, "_get", fake_get):
             api = KubeletApi(
-                FakeKubernetesApi(), host_ip="127.0.0.1", node_name="FakeNode",
+                FakeKubernetesApi(),
+                host_ip="127.0.0.1",
+                node_name="FakeNode",
             )
 
             self.assertEqual(mock_global_log.warn.call_count, 0)
@@ -894,7 +898,9 @@ class ContainerCheckerTest(TestConfigurationBase):
             ignore_pod_sandboxes=False,
         )
         cc._ContainerChecker__k8s_config_builder = K8sConfigBuilder(
-            config.k8s_log_configs, mock.Mock(), True,
+            config.k8s_log_configs,
+            mock.Mock(),
+            True,
         )
         cc.get_cluster_name = lambda *_: "the-cluster-name"
 

--- a/tests/unit/builtin_monitors/linux_system_metrics_test.py
+++ b/tests/unit/builtin_monitors/linux_system_metrics_test.py
@@ -113,8 +113,8 @@ class LinuxSystemMetricsMonitorTest(ScalyrTestCase):
 
         self.assertEqual(mock_logger.error.call_count, 0)
 
-        seen_mount_points_without_filters = self._get_mount_point_names_from_mock_logger(
-            mock_logger.info
+        seen_mount_points_without_filters = (
+            self._get_mount_point_names_from_mock_logger(mock_logger.info)
         )
         ignore_mounts = list(seen_mount_points_without_filters)[:3]
 

--- a/tests/unit/builtin_monitors/shell_monitor_test.py
+++ b/tests/unit/builtin_monitors/shell_monitor_test.py
@@ -162,7 +162,8 @@ class ShellMonitorTest(ScalyrTestCase):
 
         self.assertEqual(call_args, ("output", "stderr\n\nstdout\n"))
         self.assertEqual(
-            call_kwargs["extra_fields"]["command"], 'echo "stdout" ; >&2 echo "stderr"',
+            call_kwargs["extra_fields"]["command"],
+            'echo "stdout" ; >&2 echo "stderr"',
         )
         self.assertEqual(call_kwargs["extra_fields"]["length"], 15)
         self.assertTrue(call_kwargs["extra_fields"]["duration"] <= 1)

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -320,7 +320,8 @@ class TestConfiguration(TestConfigurationBase):
             "/run/secrets/kubernetes.io/serviceaccount/ca.crt",
         )
         self.assertEquals(
-            config.k8s_verify_kubelet_queries, True,
+            config.k8s_verify_kubelet_queries,
+            True,
         )
 
         self.assertEquals(len(config.log_configs), 3)
@@ -2470,7 +2471,7 @@ class TestParseArrayOfStrings(TestConfigurationBase):
 
 class TestConvertConfigParam(TestConfigurationBase):
     def test_none_to_anything(self):
-        """"""
+        """ """
         self.assertRaises(
             BadConfiguration,
             lambda: convert_config_param("dummy_field", None, six.text_type),
@@ -2576,7 +2577,8 @@ class TestGetConfigFromEnv(TestConfigurationBase):
 
         del os.environ["SCALYR_SERVER_ATTRIBUTES"]
         self.assertEqual(
-            None, get_config_from_env("server_attributes", convert_to=JsonObject),
+            None,
+            get_config_from_env("server_attributes", convert_to=JsonObject),
         )
         os.environ["SCALYR_SERVER_ATTRIBUTES"] = '{"serverHost": "foo1.example.com"}'
         self.assertEqual(
@@ -2853,7 +2855,10 @@ class TestJournaldLogConfigManager(TestConfigurationBase):
         logger = lcm.get_logger("test")
         logger.info("Find this string")
 
-        expected_path = os.path.join(self._log_dir, "journald_monitor.log",)
+        expected_path = os.path.join(
+            self._log_dir,
+            "journald_monitor.log",
+        )
         with open(expected_path) as f:
             self.assertTrue("Find this string" in f.read())
 
@@ -2873,7 +2878,10 @@ class TestJournaldLogConfigManager(TestConfigurationBase):
         logger = lcm.get_logger("test")
         logger.info("Find this string")
 
-        expected_path = os.path.join(self._log_dir, "journald_monitor.log",)
+        expected_path = os.path.join(
+            self._log_dir,
+            "journald_monitor.log",
+        )
         with open(expected_path) as f:
             self.assertTrue("Find this string" in f.read())
 
@@ -2896,12 +2904,16 @@ class TestJournaldLogConfigManager(TestConfigurationBase):
         logger2.info("Other thing")
 
         expected_path = os.path.join(
-            self._log_dir, "journald_" + six.text_type(hash("TEST")) + ".log",
+            self._log_dir,
+            "journald_" + six.text_type(hash("TEST")) + ".log",
         )
         with open(expected_path) as f:
             self.assertTrue("Find this string" in f.read())
 
-        expected_path = os.path.join(self._log_dir, "journald_monitor.log",)
+        expected_path = os.path.join(
+            self._log_dir,
+            "journald_monitor.log",
+        )
         with open(expected_path) as f:
             self.assertTrue("Other thing" in f.read())
 
@@ -2924,12 +2936,16 @@ class TestJournaldLogConfigManager(TestConfigurationBase):
         logger2.info("Other thing")
 
         expected_path = os.path.join(
-            self._log_dir, "journald_" + six.text_type(hash("test.*test")) + ".log",
+            self._log_dir,
+            "journald_" + six.text_type(hash("test.*test")) + ".log",
         )
         with open(expected_path) as f:
             self.assertTrue("Find this string" in f.read())
 
-        expected_path = os.path.join(self._log_dir, "journald_monitor.log",)
+        expected_path = os.path.join(
+            self._log_dir,
+            "journald_monitor.log",
+        )
         with open(expected_path) as f:
             self.assertTrue("Other thing" in f.read())
 
@@ -3230,7 +3246,9 @@ class TestWorkersConfiguration(TestConfigurationBase):
 
         assert len(config.worker_configs) == 1
         assert config.worker_configs[0] == JsonObject(
-            api_key=config.api_key, id="default", sessions=4,
+            api_key=config.api_key,
+            id="default",
+            sessions=4,
         )
 
         (
@@ -3260,7 +3278,9 @@ class TestWorkersConfiguration(TestConfigurationBase):
 
         assert len(config.worker_configs) == 1
         assert config.worker_configs[0] == JsonObject(
-            api_key=config.api_key, id="default", sessions=4,
+            api_key=config.api_key,
+            id="default",
+            sessions=4,
         )
 
         (
@@ -3297,7 +3317,11 @@ class TestWorkersConfiguration(TestConfigurationBase):
             id="default",
             sessions=config.default_sessions_per_worker,
         )
-        assert workers[1] == JsonObject(api_key="key", id="second", sessions=1,)
+        assert workers[1] == JsonObject(
+            api_key="key",
+            id="second",
+            sessions=1,
+        )
 
     def test_second_default_api_key(self):
         self._write_file_with_separator_conversion(
@@ -3426,7 +3450,9 @@ class TestWorkersConfiguration(TestConfigurationBase):
             sessions=1, api_key=config.api_key, id="default"
         )
         assert config.worker_configs[1] == JsonObject(
-            sessions=4, api_key="key2", id="second",
+            sessions=4,
+            api_key="key2",
+            id="second",
         )
 
         (

--- a/tests/unit/connection_test.py
+++ b/tests/unit/connection_test.py
@@ -168,7 +168,10 @@ class ScalyrRequestsHttpConnectionTestCase(ScalyrTestCase):
 
             expected_msg = r"hostname 'agent.invalid.scalyr.com' doesn't match either of '\*.scalyr.com', 'scalyr.com'"
             self.assertRaisesRegexp(
-                Exception, expected_msg, connection.get, request_path="/",
+                Exception,
+                expected_msg,
+                connection.get,
+                request_path="/",
             )
 
             # pylint: disable=no-member
@@ -190,7 +193,10 @@ class ScalyrRequestsHttpConnectionTestCase(ScalyrTestCase):
 
         connection = self._get_connection_cls(server="https://example.com:443")
         self.assertRaisesRegexp(
-            Exception, expected_msg, connection.get, request_path="/",
+            Exception,
+            expected_msg,
+            connection.get,
+            request_path="/",
         )
 
     def _get_connection_cls(self, server):

--- a/tests/unit/copying_manager_tests/common.py
+++ b/tests/unit/copying_manager_tests/common.py
@@ -273,7 +273,9 @@ class TestableCopyingManagerFlowController:
         )
 
     def wait_for_full_iteration(self):
-        self.run_and_stop_at(TestableCopyingManagerWorkerSession.SLEEPING,)
+        self.run_and_stop_at(
+            TestableCopyingManagerWorkerSession.SLEEPING,
+        )
 
         self.run_and_stop_at(
             TestableCopyingManagerWorkerSession.SENDING,
@@ -438,8 +440,7 @@ class TestableCopyingManagerWorkerSession(
         self.saved_active_checkpoints = None
 
     def _sleep_but_awaken_if_stopped(self, seconds):
-        """Blocks the CopyingManagerWorkerSession thread until the controller tells it to proceed.
-        """
+        """Blocks the CopyingManagerWorkerSession thread until the controller tells it to proceed."""
 
         if self._disable_flow_control:
             # flow control is disabled. Just return.
@@ -471,7 +472,7 @@ class TestableCopyingManagerWorkerSession(
         if self._disable_flow_control:
             # flow control is disabled, just return a dummy response callback.
             def get_response():
-                """"""
+                """ """
                 return "success", 0, "fake"
 
             return get_response
@@ -682,9 +683,9 @@ class TestableCopyingManagerWorker(CopyingManagerWorker):
 
 class TestableLogMatcher(LogMatcher):
     """
-        The subclass of the LogMatcher class with helper functions.
-        This is used in the TestableCopying manager
-        instead of the regular LogMatcher.
+    The subclass of the LogMatcher class with helper functions.
+    This is used in the TestableCopying manager
+    instead of the regular LogMatcher.
     """
 
     @property
@@ -765,7 +766,8 @@ class TestableCopyingManager(CopyingManager, TestableCopyingManagerFlowControlle
             )
 
     def start_manager(
-        self, logs_initial_positions=None,
+        self,
+        logs_initial_positions=None,
     ):
         """
         Overrides base class method, to initialize "scalyr_client" by default.

--- a/tests/unit/copying_manager_tests/copying_manager_new_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_new_test.py
@@ -93,7 +93,10 @@ class CopyingManagerTest(CopyingManagerCommonTest):
         super(CopyingManagerTest, self).teardown()
 
     def _init_test_environment(
-        self, use_pipelining=False, config_data=None, disable_flow_control=False,
+        self,
+        use_pipelining=False,
+        config_data=None,
+        disable_flow_control=False,
     ):
         pipeline_threshold = 1.1
         if use_pipelining:
@@ -394,7 +397,9 @@ class TestBasic(CopyingManagerTest):
         TestingConfiguration, "log_deletion_delay", new_callable=PropertyMock
     )
     @mock.patch.object(
-        TestingConfiguration, "max_new_log_detection_time", new_callable=PropertyMock,
+        TestingConfiguration,
+        "max_new_log_detection_time",
+        new_callable=PropertyMock,
     )
     def test_log_processors_lifecycle(
         self, log_deletion_delay, max_new_log_detection_time
@@ -444,7 +449,9 @@ class TestBasic(CopyingManagerTest):
         TestingConfiguration, "log_deletion_delay", new_callable=PropertyMock
     )
     @mock.patch.object(
-        TestingConfiguration, "max_new_log_detection_time", new_callable=PropertyMock,
+        TestingConfiguration,
+        "max_new_log_detection_time",
+        new_callable=PropertyMock,
     )
     def test_log_processors_lifecycle_with_glob(
         self, log_deletion_delay, max_new_log_detection_time
@@ -503,7 +510,9 @@ class TestBasic(CopyingManagerTest):
         TestingConfiguration, "log_deletion_delay", new_callable=PropertyMock
     )
     @mock.patch.object(
-        TestingConfiguration, "max_new_log_detection_time", new_callable=PropertyMock,
+        TestingConfiguration,
+        "max_new_log_detection_time",
+        new_callable=PropertyMock,
     )
     def test_log_processors_lifecycle_with_dynamic_matchers(
         self, log_deletion_delay, max_new_log_detection_time

--- a/tests/unit/copying_manager_tests/copying_manager_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_test.py
@@ -451,7 +451,10 @@ class TestCopyingManagerEnd2End(CopyingManagerTest):
 
         # shift time on checkpoint files to make it seem like the checkpoint was written in the past.
         for worker in self._manager.worker_sessions:
-            checkpoints, active_chp, = worker.get_checkpoints()
+            (
+                checkpoints,
+                active_chp,
+            ) = worker.get_checkpoints()
             checkpoints["time"] -= self._config.max_allowed_checkpoint_age + 1
             active_chp["time"] -= self._config.max_allowed_checkpoint_age + 1
             worker.write_checkpoints(worker.get_checkpoints_path(), checkpoints)
@@ -643,7 +646,9 @@ class TestCopyingManagerEnd2End(CopyingManagerTest):
             assert test_log.str_path in all_log_processors
 
     def test_logs_initial_positions(self):
-        controller = self.__create_test_instance(auto_start=False,)
+        controller = self.__create_test_instance(
+            auto_start=False,
+        )
 
         self.__append_log_lines(*"0123456789")
 

--- a/tests/unit/copying_manager_tests/copying_manager_worker_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_worker_test.py
@@ -194,7 +194,10 @@ class CopyingManagerWorkerTest(CopyingManagerCommonTest):
         return test_files, self._instance  # type: ignore
 
     def _spawn_single_log_processor(
-        self, log_file, checkpoints=None, copy_at_index_zero=False,
+        self,
+        log_file,
+        checkpoints=None,
+        copy_at_index_zero=False,
     ):
         # type: (TestableLogFile, Optional[Dict], bool)-> LogFileProcessor
         log_config = self._env_builder.get_log_config(log_file)  # type: ignore

--- a/tests/unit/json_lib/serializer_test.py
+++ b/tests/unit/json_lib/serializer_test.py
@@ -29,7 +29,8 @@ from scalyr_agent.test_base import ScalyrTestCase
 class SerializeTests(ScalyrTestCase):
     def test_length_prefixed_strings(self):
         self.assertEquals(
-            b"`s\x00\x00\x00\x0cHowdy folks!", self.serialize_string("Howdy folks!"),
+            b"`s\x00\x00\x00\x0cHowdy folks!",
+            self.serialize_string("Howdy folks!"),
         )
 
     def test_length_prefixed_strings_with_unicode(self):

--- a/tests/unit/log_processing_test.py
+++ b/tests/unit/log_processing_test.py
@@ -1545,7 +1545,10 @@ class TestLogLineRedactor(ScalyrTestCase):
             redactor,
             "sometext.... secretoption=czerwin ,andsecret123=saurabh",
             "sometext.... secretczerwin =%s,andsecretsaurabh=%s"
-            % (md5_hexdigest("option"), md5_hexdigest("123"),),
+            % (
+                md5_hexdigest("option"),
+                md5_hexdigest("123"),
+            ),
             True,
         )
 

--- a/tests/unit/monitor_utils/blocking_rate_limiter_test.py
+++ b/tests/unit/monitor_utils/blocking_rate_limiter_test.py
@@ -41,8 +41,7 @@ def always_false():
 
 
 def rate_maintainer(consecutive_success_threshold, backoff_rate, increase_rate):
-    """Returns a generator that maintains the rate at a constant level by balancing failures with successes
-    """
+    """Returns a generator that maintains the rate at a constant level by balancing failures with successes"""
     last = True
     consecutive_true = 0
     backoff_increase_ratio = float(backoff_rate) * increase_rate
@@ -331,8 +330,8 @@ class BlockingRateLimiterTest(ScalyrTestCase):
             mock_get_next_ripe_time,
         ):
             """Examine rate-increasing behavior in the context of very high actual rates"""
-            mock_get_next_ripe_time.side_effect = _mock_get_next_ripe_time_actual_rate_leads(
-                rl
+            mock_get_next_ripe_time.side_effect = (
+                _mock_get_next_ripe_time_actual_rate_leads(rl)
             )
 
             advancer = self.__create_fake_clock_advancer_thread(
@@ -372,8 +371,8 @@ class BlockingRateLimiterTest(ScalyrTestCase):
         @patch.object(rl, "_get_next_ripe_time")
         def _case2_test_successes_actual_rate_lags_target_rate(mock_get_next_ripe_time):
             """Examine rate-increasing behavior in the context of very high actual rates"""
-            mock_get_next_ripe_time.side_effect = _mock_get_next_ripe_time_actual_rate_lags(
-                rl
+            mock_get_next_ripe_time.side_effect = (
+                _mock_get_next_ripe_time_actual_rate_lags(rl)
             )
 
             advancer = self.__create_fake_clock_advancer_thread(
@@ -420,8 +419,8 @@ class BlockingRateLimiterTest(ScalyrTestCase):
         @patch.object(rl, "_get_next_ripe_time")
         def _case3_test_failures_actual_rate_lags_target_rate(mock_get_next_ripe_time):
             """Examine rate-decreasing behavior in the context of very high actual rates"""
-            mock_get_next_ripe_time.side_effect = _mock_get_next_ripe_time_actual_rate_lags(
-                rl
+            mock_get_next_ripe_time.side_effect = (
+                _mock_get_next_ripe_time_actual_rate_lags(rl)
             )
 
             advancer = self.__create_fake_clock_advancer_thread(
@@ -468,8 +467,8 @@ class BlockingRateLimiterTest(ScalyrTestCase):
         @patch.object(rl, "_get_next_ripe_time")
         def _case4_test_failures_actual_rate_leads_target_rate(mock_get_next_ripe_time):
             """Examine rate-decreasing behavior in the context of very high actual rates"""
-            mock_get_next_ripe_time.side_effect = _mock_get_next_ripe_time_actual_rate_leads(
-                rl
+            mock_get_next_ripe_time.side_effect = (
+                _mock_get_next_ripe_time_actual_rate_leads(rl)
             )
 
             advancer = self.__create_fake_clock_advancer_thread(

--- a/tests/unit/monitor_utils/k8s_test.py
+++ b/tests/unit/monitor_utils/k8s_test.py
@@ -51,8 +51,7 @@ from six.moves import range
 
 
 class Test_K8sCache(ScalyrTestCase):
-    """ Tests the _K8sCache
-    """
+    """Tests the _K8sCache"""
 
     NAMESPACE_1 = "namespace_1"
     POD_1 = "pod_1"
@@ -274,7 +273,11 @@ class TestK8sConfigBuilder(TestConfigurationBase):
             config.k8s_log_configs, self.logger, rename_no_original=True
         )
 
-        config = builder.get_log_config(self.info, self.k8s_info, self.parser,)
+        config = builder.get_log_config(
+            self.info,
+            self.k8s_info,
+            self.parser,
+        )
 
         self.assertEqual(
             "/${container_runtime}/${container_name}.log", config["rename_logfile"]
@@ -304,7 +307,11 @@ class TestK8sConfigBuilder(TestConfigurationBase):
             config.k8s_log_configs, self.logger, rename_no_original=True
         )
 
-        config = builder.get_log_config(self.info, self.k8s_info, self.parser,)
+        config = builder.get_log_config(
+            self.info,
+            self.k8s_info,
+            self.parser,
+        )
 
         self.assertEqual("match_pod", config["test"])
 
@@ -332,7 +339,11 @@ class TestK8sConfigBuilder(TestConfigurationBase):
             config.k8s_log_configs, self.logger, rename_no_original=True
         )
 
-        config = builder.get_log_config(self.info, self.k8s_info, self.parser,)
+        config = builder.get_log_config(
+            self.info,
+            self.k8s_info,
+            self.parser,
+        )
 
         self.assertEqual("match_namespace", config["test"])
 
@@ -360,7 +371,11 @@ class TestK8sConfigBuilder(TestConfigurationBase):
             config.k8s_log_configs, self.logger, rename_no_original=True
         )
 
-        config = builder.get_log_config(self.info, self.k8s_info, self.parser,)
+        config = builder.get_log_config(
+            self.info,
+            self.k8s_info,
+            self.parser,
+        )
 
         self.assertEqual("match_container", config["test"])
 
@@ -392,7 +407,11 @@ class TestK8sConfigBuilder(TestConfigurationBase):
             config.k8s_log_configs, self.logger, rename_no_original=True
         )
 
-        config = builder.get_log_config(self.info, self.k8s_info, self.parser,)
+        config = builder.get_log_config(
+            self.info,
+            self.k8s_info,
+            self.parser,
+        )
 
         self.assertEqual("multi match", config["test"])
 
@@ -416,7 +435,11 @@ class TestK8sConfigBuilder(TestConfigurationBase):
             config.k8s_log_configs, self.logger, rename_no_original=True
         )
 
-        config = builder.get_log_config(self.info, self.k8s_info, self.parser,)
+        config = builder.get_log_config(
+            self.info,
+            self.k8s_info,
+            self.parser,
+        )
 
         self.assertFalse("test" in config)
 
@@ -444,7 +467,11 @@ class TestK8sConfigBuilder(TestConfigurationBase):
             config.k8s_log_configs, self.logger, rename_no_original=True
         )
 
-        config = builder.get_log_config(self.info, self.k8s_info, self.parser,)
+        config = builder.get_log_config(
+            self.info,
+            self.k8s_info,
+            self.parser,
+        )
 
         self.assertEqual(self.parser, config["parser"])
         self.assertEqual(self.info["log_path"], config["path"])
@@ -711,8 +738,7 @@ class TestKubernetesApiRateLimited(ScalyrTestCase):
 
 
 class TestDockerMetricFetcher(ScalyrTestCase):
-    """Tests the DockerMetricFetch abstraction.
-    """
+    """Tests the DockerMetricFetch abstraction."""
 
     def setUp(self):
         super(TestDockerMetricFetcher, self).setUp()
@@ -720,8 +746,7 @@ class TestDockerMetricFetcher(ScalyrTestCase):
         self._fetcher = DockerMetricFetcher(self._faker, 5)
 
     def test_basic_prefetch(self):
-        """Tests the typical prefetch and then get_metrics path.. just for one container.
-        """
+        """Tests the typical prefetch and then get_metrics path.. just for one container."""
         self._fetcher.prefetch_metrics("foo")
         self.assertTrue(self._faker.wait_for_requests(1))
         self.assertEquals(0, self._fetcher.idle_workers())
@@ -731,8 +756,7 @@ class TestDockerMetricFetcher(ScalyrTestCase):
         self.assertEqual(10, value)
 
     def test_multiple_prefetch(self):
-        """Tests the typical prefetch and then get_metrics path for multiple concurrent requests.
-        """
+        """Tests the typical prefetch and then get_metrics path for multiple concurrent requests."""
         self._fetcher.prefetch_metrics("foo")
         self._fetcher.prefetch_metrics("bar")
         self.assertTrue(self._faker.wait_for_requests(2))
@@ -784,8 +808,7 @@ class TestDockerMetricFetcher(ScalyrTestCase):
         self.assertEquals(5, self._fetcher.idle_workers())
 
     def test_stopped(self):
-        """Tests that stopping the abstraction terminates any calls blocked on `get_metrics`.
-        """
+        """Tests that stopping the abstraction terminates any calls blocked on `get_metrics`."""
         self._fetcher.prefetch_metrics("foo")
         self.assertTrue(self._faker.wait_for_requests(1))
 
@@ -805,8 +828,7 @@ class TestDockerMetricFetcher(ScalyrTestCase):
 
 
 class TestK8sNamespaceFilter(ScalyrTestCase):
-    """Tests the DockerMetricFetch abstraction.
-    """
+    """Tests the DockerMetricFetch abstraction."""
 
     def test_basic_blacklist(self):
         test_filter = K8sNamespaceFilter(global_include=["*"], global_ignore=["kube"])
@@ -1171,8 +1193,7 @@ class FakeK8s(object):
             self.__lock.release()
 
     def stop(self):
-        """Wakes up anything waiting on a pending requests.  Called when the test is finished.
-        """
+        """Wakes up anything waiting on a pending requests.  Called when the test is finished."""
         self.__condition_var.acquire()
         try:
             if self.__pending_request is not None:
@@ -1313,8 +1334,7 @@ class FakeCache(object):
         )
 
     def stop(self):
-        """Stops the cache.  Called when the test is finished.
-        """
+        """Stops the cache.  Called when the test is finished."""
         self.k8s.stop()
 
     def set_response(self, namespace, name, **kwargs):

--- a/tests/unit/scalyr_client_test.py
+++ b/tests/unit/scalyr_client_test.py
@@ -1182,7 +1182,9 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
     @mock.patch("scalyr_agent.scalyr_client.time.time", mock.Mock(return_value=0))
     def test_send_request_timestamp_doesnt_increases_monotonically(self):
         session = ScalyrClientSession(
-            "https://dummserver.com", "DUMMY API KEY", SCALYR_VERSION,
+            "https://dummserver.com",
+            "DUMMY API KEY",
+            SCALYR_VERSION,
         )
 
         session._ScalyrClientSession__connection = mock.Mock()
@@ -1334,9 +1336,10 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
 
         serialized_data = add_events_request.get_payload()
 
-        (path, request,) = session._ScalyrClientSession__connection.post.call_args_list[
-            0
-        ]
+        (
+            path,
+            request,
+        ) = session._ScalyrClientSession__connection.post.call_args_list[0]
 
         _, decompress_func = scalyr_util.get_compress_and_decompress_func(
             compression_type

--- a/tests/unit/scalyr_logging_test.py
+++ b/tests/unit/scalyr_logging_test.py
@@ -623,7 +623,6 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
             self._metric_name_blacklist = []
 
         def increment_counter(self, reported_lines=0, errors=0):
-            """Increment some of the counters pertaining to the performance of this monitor.
-            """
+            """Increment some of the counters pertaining to the performance of this monitor."""
             self.reported_lines += reported_lines
             self.errors += errors

--- a/tests/unit/scalyr_monitor_test.py
+++ b/tests/unit/scalyr_monitor_test.py
@@ -166,7 +166,8 @@ class MonitorConfigTest(ScalyrTestCase):
         test_array = ["a", 1, False]
         json_arr = JsonArray(*test_array)
         self.assertEquals(
-            self.get(list(json_arr), convert_to=JsonArray), JsonArray(*test_array),
+            self.get(list(json_arr), convert_to=JsonArray),
+            JsonArray(*test_array),
         )
 
         # list -> ArrayOfStrings not supported

--- a/tests/unit/syslog_monitor_test.py
+++ b/tests/unit/syslog_monitor_test.py
@@ -271,8 +271,8 @@ class SyslogMonitorConfigTest(SyslogMonitorTestCase):
 
 class TestSyslogMonitor(SyslogMonitor):
     """subclass of SyslogMonitor with overridden 'increment_counter'.
-        Provides ability to suspend test thread until written lines are handled by 'increment_counter' method.
-        """
+    Provides ability to suspend test thread until written lines are handled by 'increment_counter' method.
+    """
 
     __test__ = False
 

--- a/tests/unit/util/date_utils_test.py
+++ b/tests/unit/util/date_utils_test.py
@@ -174,8 +174,10 @@ class DateUtilsTestCase(ScalyrTestCase):
         ]
 
         for input_str, expected_ts in zip(input_strs, expected_tss):
-            result_with_strptime = date_parsing_utils._rfc3339_to_nanoseconds_since_epoch_strptime(
-                input_str
+            result_with_strptime = (
+                date_parsing_utils._rfc3339_to_nanoseconds_since_epoch_strptime(
+                    input_str
+                )
             )
             result_without_strptime = scalyr_util.rfc3339_to_nanoseconds_since_epoch(
                 input_str

--- a/tests/unit/util/util_test.py
+++ b/tests/unit/util/util_test.py
@@ -765,8 +765,7 @@ class TestScriptEscalator(ScalyrTestCase):
 
 
 class TestRedirectorServer(ScalyrTestCase):
-    """Tests the RedirectorServer code using fakes for stdout, stderr and the channel.
-    """
+    """Tests the RedirectorServer code using fakes for stdout, stderr and the channel."""
 
     def setUp(self):
         super(TestRedirectorServer, self).setUp()
@@ -842,8 +841,7 @@ class TestRedirectorServer(ScalyrTestCase):
 
 
 class TestRedirectorClient(ScalyrTestCase):
-    """Test the RedirectorClient by faking out the client channel and also the clock.
-    """
+    """Test the RedirectorClient by faking out the client channel and also the clock."""
 
     def setUp(self):
         super(TestRedirectorClient, self).setUp()
@@ -933,8 +931,7 @@ class TestRedirectorClient(ScalyrTestCase):
 
 
 class TestRedirectionService(ScalyrTestCase):
-    """Tests both the RedirectorServer and the RedirectorClient communicating together.
-    """
+    """Tests both the RedirectorServer and the RedirectorClient communicating together."""
 
     def setUp(self):
         super(TestRedirectionService, self).setUp()
@@ -1078,8 +1075,7 @@ class FakeSys(object):
 
 
 class TestHistogramTracker(ScalyrTestCase):
-    """Tests the HistogramTracker abstraction.
-    """
+    """Tests the HistogramTracker abstraction."""
 
     def setUp(self):
         super(TestHistogramTracker, self).setUp()

--- a/tests/utils/agent_runner.py
+++ b/tests/utils/agent_runner.py
@@ -65,8 +65,8 @@ def _path_or_text(fn):
 
 class AgentRunner(object):
     """
-       Agent runner provides ability to launch Scalyr agent with needed configuration settings.
-       """
+    Agent runner provides ability to launch Scalyr agent with needed configuration settings.
+    """
 
     def __init__(
         self,

--- a/tests/utils/image_builder.py
+++ b/tests/utils/image_builder.py
@@ -54,7 +54,7 @@ def _copy_agent_source(src_path, dest_path):
 @six.add_metaclass(ABCMeta)
 class AgentImageBuilder(object):
     """
-     Abstraction to build docker images.
+    Abstraction to build docker images.
     """
 
     IMAGE_TAG = None  # type: six.text_type

--- a/tests/utils/log_reader.py
+++ b/tests/utils/log_reader.py
@@ -76,8 +76,10 @@ class LogReader(threading.Thread):
         for pattern, (compiled_pattern, message) in self._error_line_patterns.items():
             if compiled_pattern.match(line):
                 if not message:
-                    message = "Log file {0} contains error line: '{1}'. Pattern: {2}.".format(
-                        self._file_path, line, pattern
+                    message = (
+                        "Log file {0} contains error line: '{1}'. Pattern: {2}.".format(
+                            self._file_path, line, pattern
+                        )
                     )
                 raise LogReaderError(message)
 
@@ -90,8 +92,7 @@ class LogReader(threading.Thread):
         self._check_line_for_error(line)
 
     def _line_generator(self):  # type: () -> Generator
-        """Generator that reads all available lines.
-        """
+        """Generator that reads all available lines."""
         for line in self._file:
             line = line.strip("\n")
             self._new_line_callback(line)


### PR DESCRIPTION
This PR reformats code with latest version of black which contains some fixes to the code formatting logic.

I also added no fmt pragmats around monitor docstring code which we don't want to auto re-format since it's used for generating Markdown docs.


Note: Locally you need to re-create tox virtual environments to install latest version of black (``tox -elint --recreate``, ``tox -eblack --recreate``..