### PR TITLE
Move all command line handling to the agent main.

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -47,6 +47,7 @@ import re
 from io import open
 import pathlib as pl
 from optparse import OptionParser
+import argparse
 
 if False:
     from typing import Optional
@@ -71,6 +72,7 @@ from scalyr_agent import __scalyr__
 import scalyr_agent.scalyr_logging as scalyr_logging
 import scalyr_agent.util as scalyr_util
 import scalyr_agent.remote_shell as remote_shell
+from scalyr_agent import config_main
 
 # We have to be careful to set this logger class very early in processing, even before other
 # imports to ensure that any loggers created are AgentLoggers.
@@ -2087,24 +2089,51 @@ class WorkerThread(object):
 
 if __name__ == "__main__":
     my_controller = PlatformController.new_platform()
-    parser = OptionParser(
-        usage="Usage: scalyr-agent-2 [options] (start|stop|status|restart|condrestart|version)",
-        version="scalyr-agent v" + __scalyr__.SCALYR_VERSION,
+
+    commands = ["start", "stop", "status", "restart", "condrestart", "version", "config"]
+
+    if __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.WINDOWS:
+        # If this is Windows, then also add service option.
+        # Using this option we can use windows executable as a base for the Windows Agent service.
+        # It has to save us from building multiple frozen binaries, when packaging.
+        commands.append("service")
+
+    command_parser = argparse.ArgumentParser(
+        usage=f"Usage: scalyr-agent-2 [options] ({commands})",
     )
-    parser.add_option(
+    command_parser.add_argument(
+        "command",
+        choices=commands
+    )
+
+    command_args, other_argv = command_parser.parse_known_args()
+    # Add the config option. So we can configure the agent from the same executable.
+    # It has to save us from building multiple frozen binaries, when packaging.
+    if command_args.command == "config":
+        config_main.parse_config_options(other_argv)
+        exit(0)
+
+    if command_args.command == "service":
+        from scalyr_agent import platform_windows
+        platform_windows.parse_options()
+        exit(0)
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
         "-c",
         "--config-file",
         dest="config_filename",
         help="Read configuration from FILE",
         metavar="FILE",
     )
-    parser.add_option(
+    parser.add_argument(
         "--extra-config-dir",
         default=None,
         help="An extra directory to check for configuration files",
         metavar="PATH",
     )
-    parser.add_option(
+    parser.add_argument(
         "-q",
         "--quiet",
         action="store_true",
@@ -2112,7 +2141,7 @@ if __name__ == "__main__":
         default=False,
         help="Only print error messages when running the start, stop, and condrestart commands",
     )
-    parser.add_option(
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -2120,7 +2149,7 @@ if __name__ == "__main__":
         default=False,
         help="For status command, prints detailed information about running agent.",
     )
-    parser.add_option(
+    parser.add_argument(
         "-H",
         "--health_check",
         action="store_true",
@@ -2128,23 +2157,21 @@ if __name__ == "__main__":
         default=False,
         help="For status command, prints health check status. Return code will be 0 for a passing check, and 2 for failing",
     )
-    parser.add_option(
+    parser.add_argument(
         "--format",
         dest="status_format",
         default="text",
         help="Format to use (text / json) for the agent status command.",
     )
 
-    parser.add_option(
-        "",
+    parser.add_argument(
         "--no-fork",
         action="store_true",
         dest="no_fork",
         default=False,
         help="For the run command, does not fork the program to the background.",
     )
-    parser.add_option(
-        "",
+    parser.add_argument(
         "--no-check-remote-server",
         action="store_true",
         dest="no_check_remote",
@@ -2155,34 +2182,8 @@ if __name__ == "__main__":
     )
     my_controller.add_options(parser)
 
-    (options, args) = parser.parse_args()
+    options = parser.parse_args(args=other_argv)
     my_controller.consume_options(options)
-
-    if len(args) < 1:
-        print(
-            'You must specify a command, such as "start", "stop", or "status".',
-            file=sys.stderr,
-        )
-        parser.print_help(sys.stderr)
-        sys.exit(1)
-    elif len(args) > 1:
-        print(
-            'Too many commands specified.  Only specify one of "start", "stop", "status".',
-            file=sys.stderr,
-        )
-        parser.print_help(sys.stderr)
-        sys.exit(1)
-    elif args[0] not in (
-        "start",
-        "stop",
-        "status",
-        "restart",
-        "condrestart",
-        "version",
-    ):
-        print('Unknown command given: "%s"' % args[0], file=sys.stderr)
-        parser.print_help(sys.stderr)
-        sys.exit(1)
 
     if options.config_filename is not None and not os.path.isabs(
         options.config_filename
@@ -2192,7 +2193,7 @@ if __name__ == "__main__":
     main_rc = 1
     try:
         main_rc = ScalyrAgent(my_controller).main(
-            options.config_filename, args[0], options
+            options.config_filename, command_args.command, options
         )
     except Exception as mainExcept:
         print(six.text_type(mainExcept), file=sys.stderr)

--- a/scalyr_agent/config_main.py
+++ b/scalyr_agent/config_main.py
@@ -38,6 +38,7 @@ import tempfile
 import traceback
 import errno
 import itertools
+import argparse
 from io import open
 
 from optparse import OptionParser
@@ -1372,17 +1373,16 @@ def configure_agent_service_for_systemd_management():
     )
 
 
-if __name__ == "__main__":
-    parser = OptionParser(usage="Usage: scalyr-agent-2-config [options]")
-    parser.add_option(
+def parse_config_options(argv):
+    parser = argparse.ArgumentParser(usage="Usage: scalyr-agent-2-config [options]")
+    parser.add_argument(
         "-c",
         "--config-file",
         dest="config_filename",
         help="Read configuration from FILE",
         metavar="FILE",
     )
-    parser.add_option(
-        "",
+    parser.add_argument(
         "--set-key-from-stdin",
         action="store_true",
         dest="set_key_from_stdin",
@@ -1390,23 +1390,20 @@ if __name__ == "__main__":
         help="Update the configuration file with a new API key read from standard input.  "
         "The API key is used to authenticate requests to the Scalyr servers for the account.",
     )
-    parser.add_option(
-        "",
+    parser.add_argument(
         "--set-key",
         dest="api_key",
         help="Update the configuration file with the new API key."
         "The API key is used to authenticate requests to the Scalyr servers for the account.",
     )
-    parser.add_option(
-        "",
+    parser.add_argument(
         "--set-scalyr-server",
         dest="scalyr_server",
         help="Updates the configuration to send all log uploads to the specified server.  This will "
         "create a configuration file fragment `scalyr_server.json` in the config directory.  It "
         "will overwrite any existing file at that path.",
     )
-    parser.add_option(
-        "",
+    parser.add_argument(
         "--set-server-host",
         dest="server_host",
         help="Adds a new configuration file in the ``agent.d`` directory to set the serverHost "
@@ -1415,14 +1412,12 @@ if __name__ == "__main__":
         "must be sure the ``agent.json`` file nor any file in ``agent.d`` sets a value for "
         "``serverHost`` otherwise this might not work.",
     )
-    parser.add_option(
-        "",
+    parser.add_argument(
         "--set-user",
         dest="executing_user",
         help="Update which user account is used to run the agent.",
     )
-    parser.add_option(
-        "",
+    parser.add_argument(
         "--upgrade-tarball",
         dest="upgrade_tarball",
         help="Upgrade the agent to the new version contained in the specified tarball file."
@@ -1436,8 +1431,7 @@ if __name__ == "__main__":
         "which will be copied over to the new installation).  If you may have modified other files "
         "then use the --preserve-old-install option to prevent it from being deleted.",
     )
-    parser.add_option(
-        "",
+    parser.add_argument(
         "--preserve-old-install",
         action="store_true",
         dest="preserve_old_install",
@@ -1445,8 +1439,7 @@ if __name__ == "__main__":
         help="When performing a tarball upgrade, move the old install to a temporary directory "
         "instead of deleting it.",
     )
-    parser.add_option(
-        "",
+    parser.add_argument(
         "--import-config",
         dest="import_config",
         help="Extracts the agent configuration files from the provided gzipped tarball, overwriting the"
@@ -1456,16 +1449,14 @@ if __name__ == "__main__":
         "extracted files are reset to be the same owner/group of the current configuration file to "
         "avoid permission problems.",
     )
-    parser.add_option(
-        "",
+    parser.add_argument(
         "--export-config",
         dest="export_config",
         help="Creates a new gzipped tarball using the current agent configuration files stored in the "
         "`agent.json` file and the `agent.d` directory.  Pass `-` to write the tarball to stdout. "
         "Note, this only copies files that end in `.json`.",
     )
-    parser.add_option(
-        "",
+    parser.add_argument(
         "--docker-create-custom-dockerfile",
         dest="create_custom_dockerfile",
         help="Creates a gzipped tarball that will extract to a Dockerfile that will build a custom "
@@ -1475,8 +1466,7 @@ if __name__ == "__main__":
         "containers.  The option value should either be a path to write the tarball or `-` to "
         "write it to stdout.",
     )
-    parser.add_option(
-        "",
+    parser.add_argument(
         "--k8s-create-custom-dockerfile",
         dest="create_custom_k8s_dockerfile",
         help="Creates a gzipped tarball that will extract to a Dockerfile that will build a custom "
@@ -1488,16 +1478,14 @@ if __name__ == "__main__":
         "write it to stdout.",
     )
 
-    parser.add_option(
-        "",
+    parser.add_argument(
         "--set-python",
         dest="set_python",
         choices=DEFAULT + [PYTHON2, PYTHON3],
         help="Switch current python interpreter. Can be selected from python2 and python3.",
     )
 
-    parser.add_option(
-        "",
+    parser.add_argument(
         "--report-python-version",
         action="store_true",
         dest="report_python_version",
@@ -1507,24 +1495,21 @@ if __name__ == "__main__":
 
     # TODO: These options are only available on Windows platforms
     if sys.platform.startswith("win"):
-        parser.add_option(
-            "",
+        parser.add_argument(
             "--upgrade-windows",
             dest="upgrade_windows",
             action="store_true",
             default=False,
             help="Upgrade the agent if a new version is available",
         )
-        parser.add_option(
-            "",
+        parser.add_argument(
             "--release-track",
             dest="release_track",
             default="stable",
             help="The release track to use when upgrading using --upgrade-windows.  This defaults to "
             '"stable" and is what consumers should use.',
         )
-        parser.add_option(
-            "",
+        parser.add_argument(
             "--upgrade-without-ui",
             dest="upgrade_windows_no_ui",
             action="store_true",
@@ -1534,16 +1519,14 @@ if __name__ == "__main__":
         )
         # TODO: Once other packages (rpm, debian) include the 'templates' directory, we can make this available
         # beyond just Windows.
-        parser.add_option(
-            "",
+        parser.add_argument(
             "--init-config",
             dest="init_config",
             action="store_true",
             default=False,
             help="Create an initial copy of the configuration file in the appropriate location.",
         )
-        parser.add_option(
-            "",
+        parser.add_argument(
             "--no-error-if-config-exists",
             dest="init_config_ignore_exists",
             action="store_true",
@@ -1553,8 +1536,7 @@ if __name__ == "__main__":
         # These are a weird options we use to start the agent after the Windows install process finishes if there
         # was an agent running before.  If there was an agent, the write a special file
         # called the conditional restart marker.  So, if it exists, then we should start the agent.
-        parser.add_option(
-            "",
+        parser.add_argument(
             "--mark-conditional-restart",
             dest="mark_conditional_restart",
             action="store_true",
@@ -1562,8 +1544,7 @@ if __name__ == "__main__":
             help="Creates the marker file to restart the agent next time --conditional-restart is "
             "specified if the agent is currently running.",
         )
-        parser.add_option(
-            "",
+        parser.add_argument(
             "--conditional-restart",
             dest="conditional_restart",
             action="store_true",
@@ -1576,8 +1557,7 @@ if __name__ == "__main__":
         # to create initial config by the install which means we can't correctly set those
         # permissions inside the .wxs wix spec file.
         # Right now it can only be used with "--init-config" flag on Windows.
-        parser.add_option(
-            "",
+        parser.add_argument(
             "--fix-config-permissions",
             dest="fix_config_permissions",
             action="store_true",
@@ -1590,8 +1570,7 @@ if __name__ == "__main__":
 
     # Add Linux specific options
     if sys.platform.startswith("linux"):
-        parser.add_option(
-            "",
+        parser.add_argument(
             "--systemd-managed",
             dest="systemd_managed",
             action="store_true",
@@ -1599,11 +1578,11 @@ if __name__ == "__main__":
             help="Configure the agent to be managed by systemd instead of init.d which is a default",
         )
 
-    (options, args) = parser.parse_args()
-    if len(args) > 1:
-        print("Could not parse commandline arguments.", file=sys.stderr)
-        parser.print_help(sys.stderr)
-        sys.exit(1)
+    options = parser.parse_args(args=argv)
+    # if len(args) > 1:
+    #     print("Could not parse commandline arguments.", file=sys.stderr)
+    #     parser.print_help(sys.stderr)
+    #     sys.exit(1)
 
     controller = PlatformController.new_platform()
     default_paths = controller.default_paths
@@ -1783,3 +1762,7 @@ if __name__ == "__main__":
         )
 
     sys.exit(0)
+
+
+if __name__ == '__main__':
+    parse_config_options(sys.argv)

--- a/scalyr_agent/config_main.py
+++ b/scalyr_agent/config_main.py
@@ -1579,10 +1579,6 @@ def parse_config_options(argv):
         )
 
     options = parser.parse_args(args=argv)
-    # if len(args) > 1:
-    #     print("Could not parse commandline arguments.", file=sys.stderr)
-    #     parser.print_help(sys.stderr)
-    #     sys.exit(1)
 
     controller = PlatformController.new_platform()
     default_paths = controller.default_paths

--- a/scalyr_agent/platform_controller.py
+++ b/scalyr_agent/platform_controller.py
@@ -20,6 +20,8 @@ from __future__ import absolute_import
 
 __author__ = "czerwin@scalyr.com"
 
+import argparse
+
 if False:  # NOSONAR
     from typing import List
     from typing import Type
@@ -120,7 +122,7 @@ class PlatformController(object):
         """
         return False
 
-    def add_options(self, options_parser):
+    def add_options(self, options_parser: argparse.ArgumentParser):
         """Invoked by the main method to allow the platform to add in platform-specific options to the
         OptionParser used to parse the commandline options.
 
@@ -132,7 +134,7 @@ class PlatformController(object):
         """
         pass
 
-    def consume_options(self, options):
+    def consume_options(self, options: argparse.Namespace):
         """Invoked by the main method to allow the platform to consume any command line options previously requested
         in the 'add_options' call.
 

--- a/scalyr_agent/platform_posix.py
+++ b/scalyr_agent/platform_posix.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 
 __author__ = "czerwin@scalyr.com"
 
+import argparse
 import errno
 import fcntl
 import sys
@@ -94,21 +95,20 @@ class PosixPlatformController(PlatformController):
         """
         return __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.POSIX
 
-    def add_options(self, options_parser):
+    def add_options(self, options_parser: argparse.ArgumentParser):
         """Invoked by the main method to allow the platform to add in platform-specific options to the
         OptionParser used to parse the commandline options.
 
         @param options_parser:
         @type options_parser: optparse.OptionParser
         """
-        options_parser.add_option(
+        options_parser.add_argument(
             "-p",
             "--pid-file",
             dest="pid_file",
             help="The path storing the running agent's process id.  Only used if config cannot be parsed.",
         )
-        options_parser.add_option(
-            "",
+        options_parser.add_argument(
             "--no-change-user",
             action="store_true",
             dest="no_change_user",
@@ -118,7 +118,7 @@ class PosixPlatformController(PlatformController):
             "in changing to the correct user.  Users should not need to set this option.",
         )
 
-    def consume_options(self, options):
+    def consume_options(self, options: argparse.Namespace):
         """Invoked by the main method to allow the platform to consume any command line options previously requested
         in the 'add_options' call.
 
@@ -282,6 +282,11 @@ class PosixPlatformController(PlatformController):
         # Do the first fork.
 
         debug_logger("Forking service")
+
+        # Flush standard outputs before the fork. If not flushed, then all output, that is done before fork,
+        # will be duplicated by child process.
+        sys.stdout.flush()
+        sys.stderr.flush()
         try:
             pid = os.fork()
             if pid > 0:

--- a/scalyr_agent/platform_windows.py
+++ b/scalyr_agent/platform_windows.py
@@ -18,7 +18,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
 
-
+import argparse
 import atexit
 import errno
 
@@ -685,21 +685,19 @@ class WindowsPlatformController(PlatformController):
             else:
                 raise e
 
-    def add_options(self, options_parser):
+    def add_options(self, options_parser: argparse.ArgumentParser):
         """Invoked by the main method to allow the platform to add in platform-specific options to the
         OptionParser used to parse the commandline options.
 
         @param options_parser:
         @type options_parser: optparse.OptionParser
         """
-        options_parser.add_option(
-            "",
+        options_parser.add_argument(
             "--redirect-to-pipe",
             dest="redirect_pipe",
             help="Used to redirect stdin/stdout to a named pipe.  Used internally.",
         )
-        options_parser.add_option(
-            "",
+        options_parser.add_argument(
             "--no-change-user",
             action="store_true",
             dest="no_change_user",
@@ -709,8 +707,7 @@ class WindowsPlatformController(PlatformController):
             "in changing to the correct user.  Users should not need to set this option.",
         )
 
-        options_parser.add_option(
-            "-n",
+        options_parser.add_argument(
             "--no-warn-escalation",
             action="store_true",
             dest="no_escalation_warning",
@@ -721,7 +718,7 @@ class WindowsPlatformController(PlatformController):
             "requires that dialog box to be presented.",
         )
 
-    def consume_options(self, options):
+    def consume_options(self, options: argparse.Namespace):
         """Invoked by the main method to allow the platform to consume any command line options previously requested
         in the 'add_options' call.
 
@@ -906,10 +903,14 @@ class PipeRedirectorClient(RedirectorClient):
                 self.__pipe_handle = None
 
 
-if __name__ == "__main__":
+def parse_options():
     if len(sys.argv) == 1:
         servicemanager.Initialize()
         servicemanager.PrepareToHostSingle(ScalyrAgentService)
         servicemanager.StartServiceCtrlDispatcher()
     else:
         win32serviceutil.HandleCommandLine(ScalyrAgentService)
+
+
+if __name__ == "__main__":
+    parse_options()


### PR DESCRIPTION
Move every command line handling to the agent main in order to have a single executable. It is crucial for us since each frozen binary executable is pretty heavy and affects package size. All config and windows service command-line parsing is moved to the agent_main.py as separate sub-parsers.