### PR TITLE
Fix graphite monitor

### DIFF
--- a/scalyr_agent/builtin_monitors/graphite_monitor.py
+++ b/scalyr_agent/builtin_monitors/graphite_monitor.py
@@ -250,6 +250,8 @@ You can also use this data in [Dashboards](/help/dashboards) and [Alerts](/help/
         else:
             pickle_server = None
 
+        # NOTE: We assign those variables so we can access them during the tests to verify
+        # corectness
         self.__text_server = text_server
         self.__pickle_server = pickle_server
 

--- a/scalyr_agent/builtin_monitors/graphite_monitor.py
+++ b/scalyr_agent/builtin_monitors/graphite_monitor.py
@@ -349,6 +349,11 @@ class GraphiteTextServer(ServerProcessor):
 class GraphitePickleServer(ServerProcessor):
     """Accepts connections on a server socket and handles them using Graphite's pickle protocol format, emitting
     the received metrics to the log.
+
+    NOTE (Tomaz): Pickle can contain arbitrary Python object data so we should note in the docs that
+    accepting arbitrary pickle data could be very dangerous and advise users against using it -
+    and in case they do need to use it, the should have additonal step in between which sanitized
+    pickled data and ensures it's safe.
     """
 
     def __init__(

--- a/scalyr_agent/builtin_monitors/graphite_monitor.py
+++ b/scalyr_agent/builtin_monitors/graphite_monitor.py
@@ -322,6 +322,8 @@ class GraphiteTextServer(ServerProcessor):
             # This is how the carbon graphite server parses the line.  We could be more forgiving but if it works
             # for them, then we can do it as well.
             metric, value, orig_timestamp = request.strip().split()
+            # Metric name can be of bytes type, but we need to make sure it's unicode type
+            metric = six.ensure_text(metric)
             value = float(value)
             orig_timestamp = float(orig_timestamp)
             # Include the time that the original graphite request said to associate with the metric value.

--- a/scalyr_agent/builtin_monitors/graphite_monitor.py
+++ b/scalyr_agent/builtin_monitors/graphite_monitor.py
@@ -218,6 +218,9 @@ You can also use this data in [Dashboards](/help/dashboards) and [Alerts](/help/
             "monitor_log_flush_delay", convert_to=float, default=1.0, min_value=0
         )
 
+        self.__text_server = None
+        self.__pickle_server = None
+
     def run(self):
         # We have to (maybe) start up two servers.  Since each server requires its own thread, we may have
         # to create a new one (since we can use this thread to run one of the servers).
@@ -246,6 +249,9 @@ You can also use this data in [Dashboards](/help/dashboards) and [Alerts](/help/
             )
         else:
             pickle_server = None
+
+        self.__text_server = text_server
+        self.__pickle_server = pickle_server
 
         if not self.__accept_plaintext:
             pickle_server.run()

--- a/tests/unit/builtin_monitors/graphite_monitor_test.py
+++ b/tests/unit/builtin_monitors/graphite_monitor_test.py
@@ -18,9 +18,9 @@ from __future__ import absolute_import
 import time
 import socket
 import pickle
-import struct
 import random
 
+from scalyr_agent import compat
 from scalyr_agent.builtin_monitors.graphite_monitor import GraphiteMonitor
 from scalyr_agent.builtin_monitors.graphite_monitor import GraphiteTextServer
 from scalyr_agent.builtin_monitors.graphite_monitor import GraphitePickleServer
@@ -113,7 +113,7 @@ class GraphiteMonitorTestCase(ScalyrTestCase):
             mock_data.append(("system.loadavg_5min", (1603104000002, 10.2)))
             mock_data.append(("system.loadavg_15min", (1603104000003, 10.3)))
             mock_request = pickle.dumps(mock_data, 1)
-            mock_request_size = struct.pack("!L", len(mock_request))
+            mock_request_size = compat.struct_pack_unicode("!L", len(mock_request))
 
             self.assertEqual(mock_logger.emit_value.call_count, 0)
             self.assertEqual(mock_logger.warn.call_count, 0)

--- a/tests/unit/builtin_monitors/graphite_monitor_test.py
+++ b/tests/unit/builtin_monitors/graphite_monitor_test.py
@@ -15,16 +15,137 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
+import time
+import socket
 import pickle
+import struct
+import random
 
+from scalyr_agent.builtin_monitors.graphite_monitor import GraphiteMonitor
 from scalyr_agent.builtin_monitors.graphite_monitor import GraphiteTextServer
 from scalyr_agent.builtin_monitors.graphite_monitor import GraphitePickleServer
-from scalyr_agent.scalyr_logging import AgentLogger
 from scalyr_agent.test_base import ScalyrTestCase
 
 import mock
 
-__all__ = ["GraphiteMonitorTextServerTestCase", "GraphiteMonitorPickleServerTestCase"]
+__all__ = [
+    "GraphiteMonitorTestCase",
+    "GraphiteMonitorTextServerTestCase",
+    "GraphiteMonitorPickleServerTestCase",
+]
+
+
+class GraphiteMonitorTestCase(ScalyrTestCase):
+    """
+    Test class where we actually start the TCP server and also exercise the server processing
+    pipeline and not just request parsing.
+    """
+
+    def test_plaintext_server_start_actual_server_parse_request_success(self):
+        mock_logger = mock.Mock()
+        mock_port = random.randint(5000, 65000)
+        monitor_config = {
+            "module": "graphite_monitor",
+            "accept_plaintext": True,
+            "buffer_size": 8096,
+            "max_request_size": 1024 * 4,
+            "plaintext_port": mock_port,
+        }
+        monitor = GraphiteMonitor(monitor_config=monitor_config, logger=mock_logger)
+
+        try:
+            monitor.start()
+
+            # Give server some time to start up
+            time.sleep(1)
+
+            mock_request_1 = b"custom.metric.data.number1 5 1603104000001"
+            mock_request_2 = b"custom.metric.data.number2 5.2 1603104000002"
+
+            self.assertEqual(mock_logger.emit_value.call_count, 0)
+            self.assertEqual(mock_logger.warn.call_count, 0)
+
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.connect(("127.0.0.1", mock_port))
+            sock.send(mock_request_1 + b"\n")
+            sock.send(mock_request_2 + b"\n")
+            sock.close()
+
+            # Give server some time to process the request
+            time.sleep(1)
+
+            self.assertEqual(mock_logger.warn.call_count, 0)
+            self.assertEqual(mock_logger.emit_value.call_count, 2)
+            mock_logger.emit_value.assert_any_call(
+                "custom.metric.data.number1",
+                5.0,
+                extra_fields={"orig_time": 1603104000001.0},
+            )
+            mock_logger.emit_value.assert_any_call(
+                "custom.metric.data.number2",
+                5.2,
+                extra_fields={"orig_time": 1603104000002.0},
+            )
+        finally:
+            monitor.stop()
+
+    def test_pickle_server_start_actual_server_parse_request_success(self):
+        mock_logger = mock.Mock()
+        mock_port = random.randint(5000, 65000)
+        monitor_config = {
+            "module": "graphite_monitor",
+            "accept_plaintext": False,
+            "accept_pickle": True,
+            "buffer_size": 8096,
+            "max_request_size": 1024 * 4,
+            "pickle_port": mock_port,
+        }
+        monitor = GraphiteMonitor(monitor_config=monitor_config, logger=mock_logger)
+
+        try:
+            monitor.start()
+
+            # Give server some time to start up
+            time.sleep(1)
+
+            mock_data = []
+            mock_data.append(("system.loadavg_1min", (1603104000001, 10.1)))
+            mock_data.append(("system.loadavg_5min", (1603104000002, 10.2)))
+            mock_data.append(("system.loadavg_15min", (1603104000003, 10.3)))
+            mock_request = pickle.dumps(mock_data, 1)
+            mock_request_size = struct.pack("!L", len(mock_request))
+
+            self.assertEqual(mock_logger.emit_value.call_count, 0)
+            self.assertEqual(mock_logger.warn.call_count, 0)
+
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.connect(("127.0.0.1", mock_port))
+            sock.send(mock_request_size)
+            sock.send(mock_request)
+            sock.close()
+
+            # Give server some time to process the request
+            time.sleep(1)
+
+            self.assertEqual(mock_logger.warn.call_count, 0)
+            self.assertEqual(mock_logger.emit_value.call_count, 3)
+            mock_logger.emit_value.assert_any_call(
+                "system.loadavg_1min",
+                10.1,
+                extra_fields={"orig_time": 1603104000001.0},
+            )
+            mock_logger.emit_value.assert_any_call(
+                "system.loadavg_5min",
+                10.2,
+                extra_fields={"orig_time": 1603104000002.0},
+            )
+            mock_logger.emit_value.assert_any_call(
+                "system.loadavg_15min",
+                10.3,
+                extra_fields={"orig_time": 1603104000003.0},
+            )
+        finally:
+            monitor.stop()
 
 
 class GraphiteMonitorTextServerTestCase(ScalyrTestCase):

--- a/tests/unit/builtin_monitors/graphite_monitor_test.py
+++ b/tests/unit/builtin_monitors/graphite_monitor_test.py
@@ -1,0 +1,58 @@
+# Copyright 2014-2022 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+
+from scalyr_agent.builtin_monitors.graphite_monitor import GraphiteTextServer
+from scalyr_agent.scalyr_logging import AgentLogger
+from scalyr_agent.test_base import ScalyrTestCase
+
+import mock
+
+__all__ = ["GraphiteMonitorTextServerTest"]
+
+
+class GraphiteMonitorTextServerTest(ScalyrTestCase):
+    def test_execute_request_mock_logger_success(self):
+        mock_logger = mock.Mock()
+        server = GraphiteTextServer(only_accept_local=True, port=5899,
+                                    run_state=None, buffer_size=1024,
+                                    max_request_size=1024*5, max_connection_idle_time=10,
+                                    logger=mock_logger)
+
+        # 1. Unicode request data type
+        mock_request = "custom.metric.data.number1 5 1603104000001"
+        self.assertEqual(mock_logger.emit_value.call_count, 0)
+        self.assertEqual(mock_logger.warn.call_count, 0)
+
+        server.execute_request(request=mock_request)
+        self.assertEqual(mock_logger.emit_value.call_count, 1)
+        self.assertEqual(mock_logger.warn.call_count, 0)
+        mock_logger.emit_value.assert_called_with("custom.metric.data.number1",
+                                                  5.0, extra_fields={'orig_time': 1603104000001.0})
+
+        # 2. Bytes request data type
+        mock_logger.reset_mock()
+
+        mock_request = b"custom.metric.data.number2 6.2 1603104000002"
+        self.assertEqual(mock_logger.emit_value.call_count, 0)
+        self.assertEqual(mock_logger.warn.call_count, 0)
+
+        server.execute_request(request=mock_request)
+        self.assertEqual(mock_logger.emit_value.call_count, 1)
+        self.assertEqual(mock_logger.warn.call_count, 0)
+        mock_logger.emit_value.assert_called_with("custom.metric.data.number2",
+                                                  6.2, extra_fields={'orig_time': 1603104000002.0})

--- a/tests/unit/builtin_monitors/graphite_monitor_test.py
+++ b/tests/unit/builtin_monitors/graphite_monitor_test.py
@@ -149,6 +149,11 @@ class GraphiteMonitorTestCase(ScalyrTestCase):
 
 
 class GraphiteMonitorTextServerTestCase(ScalyrTestCase):
+    """
+    Test cases whre we don't start actual TCP server but just exercise the request / data parsing
+    code.
+    """
+
     def test_execute_request_mock_logger_success(self):
         mock_logger = mock.Mock()
         server = GraphiteTextServer(
@@ -193,6 +198,11 @@ class GraphiteMonitorTextServerTestCase(ScalyrTestCase):
 
 
 class GraphiteMonitorPickleServerTestCase(ScalyrTestCase):
+    """
+    Test cases whre we don't start actual TCP server but just exercise the request / data parsing
+    code.
+    """
+
     def test_execute_request_mock_logger_success(self):
         mock_logger = mock.Mock()
         server = GraphitePickleServer(

--- a/tests/unit/builtin_monitors/graphite_monitor_test.py
+++ b/tests/unit/builtin_monitors/graphite_monitor_test.py
@@ -15,23 +15,30 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
+import pickle
 
 from scalyr_agent.builtin_monitors.graphite_monitor import GraphiteTextServer
+from scalyr_agent.builtin_monitors.graphite_monitor import GraphitePickleServer
 from scalyr_agent.scalyr_logging import AgentLogger
 from scalyr_agent.test_base import ScalyrTestCase
 
 import mock
 
-__all__ = ["GraphiteMonitorTextServerTest"]
+__all__ = ["GraphiteMonitorTextServerTestCase", "GraphiteMonitorPickleServerTestCase"]
 
 
-class GraphiteMonitorTextServerTest(ScalyrTestCase):
+class GraphiteMonitorTextServerTestCase(ScalyrTestCase):
     def test_execute_request_mock_logger_success(self):
         mock_logger = mock.Mock()
-        server = GraphiteTextServer(only_accept_local=True, port=5899,
-                                    run_state=None, buffer_size=1024,
-                                    max_request_size=1024*5, max_connection_idle_time=10,
-                                    logger=mock_logger)
+        server = GraphiteTextServer(
+            only_accept_local=True,
+            port=5899,
+            run_state=None,
+            buffer_size=1024,
+            max_request_size=1024 * 5,
+            max_connection_idle_time=10,
+            logger=mock_logger,
+        )
 
         # 1. Unicode request data type
         mock_request = "custom.metric.data.number1 5 1603104000001"
@@ -39,10 +46,13 @@ class GraphiteMonitorTextServerTest(ScalyrTestCase):
         self.assertEqual(mock_logger.warn.call_count, 0)
 
         server.execute_request(request=mock_request)
-        self.assertEqual(mock_logger.emit_value.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 0)
-        mock_logger.emit_value.assert_called_with("custom.metric.data.number1",
-                                                  5.0, extra_fields={'orig_time': 1603104000001.0})
+        self.assertEqual(mock_logger.emit_value.call_count, 1)
+        mock_logger.emit_value.assert_called_with(
+            "custom.metric.data.number1",
+            5.0,
+            extra_fields={"orig_time": 1603104000001.0},
+        )
 
         # 2. Bytes request data type
         mock_logger.reset_mock()
@@ -52,7 +62,52 @@ class GraphiteMonitorTextServerTest(ScalyrTestCase):
         self.assertEqual(mock_logger.warn.call_count, 0)
 
         server.execute_request(request=mock_request)
-        self.assertEqual(mock_logger.emit_value.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 0)
-        mock_logger.emit_value.assert_called_with("custom.metric.data.number2",
-                                                  6.2, extra_fields={'orig_time': 1603104000002.0})
+        self.assertEqual(mock_logger.emit_value.call_count, 1)
+        mock_logger.emit_value.assert_called_with(
+            "custom.metric.data.number2",
+            6.2,
+            extra_fields={"orig_time": 1603104000002.0},
+        )
+
+
+class GraphiteMonitorPickleServerTestCase(ScalyrTestCase):
+    def test_execute_request_mock_logger_success(self):
+        mock_logger = mock.Mock()
+        server = GraphitePickleServer(
+            only_accept_local=True,
+            port=5899,
+            run_state=None,
+            buffer_size=1024,
+            max_request_size=1024 * 5,
+            max_connection_idle_time=10,
+            logger=mock_logger,
+        )
+
+        mock_data = []
+        mock_data.append(("system.loadavg_1min", (1603104000001, 10.1)))
+        mock_data.append(("system.loadavg_5min", (1603104000002, 10.2)))
+        mock_data.append(("system.loadavg_15min", (1603104000003, 10.3)))
+        mock_request = pickle.dumps(mock_data, 1)
+
+        self.assertEqual(mock_logger.emit_value.call_count, 0)
+        self.assertEqual(mock_logger.warn.call_count, 0)
+
+        server.execute_request(request=mock_request)
+        self.assertEqual(mock_logger.warn.call_count, 0)
+        self.assertEqual(mock_logger.emit_value.call_count, 3)
+        mock_logger.emit_value.assert_any_call(
+            "system.loadavg_1min",
+            10.1,
+            extra_fields={"orig_time": 1603104000001.0},
+        )
+        mock_logger.emit_value.assert_any_call(
+            "system.loadavg_5min",
+            10.2,
+            extra_fields={"orig_time": 1603104000002.0},
+        )
+        mock_logger.emit_value.assert_any_call(
+            "system.loadavg_15min",
+            10.3,
+            extra_fields={"orig_time": 1603104000003.0},
+        )


### PR DESCRIPTION
This pull request fixes a bug in Graphite monitor where we didn't correctly convert incoming request data (metric name) from bytes to unicode type which is expected by the ``emit_value()`` method.

In addition to that, I added some test cases since we had none. There is a simple test case where we just exercise the parsing code path and there is a bit more involved one which starts actual TCP servers so we also exercise the TCP server request processing code.

Tests are still not exhaustive and don't cover all the possible scenarios and edge cases, but it's a start.