### PR TITLE
Update Kubernetes monitor to log INFO message when containerd runtime environment is detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ Packaged by Yan Shnayder <yans@sentinelone.com> on Oct 1, 2021 14:10 -0800
 
 Other:
 * Added a LetsEncrypt root certificate to the Agent's included certificate bundle.
-* Update Kubernetes monitor to print a message that some container level metrics
-  won't be available when detected runtime is ``containerd`` and not ``docker``.
+* Update Kubernetes monitor to log a message under INFO log level that some container level metrics won't be available when detected runtime is ``containerd`` and not ``docker`` and container level metrics reporting is enabled.
 
 ## 2.1.24 "Xuntian" - Oct 26, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Packaged by Yan Shnayder <yans@sentinelone.com> on Oct 1, 2021 14:10 -0800
 
 Other:
 * Added a LetsEncrypt root certificate to the Agent's included certificate bundle.
+* Update Kubernetes monitor to print a message that some container level metrics
+  won't be available when detected runtime is ``containerd`` and not ``docker``.
 
 ## 2.1.24 "Xuntian" - Oct 26, 2021
 

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -2535,6 +2535,7 @@ class ContainerChecker(object):
         self.__always_use_docker = self._config.get("k8s_always_use_docker")
         self.__cri_query_filesystem = self._config.get("k8s_cri_query_filesystem")
         self.__sidecar_mode = self._config.get("k8s_sidecar_mode")
+        self.__report_container_metrics = self._config.get("report_container_metrics")
 
         self.__k8s_log_configs = self._global_config.k8s_log_configs
 

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -2707,12 +2707,17 @@ class ContainerChecker(object):
                 "Container runtime is '%s'" % (self._container_runtime),
             )
 
-            if self.__report_container_metrics and self._container_runtime == "containerd":
-                self._logger.log(scalyr_logging.DEBUG_LEVEL_0,
-                                 "Detected containerd runtime, some container level metrics "
-                                 "such as docker.mem.limit and docker.cpu.throttling.* won't "
-                                 "be available, because they are not exposed by containerd "
-                                 "runtime.")
+            if (
+                self.__report_container_metrics
+                and self._container_runtime == "containerd"
+            ):
+                self._logger.log(
+                    scalyr_logging.DEBUG_LEVEL_0,
+                    "Detected containerd runtime, some container level metrics "
+                    "such as docker.mem.limit and docker.cpu.throttling.* won't "
+                    "be available, because they are not exposed by containerd "
+                    "runtime.",
+                )
 
             if self.__always_use_docker or (
                 self._container_runtime == "docker" and not self.__always_use_cri

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -2707,6 +2707,13 @@ class ContainerChecker(object):
                 "Container runtime is '%s'" % (self._container_runtime),
             )
 
+            if self.__report_container_metrics and self._container_runtime == "containerd":
+                self._logger.log(scalyr_logging.DEBUG_LEVEL_0,
+                                 "Detected containerd runtime, some container level metrics "
+                                 "such as docker.mem.limit and docker.cpu.throttling.* won't "
+                                 "be available, because they are not exposed by containerd "
+                                 "runtime.")
+
             if self.__always_use_docker or (
                 self._container_runtime == "docker" and not self.__always_use_cri
             ):


### PR DESCRIPTION
This pull request updates Kubernetes monitor to print a message which warns used that some metrics won't be reported / available when container level metrics reporting is enabled and containerd runtime is detected.

This message is logged under INFO and not WARN log level since it's an informational message and there isn't anything we or user can do at the moment since this data is not available through Kubelet metrics API when using containerd runtime.