### PR TITLE
Throw more user-friendly errors when we fail to parse config fragment file due to invalid content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Packaged by Yan Shnayder <yans@sentinelone.com> on Oct 1, 2021 14:10 -0800
 Improvements:
 * Implemented optional line merging when running in Docker based Kubernetes to work around Docker's own 16KB line length limit. Use the ``merge_json_parsed_lines`` config option or ``SCALYR_MERGE_JSON_PARSED_LINES`` environment variable to enable this functionality.
 
+Bug fixes:
+* Update agent to throw more user-friendly error when we fail to parse fragment file due to invalid content.
+
 ## 2.1.23 "Whipple" - Sept 16, 2021
 
 <!---

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -232,6 +232,15 @@ class Configuration(object):
                 self.__additional_paths.append(fp)
                 content = scalyr_util.read_config_file_as_json(fp)
 
+                if not isinstance(content, (dict, JsonObject)):
+                    raise BadConfiguration(
+                        'Invalid content inside configuration fragment file "%s". '
+                        "Expected JsonObject (dictionary), got %s."
+                        % (fp, type(content).__name__),
+                        "multiple",
+                        "invalidConfigFragmentType",
+                    )
+
                 # if deprecated key names are used, then replace them with their current versions.
                 for k, v in list(content.items()):
                     for (


### PR DESCRIPTION
This pull request updates configuration parsing code to throw more user-friendly error when we fail to parse / load config file fragment because it contains invalid content (aka top level type is not an object / dictionary).

Before:

```bash
Error reading configuration file: 'JsonArray' object has no attribute 'items'
Terminating agent, please fix the configuration file and restart agent.
Traceback (most recent call last):
  File "scalyr_agent/agent_main.py", line 328, in main
    config_file_path, log_warnings=log_warnings
  File "scalyr_agent/agent_main.py", line 438, in __read_and_verify_config
    self.__verify_config(config)
  File "scalyr_agent/agent_main.py", line 480, in __verify_config
    config.parse()
  File "/home/kami/w/scalyr/scalyr-agent-2/scalyr_agent/configuration.py", line 245, in parse
    for k, v in list(content.items()):
AttributeError: 'JsonArray' object has no attribute 'items'
```

After:

```bash
Error reading configuration file: Invalid content inside configuration fragment file "/home/kami/scalyr-agent-dev/config/agent.d/redis_monitor.json". Expected JsonObject (dictionary), got JsonArray. [[badField="multiple" errorCode="invalidConfigFragmentType"]]
Terminating agent, please fix the configuration file and restart agent.
Traceback (most recent call last):
  File "scalyr_agent/agent_main.py", line 328, in main
    config_file_path, log_warnings=log_warnings
  File "scalyr_agent/agent_main.py", line 438, in __read_and_verify_config
    self.__verify_config(config)
  File "scalyr_agent/agent_main.py", line 480, in __verify_config
    config.parse()
  File "/home/kami/w/scalyr/scalyr-agent-2/scalyr_agent/configuration.py", line 443, in parse
    raise e
  File "/home/kami/w/scalyr/scalyr-agent-2/scalyr_agent/configuration.py", line 241, in parse
    "invalidConfigFragmentType",
scalyr_agent.config_util.BadConfiguration: Invalid content inside configuration fragment file "/home/kami/scalyr-agent-dev/config/agent.d/redis_monitor.json". Expected JsonObject (dictionary), got JsonArray. [[badField="multiple" errorCode="invalidConfigFragmentType"]]
```

I encountered this error while working on helm chart.