### PR TITLE
Adding Docker buildx to support arm64 docker builds

### DIFF
--- a/docker/scripts/container_builder_base.sh
+++ b/docker/scripts/container_builder_base.sh
@@ -144,15 +144,12 @@ do
    TAG_OPTIONS="$TAG_OPTIONS -t $x"
 done
 
-run_docker_command "build $TAG_OPTIONS ." "$QUIET" || die "Failed to build the container image"
-
 if [ ! -z "$PUBLISH" ]; then
   report_progress "Publishing image(s)." "$QUIET";
-
-  for x in "${IMAGES[@]}"
-  do
-    run_docker_command "push $x" "$QUIET";
-  done
+  run_docker_command "buildx build --push --platform linux/arm64,linux/amd64 $TAG_OPTIONS ." "$QUIET" || die "Failed to build the container image"
+else
+  report_progress "Building to image(s) to local cache." "$QUIET";
+  run_docker_command "buildx build -o type=image --platform linux/arm64,linux/amd64 $TAG_OPTIONS ." "$QUIET" || die "Failed to build the container image"
 fi
 
 report_progress "Success." "$QUIET";

--- a/docker/scripts/container_builder_base.sh
+++ b/docker/scripts/container_builder_base.sh
@@ -144,6 +144,15 @@ do
    TAG_OPTIONS="$TAG_OPTIONS -t $x"
 done
 
+# Look for prescense of docker buildx instance, otherwise create one
+HAS_BUILD_X=$(docker buildx ls | grep 'docker-container')
+
+if [ -z "$HAS_BUILD_X" ]; then
+  report_progress "Adding Docker buildx instance" "$QUIET";
+  run_docker_command "buildx create --use" "$QUIET" || die "Failed to create new builder instance"
+fi
+
+# If publishing, push all images together; otherwise just put them in local cache
 if [ ! -z "$PUBLISH" ]; then
   report_progress "Publishing image(s)." "$QUIET";
   run_docker_command "buildx build --push --platform linux/arm64,linux/amd64 $TAG_OPTIONS ." "$QUIET" || die "Failed to build the container image"

--- a/docker/scripts/container_builder_base.sh
+++ b/docker/scripts/container_builder_base.sh
@@ -144,7 +144,7 @@ do
    TAG_OPTIONS="$TAG_OPTIONS -t $x"
 done
 
-# Look for prescense of docker buildx instance, otherwise create one
+# Look for presence of docker buildx instance, otherwise create one
 # 'docker-container' is what the driver is called:
 # https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images
 HAS_BUILD_X=$(docker buildx ls | grep 'docker-container' | cut -d ' ' -f 1)
@@ -153,7 +153,7 @@ if [ -z "$HAS_BUILD_X" ]; then
   report_progress "Adding Docker buildx instance" "$QUIET";
   run_docker_command "buildx create --use" "$QUIET" || die "Failed to create new builder instance"
 else
-  run_docker_command "buildx use $HAS_BUILD_X" "$QUIET" || die "Failed to create new builder instance"
+  run_docker_command "buildx use $HAS_BUILD_X" "$QUIET" || die "Failed to use $HAS_BUILD_X builder instance"
 fi
 
 # If publishing, push all images together; otherwise just put them in local cache
@@ -161,7 +161,7 @@ if [ ! -z "$PUBLISH" ]; then
   report_progress "Publishing image(s)." "$QUIET";
   run_docker_command "buildx build --push --platform linux/arm64,linux/amd64 $TAG_OPTIONS ." "$QUIET" || die "Failed to build the container image"
 else
-  report_progress "Building to image(s) to local cache." "$QUIET";
+  report_progress "Building image(s) to local cache." "$QUIET";
   run_docker_command "buildx build -o type=image --platform linux/arm64,linux/amd64 $TAG_OPTIONS ." "$QUIET" || die "Failed to build the container image"
 fi
 

--- a/docker/scripts/container_builder_base.sh
+++ b/docker/scripts/container_builder_base.sh
@@ -145,11 +145,15 @@ do
 done
 
 # Look for prescense of docker buildx instance, otherwise create one
-HAS_BUILD_X=$(docker buildx ls | grep 'docker-container')
+# 'docker-container' is what the driver is called:
+# https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images
+HAS_BUILD_X=$(docker buildx ls | grep 'docker-container' | cut -d ' ' -f 1)
 
 if [ -z "$HAS_BUILD_X" ]; then
   report_progress "Adding Docker buildx instance" "$QUIET";
   run_docker_command "buildx create --use" "$QUIET" || die "Failed to create new builder instance"
+else
+  run_docker_command "buildx use $HAS_BUILD_X" "$QUIET" || die "Failed to create new builder instance"
 fi
 
 # If publishing, push all images together; otherwise just put them in local cache


### PR DESCRIPTION
- Uses docker buildx 
- Publish to both linux/arm64 and linux/amd64 
- Noticed about a 60-70 second build increase time when a buildx builder e.g. (`docker buildx create`), but if the Jenkins agent has a multi-architecture builder installed and reused this build time goes down to 20-30 seconds, so that increase in build time should only happen the first time an Jenkins agent runs this build