### PR TITLE
New docker builds draft

### DIFF
--- a/.github/workflows/build-docker-and-k8s.yml
+++ b/.github/workflows/build-docker-and-k8s.yml
@@ -2,7 +2,10 @@ name: "Docker and K8s"
 
 on: push
 
+
+
 jobs:
+
   build:
     runs-on: ubuntu-latest
     services:
@@ -43,6 +46,22 @@ jobs:
     - name: Inspect
       run: |
         docker buildx imagetools inspect localhost:5000/scalyr/scalyr-agent-2:latest
+
+
+    - name: Test
+      env:
+        SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
+      run: |
+        docker pull localhost:5000/scalyr/scalyr-agent-2:latest
+        docker run -d --name scalyr-docker-agent \
+        -e SCALYR_API_KEY=$SCALYR_API_KEY \
+        -v /var/run/docker.sock:/var/scalyr/docker.sock \
+        -v /var/lib/docker/containers:/var/lib/docker/containers \
+        localhost:5000/scalyr/scalyr-agent-2:latest
+
+        sleep 10
+
+
 
 
 #

--- a/.github/workflows/build-docker-and-k8s.yml
+++ b/.github/workflows/build-docker-and-k8s.yml
@@ -76,9 +76,6 @@ jobs:
         echo "arm64:"
         docker logs scalyr-docker-agent-arm64
 
-        docker kill -f scalyr-docker-agent-amd64
-        docker kill -f scalyr-docker-agent-arm64
-
 
 
 

--- a/.github/workflows/build-docker-and-k8s.yml
+++ b/.github/workflows/build-docker-and-k8s.yml
@@ -61,6 +61,12 @@ jobs:
 
         sleep 10
 
+        docker logs scalyr-docker-agent
+
+        docker kill -f scalyr-docker-agent
+
+
+
 
 
 

--- a/.github/workflows/build-docker-and-k8s.yml
+++ b/.github/workflows/build-docker-and-k8s.yml
@@ -1,0 +1,27 @@
+name: "Docker and K8s"
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: all
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Build
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        tags: scalyr/scalyr-agent-2:latest

--- a/.github/workflows/build-docker-and-k8s.yml
+++ b/.github/workflows/build-docker-and-k8s.yml
@@ -11,6 +11,7 @@ jobs:
         ports:
           - 5000:5000
 
+
 #    strategy:
 #      matrix:
 #        platforms: [ linux/amd64, linux/arm64 ]
@@ -35,6 +36,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
+        push: true
         platforms: linux/amd64,linux/arm64
         tags: localhost:5000/scalyr/scalyr-agent-2:latest
 

--- a/.github/workflows/build-docker-and-k8s.yml
+++ b/.github/workflows/build-docker-and-k8s.yml
@@ -5,6 +5,15 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+
+#    strategy:
+#      matrix:
+#        platforms: [ linux/amd64, linux/arm64 ]
 
     steps:
     - name: Checkout repository
@@ -19,9 +28,26 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
+      with:
+        driver-opts: network=host
 
     - name: Build
       uses: docker/build-push-action@v2
       with:
         context: .
-        tags: scalyr/scalyr-agent-2:latest
+        platforms: linux/amd64,linux/arm64
+        tags: localhost:5000/scalyr/scalyr-agent-2:latest
+
+    - name: Inspect
+      run: |
+        docker buildx imagetools inspect localhost:5000/scalyr/scalyr-agent-2:latest
+
+
+#
+#  test:
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        platforms: [linux/amd64, linux/arm64]
+#
+#    st

--- a/.github/workflows/build-docker-and-k8s.yml
+++ b/.github/workflows/build-docker-and-k8s.yml
@@ -53,17 +53,31 @@ jobs:
         SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
       run: |
         docker pull localhost:5000/scalyr/scalyr-agent-2:latest
-        docker run -d --name scalyr-docker-agent \
-        -e SCALYR_API_KEY=$SCALYR_API_KEY \
-        -v /var/run/docker.sock:/var/scalyr/docker.sock \
-        -v /var/lib/docker/containers:/var/lib/docker/containers \
-        localhost:5000/scalyr/scalyr-agent-2:latest
+        docker run -d --name scalyr-docker-agent-amd64 \
+          --platform linux/amd64 \
+          -e SCALYR_API_KEY=$SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN \
+          -v /var/run/docker.sock:/var/scalyr/docker.sock \
+          -v /var/lib/docker/containers:/var/lib/docker/containers \
+          localhost:5000/scalyr/scalyr-agent-2:latest
+
+        docker pull localhost:5000/scalyr/scalyr-agent-2:latest
+        docker run -d --name scalyr-docker-agent-arm64 \
+          --platform linux/arm64 \
+          -e SCALYR_API_KEY=$SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN \
+          -v /var/run/docker.sock:/var/scalyr/docker.sock \
+          -v /var/lib/docker/containers:/var/lib/docker/containers \
+          localhost:5000/scalyr/scalyr-agent-2:latest
 
         sleep 10
 
-        docker logs scalyr-docker-agent
+        echo "amd64:"
+        docker logs scalyr-docker-agent-amd64
 
-        docker kill -f scalyr-docker-agent
+        echo "arm64:"
+        docker logs scalyr-docker-agent-arm64
+
+        docker kill -f scalyr-docker-agent-amd64
+        docker kill -f scalyr-docker-agent-arm64
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:2.7-slim as build
+
+MAINTAINER Scalyr Inc <support@scalyr.com>
+
+RUN apt-get update && apt-get install -y build-essential
+
+# install python dependencies
+ADD ./docker/requirements.txt /tmp/requirements.txt
+RUN pip --no-cache-dir install --root /tmp/dependencies -r /tmp/requirements.txt
+
+
+ADD . /scalyr-agent-2
+WORKDIR /tmp/build
+
+# build container tarball.
+RUN python /scalyr-agent-2/build_package.py k8s_builder --only-container-tarball
+
+RUN mkdir /tmp/build/source
+RUN tar -xf scalyr-k8s-agent.tar.gz -C /tmp/build/source
+
+FROM python:2.7-slim
+
+COPY --from=build /tmp/build/source /
+COPY --from=build  /tmp/dependencies/ /
+
+CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /tmp/build
 RUN python /scalyr-agent-2/build_package.py docker_json_builder --only-container-tarball
 
 RUN mkdir /tmp/build/source
-RUN tar -xf scalyr-k8s-agent.tar.gz -C /tmp/build/source
+RUN tar -xf scalyr-docker-agent.tar.gz -C /tmp/build/source
 
 FROM python:2.7-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ADD . /scalyr-agent-2
 WORKDIR /tmp/build
 
 # build container tarball.
-RUN python /scalyr-agent-2/build_package.py k8s_builder --only-container-tarball
+RUN python /scalyr-agent-2/build_package.py docker_json_builder --only-container-tarball
 
 RUN mkdir /tmp/build/source
 RUN tar -xf scalyr-k8s-agent.tar.gz -C /tmp/build/source

--- a/build_package.py
+++ b/build_package.py
@@ -80,7 +80,7 @@ PACKAGE_TYPES = [
 ]
 
 
-def build_package(package_type, variant, no_versioned_file_name, coverage_enabled):
+def build_package(package_type, variant, no_versioned_file_name, coverage_enabled, build_only_container_tarball=False):
     """Builds the scalyr-agent-2 package specified by the arguments.
 
     The package is left in the current working directory.  The file name of the
@@ -169,6 +169,7 @@ def build_package(package_type, variant, no_versioned_file_name, coverage_enable
                 "scalyr-k8s-agent",
                 ["scalyr/scalyr-k8s-agent"],
                 coverage_enabled=coverage_enabled,
+                build_only_container_tarball=build_only_container_tarball
             )
         else:
             assert package_type in ("deb", "rpm")
@@ -628,6 +629,7 @@ def build_container_builder(
     image_name,
     image_repos,
     coverage_enabled=False,
+    build_only_container_tarball=False
 ):
     """Builds an executable script in the current working directory that will build the container image for the various
     Docker and Kubernetes targets.  This script embeds all assets it needs in it so it can be a standalone artifact.
@@ -654,6 +656,11 @@ def build_container_builder(
     @return: The file name of the built artifact.
     """
     build_container_tarball(source_tarball, base_configs=base_configs)
+
+    if build_only_container_tarball:
+        #shutil.copy(source_tarball, os.path.join(__source_root__))
+        return source_tarball
+
 
     agent_source_root = __source_root__
     # Make a copy of the right Dockerfile to embed in the script.
@@ -1855,6 +1862,15 @@ if __name__ == "__main__":
         help="Enable coverage analysis. Can be used in smoketests. Only works with docker/k8s.",
     )
 
+    parser.add_option(
+        "",
+        "--only-container-tarball",
+        dest="only_container_tarball",
+        action="store_true",
+        default=False,
+        help="Only works with docker/k8s.",
+    )
+
     (options, args) = parser.parse_args()
     # If we are just suppose to create the build_info, then do it and exit.  We do not bother to check to see
     # if they specified a package.
@@ -1888,6 +1904,7 @@ if __name__ == "__main__":
         options.variant,
         options.no_versioned_file_name,
         options.coverage,
+        build_only_container_tarball=options.only_container_tarball
     )
     print("Built %s" % artifact)
     sys.exit(0)

--- a/build_package.py
+++ b/build_package.py
@@ -142,6 +142,7 @@ def build_package(package_type, variant, no_versioned_file_name, coverage_enable
                 "scalyr-docker-agent-json",
                 ["scalyr/scalyr-agent-docker-json"],
                 coverage_enabled=coverage_enabled,
+                build_only_container_tarball=build_only_container_tarball
             )
         elif package_type == "docker_api_builder":
             # An image for running on Docker configured to fetch logs via the Docker API using
@@ -169,7 +170,6 @@ def build_package(package_type, variant, no_versioned_file_name, coverage_enable
                 "scalyr-k8s-agent",
                 ["scalyr/scalyr-k8s-agent"],
                 coverage_enabled=coverage_enabled,
-                build_only_container_tarball=build_only_container_tarball
             )
         else:
             assert package_type in ("deb", "rpm")


### PR DESCRIPTION
This draft PR shows how we can produce Docker-based releases. The main idea is simple - the build has to be done from the static Dockerfile.  After that, the build and publishing process has to become much easier.  We also can drop building images on Jenkins and just start pushing docker images from GitHub actions, for example, on the new release tag, (there's also [docker automated builds](https://docs.docker.com/docker-hub/builds/) but it may require a subscription.)