### PR TITLE
Re-enable AMI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -732,9 +732,6 @@ commands:
             export SECRET_KEY=${AWS_SECRET_KEY}
             export INSTALLER_SCRIPT_URL="<< parameters.installer_script_url >>"
 
-            # TODO: Re-enable once SSH access issue is resolved
-            exit 1
-
             # If testing type is "development" we use installer script which is built in another job.
             if [ "<< parameters.test_type >>" = "development" ]; then
               export INSTALLER_SCRIPT_URL="/tmp/workspace/installScalyrAgentV2.sh"

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -221,8 +221,8 @@ PRIVATE_KEY_PATH = get_env_throw_if_not_set("PRIVATE_KEY_PATH")
 PRIVATE_KEY_PATH = os.path.expanduser(PRIVATE_KEY_PATH)
 
 SECURITY_GROUPS_STR = get_env_throw_if_not_set(
-    "SECURITY_GROUPS", "allow-ssh-rdp"
-)  # sg-02efe05c115d41622
+    "SECURITY_GROUPS", "circleci-remote-access"
+)  # sg-075bf2191cf04c821
 SECURITY_GROUPS = SECURITY_GROUPS_STR.split(",")  # type: List[str]
 
 SCALYR_API_KEY = get_env_throw_if_not_set("SCALYR_API_KEY")


### PR DESCRIPTION
This PR updates AMI tests script to use new security group ID and re-enabled them.