### PR TITLE
Fix missing timestamp in file processors checkpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Packaged by Steven Czerwinski <stevenc@sentinelone.com> on Aug 12, 2021 16:00 -0
 Bug fixes:
 * Fix docker container builder scripts to only use `buildx` if it is available.
 * Fix memory leak in the Syslog monitor which is caused by a bug in standard TCP/UDP servers in Python 3 (https://bugs.python.org/issue37193). The version of Python for Windows was updated to 3.8.10. For Linux users, who run agent on Python 3 and use Syslog monitor, it is also recommended to check if their Python 3 installation is up to date and has appropriate bug fixes.
+* Fix bug in the copying manager which works with monitor (such as Docker or Syslog monitor). This bug might cause re-uploading of the old log messages in some edge cases. 
 
 ## 2.1.22 "Volans" - Aug 11, 2021
 

--- a/scalyr_agent/copying_manager/worker.py
+++ b/scalyr_agent/copying_manager/worker.py
@@ -1083,10 +1083,8 @@ class CopyingManagerWorkerSession(
         """
         checkpoints = {}
         for processor in log_processors:
-            state = processor.get_checkpoint()
+            state = processor.get_checkpoint(checkpoint_time=current_time)
 
-            # also add the timestamp to each state. This is needed to discard stale ones.
-            state["time"] = current_time
             checkpoints[processor.get_log_path()] = state
 
         return checkpoints

--- a/tests/unit/copying_manager_tests/copying_manager_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_test.py
@@ -16,7 +16,7 @@
 # author: Steven Czerwinski <czerwin@scalyr.com>
 
 #
-# Those test just the same test from previos copying manager, but adapted to the new copying manager.
+# Those test just the same test from previous copying manager, but adapted to the new copying manager.
 #
 
 from __future__ import unicode_literals

--- a/tests/unit/copying_manager_tests/copying_manager_worker_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_worker_test.py
@@ -677,6 +677,9 @@ class TestCopyingManagerWorkerCheckpoints(CopyingManagerWorkerTest):
 
         assert test_file.str_path in checkpoints
 
+        for path, state in checkpoints.items():
+            assert "time" in state, "Checkpoint state for the file {} does not have required 'time' field.".format(path)
+
         # create new worker. Imitate second launch. Worker must start from beginning of the file.
         self._instance = worker = self._create_worker_session()
         self._spawn_single_log_processor(test_file, copy_at_index_zero=True)
@@ -695,6 +698,9 @@ class TestCopyingManagerWorkerCheckpoints(CopyingManagerWorkerTest):
 
         checkpoints = self._env_builder.get_checkpoints(worker.get_id())["checkpoints"]
         assert test_file.str_path in checkpoints
+
+        for path, state in checkpoints.items():
+            assert "time" in state, "Checkpoint state for the file {} does not have required 'time' field.".format(path)
 
         # create new worker. Imitate third launch.
         # Now we also provide checkpoints from previous run, so it have to ignore "copy_at_index_zero".
@@ -717,5 +723,8 @@ class TestCopyingManagerWorkerCheckpoints(CopyingManagerWorkerTest):
         processor.close()
         worker.wait_for_full_iteration()
         closed_files_checkpoints = worker.get_and_reset_closed_files_checkpoints()
+
+        for path, state in closed_files_checkpoints.items():
+            assert "time" in state, "Checkpoint state for the file {} does not have required 'time' field.".format(path)
 
         assert processor.get_log_path() in closed_files_checkpoints

--- a/tests/unit/copying_manager_tests/copying_manager_worker_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_worker_test.py
@@ -678,7 +678,11 @@ class TestCopyingManagerWorkerCheckpoints(CopyingManagerWorkerTest):
         assert test_file.str_path in checkpoints
 
         for path, state in checkpoints.items():
-            assert "time" in state, "Checkpoint state for the file {} does not have required 'time' field.".format(path)
+            assert (
+                "time" in state
+            ), "Checkpoint state for the file {} does not have required 'time' field.".format(
+                path
+            )
 
         # create new worker. Imitate second launch. Worker must start from beginning of the file.
         self._instance = worker = self._create_worker_session()
@@ -700,7 +704,11 @@ class TestCopyingManagerWorkerCheckpoints(CopyingManagerWorkerTest):
         assert test_file.str_path in checkpoints
 
         for path, state in checkpoints.items():
-            assert "time" in state, "Checkpoint state for the file {} does not have required 'time' field.".format(path)
+            assert (
+                "time" in state
+            ), "Checkpoint state for the file {} does not have required 'time' field.".format(
+                path
+            )
 
         # create new worker. Imitate third launch.
         # Now we also provide checkpoints from previous run, so it have to ignore "copy_at_index_zero".
@@ -725,6 +733,10 @@ class TestCopyingManagerWorkerCheckpoints(CopyingManagerWorkerTest):
         closed_files_checkpoints = worker.get_and_reset_closed_files_checkpoints()
 
         for path, state in closed_files_checkpoints.items():
-            assert "time" in state, "Checkpoint state for the file {} does not have required 'time' field.".format(path)
+            assert (
+                "time" in state
+            ), "Checkpoint state for the file {} does not have required 'time' field.".format(
+                path
+            )
 
         assert processor.get_log_path() in closed_files_checkpoints


### PR DESCRIPTION
This PR fixes a very nasty bug that was introduced with sharded copying manager. 

The copying manager does not put the 'time' field (it was also added with the copying manager) to the checkpoint object for the files which are immediately removed (by some monitor, as fact). Because of the missing 'time' field, another step - merging checkpoints from all workers, also works wrong and loses such checkpoints. This makes the copying manager reuse the older checkpoint when the log file was removed and added back, and old log lines may be re-uploaded.

The copying manager support tho ways to remove a file from being copied:

1.  To schedule it for removal and so it waits for EOF. 
2.  Remove immediately. 

The first case worked as it should but the second produced checkpoints without a 'time' field.

The fix is to add this field in the 'LogFileProcessor.get_checkpoint' method, to guarantee that every checkpoint has its `time` field.