### PR TITLE
Fix issue with osx unit test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -846,7 +846,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            eval "$(pyenv init -)"
+            eval "$(pyenv init --path)"
             pyenv local $PYTHON
             python -m pip install virtualenv
             python -m virtualenv venv


### PR DESCRIPTION
Pyenv had an update that stopped adding packages to the PATH by default on OSX. A change to the cli options fixes this.