### PR TITLE
Include pympler dependency for memory profiling as part of the Docker Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
+## 2.1.26 "TBW" - Dec 17, 2021
+
+<!---
+Packaged by Yan Shnayder <yans@sentinelone.com> on Nov 17, 2021 14:10 -0800
+--->
+
+Other:
+* Update agent Docker image to include ``pympler`` dependency by default. This means memory profiling can be enabled via the agent configuration option without the need to modify and re-build the Docker image.
+
 ## 2.1.25 "Hamarus" - Nov 17, 2021
 
 <!---
@@ -65,7 +74,7 @@ Bug fixes:
 * Fix an issue where LogFileIterator during the copy-truncate process picks wrong pending file with a similar name causing loss of the log and showing negative bytes in agent status.
 
 Other:
-* The discovery logic of the log files, which have been rotated with copy truncate method, now can handle only default rogrotate configurations. 
+* The discovery logic of the log files, which have been rotated with copy truncate method, now can handle only default rogrotate configurations.
 * Agent now emits a warning if running under Python 2.6 which we will stop supporting in the next release.
 
 ## 2.1.20 "Tabeisshi" - April 19, 2021

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -2,7 +2,12 @@
 ujson==1.35
 orjson==3.5.2; python_version >= '3.6'
 orjson==2.0.11; python_version == '3.5'
+# Two dependencies below are used for CPU and memory profiling which is opt-in and disabled by
+# default. We include it in the Docker image to make  troubleshooting (profiling) easier for the
+# end user (no need to rebuild Docker image - user can simply enable the corresponding agent config
+# option)
 yappi==1.2.3
+pympler==0.8
 # the version of 'requests' library that 'docker' uses as a dependency is higher than we use in agent,
 # to prevent versions conflict, install the appropriate version of 'requests', to force 'docker' to reuse it.
 requests==2.15.1


### PR DESCRIPTION
This pull request updates Docker requirements file so we also include ``pympler`` dependency which is used for memory profiling.

Profiling functionality is opt-in via scalyr agent config option. We already include dependency which is used for CPU profiler in the Docker Image, but we don't include one which is used for memory profiling.

Including it makes it easier to troubleshoot (profile) for the end user since they can just turn on the corresponding config option and there is no need to re-build and modify Docker images to get that dependency installed.

## TODO

- [x] Changelog entry