### PR TITLE
New process level agent benchmark with 500k log line size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1852,7 +1852,7 @@ jobs:
       - codespeed_agent_process_benchmark:
           codespeed_executable: "Python 2.7.17 - loaded conf 5"
           codespeed_environment: "Circle CI Docker Executor Medium Size"
-          agent_config: "benchmarks/configs/agent_single_50mb_access_log_file.json"
+          agent_config: "benchmarks/configs/agent_single_50mb_genlog_500k_line_file.json"
           agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/scalyr_genlog_500k_line_50_mb.log"
           agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-5"
           run_time: 140
@@ -1868,7 +1868,7 @@ jobs:
       - codespeed_agent_process_benchmark:
           codespeed_executable: "Python 3.5.9 - loaded conf 6"
           codespeed_environment: "Circle CI Docker Executor Medium Size"
-          agent_config: "benchmarks/configs/agent_single_50mb_access_log_file.json"
+          agent_config: "benchmarks/configs/agent_single_50mb_genlog_500k_line_file.json"
           agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/scalyr_genlog_500k_line_50_mb.log"
           agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-6"
           run_time: 140

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1807,22 +1807,6 @@ jobs:
           capture_line_counts: true
           cache_key_name: "benchmarks-loaded-agent-growing-log-file-py-35"
 
-  benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35:
-    working_directory: ~/scalyr-agent-2
-    docker:
-      - image: circleci/python:3.5.9
-    steps:
-      - codespeed_agent_process_benchmark:
-          codespeed_executable: "Python 3.5.9 - loaded conf 4"
-          codespeed_environment: "Circle CI Docker Executor Medium Size"
-          agent_config: "benchmarks/configs/agent_2-growing_logs-monitors-multiprocess-2-worker.json"
-          run_time: 140
-          agent_pre_run_command: "touch /tmp/random.log & touch /tmp/random2.log"
-          agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 2M 10 100 1 & benchmarks/scripts/write-random-lines.sh /tmp/random2.log 2M 10 100 1 &"
-          agent_server_host: "ci-codespeed-benchmarks-py35-loaded-conf-4"
-          capture_line_counts: true
-          cache_key_name: "agent_2-growing_logs-monitors-multiprocess-2-worker-py-35"
-
   benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
     working_directory: ~/scalyr-agent-2
     docker:
@@ -1843,6 +1827,54 @@ jobs:
           agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-3"
           capture_line_counts: true
           cache_key_name: "benchmarks-loaded-agent-growing-log-file-180-py-27"
+
+  benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35:
+    working_directory: ~/scalyr-agent-2
+    docker:
+      - image: circleci/python:3.5.9
+    steps:
+      - codespeed_agent_process_benchmark:
+          codespeed_executable: "Python 3.5.9 - loaded conf 4"
+          codespeed_environment: "Circle CI Docker Executor Medium Size"
+          agent_config: "benchmarks/configs/agent_2-growing_logs-monitors-multiprocess-2-worker.json"
+          run_time: 140
+          agent_pre_run_command: "touch /tmp/random.log & touch /tmp/random2.log"
+          agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 2M 10 100 1 & benchmarks/scripts/write-random-lines.sh /tmp/random2.log 2M 10 100 1 &"
+          agent_server_host: "ci-codespeed-benchmarks-py35-loaded-conf-4"
+          capture_line_counts: true
+          cache_key_name: "agent_2-growing_logs-monitors-multiprocess-2-worker-py-35"
+
+  benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27:
+    working_directory: ~/scalyr-agent-2
+    docker:
+      - image: circleci/python:2.7.17
+    steps:
+      - codespeed_agent_process_benchmark:
+          codespeed_executable: "Python 2.7.17 - loaded conf 5"
+          codespeed_environment: "Circle CI Docker Executor Medium Size"
+          agent_config: "benchmarks/configs/agent_single_50mb_access_log_file.json"
+          agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/scalyr_genlog_500k_line_50_mb.log"
+          agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-5"
+          run_time: 140
+          capture_agent_status_metrics: true
+          capture_line_counts: true
+          cache_key_name: "benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27"
+
+  benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35:
+    working_directory: ~/scalyr-agent-2
+    docker:
+      - image: circleci/python:3.5.9
+    steps:
+      - codespeed_agent_process_benchmark:
+          codespeed_executable: "Python 3.5.9 - loaded conf 6"
+          codespeed_environment: "Circle CI Docker Executor Medium Size"
+          agent_config: "benchmarks/configs/agent_single_50mb_access_log_file.json"
+          agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/scalyr_genlog_500k_line_50_mb.log"
+          agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-6"
+          run_time: 140
+          capture_agent_status_metrics: true
+          capture_line_counts: true
+          cache_key_name: "benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27"
 
   benchmarks-micro-py-35:
     working_directory: ~/scalyr-agent-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ master_and_release_only: &master_and_release_only
       only:
         - master
         - release
-        - improve_coverage
         # Those short lived branches are automatically created by our StackStorm build automation
         # so we can ensure all the jobs (including the ones which only run on master) pass before
         # merging a PR.
@@ -21,6 +20,7 @@ benchmarks_master_and_release_only: &benchmarks_master_and_release_only
       only:
         - master
         - release
+        - new_end_to_end_benchmark
 
 master_only: &master_only
   filters:
@@ -2428,6 +2428,10 @@ workflows:
          <<: *benchmarks_master_and_release_only
      - benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35:
          <<: *benchmarks_master_and_release_only
+     - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27:
+         <<: *benchmarks_master_and_release_only
+     - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35:
+         <<: *benchmarks_master_and_release_only
      - send-benchmark-results-and-graphs-to-slack:
          requires:
            - benchmarks-idle-agent-py-27
@@ -2440,6 +2444,8 @@ workflows:
            - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35
            - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27
            - benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35
+           - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27
+           - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35
          <<: *benchmarks_master_and_release_only
  weekly-circle-ci-usage-report:
    triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ benchmarks_master_and_release_only: &benchmarks_master_and_release_only
       only:
         - master
         - release
-        - new_end_to_end_benchmark
 
 master_only: &master_only
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ benchmarks_master_and_release_only: &benchmarks_master_and_release_only
       only:
         - master
         - release
+        - new_end_to_end_benchmark
 
 master_only: &master_only
   filters:
@@ -2431,21 +2432,21 @@ workflows:
          <<: *benchmarks_master_and_release_only
      - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35:
          <<: *benchmarks_master_and_release_only
-     - send-benchmark-results-and-graphs-to-slack:
-         requires:
-           - benchmarks-idle-agent-py-27
-           - benchmarks-idle-agent-py-35
-           - benchmarks-idle-agent-no-monitors-py-27
-           - benchmarks-idle-agent-no-monitors-py-35
-           - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27
-           - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35
-           - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27
-           - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35
-           - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27
-           - benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35
-           - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27
-           - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35
-         <<: *benchmarks_master_and_release_only
+           # - send-benchmark-results-and-graphs-to-slack:
+           #     requires:
+           #       - benchmarks-idle-agent-py-27
+           #       - benchmarks-idle-agent-py-35
+           #       - benchmarks-idle-agent-no-monitors-py-27
+           #       - benchmarks-idle-agent-no-monitors-py-35
+           #       - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27
+           #       - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35
+           #       - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27
+           #       - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35
+           #       - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27
+           #       - benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35
+           #       - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27
+           #       - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35
+           #     <<: *benchmarks_master_and_release_only
  weekly-circle-ci-usage-report:
    triggers:
      - schedule:

--- a/benchmarks/configs/agent_single_50mb_genlog_500k_line_file.json
+++ b/benchmarks/configs/agent_single_50mb_genlog_500k_line_file.json
@@ -2,9 +2,9 @@
   // We want to consume whole file from the beginning so we set max offset to 100 MB
   max_log_offset_size: 104857600,
 
-  // 600 KB
-  max_line_size: 614400,
-  read_page_size: 614400,
+  // 510 KB
+  max_line_size: 512000,
+  read_page_size: 512000,
 
   logs: [
      {

--- a/benchmarks/configs/agent_single_50mb_genlog_500k_line_file.json
+++ b/benchmarks/configs/agent_single_50mb_genlog_500k_line_file.json
@@ -1,0 +1,18 @@
+{
+  // We want to consume whole file from the beginning so we set max offset to 100 MB
+  max_log_offset_size: 104857600,
+
+  // 600 KB
+  max_line_size: 614400,
+  read_page_size: 614400,
+
+  logs: [
+     {
+         path: "/tmp/scalyr_genlog_500k_line_50_mb.log",
+         copy_from_start: true
+     }
+  ],
+
+  monitors: [
+  ]
+}


### PR DESCRIPTION
This PR adds and hooks up new benchmark to CodeSpeed.

This benchmark measures agent resource utilization for an existing which ingests existing 50 MB log file with 500k log lines (generated with scalyr-genlog) log file on disk.