### PR TITLE
Frozen binaries/k8s and docker builder

### DIFF
--- a/.github/workflows/packages-build.yml
+++ b/.github/workflows/packages-build.yml
@@ -9,28 +9,28 @@ jobs:
       matrix:
         include:
           - package_type: "deb"
-            package_name: "scalyr-agent-2_*.*.*_all.deb"
+            package_filename_glob: "scalyr-agent-2_*.*.*_all.deb"
             os: ubuntu-20.04
             python-version: "3.8"
           - package_type: "rpm"
-            package_name: "scalyr-agent-2-*.*.*-*.noarch.rpm"
+            package_filename_glob: "scalyr-agent-2-*.*.*-*.noarch.rpm"
             os: ubuntu-20.04
             python-version: "3.8"
           - package_type: "tar"
-            package_name: "scalyr-agent-*.*.*.tar.gz"
+            package_filename_glob: "scalyr-agent-*.*.*.tar.gz"
             os: ubuntu-20.04
             python-version: "3.8"
           - package_type: "msi"
-            package_name: "ScalyrAgentInstaller-*.*.*.msi"
+            package_filename_glob: "ScalyrAgentInstaller-*.*.*.msi"
             os: windows-2019
             python-version: "3.8"
           - package_type: "k8s"
             os: ubuntu-20.04
-            package_name: "scalyr-agent-k8s-*.*.*"
+            package_filename_glob: "scalyr-agent-k8s-*.*.*"
             python-version: "3.8"
           - package_type: "docker-json"
             os: ubuntu-20.04
-            package_name: "scalyr-agent-docker-json-*.*.*"
+            package_filename_glob: "scalyr-agent-docker-json-*.*.*"
             python-version: "3.8"
     steps:
       - name: Checkout repository
@@ -77,7 +77,7 @@ jobs:
         with:
           name: "package-${{ matrix.package_type }}"
           path: |
-            agent-build-output/${{ matrix.package_name }}*
+            agent-build-output/${{ matrix.package_filename_glob }}*
 
 
 
@@ -87,7 +87,7 @@ jobs:
         with:
           name: "package-test-${{ matrix.package_type }}"
           path: |
-            agent-build-output/package_test_frozen_binary/package_test*
+            agent-build-output/package_test_frozen_binary/package_test_runner*
 
 
 
@@ -161,7 +161,7 @@ jobs:
       - name: Make package test frozen binaries executable.
         if: matrix.package_type != 'k8s' && matrix.package_type != 'docker-json'
         run: |
-          chmod +x ~/package_test/package_test*
+          chmod +x ~/package_test/package_test_runner*
 
       - name: Test.
         shell: bash
@@ -169,7 +169,7 @@ jobs:
           SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
         run: |
           # Define the package_test_path option only if package test file is presented in artifacts.
-          package_test_path="$(ls ~/package_test/package_test* || true)"
+          package_test_path="$(ls ~/package_test/package_test_runner* || true)"
           if [ -f "${package_test_path}" ]; then
             package_test_path_option="--package-test-path ${package_test_path}"
           else

--- a/.github/workflows/packages-build.yml
+++ b/.github/workflows/packages-build.yml
@@ -145,7 +145,7 @@ jobs:
           name: "package-test-${{ matrix.package_type }}"
           path: ~/package_test
 
-      - name: Start minikube for the test of the kuberneter build.
+      - name: Start minikube for the test of the kubernetes build.
         if: ${{ matrix.package_type == 'k8s' }}
         shell: bash
         run: |

--- a/.github/workflows/packages-build.yml
+++ b/.github/workflows/packages-build.yml
@@ -7,17 +7,31 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        package_type: ["deb", "rpm"]
-        python-version: [3.8]
-        os: [ubuntu-20.04]
         include:
-          - os: ubuntu-20.04
-            package_type: "tar"
+          - package_type: "deb"
+            package_name: "scalyr-agent-2_*.*.*_all.deb"
+            os: ubuntu-20.04
             python-version: "3.8"
-          - os: windows-2019
-            package_type: "msi"
+          - package_type: "rpm"
+            package_name: "scalyr-agent-2-*.*.*-*.noarch.rpm"
+            os: ubuntu-20.04
             python-version: "3.8"
-
+          - package_type: "tar"
+            package_name: "scalyr-agent-*.*.*.tar.gz"
+            os: ubuntu-20.04
+            python-version: "3.8"
+          - package_type: "msi"
+            package_name: "ScalyrAgentInstaller-*.*.*.msi"
+            os: windows-2019
+            python-version: "3.8"
+          - package_type: "k8s"
+            os: ubuntu-20.04
+            package_name: "scalyr-agent-k8s-*.*.*"
+            python-version: "3.8"
+          - package_type: "docker-json"
+            os: ubuntu-20.04
+            package_name: "scalyr-agent-docker-json-*.*.*"
+            python-version: "3.8"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -57,24 +71,23 @@ jobs:
         shell: bash
         run: |
           python agent_build/build_package.py ${{ matrix.package_type }} build --output-dir agent-build-output
-          ls -al agent-build-output/${{ matrix.package_type }}/*.${{ matrix.package_type }}*
-
 
       - name: Save the package.
         uses: actions/upload-artifact@v2
         with:
           name: "package-${{ matrix.package_type }}"
           path: |
-            agent-build-output/${{ matrix.package_type }}/*.${{ matrix.package_type }}*
+            agent-build-output/${{ matrix.package_name }}*
 
 
 
       - name: Save the frozen test script.
         uses: actions/upload-artifact@v2
+        if: matrix.package_type != 'k8s' && matrix.package_type != 'docker-json'
         with:
           name: "package-test-${{ matrix.package_type }}"
           path: |
-            agent-build-output/${{ matrix.package_type }}/frozen_binary_test/package_test*
+            agent-build-output/package_test_frozen_binary/package_test*
 
 
 
@@ -84,56 +97,89 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        package_type: ["deb"]
         os: ["ubuntu-20.04"]
         docker-image: ["ubuntu:14.04", "ubuntu:16.04", "ubuntu:18.04", "ubuntu:20.04"]
-        package_type: ["deb"]
         python-version: [3.8]
         include:
-          - os: ubuntu-20.04
+          - package_type: "rpm"
+            os: ubuntu-20.04
             docker-image: "centos:7"
-            package_type: "rpm"
             python-version: "3.8"
-          - os: ubuntu-20.04
+          - package_type: "rpm"
+            os: ubuntu-20.04
             docker-image: "centos:8"
-            package_type: "rpm"
             python-version: "3.8"
-          - os: ubuntu-20.04
+          - package_type: "rpm"
+            os: ubuntu-20.04
             docker-image: "amazonlinux:2"
-            package_type: "rpm"
             python-version: "3.8"
-          - os: ubuntu-20.04
-            package_type: "tar"
+          - package_type: "tar"
+            os: ubuntu-20.04
             docker-image: "ubuntu:14.04"
             python-version: "3.8"
-          - os: windows-2019
-            package_type: "msi"
+          - package_type: "msi"
+            os: windows-2019
+            python-version: "3.8"
+          - package_type: "k8s"
+            os: ubuntu-20.04
+            python-version: "3.8"
+          - package_type: "docker-json"
+            os: ubuntu-20.04
             python-version: "3.8"
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - uses: actions/download-artifact@v2
+      - name: Download package.
+        uses: actions/download-artifact@v2
         with:
           name: "package-${{ matrix.package_type }}"
           path: ~/package
 
-      - uses: actions/download-artifact@v2
+      - name: Download package test (if presented).
+        uses: actions/download-artifact@v2
+        if: matrix.package_type != 'k8s' && matrix.package_type != 'docker-json'
         with:
           name: "package-test-${{ matrix.package_type }}"
           path: ~/package_test
 
-      - name: Test.
+      - name: Start minikube for the test of the kuberneter build.
+        if: ${{ matrix.package_type == 'k8s' }}
         shell: bash
         run: |
-          ls -al ~/package_test
+          minikube start
+
+      # All downloaded artifacts lose their permissions, so we have to make script executable once more.
+      - name: Make Kubernetes and docker package builder scripts executable.
+        if: matrix.package_type == 'k8s' || matrix.package_type == 'docker-json'
+        run: |
+          chmod +x ~/package/*
+
+      # All downloaded artifacts lose their permissions, so we have to make script executable once more.
+      - name: Make package test frozen binaries executable.
+        if: matrix.package_type != 'k8s' && matrix.package_type != 'docker-json'
+        run: |
           chmod +x ~/package_test/package_test*
-          ls ~/package/*.${{ matrix.package_type }}*
+
+      - name: Test.
+        shell: bash
+        env:
+          SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
+        run: |
+          # Define the package_test_path option only if package test file is presented in artifacts.
+          package_test_path="$(ls ~/package_test/package_test* || true)"
+          if [ -f "${package_test_path}" ]; then
+            package_test_path_option="--package-test-path ${package_test_path}"
+          else
+            package_test_path_option=""
+          fi
+
+
           python3 tests/package_tests/package_test_runner.py \
+            --package-type ${{ matrix.package_type }} \
             --docker-image "${{ matrix.docker-image }}" \
-            --package-path ~/package/*.${{ matrix.package_type }}* \
-            --package-test-path ~/package_test/package_test* \
-            --scalyr-api-key "0v7dW1EIPpglMcSjGywUdgY9xTNWQP/kas6qHEmiUG5w-"
-
-
-
+            --package-path ~/package/* \
+            ${package_test_path_option} \
+            --scalyr-api-key "$SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN"

--- a/agent_build/Dockerfile
+++ b/agent_build/Dockerfile
@@ -11,6 +11,7 @@ ADD ./docker /scalyr-agent-2/docker
 ADD ./monitors /scalyr-agent-2/monitors
 ADD ./VERSION /scalyr-agent-2/VERSION
 ADD ./CHANGELOG.md /scalyr-agent-2/CHANGELOG.md
+ADD ./certs /scalyr-agent-2/certs
 
 # Also add the package test script, so the packager also can make the frozen binary for it.
 # This frozen binary later can be used to run package test on systems without python.

--- a/agent_build/Dockerfile
+++ b/agent_build/Dockerfile
@@ -13,9 +13,9 @@ ADD ./VERSION /scalyr-agent-2/VERSION
 ADD ./CHANGELOG.md /scalyr-agent-2/CHANGELOG.md
 ADD ./certs /scalyr-agent-2/certs
 
-# Also add the package test script, so the packager also can make the frozen binary for it.
-# This frozen binary later can be used to run package test on systems without python.
-ADD ./tests/package_tests/package_test.py /scalyr-agent-2/tests/package_tests/package_test.py
+# Also add the package test module, so the packager also can make the frozen binary for the package tests.
+# This frozen binary later can be used to run package tests on systems without python.
+ADD ./tests/package_tests/ /scalyr-agent-2/tests/package_tests/
 
 ARG BUILD_COMMAND
 

--- a/agent_build/build_package.py
+++ b/agent_build/build_package.py
@@ -570,7 +570,7 @@ class PackageBuilder(abc.ABC):
         package_test_pyinstaller_output = self._build_output_path / "package_test_frozen_binary"
 
         package_test_script_path = (
-            __SOURCE_ROOT__ / "tests" / "package_tests" / "package_test.py"
+            __SOURCE_ROOT__ / "tests" / "package_tests" / "package_test_runner.py"
         )
 
         subprocess.check_call(

--- a/agent_build/build_package.py
+++ b/agent_build/build_package.py
@@ -24,6 +24,8 @@ import sys
 import stat
 import hashlib
 import uuid
+import os
+import re
 import io
 from typing import Union, Optional
 
@@ -82,7 +84,11 @@ class PackageBuilder(abc.ABC):
 
     # The list of files which are somehow used during the preparation of the build environment. This is needed to
     # calculate their checksum. (see action 'dump-checksum')
-    FILES_USED_IN_BUILD_ENVIRONMENT: Union[str, pl.Path] = []
+    FILES_USED_IN_BUILD_ENVIRONMENT: Union[str, pl.Path] = [
+        __SOURCE_ROOT__ / "agent_build" / "requirements.txt",
+        __SOURCE_ROOT__ / "agent_build" / "monitors_requirements.txt",
+        __SOURCE_ROOT__ / "agent_build" / "frozen-binary-builder-requirements.txt",
+    ]
 
     # If this flag True, then the builder will run inside the docker.
     DOCKERIZED = False
@@ -95,6 +101,10 @@ class PackageBuilder(abc.ABC):
 
     # The type of the installation. For more info, see the 'InstallType' in the scalyr_agent/__scalyr__.py
     INSTALL_TYPE = None
+
+    # Add agent source code as a bundled frozen binary if True, or
+    # add the source code as it is.
+    USE_FROZEN_BINARIES: bool = True
 
     def __init__(
         self,
@@ -109,6 +119,9 @@ class PackageBuilder(abc.ABC):
         """
         # The path where the build output will be stored.
         self._build_output_path: Optional[pl.Path] = None
+
+        # Folder with intermediate and temporary results of the build.
+        self._intermediate_results_path: Optional[pl.Path] = None
 
         # The path of the folder where all files of the package will be stored.
         # May be help full for the debug purposes.
@@ -130,12 +143,15 @@ class PackageBuilder(abc.ABC):
             shutil.rmtree(output_path)
 
         output_path.mkdir(parents=True)
-        self._build_output_path = pl.Path(output_path) / type(self).PACKAGE_TYPE
-        self._package_files_path = self._build_output_path / "package_root"
 
         # If locally option is specified or builder class is not dockerized by default then just build the package
         # directly on this system.
         if locally or not type(self).DOCKERIZED:
+            self._build_output_path = pl.Path(output_path)
+            self._package_files_path = self._build_output_path / "package_root"
+            self._package_files_path.mkdir()
+            self._intermediate_results_path = self._build_output_path / "intermediate_results"
+            self._intermediate_results_path.mkdir()
             self._build(output_path=output_path)
 
         # The package has to be build inside the docker.
@@ -195,7 +211,7 @@ class PackageBuilder(abc.ABC):
 
             # The image is build and package has to be fetched from it, so create the container...
 
-            # Remove the container wth the same name if exists.
+            # Remove the container with the same name if exists.
             container_name = image_name
             subprocess.check_call(["docker", "rm", "-f", container_name])
 
@@ -521,6 +537,58 @@ class PackageBuilder(abc.ABC):
     def _get_build_environment_docker_image_name(cls):
         return f"package-builder-base-{cls._get_build_environment_files_checksum()}".lower()
 
+    def _build_frozen_binary(self, output_path: Union[str, pl.Path]):
+        """
+        Build the frozen binary using the PyInstaller library.
+        """
+        output_path = pl.Path(output_path)
+
+        spec_file_path = __SOURCE_ROOT__ / "agent_build" / "pyinstaller_spec.spec"
+
+        # Create the special folder in the package output directory where the Pyinstaller's output will be stored.
+        # That may be useful during the debugging.
+        pyinstaller_output = self._intermediate_results_path / "frozen_binary"
+        pyinstaller_output.mkdir(parents=True, exist_ok=True)
+
+        frozen_binary_output = pyinstaller_output / "dist"
+
+        # Run the PyInstaller.
+
+        subprocess.check_call(
+            [sys.executable, "-m", "PyInstaller", str(spec_file_path)],
+            cwd=str(pyinstaller_output),
+        )
+
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        # Make frozen binaries executable and copy them into output folder.
+        for child_path in frozen_binary_output.iterdir():
+            child_path.chmod(child_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
+            shutil.copy2(child_path, output_path)
+
+        # Also build the frozen binary for the package test script, they will be used to test the packages later.
+        package_test_pyinstaller_output = self._build_output_path / "package_test_frozen_binary"
+
+        package_test_script_path = (
+            __SOURCE_ROOT__ / "tests" / "package_tests" / "package_test.py"
+        )
+
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "PyInstaller",
+                str(package_test_script_path),
+                "--distpath",
+                str(package_test_pyinstaller_output),
+                "--onefile",
+            ]
+        )
+
+        # Make the package test frozen binaries executable.
+        for child_path in package_test_pyinstaller_output.iterdir():
+            child_path.chmod(child_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
+
     def _build_package_files(self, output_path: Union[str, pl.Path]):
         """
         Build the basic structure for all packages.
@@ -563,6 +631,30 @@ class PackageBuilder(abc.ABC):
         package_type_file_path = output_path / "install_type"
         package_type_file_path.write_text(type(self).INSTALL_TYPE)
 
+        # Create bin directory with executables.
+        bin_path = output_path / "bin"
+        bin_path.mkdir()
+
+        if type(self).USE_FROZEN_BINARIES:
+            self._build_frozen_binary(bin_path)
+        else:
+            source_code_path = output_path / "py"
+
+            shutil.copytree(__SOURCE_ROOT__ / "scalyr_agent", source_code_path / "scalyr_agent")
+
+            agent_main_executable_path = bin_path / "scalyr-agent-2"
+            agent_main_executable_path.symlink_to(pl.Path("..", "py", "scalyr_agent", "agent_main.py"))
+
+            agent_config_executable_path = bin_path / "scalyr-agent-2-config"
+            agent_config_executable_path.symlink_to(pl.Path("..", "py", "scalyr_agent", "config_main.py"))
+
+            # Don't include the tests directories.  Also, don't include the .idea directory created by IDE.
+            common.recursively_delete_dirs_by_name(source_code_path, r"\.idea", "tests", "__pycache__")
+            recursively_delete_files_by_name(
+                source_code_path,
+                r".*\.pyc", r".*\.pyo", r".*\.pyd", r"all_tests\.py", r".*~"
+            )
+
     @abc.abstractmethod
     def _build(self, output_path: Union[str, pl.Path]):
         """
@@ -572,76 +664,7 @@ class PackageBuilder(abc.ABC):
         pass
 
 
-class FrozenBinaryPackageBuilder(PackageBuilder):
-    """
-    Package builder which is able to build the agent frozen binaries using the PyInstaller library..
-    """
-
-    FILES_USED_IN_BUILD_ENVIRONMENT = [
-        __SOURCE_ROOT__ / "agent_build" / "requirements.txt",
-        __SOURCE_ROOT__ / "agent_build" / "frozen-binary-builder-requirements.txt",
-    ]
-
-    def __init__(
-        self,
-        variant: str = None,
-        no_versioned_file_name: bool = False,
-    ):
-        super(FrozenBinaryPackageBuilder, self).__init__(
-            variant=variant, no_versioned_file_name=no_versioned_file_name
-        )
-
-        self._frozen_binary_output: Optional[pl.Path] = None
-
-    def _build_frozen_binary(self):
-        """
-        Build the frozen binary using the PyInstaller library.
-        """
-        spec_file_path = __SOURCE_ROOT__ / "agent_build" / "pyinstaller_spec.spec"
-
-        # Create the special folder in the package output directory where the Pyinstaller's output will be stored.
-        # That may be useful during the debugging.
-        pyinstaller_output = self._build_output_path / "frozen_binary"
-        pyinstaller_output.mkdir(parents=True)
-
-        self._frozen_binary_output = pyinstaller_output / "dist"
-
-        # Run the PyInstaller.
-
-        subprocess.check_call(
-            [sys.executable, "-m", "PyInstaller", str(spec_file_path)],
-            cwd=str(pyinstaller_output),
-        )
-
-        # Make frozen binaries executable.
-        for child_path in self._frozen_binary_output.iterdir():
-            child_path.chmod(child_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
-
-        # Also build the frozen binary for the package test script, they will be used to test the packages later.
-        package_test_pyinstaller_output = self._build_output_path / "frozen_binary_test"
-
-        package_test_script_path = (
-            __SOURCE_ROOT__ / "tests" / "package_tests" / "package_test.py"
-        )
-
-        subprocess.check_call(
-            [
-                sys.executable,
-                "-m",
-                "PyInstaller",
-                str(package_test_script_path),
-                "--distpath",
-                str(package_test_pyinstaller_output),
-                "--onefile",
-            ]
-        )
-
-        # Make the package test frozen binaries executable
-        for child_path in package_test_pyinstaller_output.iterdir():
-            child_path.chmod(child_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
-
-
-class LinuxPackageBuilder(FrozenBinaryPackageBuilder):
+class LinuxPackageBuilder(PackageBuilder):
     """
     The base package builder for all Linux packages.
     """
@@ -691,12 +714,7 @@ class LinuxFhsBasedPackageBuilder(LinuxPackageBuilder):
         pl.Path(output_path, "var/log/scalyr-agent-2").mkdir(parents=True)
         pl.Path(output_path, "var/lib/scalyr-agent-2").mkdir(parents=True)
 
-        # Build frozen binaries.
-        self._build_frozen_binary()
         bin_path = install_root / "bin"
-        # Copy frozen binaries
-        shutil.copytree(self._frozen_binary_output, bin_path)
-        # Create symlink to the frozen binaries in the /usr/sbin folder.
         usr_sbin_path = self._package_files_path / "usr/sbin"
         usr_sbin_path.mkdir(parents=True)
         for binary_path in bin_path.iterdir():
@@ -707,6 +725,181 @@ class LinuxFhsBasedPackageBuilder(LinuxPackageBuilder):
                 "..", "share", "scalyr-agent-2", "bin", binary_path.name
             )
             binary_symlink_path.symlink_to(symlink_target_path)
+
+
+class ContainerPackageBuilder(LinuxFhsBasedPackageBuilder):
+    """
+    The base builder for all docker and kubernetes based images . It builds an executable script in the current working
+     directory that will build the container image for the various Docker and Kubernetes targets.
+     This script embeds all assets it needs in it so it can be a standalone artifact. The script is based on
+     `docker/scripts/container_builder_base.sh`. See that script for information on it can be used."
+    """
+    # Path to the configuration which should be used in this build.
+    CONFIG_PATH = None
+    # The file path for the Dockerfile to embed in the script, relative to the top of the agent source directory.
+    DOCKERFILE_PATH = None
+
+    # The name of the result image.
+    RESULT_IMAGE_NAME = None
+
+    # A list of repositories that should be added as tags to the image once it is built.
+    # Each repository will have two tags added -- one for the specific agent version and one for `latest`.
+    IMAGE_REPOS = None
+
+    USE_FROZEN_BINARIES = False
+
+    def _build_package_files(self, output_path: Union[str, pl.Path]):
+        super(ContainerPackageBuilder, self)._build_package_files(
+            output_path=output_path
+        )
+
+        # Need to create some docker specific directories.
+        pl.Path(output_path / "var/log/scalyr-agent-2/containers").mkdir()
+
+        # Copy config
+        self._add_config(type(self).CONFIG_PATH, self._package_files_path / "etc/scalyr-agent-2")
+
+    def _build(self, output_path: Union[str, pl.Path]):
+        self._build_package_files(
+            output_path=self._package_files_path
+        )
+
+        container_tarball_path = self._intermediate_results_path / "scalyr-agent.tar.gz"
+
+        # Do a manual walk over the contents of root so that we can use `addfile` to add the tarfile... which allows
+        # us to reset the owner/group to root.  This might not be that portable to Windows, but for now, Docker is
+        # mainly Posix.
+        with tarfile.open(container_tarball_path, "w:gz") as container_tar:
+
+            for root, dirs, files in os.walk(self._package_files_path):
+                to_copy = []
+                for name in dirs:
+                    to_copy.append(os.path.join(root, name))
+                for name in files:
+                    to_copy.append(os.path.join(root, name))
+
+                for x in to_copy:
+                    file_entry = container_tar.gettarinfo(
+                        x, arcname=str(pl.Path(x).relative_to(self._package_files_path))
+                    )
+                    file_entry.uname = "root"
+                    file_entry.gname = "root"
+                    file_entry.uid = 0
+                    file_entry.gid = 0
+
+                    if file_entry.isreg():
+                        with open(x, "rb") as fp:
+                            container_tar.addfile(file_entry, fp)
+                    else:
+                        container_tar.addfile(file_entry)
+
+        # Tar it up but hold the tarfile in memory.  Note, if the source tarball really becomes massive, might have to
+        # rethink this.
+        tar_out = io.BytesIO()
+        with tarfile.open("assets.tar.gz", "w|gz", tar_out) as tar:
+            # Add dockerfile.
+            tar.add(str(type(self).DOCKERFILE_PATH), arcname="Dockerfile")
+            # Add requirement files.
+            tar.add(str(__PARENT_DIR__ / "requirements.txt"), arcname="requirements.txt")
+            tar.add(
+                str(__PARENT_DIR__ / "linux/k8s_and_docker/container_requirements.txt"),
+                arcname="container_requirements.txt"
+            )
+            # Add container source tarball.
+            tar.add(container_tarball_path, arcname="scalyr-agent.tar.gz")
+
+        if self._variant is None:
+            version_string = self._package_version
+        else:
+            version_string = "%s.%s" % (self._package_version, self._variant)
+
+        builder_name = f"scalyr-agent-{type(self).PACKAGE_TYPE}"
+        if self._no_versioned_file_name:
+            output_name = builder_name
+        else:
+            output_name = "%s-%s" % (builder_name, version_string)
+
+        # Read the base builder script into memory
+        base_script_path = __SOURCE_ROOT__ / "docker/scripts/container_builder_base.sh"
+        base_script = base_script_path.read_text()
+
+        # The script has two lines defining environment variables (REPOSITORIES and TAGS) that we need to overwrite to
+        # set them to what we want.  We'll just do some regex replace to do that.
+        base_script = re.sub(
+            r"\n.*OVERRIDE_REPOSITORIES.*\n",
+            '\nREPOSITORIES="%s"\n' % ",".join(type(self).IMAGE_REPOS),
+            base_script,
+        )
+        base_script = re.sub(
+            r"\n.*OVERRIDE_TAGS.*\n",
+            '\nTAGS="%s"\n' % "%s,latest" % version_string,
+            base_script,
+        )
+
+        # Write one file that has the contents of the script followed by the contents of the tarfile.
+        builder_script_path = self._build_output_path / output_name
+        with builder_script_path.open("wb") as f:
+            f.write(base_script.encode("utf-8"))
+
+            f.write(tar_out.getvalue())
+
+        # Make the script executable.
+        st = builder_script_path.stat()
+        builder_script_path.chmod(st.st_mode | stat.S_IEXEC | stat.S_IXGRP)
+
+
+class K8sPackageBuilder(ContainerPackageBuilder):
+    """
+    An image for running the agent on Kubernetes.
+    """
+    PACKAGE_TYPE = "k8s"
+    TARBALL_NAME = "scalyr-k8s-agent.tar.gz"
+    CONFIG_PATH = __SOURCE_ROOT__ / "docker/k8s-config"
+    DOCKERFILE_PATH = __SOURCE_ROOT__ / "docker/Dockerfile.k8s"
+    RESULT_IMAGE_NAME = "scalyr-k8s-agent"
+    IMAGE_REPOS = ["scalyr/scalyr-k8s-agent"]
+
+
+class DockerJsonPackageBuilder(ContainerPackageBuilder):
+    """
+    An image for running on Docker configured to fetch logs via the file system (the container log
+    directory is mounted to the agent container.)  This is the preferred way of running on Docker.
+    This image is published to scalyr/scalyr-agent-docker-json.
+    """
+    PACKAGE_TYPE = "docker-json"
+    TARBALL_NAME = "scalyr-docker-agent.tar.gz"
+    CONFIG_PATH = __SOURCE_ROOT__ / "docker/docker-json-config"
+    DOCKERFILE_PATH = __SOURCE_ROOT__ / "docker/Dockerfile"
+    RESULT_IMAGE_NAME = "scalyr-docker-agent-json"
+    IMAGE_REPOS = ["scalyr/scalyr-agent-docker-json"]
+
+
+class DockerSyslogPackageBuilder(ContainerPackageBuilder):
+    """
+    An image for running on Docker configured to receive logs from other containers via syslog.
+    This is the deprecated approach (but is still published under scalyr/scalyr-docker-agent for
+    backward compatibility.)  We also publish this under scalyr/scalyr-docker-agent-syslog to help
+    with the eventual migration.
+    """
+    PACKAGE_TYPE = "docker-syslog"
+    TARBALL_NAME = "scalyr-docker-agent.tar.gz"
+    CONFIG_PATH = __SOURCE_ROOT__ / "docker/docker-syslog-config"
+    DOCKERFILE_PATH = __SOURCE_ROOT__ / "docker/Dockerfile.syslog"
+    RESULT_IMAGE_NAME = "scalyr-docker-agent-syslog"
+    IMAGE_REPOS = ["scalyr/scalyr-agent-docker-syslog", "scalyr/scalyr-agent-docker"]
+
+
+class DockerApiPackageBuilder(ContainerPackageBuilder):
+    """
+    An image for running on Docker configured to fetch logs via the Docker API using docker_raw_logs: false
+    configuration option.
+    """
+    PACKAGE_TYPE = "docker-api"
+    TARBALL_NAME = "scalyr-docker-agent.tar.gz"
+    CONFIG_PATH = __SOURCE_ROOT__ / "docker/docker-api-config"
+    DOCKERFILE_PATH = __SOURCE_ROOT__ / "docker/Dockerfile"
+    RESULT_IMAGE_NAME = "scalyr-docker-agent-api"
+    IMAGE_REPOS = ["scalyr/scalyr-agent-docker-api"]
 
 
 class FpmBasedPackageBuilder(LinuxFhsBasedPackageBuilder):
@@ -966,11 +1159,8 @@ class TarballPackageBuilder(LinuxPackageBuilder):
         )
 
         # Build frozen binary.
-        self._build_frozen_binary()
-
         bin_path = self._package_files_path / "bin"
-        # Copy frozen binaries
-        shutil.copytree(self._frozen_binary_output, bin_path)
+        self._build_frozen_binary(bin_path)
 
         if self._variant is None:
             base_archive_name = "scalyr-agent-%s" % self._package_version
@@ -994,7 +1184,7 @@ class TarballPackageBuilder(LinuxPackageBuilder):
         tar.close()
 
 
-class MsiWindowsPackageBuilder(FrozenBinaryPackageBuilder):
+class MsiWindowsPackageBuilder(PackageBuilder):
     PACKAGE_TYPE = "msi"
     INSTALL_TYPE = "package"
     PREPARE_BUILD_ENVIRONMENT_SCRIPT_PATH = (
@@ -1044,9 +1234,8 @@ class MsiWindowsPackageBuilder(FrozenBinaryPackageBuilder):
         self._add_certs(certs_path, intermediate_certs=False, copy_other_certs=False)
 
         # Build frozen binaries and copy them into bin folder.
-        self._build_frozen_binary()
         bin_path = scalyr_dir / "bin"
-        shutil.copytree(self._frozen_binary_output, bin_path)
+        self._build_frozen_binary(bin_path)
 
         shutil.copy(_AGENT_BUILD_PATH / "windows/files/ScalyrShell.cmd", bin_path)
 
@@ -1123,6 +1312,10 @@ package_types_to_builders = {
         RpmPackageBuilder,
         TarballPackageBuilder,
         MsiWindowsPackageBuilder,
+        K8sPackageBuilder,
+        DockerJsonPackageBuilder,
+        DockerSyslogPackageBuilder,
+        DockerApiPackageBuilder
     ]
 }
 
@@ -1144,7 +1337,7 @@ def main():
         "by default inside the docker.",
     )
 
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers = parser.add_subparsers(dest="command")
 
     prepare_environment_parser = subparsers.add_parser("prepare-build-environment")
     prepare_environment_parser.add_argument(

--- a/agent_build/common.py
+++ b/agent_build/common.py
@@ -89,22 +89,14 @@ def recursively_delete_dirs_by_name(
 
     # Walk down the file tree, top down, allowing us to prune directories as we go.
     for root, dirs, files in os.walk(root_dir):
-        # The list of directories at the current level to delete.
-        to_remove = []
-
         # Examine all directories at this level, see if any get a match
         for dir_path in dirs:
-            remove_it = False
             for matcher in matchers:
                 if matcher.match(dir_path):
-                    remove_it = True
-            if remove_it:
-                to_remove.append(dir_path)
-
-        # Go back and delete it.  Also, remove it from dirs so that we don't try to walk down it.
-        for remove_dir_path in to_remove:
-            shutil.rmtree(os.path.join(root, remove_dir_path))
-            dirs.remove(remove_dir_path)
+                    shutil.rmtree(os.path.join(root, dir_path))
+                    # Also, remove it from dirs so that we don't try to walk down it.
+                    dirs.remove(dir_path)
+                    break
 
 
 class BadChangeLogFormat(Exception):

--- a/agent_build/linux/k8s_and_docker/container_requirements.txt
+++ b/agent_build/linux/k8s_and_docker/container_requirements.txt
@@ -1,0 +1,2 @@
+# dependencies for docker images.
+docker==4.1.0

--- a/agent_build/linux/prepare_build_environment.sh
+++ b/agent_build/linux/prepare_build_environment.sh
@@ -53,6 +53,7 @@ gem cleanup
 # Install pyinstaller and other possible requirements.
 python3 -m pip install -r /scalyr-agent-2/agent_build/frozen-binary-builder-requirements.txt
 python3 -m pip install -r /scalyr-agent-2/agent_build/requirements.txt
+python3 -m pip install -r /scalyr-agent-2/agent_build/monitors_requirements.txt
 
 yum install -y git rpm-build
 

--- a/agent_build/monitors_requirements.txt
+++ b/agent_build/monitors_requirements.txt
@@ -1,0 +1,4 @@
+# Dependencies for agent's monitors. They are defined in a separate file to avoid their installation
+# in some specific build, such as for docker or kubernetes.
+redis==2.10.5
+# TODO: add other dependencies.

--- a/agent_build/requirements.txt
+++ b/agent_build/requirements.txt
@@ -1,8 +1,7 @@
 orjson==3.5.1
-
+# TODO: remove six from the code base.
 six==1.14.0
-redis==2.10.5
-requests==2.15.1
+requests==2.26.0
 
 
 psutil==5.7.0; platform_system == "Windows"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,21 +1,23 @@
 # base image that creates all necessary dependencies for
 # the scalyr-agent
 # NOTE: multi-stage builds require Docker 17.05 or greater
-FROM python:2.7-slim as scalyr-dependencies
+FROM python:3.8-slim as scalyr-dependencies
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 RUN apt-get update && apt-get install -y build-essential
 
 # install python dependencies
 ADD requirements.txt requirements.txt
+ADD container_requirements.txt container_requirements.txt
 RUN pip --no-cache-dir install --root /tmp/dependencies -r requirements.txt
+RUN pip --no-cache-dir install --root /tmp/dependencies -r container_requirements.txt
 
 # main image - copies dependencies from scalyr-dependencies and extracts
 # the tar-zipped file containing the scalyr-agent code
-FROM python:2.7-slim as scalyr
+FROM python:3.8-slim as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 COPY --from=scalyr-dependencies  /tmp/dependencies/ /
-ADD scalyr-docker-agent.tar.gz /
+ADD scalyr-agent.tar.gz /
 
 CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]

--- a/docker/Dockerfile.k8s
+++ b/docker/Dockerfile.k8s
@@ -1,23 +1,25 @@
 # base image that creates all necessary dependencies for
 # the scalyr-agent
 # NOTE: multi-stage builds require Docker 17.05 or greater
-FROM python:2.7-slim as scalyr-dependencies
+FROM python:3.8-slim as scalyr-dependencies
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 RUN apt-get update && apt-get install -y build-essential
 
 # install python dependencies
 ADD requirements.txt requirements.txt
+ADD container_requirements.txt container_requirements.txt
 RUN pip --no-cache-dir install --root /tmp/dependencies -r requirements.txt
+RUN pip --no-cache-dir install --root /tmp/dependencies -r container_requirements.txt
 
 # main image - copies dependencies from scalyr-dependencies and extracts
 # the tar-zipped file containing the scalyr-agent code
-FROM python:2.7-slim as scalyr
+FROM python:3.8-slim as scalyr
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 # Configure agent to only emit log messages with ERROR and above to stdout by default
 ENV SCALYR_STDOUT_SEVERITY ERROR
 COPY --from=scalyr-dependencies  /tmp/dependencies/ /
-ADD scalyr-k8s-agent.tar.gz /
+ADD scalyr-agent.tar.gz /
 
 CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]

--- a/docker/scripts/container_builder_base.sh
+++ b/docker/scripts/container_builder_base.sh
@@ -84,6 +84,7 @@ while (( $# > 0)); do
       untar_tarball $0 || die "Failed to extract packages";
       cp $TMPDIR/Dockerfile ./ || die "Failed to copy the Dockerfile to current directory";
       cp $TMPDIR/requirements.txt ./ || die "Failed to copy the requirements.txt to current directory";
+      cp $TMPDIR/container_requirements.txt ./ || die "Failed to copy the agent requirements.txt to current directory";
       cp $TMPDIR/*.tar.gz ./ ||
         die "Failed to copy the source tarball to the current directory";
       exit 0;;

--- a/scalyr_agent/__scalyr__.py
+++ b/scalyr_agent/__scalyr__.py
@@ -50,7 +50,7 @@ PY3_pre_32 = PY3 and sys.version_info < (3, 2)
 # Install using tarball:
 #   Here the install root is the path to the extracted tarball.
 #
-# Install using rpm/deb package:
+# Install using rpm/deb/kubernetes/docker package:
 #   Here the install root is /usr/share/scalyr-agent-2.
 #
 # Install using msi package for Windows:
@@ -61,7 +61,11 @@ PY3_pre_32 = PY3 and sys.version_info < (3, 2)
 #   install_type: File which contains the type of the installed package. Agent reads this file during the start in order
 #       to find all essential paths on the system where it runs. Soo the 'InstallType' enum class to see its possible
 #       values.
-#   bin/: The directory with executables.
+#   py/: Directory with the source code of the agent. Only used in the Kubernetes and Docker images, other build use
+#       frozen binaries.
+#   bin/: The directory with executables. For the majority of the package types, it contains frozen binaries of the
+#       agent. In case of Kubernetes or Docker it contains symlinks to agent executable scripts in the source code which
+#       is located in the 'py' folder.
 #   certs/: Certificates directory.
 #   monitors/: The folder for custom monitors.
 #   misc/: Miscellaneous files.
@@ -110,6 +114,10 @@ class InstallType(enum.Enum):
 
 
 def __read_install_type_from_type_file(path: pl.Path) -> InstallType:
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Can not determine the package installation type. The file '{path}' is not found."
+        )
     # Read the type of the package from the file.
     install_type = path.read_text().strip()
     # Check if the package type is one of the valid install types.
@@ -140,28 +148,38 @@ def __determine_install_root_and_type() -> Tuple[str, InstallType]:
         # All agent packages have the special file 'install_type' which contains the type of the package.
         # This file is always located in the install root, so it is a good way to verify if it is a install root or not.
         install_type_file_path = install_root / "install_type"
-        if not install_type_file_path.is_file():
-            # For now, we expect that the frozen binary can only be run correctly as a part of a package,
-            # so if there's no an 'install_type' file, then something went wrong.
-            raise FileNotFoundError(
-                f"Can not determine the package installation type. The file '{install_type_file_path}' is not found."
-            )
 
         return str(install_root), __read_install_type_from_type_file(
             install_type_file_path
         )
 
     else:
-        # The agent code is not frozen.
-        # For now, there is only one possible scenario which is handled:
-        #   There is no any package installation and agent started directly from the source repo, the most likely,
-        #   during the development process (DEV_INSTALL). The install root is a source root.
+        # The agent code is not frozen. The main task here is determine whether the agent has been started from the
+        # source code (aka DEV_INSTALL) or from the package installation. In packages, the source code is located in the
+        # '<install_root>/py' folder, so it has to be enough to verify if the parent folder of the 'scalyr_agent'
+        # package is a folder named 'py'.
 
-        # Get install root, which should be a parent directory for the 'scalyr_agent' package directory where the
-        # '__scalyr__.py' file is located.
-        install_root = pl.Path(__file__).absolute().parent.parent
+        script_path = pl.Path(sys.argv[0])
 
-        return str(install_root), InstallType.DEV_INSTALL
+        # First of all get the real path of the executed script if it is a symlink.
+        while script_path.is_symlink():
+            script_path = pl.Path(script_path.parent, os.readlink(script_path)).resolve()
+
+        # parent folder of the script has to be a 'scalyr_agent' package folder.
+        package_folder = script_path.parent
+
+        # Get the source code root. The name of the folder has to be 'py'
+        source_code_root = package_folder.parent
+
+        if source_code_root.name == "py":
+            install_root = source_code_root.parent
+            install_type_file_path = install_root / "install_type"
+
+            return str(install_root), __read_install_type_from_type_file(install_type_file_path)
+        else:
+            # The name of hte parent folder of the 'scalyr_agent' package is not 'py', so it is likely that it
+            # started from source code.
+            return str(source_code_root), InstallType.DEV_INSTALL
 
 
 __install_root__, INSTALL_TYPE = __determine_install_root_and_type()

--- a/tests/package_tests/common.py
+++ b/tests/package_tests/common.py
@@ -55,8 +55,10 @@ class LogVerifierCheck:
 
     def perform(self, new_text, whole_log_text) -> Union[LogVerifierCheckResult, Tuple[LogVerifierCheckResult, str]]:
         """
-        Perform test or check of the line.
-        :param line: Line to check.
+        Perform test or check of the line. The check may be performed against new data of the whole data of the
+        log file.
+        :param new_text: new text that that has been added from the previous check.
+        :param whole_log_text: the whole text of the log file.
         """
         pass
 

--- a/tests/package_tests/common.py
+++ b/tests/package_tests/common.py
@@ -1,0 +1,93 @@
+# Copyright 2014-2021 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import queue
+import threading
+import re
+from typing import IO
+
+AGENT_LOG_LINE_TIMESTAMP = r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+Z"
+
+# The pattern to match the periodic message lines with network request statistics. This message is written only when
+# all startup messages are written, so it's a good time to stop the verification of the agent.log file.
+AGENT_LOG_REQESTS_STATS_LINE_PATTERN = rf"{AGENT_LOG_LINE_TIMESTAMP} INFO \[core] \[scalyr-agent-2:\d+] " \
+                                       r"agent_requests requests_sent=(?P<requests_sent>\d+) " \
+                                       r"requests_failed=(?P<requests_failed>\d+) " \
+                                       r"bytes_sent=(?P<bytes_sent>\d+) " \
+                                       r".+"
+
+# 5 min.
+COMMON_TIMEOUT = 5 * 60
+
+class TestFail(Exception):
+    pass
+
+
+class PipeReader:
+    """
+    Simple reader to read process pipes. Since it's not possible to perform a non-blocking read from pipe,
+    we just read it in a separate thread and put it to the queue.
+    """
+    def __init__(self, pipe: IO):
+        self._pipe = pipe
+        self._queue = queue.Queue()
+        self._started = False
+        self._thread = None
+
+    def read_pipe(self):
+        """
+        Reads lines from pipe. Runs in a separate thread.
+        """
+        while True:
+            line = self._pipe.readline()
+            if line == b'':
+                break
+            self._queue.put(line.decode())
+
+    def next_line(self, timeout: int):
+        """
+        Return lines from queue if presented.
+        """
+        if not self._thread:
+            self._thread = threading.Thread(target=self.read_pipe)
+            self._thread.start()
+        return self._queue.get(timeout=timeout)
+
+
+def check_agent_log_request_stats_in_line(line: str) -> bool:
+    # Match for the requests status message.
+    m = re.match(AGENT_LOG_REQESTS_STATS_LINE_PATTERN, line)
+
+    if m:
+        # The requests status message is found.
+        # Also do a final check for a valid request stats.
+        md = m.groupdict()
+        requests_sent = int(md["requests_sent"])
+        bytes_sent = int(md["bytes_sent"])
+        if bytes_sent <= 0 and requests_sent <= 0:
+            raise TestFail(
+                "Agent log says that during the run the agent has sent zero bytes or requests."
+            )
+        return True
+    else:
+        return False
+
+
+def check_if_line_an_error(line: str):
+    """
+    Check if the agent log line is error.
+    """
+    if re.match(rf"{AGENT_LOG_LINE_TIMESTAMP} ERROR .*", line):
+        raise TestFail(f'The next line message is an error:\n"{line}"')
+

--- a/tests/package_tests/docker_test.py
+++ b/tests/package_tests/docker_test.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright 2014-2021 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import pathlib as pl
+import subprocess
+import sys
+import time
+import datetime
+from typing import Union
+
+sys.path.append(str(pl.Path(__file__).absolute().parent.parent.parent))
+
+from tests.package_tests.common import PipeReader, check_agent_log_request_stats_in_line, check_if_line_an_error
+from tests.package_tests.common import COMMON_TIMEOUT
+
+
+def build_agent_image(builder_path: pl.Path):
+    # Call the image builder script.
+    subprocess.check_call(
+        [str(builder_path), "--tags", "docker-test"],
+    )
+
+
+_AGENT_CONTAINER_NAME = "scalyr-agent-docker-test"
+
+
+def _delete_agent_container():
+
+    # Kill and remove the previous container, if exists.
+    subprocess.check_call(
+        ["docker", "rm", "-f", _AGENT_CONTAINER_NAME]
+    )
+
+
+def _test(scalyr_api_key: str):
+
+    # Run agent inside the container.
+    subprocess.check_call(
+        [
+            "docker", "run", "-d", "--name", _AGENT_CONTAINER_NAME, "-e", f"SCALYR_API_KEY={scalyr_api_key}",
+            "-v", "/var/run/docker.sock:/var/scalyr/docker.sock", "scalyr/scalyr-agent-docker-json:docker-test"
+        ]
+    )
+
+    # Wait a little.
+    time.sleep(3)
+
+    # Execute tail -f command on the agent.log inside the container to read its content.
+    agent_log_tail_process = subprocess.Popen(
+        ["docker", "exec", "-i", _AGENT_CONTAINER_NAME, "tail", "-f", "-n+1", "/var/log/scalyr-agent-2/agent.log"],
+        stdout=subprocess.PIPE
+    )
+
+    # Read lines from agent.log.
+    pipe_reader = PipeReader(pipe=agent_log_tail_process.stdout)
+
+    timeout_time = datetime.datetime.now() + datetime.timedelta(seconds=COMMON_TIMEOUT)
+    try:
+        while True:
+
+            seconds_until_timeout = timeout_time - datetime.datetime.now()
+            line = pipe_reader.next_line(timeout=seconds_until_timeout.seconds)
+            print(line)
+            # Look for any ERROR message.
+            check_if_line_an_error(line)
+
+            # TODO: add more checks.
+
+            if check_agent_log_request_stats_in_line(line):
+                # The requests status message is found. Stop the loop.
+                break
+    finally:
+        agent_log_tail_process.terminate()
+
+    agent_log_tail_process.communicate()
+
+    print("Test passed!")
+
+
+def main(
+    builder_path: Union[str, pl.Path],
+    scalyr_api_key: str
+):
+
+    build_agent_image(builder_path)
+    _delete_agent_container()
+
+    try:
+        _test(scalyr_api_key)
+    finally:
+        _delete_agent_container()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--package-path", required=True)
+    parser.add_argument("--scalyr-api-key", required=True)
+
+    args = parser.parse_args()
+    main(
+        builder_path=args.package_path,
+        scalyr_api_key=args.scalyr_api_key
+    )

--- a/tests/package_tests/k8s_test.py
+++ b/tests/package_tests/k8s_test.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# Copyright 2014-2021 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import datetime
+import os
+import re
+import subprocess
+import pathlib as pl
+import tempfile
+import time
+import sys
+from typing import Union
+
+__SOURCE_ROOT__ = pl.Path(__file__).absolute().parent.parent.parent
+sys.path.append(str(__SOURCE_ROOT__))
+
+
+# Timeout 5 minutes.
+from tests.package_tests.common import PipeReader, check_agent_log_request_stats_in_line, check_if_line_an_error
+from tests.package_tests.common import COMMON_TIMEOUT
+
+
+
+
+def build_agent_image(builder_path: pl.Path):
+    # Get the information about minikube's docker environment.
+    output = subprocess.check_output(
+        "minikube docker-env", shell=True
+    ).decode()
+
+    # Parse environment variables from the 'minikube docker-env' output
+    env = os.environ.copy()
+    for e in re.findall(r'export (\w+=".+")', output):
+        (n, v), = re.findall(r'(\w+)="(.+)"', e)
+        env[n] = v
+
+    # Call the image builder script. We also pass previously parsed docker-env variables to build this image
+    # within the minikube's docker, so the result agent's image is available for kubernetes.
+    subprocess.check_call(
+        [str(builder_path), "--tags", "k8s_test"],
+        env=env
+    )
+
+
+_SCALYR_SERVICE_ACCOUNT_MANIFEST_PATH = __SOURCE_ROOT__ / "k8s" / "scalyr-service-account.yaml"
+
+
+def _delete_k8s_objects():
+    # Delete previously created objects, if presented.
+    try:
+        subprocess.check_call(
+            "kubectl delete daemonset scalyr-agent-2", shell=True
+        )
+    except subprocess.CalledProcessError:
+        pass
+    try:
+        subprocess.check_call(
+            "kubectl delete secret scalyr-api-key", shell=True,
+        )
+    except subprocess.CalledProcessError:
+        pass
+    try:
+        subprocess.check_call(
+            "kubectl delete configmap scalyr-config", shell=True,
+        )
+    except subprocess.CalledProcessError:
+        pass
+    try:
+        subprocess.check_call(
+            ["kubectl", "delete", "-f", str(_SCALYR_SERVICE_ACCOUNT_MANIFEST_PATH)],
+        )
+    except subprocess.CalledProcessError:
+        pass
+
+
+def _test(scalyr_api_key: str):
+    # Create agent's service account.
+    subprocess.check_call(
+        ["kubectl", "create", "-f", str(_SCALYR_SERVICE_ACCOUNT_MANIFEST_PATH)]
+    )
+
+    # Define API key
+    subprocess.check_call(
+        ["kubectl", "create", "secret", "generic", "scalyr-api-key", f"--from-literal=scalyr-api-key={scalyr_api_key}"]
+    )
+
+    # Create configmap
+    subprocess.check_call(
+        [
+            "kubectl", "create", "configmap", "scalyr-config",
+            "--from-literal=SCALYR_K8S_CLUSTER_NAME=ci-agent-k8s-",
+        ]
+    )
+
+    # Modify the manifest for the agent's daemonset.
+    scalyr_agent_manifest_source_path = __SOURCE_ROOT__ / "k8s/scalyr-agent-2.yaml"
+    scalyr_agent_manifest = scalyr_agent_manifest_source_path.read_text()
+
+    # Change the production image name to the local one.
+    scalyr_agent_manifest = re.sub(
+        r"image: scalyr/scalyr-k8s-agent:\d+\.\d+\.\d+",
+        "image: scalyr/scalyr-k8s-agent:k8s_test",
+        scalyr_agent_manifest
+    )
+
+    # Change image pull policy to be able to bull the local image.
+    scalyr_agent_manifest = re.sub(
+        r"imagePullPolicy: \w+", "imagePullPolicy: Never", scalyr_agent_manifest
+    )
+
+    # Create new manifest file for the agent daemonset.
+    tmp_dir = tempfile.TemporaryDirectory(prefix="scalyr-agent-k8s-test")
+
+    scalyr_agent_manifest_path = pl.Path(tmp_dir.name) / "scalyr-agent-2.yaml"
+
+    scalyr_agent_manifest_path.write_text(scalyr_agent_manifest)
+
+    # Create agent's daemonset.
+    subprocess.check_call([
+        "kubectl", "create", "-f", str(scalyr_agent_manifest_path)
+    ])
+
+    # Get name of the created pod.
+    pod_name = subprocess.check_output(
+        "kubectl get pods --sort-by=.metadata.creationTimestamp -o jsonpath=\"{.items[-1].metadata.name}\"", shell=True
+    ).decode().strip()
+
+    # Wait a little.
+    time.sleep(3)
+
+    # Execute tail -f command on the agent.log inside the pod to read its content.
+    agent_log_tail_process = subprocess.Popen(
+        ["kubectl", "exec", pod_name, "--container", "scalyr-agent", "--", "tail", "-f", "-n+1",
+         "/var/log/scalyr-agent-2/agent.log"],
+        stdout=subprocess.PIPE
+    )
+    found_errors = []
+
+    # Read lines from agent.log.
+    pipe_reader = PipeReader(pipe=agent_log_tail_process.stdout)
+
+    timeout_time = datetime.datetime.now() + datetime.timedelta(seconds=COMMON_TIMEOUT)
+    error_lines = []
+    try:
+        while True:
+
+            seconds_until_timeout = timeout_time - datetime.datetime.now()
+            line = pipe_reader.next_line(timeout=seconds_until_timeout.seconds)
+            print(line)
+            # Look for any ERROR message.
+            if check_if_line_an_error(line):
+                error_lines.append(line)
+
+            # TODO: add more checks.
+
+            if check_agent_log_request_stats_in_line(line):
+                # The requests status message is found. Stop the loop.
+                break
+    finally:
+        agent_log_tail_process.terminate()
+
+    agent_log_tail_process.communicate()
+
+    print("Test passed!")
+
+    tmp_dir.cleanup()
+
+
+def main(
+        builder_path: Union[str, pl.Path],
+        scalyr_api_key: str
+):
+    builder_path = pl.Path(builder_path)
+
+    build_agent_image(builder_path)
+
+    _delete_k8s_objects()
+
+    try:
+        _test(scalyr_api_key)
+    finally:
+        _delete_k8s_objects()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--package-path", required=True)
+    parser.add_argument("--scalyr-api-key", required=True)
+
+    args = parser.parse_args()
+    main(
+        builder_path=args.package_path,
+        scalyr_api_key=args.scalyr_api_key
+    )

--- a/tests/package_tests/k8s_test.py
+++ b/tests/package_tests/k8s_test.py
@@ -29,7 +29,7 @@ sys.path.append(str(__SOURCE_ROOT__))
 
 
 # Timeout 5 minutes.
-from tests.package_tests.common import PipeReader, check_agent_log_request_stats_in_line, check_if_line_an_error
+from tests.package_tests.common import PipeReader, check_agent_log_request_stats_in_line, assert_and_throw_if_line_an_error
 from tests.package_tests.common import COMMON_TIMEOUT
 
 
@@ -147,22 +147,21 @@ def _test(scalyr_api_key: str):
          "/var/log/scalyr-agent-2/agent.log"],
         stdout=subprocess.PIPE
     )
-    found_errors = []
-
-    # Read lines from agent.log.
+    # Read lines from agent.log. Create pipe reader to read lines from the previously created tail process.
+    # Also set the mode for the process' std descriptor as non-blocking.
+    os.set_blocking(agent_log_tail_process.stdout.fileno(), False)
     pipe_reader = PipeReader(pipe=agent_log_tail_process.stdout)
 
     timeout_time = datetime.datetime.now() + datetime.timedelta(seconds=COMMON_TIMEOUT)
-    error_lines = []
+
     try:
         while True:
-
-            seconds_until_timeout = timeout_time - datetime.datetime.now()
-            line = pipe_reader.next_line(timeout=seconds_until_timeout.seconds)
-            print(line)
+            seconds_until_timeout = (timeout_time - datetime.datetime.now()).seconds
+            if seconds_until_timeout <= 0:
+                raise TimeoutError("Test has timed out.")
+            line = pipe_reader.next_line(timeout=seconds_until_timeout)
             # Look for any ERROR message.
-            if check_if_line_an_error(line):
-                error_lines.append(line)
+            assert_and_throw_if_line_an_error(line)
 
             # TODO: add more checks.
 
@@ -171,8 +170,7 @@ def _test(scalyr_api_key: str):
                 break
     finally:
         agent_log_tail_process.terminate()
-
-    agent_log_tail_process.communicate()
+        pipe_reader.close()
 
     print("Test passed!")
 

--- a/tests/package_tests/package_test.py
+++ b/tests/package_tests/package_test.py
@@ -115,7 +115,6 @@ def stop_agent(package_type: str):
         subprocess.check_call([binary_path, "stop"])
 
 
-
 def configure_agent(package_type: str, api_key: str):
     if package_type in ["deb", "rpm"]:
         config_path = pathlib.Path(AGENT_CONFIG_PATH)
@@ -123,13 +122,16 @@ def configure_agent(package_type: str, api_key: str):
         install_path = _get_tarball_install_path()
         config_path = install_path / "config/agent.json"
     elif package_type == "msi":
-        config_path = _get_msi_install_path() / "config", "agent.json"
+        config_path = _get_msi_install_path() / "config" / "agent.json"
 
     config = {}
     config["api_key"] = api_key
 
     config["server_attributes"] = {"serverHost": "ARTHUR_TEST"}
+
+    # TODO enable and test system and process monitors
     config["implicit_metric_monitor"] = False
+    config["implicit_agent_process_metrics_monitor"] = False
     config["verify_server_certificate"] = False
     config_path.write_text(json.dumps(config))
 
@@ -151,13 +153,14 @@ def remove_package(package_type: str):
 
 AGENT_CONFIG_PATH = "/etc/scalyr-agent-2/agent.json"
 
+
 def _get_logs_path(package_type: str) -> pl.Path:
     if package_type in ["deb", "rpm"]:
         return pl.Path("/var/log/scalyr-agent-2")
     elif package_type == "tar":
         return _get_tarball_install_path() / "log"
     elif package_type == "msi":
-        _get_msi_install_path() / "log"
+        return _get_msi_install_path() / "log"
 
 
 
@@ -192,6 +195,9 @@ def run(
 
         # Start agent.log file verification.
         agent_log_verifier.verify(timeout=300)
+
+        logging.info("Agent.log:")
+        logging.info(agent_log_path.read_text())
 
     get_agent_status(package_type)
 

--- a/tests/package_tests/package_test_runner.py
+++ b/tests/package_tests/package_test_runner.py
@@ -25,7 +25,7 @@ import logging
 logging.basicConfig(level=logging.INFO, format="[%(levelname)s] [%(filename)s] %(message)s")
 
 
-_PARENT_DIR = pl.Path(__file__).parent
+_PARENT_DIR = pl.Path(__file__).parent.absolute().resolve()
 __SOURCE_ROOT__ = _PARENT_DIR.parent.parent
 
 # Add the source root to the PYTHONPATH. Since this is a script,this is required in order to be able to

--- a/tests/package_tests/package_test_runner.py
+++ b/tests/package_tests/package_test_runner.py
@@ -22,6 +22,7 @@ _PARENT_DIR = pl.Path(__file__).parent
 parser = argparse.ArgumentParser()
 
 parser.add_argument("--package-path", required=True)
+parser.add_argument("--package-type", required=True)
 parser.add_argument("--package-test-path")
 parser.add_argument("--docker-image")
 parser.add_argument("--scalyr-api-key", required=True)
@@ -30,11 +31,19 @@ parser.add_argument("--scalyr-api-key", required=True)
 args = parser.parse_args()
 
 package_path = pl.Path(args.package_path)
+package_type = args.package_type
 
 if args.package_test_path:
     package_test_path = pl.Path(args.package_test_path)
 else:
-    package_test_path = _PARENT_DIR / "package_test.py"
+    if package_type in ["deb", "rpm", "msi", "tar"]:
+        package_test_path = _PARENT_DIR / "package_test.py"
+    elif package_type == "k8s":
+        package_test_path = _PARENT_DIR / "k8s_test.py"
+    elif package_type in ["docker-json"]:
+        package_test_path = _PARENT_DIR / "docker_test.py"
+    else:
+        raise ValueError(f"Wrong package type - {package_type}")
 
 if args.docker_image:
     subprocess.check_call(

--- a/tests/package_tests/package_test_runner.py
+++ b/tests/package_tests/package_test_runner.py
@@ -59,7 +59,7 @@ if args.docker_image:
             # map the package file.
             "-v", f"{package_path}:/{package_path.name}", "--init",
             # specify the image.
-            "args.docker_image",
+            args.docker_image,
             # Command to run the test executable inside the container.
             "/package_test", "--package-path", f"/{package_path.name}", "--scalyr-api-key", args.scalyr_api_key
         ]

--- a/tests/package_tests/package_test_runner.py
+++ b/tests/package_tests/package_test_runner.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+#
+# This script is just a "wrapper" for all other test scripts in the folder.
+# The script accepts a package type, so it can pick an appropriate test script for this type for this package and run it.
+#
 import pathlib as pl
 import argparse
 import subprocess
@@ -46,15 +49,27 @@ else:
         raise ValueError(f"Wrong package type - {package_type}")
 
 if args.docker_image:
+    # Run the test inside the docker.
+    # fmt: off
     subprocess.check_call(
-        f"docker run -i --rm -v {package_test_path}:/package_test -v {package_path}:/{package_path.name} "
-        f"--init {args.docker_image} /package_test --package-path /{package_path.name} "
-        f"--scalyr-api-key {args.scalyr_api_key}",
-        shell=True,
+        [
+            "docker", "run", "-i", "--rm",
+            # map the test executable.
+            "-v", f"{package_test_path}:/package_test",
+            # map the package file.
+            "-v", f"{package_path}:/{package_path.name}", "--init",
+            # specify the image.
+            "args.docker_image",
+            # Command to run the test executable inside the container.
+            "/package_test", "--package-path", f"/{package_path.name}", "--scalyr-api-key", args.scalyr_api_key
+        ]
     )
+    # fmt: on
 else:
+    # Rus the test script.
     subprocess.check_call(
-        f"{package_test_path} --package-path {package_path} "
-        f"--scalyr-api-key {args.scalyr_api_key}",
-        shell=True,
+        [
+            str(package_test_path), "--package-path", str(package_path),
+            "--scalyr-api-key", args.scalyr_api_key
+        ]
     )


### PR DESCRIPTION
This pull request adds a new build process for the Kubernetes and Docker images of the Scalyr Agent.

**Important notion:** Kubernetes and docker images still rely on the source code. Due to the nature of the docker images, we can bundle all dependencies during the image build so we don't have to use frozen binaries. This, in turn, should help to support multi-architecture docker builds easier, without building architecture-specific frozen binaries. 