### PR TITLE
Fix build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2464,7 +2464,7 @@ workflows:
  daily-stable-ami-package-install-tests:
    triggers:
      - schedule:
-         cron: "0 0 * * *"
+         cron: "0 2 * * *"
          filters:
            branches:
              only:
@@ -2472,3 +2472,33 @@ workflows:
    jobs:
      - ami-tests-stable:
          context: scalyr-agent
+     - unittest-27:
+         context: scalyr-agent
+     - unittest-35:
+         context: scalyr-agent
+     - unittest-35-osx:
+         context: scalyr-agent
+     - unittest-38-windows:
+         context: scalyr-agent
+     - build-linux-packages-and-installer-script
+     - build-windows-package
+     - package-test-rpm:
+         context: scalyr-agent
+     - package-test-deb:
+         context: scalyr-agent
+     - smoke-rpm-package-py2:
+         context: scalyr-agent
+         requires:
+           - package-test-rpm
+     - smoke-rpm-package-py3:
+         context: scalyr-agent
+         requires:
+           - package-test-rpm
+     - smoke-deb-package-py2:
+         context: scalyr-agent
+         requires:
+           - package-test-deb
+     - smoke-deb-package-py3:
+         context: scalyr-agent
+         requires:
+           - package-test-deb

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -33,3 +33,6 @@ pathlib2==2.3.5; python_version <= '2.7'
 # NOTE: Not supported on windows
 udatetime==0.0.16
 futures==3.3.0; python_version <= '2.7'
+# Newer versions don't support Python 3.5 anymore
+more-itertools==8.5.0; python_version >= '3.0'
+more-itertools==5.0.0; python_version <= '2.7'


### PR DESCRIPTION
Looks like at least one transitive dependency (``more-itertools``) got updated and doesn't support Pythoin 3.5 anymore.

This PR attempts to fix the build by pinning the dependency.

We also need to work on dropping support and related code for Python < 3.7 since it's getting increasingly harder and requires more and more workarounds to get everything to pass.