### PR TITLE
Implement more robust check if buildx is supported by docker

### DIFF
--- a/docker/scripts/container_builder_base.sh
+++ b/docker/scripts/container_builder_base.sh
@@ -147,8 +147,8 @@ done
 # See if buildx is supported on the local docker.  If not, use legacy method.
 # NOTE: We need to support this until the Scalyr Jenkins-based builders have buildx
 # installed on the base AMIs.
-HAS_BUILD_X=$(docker --help | grep 'buildx')
-if [ ! -z "$HAS_BUILD_X" ]; then
+HAS_BUILD_X=$(docker buildx > /dev/null 2>&1 && echo "YES")
+if [ -z "$HAS_BUILD_X" ]; then
   # Legacy mechanism.
   # TODO: Delete this in favor of the buildx method when we can.  This is duplicated code.  
   report_progress "Docker does not support buildx.  Building only for local architecture." "$QUIET";   


### PR DESCRIPTION
There was a bug in the existing checker (checked if a variable was
non-zero length instead of zero length).  I fixed that but also
made the check a little more robust.