### PR TITLE
Update k8s livenessprobe timeout to 10s

### DIFF
--- a/k8s/default-namespace/scalyr-agent-2.yaml
+++ b/k8s/default-namespace/scalyr-agent-2.yaml
@@ -80,6 +80,7 @@ spec:
             - -H
           initialDelaySeconds: 60
           periodSeconds: 60
+          timeoutSeconds: 10
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/k8s/no-kustomize/scalyr-agent-2.yaml
+++ b/k8s/no-kustomize/scalyr-agent-2.yaml
@@ -80,6 +80,7 @@ spec:
             - -H
           initialDelaySeconds: 60
           periodSeconds: 60
+          timeoutSeconds: 10
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/k8s/scalyr-agent-2.yaml
+++ b/k8s/scalyr-agent-2.yaml
@@ -79,6 +79,7 @@ spec:
             - -H
           initialDelaySeconds: 60
           periodSeconds: 60
+          timeoutSeconds: 10
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler


### PR DESCRIPTION
As a workaround to CT-418 and a general fix to the k8s liveness probe setup we need to specify a probe timeout of greater than 5 seconds or so, going with 10 seconds to be safe.

This issue is partially due to what is mentioned in the note here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
Before k8s 1.20 the timeout configuration wasn't respected and basically didn't exist, after the fix it now defaults to 1 second which is lower than `status -H`'s wait time of 5 seconds.
When you combine that with this issue: https://github.com/kubernetes/kubernetes/issues/92464
The liveness probe will not restart the pod if the probe timeout runs out, because of this stuck pods were never restarted as we never managed to reach the `status -H` timeout of 5 seconds.