### PR TITLE
Frozen binaries: initial refactor scalyr of scalyr_agent package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1545,7 +1545,7 @@ jobs:
   lint-checks:
     working_directory: ~/scalyr-agent-2
     docker:
-      - image: circleci/python:3.6-jessie
+      - image: circleci/python:3.8-buster
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2320,185 +2320,185 @@ workflows:
    jobs:
      - lint-checks:
          context: scalyr-agent
- unit-tests:
-   <<: *skip_release_build_branch_push
-   # NOTE: To avoid massive and inflated build matrix, we currently don't run tests under multiple
-   # Python 3 versions
-   jobs:
-     - unittest-27:
-         context: scalyr-agent
-     - unittest-35:
-         context: scalyr-agent
-     - unittest-35-osx:
-         context: scalyr-agent
-     - unittest-38-windows:
-         context: scalyr-agent
- smoke-tests:
-   <<: *skip_release_build_branch_push
-   jobs:
-     - smoke-standalone-27:
-         context: scalyr-agent
-     - smoke-standalone-35:
-         context: scalyr-agent
-     - smoke-standalone-35-rate-limit:
-         context: scalyr-agent
-      # NOTE: smoke test jobs below still use old smoke tests framework
-     - smoke-docker-json:
-         context: scalyr-agent
-     - smoke-docker-api-raw-logs-disabled:
-         context: scalyr-agent
-     - smoke-docker-syslog:
-         context: scalyr-agent
-     - smoke-k8s:
-         context: scalyr-agent
-     - smoke-monitors-tests:
-         context: scalyr-agent
-     - sonarcloud-scan:
-         requires:
-           # NOTE: This is not ideal, but Circle CI doesn't support cross
-           # workflow dependencies (we can't wait on unittest-27 here) so we just wait on the
-           # slowest jobs
-           - smoke-docker-json
-           - smoke-docker-api-raw-logs-disabled
-           - smoke-docker-syslog
-           - smoke-k8s
-           - smoke-monitors-tests
- package-tests:
-   <<: *skip_release_build_branch_push
-   jobs:
-     - build-linux-packages-and-installer-script
-     - build-windows-package
-     - package-test-rpm:
-         context: scalyr-agent
-         <<: *master_and_release_only
-     - package-test-deb:
-         context: scalyr-agent
-         <<: *master_and_release_only
-     - smoke-rpm-package-py2:
-         context: scalyr-agent
-         requires:
-           - package-test-rpm
-         <<: *master_and_release_only
-     - smoke-rpm-package-py3:
-         context: scalyr-agent
-         requires:
-           - package-test-rpm
-         <<: *master_and_release_only
-     - smoke-deb-package-py2:
-         context: scalyr-agent
-         requires:
-           - package-test-deb
-         <<: *master_and_release_only
-     - smoke-deb-package-py3:
-         context: scalyr-agent
-         requires:
-           - package-test-deb
-         <<: *master_and_release_only
-     - ami-tests-development:
-          context: scalyr-agent
-          requires:
-            - build-windows-package
-            - build-linux-packages-and-installer-script
-     - ami-tests-stable:
-          context: scalyr-agent
-          <<: *master_and_release_only
- benchmarks:
-   <<: *skip_release_build_branch_push
-   jobs:
-     - benchmarks-micro-py-27
-     - benchmarks-micro-py-35
-     - benchmarks-idle-agent-py-27:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-idle-agent-py-35:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-idle-agent-no-monitors-py-27:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-idle-agent-no-monitors-py-35:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35:
-         <<: *benchmarks_master_and_release_only
-     - send-benchmark-results-and-graphs-to-slack:
-         requires:
-           - benchmarks-idle-agent-py-27
-           - benchmarks-idle-agent-py-35
-           - benchmarks-idle-agent-no-monitors-py-27
-           - benchmarks-idle-agent-no-monitors-py-35
-           - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27
-           - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35
-           - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27
-           - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35
-           - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27
-           - benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35
-           - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27
-           - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35
-         <<: *benchmarks_master_and_release_only
- weekly-circle-ci-usage-report:
-   triggers:
-     - schedule:
-         cron: "0 0 * * 0"
-         filters:
-           branches:
-             only:
-               - master
-   jobs:
-     - send-circle-ci-usage-report
-
- # We run AMI based package install tests which utilize installer script on
- # daily basis.
- # This helps us detect various installer script and other potential upstream
- # issues.
- daily-stable-ami-package-install-tests:
-   triggers:
-     - schedule:
-         cron: "0 2 * * *"
-         filters:
-           branches:
-             only:
-               - master
-   jobs:
-     - ami-tests-stable:
-         context: scalyr-agent
-     - unittest-27:
-         context: scalyr-agent
-     - unittest-35:
-         context: scalyr-agent
-     - unittest-35-osx:
-         context: scalyr-agent
-     - unittest-38-windows:
-         context: scalyr-agent
-     - build-linux-packages-and-installer-script
-     - build-windows-package
-     - package-test-rpm:
-         context: scalyr-agent
-     - package-test-deb:
-         context: scalyr-agent
-     - smoke-rpm-package-py2:
-         context: scalyr-agent
-         requires:
-           - package-test-rpm
-     - smoke-rpm-package-py3:
-         context: scalyr-agent
-         requires:
-           - package-test-rpm
-     - smoke-deb-package-py2:
-         context: scalyr-agent
-         requires:
-           - package-test-deb
-     - smoke-deb-package-py3:
-         context: scalyr-agent
-         requires:
-           - package-test-deb
+# unit-tests:
+#   <<: *skip_release_build_branch_push
+#   # NOTE: To avoid massive and inflated build matrix, we currently don't run tests under multiple
+#   # Python 3 versions
+#   jobs:
+#     - unittest-27:
+#         context: scalyr-agent
+#     - unittest-35:
+#         context: scalyr-agent
+#     - unittest-35-osx:
+#         context: scalyr-agent
+#     - unittest-38-windows:
+#         context: scalyr-agent
+# smoke-tests:
+#   <<: *skip_release_build_branch_push
+#   jobs:
+#     - smoke-standalone-27:
+#         context: scalyr-agent
+#     - smoke-standalone-35:
+#         context: scalyr-agent
+#     - smoke-standalone-35-rate-limit:
+#         context: scalyr-agent
+#      # NOTE: smoke test jobs below still use old smoke tests framework
+#     - smoke-docker-json:
+#         context: scalyr-agent
+#     - smoke-docker-api-raw-logs-disabled:
+#         context: scalyr-agent
+#     - smoke-docker-syslog:
+#         context: scalyr-agent
+#     - smoke-k8s:
+#         context: scalyr-agent
+#     - smoke-monitors-tests:
+#         context: scalyr-agent
+#     - sonarcloud-scan:
+#         requires:
+#           # NOTE: This is not ideal, but Circle CI doesn't support cross
+#           # workflow dependencies (we can't wait on unittest-27 here) so we just wait on the
+#           # slowest jobs
+#           - smoke-docker-json
+#           - smoke-docker-api-raw-logs-disabled
+#           - smoke-docker-syslog
+#           - smoke-k8s
+#           - smoke-monitors-tests
+# package-tests:
+#   <<: *skip_release_build_branch_push
+#   jobs:
+#     - build-linux-packages-and-installer-script
+#     - build-windows-package
+#     - package-test-rpm:
+#         context: scalyr-agent
+#         <<: *master_and_release_only
+#     - package-test-deb:
+#         context: scalyr-agent
+#         <<: *master_and_release_only
+#     - smoke-rpm-package-py2:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-rpm
+#         <<: *master_and_release_only
+#     - smoke-rpm-package-py3:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-rpm
+#         <<: *master_and_release_only
+#     - smoke-deb-package-py2:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-deb
+#         <<: *master_and_release_only
+#     - smoke-deb-package-py3:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-deb
+#         <<: *master_and_release_only
+#     - ami-tests-development:
+#          context: scalyr-agent
+#          requires:
+#            - build-windows-package
+#            - build-linux-packages-and-installer-script
+#     - ami-tests-stable:
+#          context: scalyr-agent
+#          <<: *master_and_release_only
+# benchmarks:
+#   <<: *skip_release_build_branch_push
+#   jobs:
+#     - benchmarks-micro-py-27
+#     - benchmarks-micro-py-35
+#     - benchmarks-idle-agent-py-27:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-idle-agent-py-35:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-idle-agent-no-monitors-py-27:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-idle-agent-no-monitors-py-35:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35:
+#         <<: *benchmarks_master_and_release_only
+#     - send-benchmark-results-and-graphs-to-slack:
+#         requires:
+#           - benchmarks-idle-agent-py-27
+#           - benchmarks-idle-agent-py-35
+#           - benchmarks-idle-agent-no-monitors-py-27
+#           - benchmarks-idle-agent-no-monitors-py-35
+#           - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27
+#           - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35
+#           - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27
+#           - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35
+#           - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27
+#           - benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35
+#           - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27
+#           - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35
+#         <<: *benchmarks_master_and_release_only
+# weekly-circle-ci-usage-report:
+#   triggers:
+#     - schedule:
+#         cron: "0 0 * * 0"
+#         filters:
+#           branches:
+#             only:
+#               - master
+#   jobs:
+#     - send-circle-ci-usage-report
+#
+# # We run AMI based package install tests which utilize installer script on
+# # daily basis.
+# # This helps us detect various installer script and other potential upstream
+# # issues.
+# daily-stable-ami-package-install-tests:
+#   triggers:
+#     - schedule:
+#         cron: "0 2 * * *"
+#         filters:
+#           branches:
+#             only:
+#               - master
+#   jobs:
+#     - ami-tests-stable:
+#         context: scalyr-agent
+#     - unittest-27:
+#         context: scalyr-agent
+#     - unittest-35:
+#         context: scalyr-agent
+#     - unittest-35-osx:
+#         context: scalyr-agent
+#     - unittest-38-windows:
+#         context: scalyr-agent
+#     - build-linux-packages-and-installer-script
+#     - build-windows-package
+#     - package-test-rpm:
+#         context: scalyr-agent
+#     - package-test-deb:
+#         context: scalyr-agent
+#     - smoke-rpm-package-py2:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-rpm
+#     - smoke-rpm-package-py3:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-rpm
+#     - smoke-deb-package-py2:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-deb
+#     - smoke-deb-package-py3:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-deb

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -1,0 +1,32 @@
+name: Build agent packages.
+
+on: [push]
+
+env:
+  DOCKER_BUILDKIT: 1
+
+
+jobs:
+  unit-tests:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ "ubuntu-20.04", "windows-2019", "macos-11" ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install python.
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8.10
+
+      - name: Install python dependencies
+        run: |
+          python3 -m pip install -r dev-requirements.txt
+
+      - name: Run unit tests.
+        run: |
+          python3 -m pytest tests/unit

--- a/benchmarks/micro/requirements-compression-algorithms.txt
+++ b/benchmarks/micro/requirements-compression-algorithms.txt
@@ -1,3 +1,1 @@
-zstandard
 brotli
-lz4

--- a/benchmarks/scripts/requirements.txt
+++ b/benchmarks/scripts/requirements.txt
@@ -1,3 +1,2 @@
-requests==2.15.1
 numpy==1.16.6
 psutil==5.7.0

--- a/build_package.py
+++ b/build_package.py
@@ -979,7 +979,7 @@ def build_base_files(base_configs="config"):
         certs/ca_certs.pem         -- The trusted SSL CA root list.
         config/agent.json          -- The configuration file.
         bin/scalyr-agent-2         -- Symlink to the agent_main.py file to run the agent.
-        bin/scalyr-agent-2-config  -- Symlink to agent_config.py to run the configuration tool
+        bin/scalyr-agent-2-config  -- Symlink to config_main.py to run the configuration tool
         build_info                 -- A file containing the commit id of the latest commit included in this package,
                                       the time it was built, and other information.
 

--- a/build_package.py
+++ b/build_package.py
@@ -1622,7 +1622,9 @@ def parse_change_log():
         return result
 
     # Begin the real work here.  Read the change log.
-    change_log_fp = open(os.path.join(__scalyr__.get_install_root(), "CHANGELOG.md"), "r")
+    change_log_fp = open(
+        os.path.join(__scalyr__.get_install_root(), "CHANGELOG.md"), "r"
+    )
 
     try:
         # Skip over the first two lines since it should be header.

--- a/build_package.py
+++ b/build_package.py
@@ -50,22 +50,11 @@ from io import open
 from optparse import OptionParser
 from time import gmtime, strftime
 
-from scalyr_agent.__scalyr__ import get_install_root, SCALYR_VERSION, scalyr_init
+from scalyr_agent import __scalyr__
+from scalyr_agent import util as scalyr_util
 
-scalyr_init()
-
-import scalyr_agent.util as scalyr_util
-
-# [start of 2->TODO]
-# Check for suitability.
-# Important. Import six as any other dependency from "third_party" libraries after "__scalyr__.scalyr_init"
 import six
 from six.moves import range
-
-# [end of 2->TOD0]
-
-# The root of the Scalyr repository should just be the parent of this file.
-__source_root__ = get_install_root()
 
 # All the different packages that this script can build.
 PACKAGE_TYPES = [
@@ -98,7 +87,7 @@ def build_package(package_type, variant, no_versioned_file_name, coverage_enable
     """
     original_cwd = os.getcwd()
 
-    version = SCALYR_VERSION
+    version = __scalyr__.SCALYR_VERSION
 
     # Create a temporary directory to build the package in.
     tmp_dir = tempfile.mkdtemp(prefix="build-scalyr-agent-packages")
@@ -238,7 +227,7 @@ def build_win32_installer_package(variant, version):
     make_directory("source_root")
     make_directory("data_files")
 
-    agent_source_root = __source_root__
+    agent_source_root = __scalyr__.get_install_root()
 
     # Populate source_root
     os.chdir("source_root")
@@ -655,7 +644,7 @@ def build_container_builder(
     """
     build_container_tarball(source_tarball, base_configs=base_configs)
 
-    agent_source_root = __source_root__
+    agent_source_root = __scalyr__.get_install_root()
     # Make a copy of the right Dockerfile to embed in the script.
     shutil.copy(make_path(agent_source_root, dockerfile), "Dockerfile")
     # copy requirements file with dependencies for docker builds.
@@ -990,7 +979,7 @@ def build_base_files(base_configs="config"):
         certs/ca_certs.pem         -- The trusted SSL CA root list.
         config/agent.json          -- The configuration file.
         bin/scalyr-agent-2         -- Symlink to the agent_main.py file to run the agent.
-        bin/scalyr-agent-2-config  -- Symlink to config_main.py to run the configuration tool
+        bin/scalyr-agent-2-config  -- Symlink to agent_config.py to run the configuration tool
         build_info                 -- A file containing the commit id of the latest commit included in this package,
                                       the time it was built, and other information.
 
@@ -1000,7 +989,7 @@ def build_base_files(base_configs="config"):
     original_dir = os.getcwd()
     # This will return the parent directory of this file.  We will use that to determine the path
     # to files like scalyr_agent/ to copy the source files
-    agent_source_root = __source_root__
+    agent_source_root = __scalyr__.get_install_root()
 
     make_directory("scalyr-agent-2/py")
     os.chdir("scalyr-agent-2")
@@ -1429,7 +1418,7 @@ def create_scriptlets():
     These are the preinstall.sh, preuninstall.sh, and postuninstall.sh scripts.
     """
 
-    scripts_path = os.path.join(__source_root__, "installer", "scripts")
+    scripts_path = os.path.join(__scalyr__.get_install_root(), "installer", "scripts")
 
     shutil.copy(os.path.join(scripts_path, "preinstall.sh"), "preinstall.sh")
     shutil.copy(os.path.join(scripts_path, "preuninstall.sh"), "preuninstall.sh")
@@ -1633,7 +1622,7 @@ def parse_change_log():
         return result
 
     # Begin the real work here.  Read the change log.
-    change_log_fp = open(os.path.join(__source_root__, "CHANGELOG.md"), "r")
+    change_log_fp = open(os.path.join(__scalyr__.get_install_root(), "CHANGELOG.md"), "r")
 
     try:
         # Skip over the first two lines since it should be header.
@@ -1738,7 +1727,7 @@ def get_build_info():
 
     try:
         # We need to execute the git command in the source root.
-        os.chdir(__source_root__)
+        os.chdir(__scalyr__.get_install_root())
         # Add in the e-mail address of the user building it.
         (rc, packager_email) = run_command(
             "git config user.email", fail_quietly=True, command_name="git"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -19,6 +19,7 @@ six==1.14.0
 ujson==1.35
 # Needed by MockHTTPServer class and related tests
 flask==1.1.1
+distro==1.6.0; platform_system != "Windows"
 
 # Used for performance optimized versions of rfc3339_to_* functions
 # NOTE: Not supported on windows

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -45,7 +45,7 @@ requests==2.26.0
 pg8000==1.10.6
 pymysql==0.9.3
 redis==2.10.5
-pysnmp=4.3.0
+pysnmp==4.3.0
 
 psutil==5.7.0; platform_system == "Windows"
 pywin32==300; platform_system == "Windows"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -32,6 +32,10 @@ udatetime==0.0.16; platform_system != "Windows"
 git+https://github.com/apache/libcloud.git@trunk#egg=apache-libcloud; platform_system != "Windows"
 paramiko==2.7.2; platform_system != "Windows"
 
+# benchmarks dependencies
+numpy==1.16.6
+brotli
+
 
 #agent dependencies
 orjson==3.6.4

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,11 +2,11 @@
 # These dependencies are not needed to run the Scalyr Agent, but mainly used for
 # running test suites, and mocking Python Objects for the Scalyr Agent.
 
+
 # Testing tools and libraries
 mock==3.0.5
 psutil==5.7.0
-pytest==4.6.9; python_version < '3.0'
-pytest==5.4.3; python_version >= '3.5'
+pytest==5.4.3;
 pytest-coverage
 pytest-timeout==1.3.4
 pytest-benchmark==3.2.3
@@ -14,25 +14,39 @@ pytest-xdist==1.31.0
 coverage==4.5.4
 codecov==2.1.9
 decorator==4.4.1
-PyYAML==5.4.1; python_version >= '3.6'
-PyYAML==5.3.1; python_version == '3.5'
-PyYAML==5.3.1; python_version <= '2.7'
-six==1.13.0
-docker==4.1.0
-# the version of 'requests' library that 'docker' uses as a dependency is higher than we use in agent,
-# to prevent versions conflict, install the appropriate version of 'requests', to force 'docker' to reuse it.
-# NOTE: We can't use requests >= 2.22.0 since we still need to support Python 2.6
-requests==2.15.1
+PyYAML==5.4.1;
+six==1.14.0
 ujson==1.35
-orjson==3.5.2; python_version >= '3.6'
-orjson==2.0.11; python_version == '3.5'
 # Needed by MockHTTPServer class and related tests
 flask==1.1.1
-pathlib2==2.3.5; python_version <= '2.7'
+
 # Used for performance optimized versions of rfc3339_to_* functions
 # NOTE: Not supported on windows
-udatetime==0.0.16
-futures==3.3.0; python_version <= '2.7'
-# Newer versions don't support Python 3.5 anymore
-more-itertools==8.5.0; python_version >= '3.0'
-more-itertools==5.0.0; python_version <= '2.7'
+udatetime==0.0.16; platform_system != "Windows"
+
+# Used in package AMI tests.
+# NOTE: We rely on change in Libcloud which allows us to specify a custom wait_period which makes
+# it less likely for us to hit EC2 rate limits when spinning up and deploying many instances
+# concurrently
+git+https://github.com/apache/libcloud.git@trunk#egg=apache-libcloud; platform_system != "Windows"
+paramiko==2.7.2; platform_system != "Windows"
+
+
+#agent dependencies
+orjson==3.6.4
+# TODO: remove six from the code base.
+six==1.14.0
+requests==2.26.0
+pg8000==1.10.6
+pymysql==0.9.3
+redis==2.10.5
+
+psutil==5.7.0; platform_system == "Windows"
+pywin32==300; platform_system == "Windows"
+
+# dependencies for docker images.
+docker==4.1.0
+
+# Compression libraries.
+zstandard==0.16.0
+lz4==3.1.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -45,6 +45,7 @@ requests==2.26.0
 pg8000==1.10.6
 pymysql==0.9.3
 redis==2.10.5
+pysnmp=4.3.0
 
 psutil==5.7.0; platform_system == "Windows"
 pywin32==300; platform_system == "Windows"

--- a/run_tests.py
+++ b/run_tests.py
@@ -23,10 +23,8 @@ from __future__ import absolute_import
 
 __author__ = "czerwin@scalyr.com"
 
-from scalyr_agent.__scalyr__ import scalyr_init
 import scalyr_agent.scalyr_logging as scalyr_logging
 
-scalyr_init()
 scalyr_logging.set_log_destination(use_stdout=True)
 
 from scalyr_agent.all_tests import run_all_tests

--- a/scalyr_agent/__init__.py
+++ b/scalyr_agent/__init__.py
@@ -47,16 +47,6 @@ from __future__ import absolute_import
 
 __author__ = "Steven Czerwinski <czerwin@scalyr.com>"
 
-# [start of 2->TODO]
-#  "Modernize" tool added "six" library almost everywhere.
-#  So we need to add third_party libraries in PYTHONPATH before "six" will be imported in any further file.
-
-from scalyr_agent.__scalyr__ import scalyr_init
-
-scalyr_init()
-
-# [end of 2->TODO]
-
 from scalyr_agent.scalyr_monitor import ScalyrMonitor
 from scalyr_agent.scalyr_monitor import BadMonitorConfiguration
 from scalyr_agent.scalyr_monitor import MonitorConfig

--- a/scalyr_agent/__scalyr__.py
+++ b/scalyr_agent/__scalyr__.py
@@ -141,14 +141,13 @@ def __determine_install_root_and_type() -> Tuple[str, InstallType]:
         package_info = json.loads(package_info_path.read_text())
         install_type_str = package_info.get("install_type")
         if not install_type_str:
-            raise ValueError(f"The required 'install_type' field is not found in the '{package_info_path}' file.")
+            raise ValueError(
+                f"The required 'install_type' field is not found in the '{package_info_path}' file."
+            )
 
         install_type = InstallType(install_type_str)
 
-        if install_type in [
-            InstallType.PACKAGE_INSTALL,
-            InstallType.TARBALL_INSTALL
-        ]:
+        if install_type in [InstallType.PACKAGE_INSTALL, InstallType.TARBALL_INSTALL]:
             # The package has to contain frozen binary.
 
             if not __is_frozen__:

--- a/scalyr_agent/__scalyr__.py
+++ b/scalyr_agent/__scalyr__.py
@@ -19,239 +19,182 @@ from __future__ import absolute_import
 
 __author__ = "czerwin@scalyr.com"
 
-# [start of 2->TODO]
-# "Modernize" tool added "six" library as a dependency in this file.
-# But in case of absence of six in site-packages we can not import "six" before scalyr_init.
-# The first option is to provide 2->3 compatibility without "six". This is easy for now,
-# because there is only one incompatible piece of code here.
-# and it can be fixed in code below...
-try:
-    # Python2
-    text_type = unicode  # type: ignore
-except NameError:
-    # Python3
-    text_type = str
-# The second option is to assure that "six" library installed in current python environment.
-# [end of 2->TOD0]
-
-
-import inspect
-import os
+import json
+import platform
+import re
+import subprocess
 import sys
-from io import open
+import pathlib as pl
+import enum
+from typing import Tuple
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 PY2_pre_279 = PY2 and sys.version_info < (2, 7, 9)
 PY3_pre_32 = PY3 and sys.version_info < (3, 2)
 
-# One of the main things this file does is correctly give the full path to two key directories regardless of install
-# type :
-#   package_root:  The directory containing the Scalyr source (contains files like 'agent_main.py', etc)
-#   install_root:  The top-level directory where Scalyr is currently installed (contains files like 'CHANGELOG.md')
+
+
+# One of the main things this file does is correctly give the full path to the following directories regardless of
+# install type :
+#   install_root:  The top-level directory where Scalyr is currently installed.
 #
 # There are several different ways we can be running, and this files has to give the correct values for each of them.
 # For example, we could just be running out of the source tree as checked into github.  Or we can be running
-# out of an RPM.  Or as part of a single Windows executable created by PyInstaller.  We handle of these cases.
+# out of some package such as Deb, Rpm, Msi for Windows and etc. We handle of these cases.
 #
 # Example layouts for different install types:
 #
 # Running from source:
-#     ~/scalyr-agent-2/VERSION
-#     ~/scalyr-agent-2/scalyr-agent/__scalyr__.py
-#     ~/scalyr-agent-2/scalyr-agent/third_party
-#
 #   Here the install root is ~/scalyr-agent-2 and the package root is ~/scalyr-agent-2/scalyr-agent
 #
 # Install using tarball:
-#     ~/scalyr-agent-2/py/scalyr_agent/VERSION
-#     ~/scalyr-agent-2/py/scalyr_agent/__scalyr__py
-#     ~/scalyr-agent-2/py/scalyr_agent/third_party
+#   Here the install root is the path to the extracted tarball.
 #
-#   Here the install root is ~/scalyr-agent-2 and the package root is ~/scalyr-agent-2/py/scalyr-agent
+# Install using rpm/deb/kubernetes/docker package:
+#   Here the install root is /usr/share/scalyr-agent-2.
 #
-# Install using rpm/deb package:
-#     /usr/share/scalyr-agent-2/py/scalyr_agent/VERSION
-#     /usr/share/scalyr-agent-2/py/scalyr_agent/__scalyr__py
-#     /usr/share/scalyr-agent-2/py/scalyr_agent/third_party
+# Install using msi package for Windows:
+#   Here the install root is C:\Program Files (x86)\Scalyr\
 #
-#   Here the install root is /usr/share/scalyr-agent-2 and the package root is /usr/share/scalyr-agent-2/py/scalyr-agent
-#
-# Install using win32 exe:
-#     C:\Program Files (x86)\Scalyr\program_files\VERSION
-#     C:\Program Files (x86)\Scalyr\program_files\__scalyr__.py
-#     (There is no third party directory... its contents gets added directly to program_files
-#
-#   Here the install root is C:\Program Files (x86)\Scalyr\ and the package root is
-#   C:\Program Files (x86)\Scalyr\program_files\
+# In spite of the package type, the internal structure of the package is common:
+#   VERSION: The package version file.
+#   install_type: File which contains the type of the installed package. Agent reads this file during the start in order
+#       to find all essential paths on the system where it runs. Soo the 'InstallType' enum class to see its possible
+#       values.
+#   py/: Directory with the source code of the agent. Only used in the Kubernetes and Docker images, other build use
+#       frozen binaries.
+#   bin/: The directory with executables. For the majority of the package types, it contains frozen binaries of the
+#       agent. In case of Kubernetes or Docker it contains symlinks to agent executable scripts in the source code which
+#       is located in the 'py' folder.
+#   certs/: Certificates directory.
+#   monitors/: The folder for custom monitors.
+#   misc/: Miscellaneous files.
 
-# Indicates if this code was compiled into a single Windows executable via PyInstaller.  If that's the case,
+
+# Indicates if this code was compiled into a single executable via PyInstaller.  If that's the case,
 # then we cannot rely on __file__ and the source is kind of through into the same directory.
 __is_frozen__ = hasattr(sys, "frozen")
 
 
-def scalyr_init():
-    """Initializes the environment to execute a Scalyr script.
-
-    This should be invoked by any Scalyr module that has a main (i.e., can invoked by the commandline to
-    perform some action).
-
-    It performs such tasks as ensures PYTHONPATH include the Scalyr package and fixing some third-party import issues.
+class PlatformType(enum.Enum):
     """
-    # If this is a win32 executable, then all the packages have already been bundled in the exec and there is no
-    # need to change the PYTHONPATH
-    if not __is_frozen__:
-        __add_scalyr_package_to_path()
-
-
-def __determine_package_root():
-    """Returns the absolute file path to the package root.
-
-    This must be invoked before the current working directory is changed by the code, so therefore should be
-    invoked during the module load.
-
-    @return: The absolute file path for the package root.
+    The Enum class with possible types of the OS. Firstly, used for the 'P'
     """
-    # We rely on the fact this file (__scalyr__.py) should be in the directory that is the package root.
-    # We could just return the parent of __file__, however, this apparently is not portable on all version of
-    # Windows.  Moreover, when running as a win32 exe, __file__ is not set.
-    if not __is_frozen__:
-        base = os.getcwd()
-        file_path = inspect.stack()[1][1]
-        if not os.path.isabs(file_path):
-            file_path = os.path.join(base, file_path)
-        file_path = os.path.dirname(os.path.realpath(file_path))
+
+    WINDOWS = "windows"
+    LINUX = "linux"
+    POSIX = "posix"
+
+
+class InstallType(enum.Enum):
+    """
+    The enumeration of the Scalyr agent installation types. It is used for INSTALL_TYPE variable in the __scalyr__
+    module.
+    """
+
+    # Those package types contain Scalyr Agent as frozen binary.
+    PACKAGE_INSTALL = "package"  # Indicates it was installed via a package manager such as RPM or Windows executable.
+    SOURCE_PACKAGE = "source_package"
+    TARBALL_INSTALL = "packageless"  # Indicates it was installed via a tarball.
+
+    # This type runs Scalyr Agent from the source code.
+    DEV_INSTALL = "dev"  # Indicates source code is running out of the original source tree, usually during dev testing.
+
+
+def __determine_platform():
+    system_name = platform.system().lower()
+    if system_name.startswith("win"):
+        return PlatformType.WINDOWS
+    elif system_name.startswith("linux"):
+        return PlatformType.LINUX
     else:
-        # encode python executable path for python 2.
-        executable_path = sys.executable
-        if type(executable_path) != text_type:
-            executable_path = text_type(executable_path, sys.getfilesystemencoding())
-        return os.path.dirname(executable_path)
-
-    return file_path
+        return PlatformType.POSIX
 
 
-__package_root__ = __determine_package_root()
+PLATFORM_TYPE = __determine_platform()
 
 
-def get_package_root():
-    """Returns the absolute path to the scalyr_agent Python package, including the scalyr_agent directory name.
+# The enum  for INSTALL_TYPE, a variable declared down below.
 
-    @return: The path to the scalyr_agent directory (which contains the Python package).
-    @rtype: six.text_type
+
+def __read_install_type_from_type_file(path: pl.Path) -> InstallType:
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Can not determine the package installation type. The file '{path}' is not found."
+        )
+    # Read the type of the package from the file.
+    install_type = path.read_text().strip()
+    # Check if the package type is one of the valid install types.
+    if install_type not in [e.value for e in InstallType]:
+        raise ValueError(
+            f"Can not determine the installation type. Unknown value: {install_type}"
+        )
+
+    return InstallType(install_type)
+
+
+def __determine_install_root_and_type() -> Tuple[str, InstallType]:
     """
-    return __package_root__
+    Determine the path for the install root and type of the installation.
+    """
+
+    source_root = pl.Path(__file__).absolute().parent.parent
+    package_info_path = source_root / "scalyr_agent" / "package_info.json"
+
+    # package_info file is not found, so it has to be no installation. (DEV_INSTALL)
+    if not package_info_path.is_file():
+
+        if not __is_frozen__:
+            return str(source_root), InstallType.DEV_INSTALL
+        else:
+            raise FileNotFoundError(
+                f"The required file '{package_info_path}' is not found. "
+                f"The development installation mode is not implemented for frozen binary"
+            )
+    else:
+        package_info = json.loads(package_info_path.read_text())
+        install_type_str = package_info.get("install_type")
+        if not install_type_str:
+            raise ValueError(f"The required 'install_type' field is not found in the '{package_info_path}' file.")
+
+        install_type = InstallType(install_type_str)
+
+        if install_type in [
+            InstallType.PACKAGE_INSTALL,
+            InstallType.TARBALL_INSTALL
+        ]:
+            # The package has to contain frozen binary.
+
+            if not __is_frozen__:
+                # Raise an error if the executable somehow is not a frozen binary.
+                raise RuntimeError(
+                    f"The type of installation is '{install_type.value}' but the executable is not a frozen binary."
+                )
+
+            # Determine install root.
+            # Since the package contains frozen binary, the path to the binary is 'sys.executable.'
+            # In the packages with the frozen binary the frozen binaries located in the '<install_root>/bin' folder.
+            install_root = pl.Path(sys.executable).parent.parent
+            return str(install_root), install_type
+
+
+__install_root__, INSTALL_TYPE = __determine_install_root_and_type()
 
 
 def get_install_root():
-    """Returns the absolute path to the root of the install location to scalyr-agent-2.  This
-    works for the different types of installation such as RPM and Debian, as well as when this
-    is running from the source tree.
-
-    For example, it will return '/usr/share/scalyr-agent-2', for Linux installs and
-    the top of the repository when running from the source tree.
-
-    @return:  The path to the scalyr-agent-2 directory.
-    @rtype: six.text_type
     """
-    # See the listed cases above.  From that, it should be clear that these rules work for the different cases.
-    parent_of_package_install = os.path.dirname(get_package_root())
-    if __is_frozen__:  # win32 install
-        return parent_of_package_install
-    elif os.path.basename(parent_of_package_install) != "py":  # Running from Source
-        return parent_of_package_install
-    else:  # Installed using tarball or rpm/debian package
-        return os.path.dirname(parent_of_package_install)
-
-
-def __add_scalyr_package_to_path():
-    """Adds the path for the scalyr package and embedded third party packages to the PYTHONPATH.
-
-    If you add any new paths in this method, be sure to add them near the top of `setup.py` as well so as not
-    to break the Windows builds.
+    The root of the agent installation.
     """
-    # prepend the third party directory first so it appears after the package root, third_party_pythonX
-    # and third_party_tls directories
-    sys.path.insert(0, os.path.join(get_package_root(), "third_party"))
-
-    if sys.version_info[0] == 2:
-        sys.path.insert(0, os.path.join(get_package_root(), "third_party_python2"))
-    else:
-        sys.path.insert(0, os.path.join(get_package_root(), "third_party_python3"))
-
-    # if we are not on windows, prepend the third party tls directory first so it appears after the package root
-    if not __is_frozen__ and (PY2_pre_279 or PY3_pre_32):
-        # Special case for backports module which is a multiple package module so we also need to
-        # add sub directory to pack when bundling a package and not installing it using setup.py
-        sys.path.insert(
-            0,
-            os.path.join(
-                get_package_root(), "third_party_tls/backports_ssl_match_hostname"
-            ),
-        )
-
-    sys.path.insert(0, os.path.dirname(get_package_root()))
+    return __install_root__
 
 
 def __determine_version():
-    """Returns the agent version number, read from the VERSION file."""
+    """
+    Returns the agent version number, read from the VERSION file."""
 
-    file_names = ["VERSION"]
-
-    if __is_frozen__:
-        # also check for VERSION.txt file because there is a reserved filename - "VERSION" in Pyinstaller,
-        # and it expects that this file is a DLL.
-        file_names.append("VERSION.txt")
-
-    def find_path():
-        # This file can be either in the package root or the install root (if you examine the cases
-        # from above).  So, just check both locations.
-        for root in [get_install_root(), get_package_root()]:
-            for file_name in file_names:
-                path = os.path.join(root, file_name)
-                if os.path.isfile(path):
-                    return path
-
-        raise Exception("Could not locate VERSION file!")
-
-    version_path = find_path()
-
-    version_fp = open(version_path, "r")
-    try:
-        return version_fp.readline().strip()
-    finally:
-        version_fp.close()
+    version_file_path = pl.Path(get_install_root()) / "VERSION"
+    return version_file_path.read_text().strip()
 
 
 SCALYR_VERSION = __determine_version()
-
-
-# The constants for INSTALL_TYPE, a variable declared down below.
-PACKAGE_INSTALL = 1  # Indicates source code was installed via a package manager such as RPM or Windows executable.
-TARBALL_INSTALL = 2  # Indicates source code was installed via a tarball created by the build_package.py script.
-DEV_INSTALL = 3  # Indicates source code is running out of the original source tree, usually during dev testing.
-MSI_INSTALL = 4  # Indicates source code was installed via a Windows MSI package
-
-
-def __determine_install_type():
-    """Returns the type of install that was used for the source currently running.
-
-    @return: The install type, drawn from the constants above.
-    @rtype: int
-    """
-    # Determine which type of install this is.  We do this based on
-    # whether or not certain files exist in the root of the source tree.
-    install_root = get_install_root()
-    if os.path.exists(os.path.join(install_root, "packageless")):
-        install_type = TARBALL_INSTALL
-    elif os.path.exists(os.path.join(install_root, "run_tests.py")):
-        install_type = DEV_INSTALL
-    elif hasattr(sys, "frozen"):
-        install_type = MSI_INSTALL
-    else:
-        install_type = PACKAGE_INSTALL
-    return install_type
-
-
-# Holds which type of installation we are currently running from.
-INSTALL_TYPE = __determine_install_type()

--- a/scalyr_agent/__scalyr__.py
+++ b/scalyr_agent/__scalyr__.py
@@ -21,8 +21,6 @@ __author__ = "czerwin@scalyr.com"
 
 import json
 import platform
-import re
-import subprocess
 import sys
 import pathlib as pl
 import enum

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -2091,7 +2091,7 @@ if __name__ == "__main__":
     my_controller = PlatformController.new_platform()
     parser = OptionParser(
         usage="Usage: scalyr-agent-2 [options] (start|stop|status|restart|condrestart|version)",
-        version="scalyr-agent v" + SCALYR_VERSION,
+        version="scalyr-agent v" + __scalyr__.SCALYR_VERSION,
     )
     parser.add_option(
         "-c",

--- a/scalyr_agent/build_info.py
+++ b/scalyr_agent/build_info.py
@@ -26,7 +26,6 @@ if False:  # NOSONAR
 
 import os
 import pathlib as pl
-from io import open
 
 import six
 

--- a/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 
 __author__ = "imron@scalyr.com"
 
+from requests.exceptions import ConnectionError
+
 from scalyr_agent import compat
 
 from scalyr_agent.monitor_utils.k8s import (
@@ -28,8 +30,6 @@ from scalyr_agent.monitor_utils.k8s import (
     K8sNamespaceFilter,
 )
 import scalyr_agent.monitor_utils.k8s as k8s_utils
-
-from scalyr_agent.third_party.requests.exceptions import ConnectionError
 
 import datetime
 import re

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -45,6 +45,8 @@ from six.moves.urllib.parse import quote_plus
 # 2. https://bugs.python.org/issue7980
 import _strptime  # NOQA
 
+from requests.exceptions import ConnectionError
+
 from scalyr_agent import compat
 
 from scalyr_agent import (
@@ -74,7 +76,6 @@ from scalyr_agent.monitor_utils.k8s import (
     QualifiedName,
 )
 import scalyr_agent.monitor_utils.k8s as k8s_utils
-from scalyr_agent.third_party.requests.exceptions import ConnectionError
 
 from scalyr_agent.util import StoppableThread, HistogramTracker
 

--- a/scalyr_agent/builtin_monitors/mysql_monitor.py
+++ b/scalyr_agent/builtin_monitors/mysql_monitor.py
@@ -482,7 +482,8 @@ class MysqlDB(object):
             (errcode, msg) = error.args
             if errcode != 2006:  # "MySQL server has gone away"
                 self._logger.exception(
-                    "Exception trying to execute query: %d '%s'" % (errcode, msg)
+                    "Exception trying to execute query: %d '%s'"  # pylint: disable=bad-string-format-type
+                    % (errcode, msg)
                 )
                 raise Exception(
                     "Database error -- "

--- a/scalyr_agent/builtin_monitors/postgres_monitor.py
+++ b/scalyr_agent/builtin_monitors/postgres_monitor.py
@@ -357,7 +357,7 @@ class PostgreSQLDb(object):
             )
             data = self._cursor.fetchone()
         except pg8000.OperationalError as error:
-            errcode = error.errcode
+            errcode = error.errcode  # pylint: disable=no-member
             if errcode != 2006:  # "PostgreSQL server has gone away"
                 raise Exception("Database error -- " + errcode)
             self.reconnect()
@@ -386,7 +386,7 @@ class PostgreSQLDb(object):
             self._cursor.execute("select pg_database_size('%s');" % self._database)
             size = self._cursor.fetchone()[0]
         except pg8000.OperationalError as error:
-            errcode = error.errcode
+            errcode = error.errcode  # pylint: disable=no-member
             if errcode != 2006:  # "PostgreSQL server has gone away"
                 raise Exception("Database error -- " + errcode)
             self.reconnect()

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -20,11 +20,11 @@ import six.moves.urllib.request
 import six.moves.urllib.parse
 import six.moves.urllib.error
 from six.moves import range
+import requests
 
 import scalyr_agent.monitor_utils.annotation_config as annotation_config
 from scalyr_agent.monitor_utils.annotation_config import BadAnnotationConfig
 from scalyr_agent.monitor_utils.blocking_rate_limiter import BlockingRateLimiter
-import scalyr_agent.third_party.requests as requests
 from scalyr_agent.util import StoppableThread
 from scalyr_agent.json_lib import JsonObject
 

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -2361,7 +2361,7 @@ class KubeletApi(object):
                 with warnings.catch_warnings():
                     warnings.simplefilter(
                         "ignore",
-                        category=requests.packages.urllib3.exceptions.InsecureRequestWarning,
+                        category=requests.packages.urllib3.exceptions.InsecureRequestWarning,  # pylint: disable=no-member
                     )
                     response = self._get(url, False)
                 if self._kubelet_url.startswith("https://"):

--- a/scalyr_agent/monitors_manager.py
+++ b/scalyr_agent/monitors_manager.py
@@ -24,6 +24,7 @@ __author__ = "czerwin@scalyr.com"
 
 import os
 import time
+import pathlib as pl
 
 from scalyr_agent.agent_status import MonitorManagerStatus
 from scalyr_agent.agent_status import MonitorStatus
@@ -32,7 +33,7 @@ from scalyr_agent.util import StoppableThread
 from scalyr_agent.configuration import Configuration
 from scalyr_agent.platform_controller import PlatformController
 
-from scalyr_agent.__scalyr__ import get_package_root
+from scalyr_agent.__scalyr__ import get_install_root
 
 import scalyr_agent.scalyr_logging as scalyr_logging
 
@@ -338,13 +339,11 @@ class MonitorsManager(StoppableThread):
         # Augment the PYTHONPATH if requested to locate the module.
         paths_to_pass = []
 
-        # Also add in scalyr_agent/../monitors/local and scalyr_agent/../monitors/contrib to the Python path to search
-        # for monitors.  (They are always in the parent directory of the scalyr_agent package.
-        path_to_package_parent = os.path.dirname(get_package_root())
-        paths_to_pass.append(os.path.join(path_to_package_parent, "monitors", "local"))
-        paths_to_pass.append(
-            os.path.join(path_to_package_parent, "monitors", "contrib")
-        )
+        # Add the monitors/local and monitors/contrib folders from the install root to the Python path to search
+        # for monitors.
+        monitors_path = pl.Path(get_install_root(), "monitors")
+        paths_to_pass.append(str(monitors_path / "local"))
+        paths_to_pass.append(str(monitors_path / "contrib"))
 
         # Add in the additional paths.
         if additional_python_paths is not None and len(additional_python_paths) > 0:

--- a/scalyr_agent/platform_controller.py
+++ b/scalyr_agent/platform_controller.py
@@ -27,7 +27,7 @@ if False:  # NOSONAR
 
 import sys
 
-from scalyr_agent.__scalyr__ import INSTALL_TYPE
+from scalyr_agent import __scalyr__
 
 # Holds a reference to the existing PlatformController instance which is populated when first
 # calling "PlatformController.existing_instance()".
@@ -36,8 +36,10 @@ PLATFORM_INSTANCE = None
 
 class PlatformController(object):
     def __init__(self):
-        """Initializes a platform instance."""
-        self._install_type = INSTALL_TYPE
+        """
+        Initializes a platform instance.
+        """
+        self._install_type = __scalyr__.INSTALL_TYPE
 
     # A list of PlatformController classes that have been registered for use.
     __platform_classes__ = []  # type: List[Type[PlatformController]]
@@ -48,7 +50,7 @@ class PlatformController(object):
         """Adds all available platforms to the '__platforms_registered__' array.
         a new platform class that could be instantiated during the 'new_platform' method.
         """
-        if sys.platform == "win32":
+        if __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.WINDOWS:
             from scalyr_agent.platform_windows import WindowsPlatformController
 
             PlatformController.__platform_classes__.append(WindowsPlatformController)

--- a/scalyr_agent/platform_controller.py
+++ b/scalyr_agent/platform_controller.py
@@ -24,9 +24,6 @@ if False:  # NOSONAR
     from typing import List
     from typing import Type
 
-
-import sys
-
 from scalyr_agent import __scalyr__
 
 # Holds a reference to the existing PlatformController instance which is populated when first

--- a/scalyr_agent/platform_linux.py
+++ b/scalyr_agent/platform_linux.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import
 
 __author__ = "czerwin@scalyr.com"
 
-import os
 from sys import platform as _platform
 
 if False:
@@ -28,18 +27,11 @@ if False:
 
 from scalyr_agent.json_lib import JsonObject
 from scalyr_agent.platform_posix import PosixPlatformController
-from scalyr_agent.platform_controller import DefaultPaths
 from scalyr_agent.configuration import Configuration
 from scalyr_agent.copying_manager.copying_manager import (
     WORKER_SESSION_PROCESS_MONITOR_ID_PREFIX,
 )
-
-from scalyr_agent.__scalyr__ import (
-    get_install_root,
-    TARBALL_INSTALL,
-    DEV_INSTALL,
-    PACKAGE_INSTALL,
-)
+from scalyr_agent import __scalyr__
 
 
 class LinuxPlatformController(PosixPlatformController):
@@ -60,38 +52,7 @@ class LinuxPlatformController(PosixPlatformController):
         @return:  True if this platform instance can handle the current server.
         @rtype: bool
         """
-        return _platform.lower().startswith("linux")
-
-    @property
-    def default_paths(self):
-        """Returns the default paths to use for various configuration options for this platform.
-
-        @return: The default paths
-        @rtype: DefaultPaths
-        """
-        if self._install_type == PACKAGE_INSTALL:
-            return DefaultPaths(
-                "/var/log/scalyr-agent-2",
-                "/etc/scalyr-agent-2/agent.json",
-                "/var/lib/scalyr-agent-2",
-            )
-        elif self._install_type == TARBALL_INSTALL:
-            install_location = get_install_root()
-            return DefaultPaths(
-                os.path.join(install_location, "log"),
-                os.path.join(install_location, "config", "agent.json"),
-                os.path.join(install_location, "data"),
-            )
-        else:
-            assert self._install_type == DEV_INSTALL
-            # For developers only.  We default to a directory ~/scalyr-agent-dev for storing
-            # all log/data information, and then require a log, config, and data subdirectory in each of those.
-            base_dir = os.path.join(os.path.expanduser("~"), "scalyr-agent-dev")
-            return DefaultPaths(
-                os.path.join(base_dir, "log"),
-                os.path.join(base_dir, "config", "agent.json"),
-                os.path.join(base_dir, "data"),
-            )
+        return __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.LINUX
 
     def get_default_monitors(self, config):  # type: (Configuration) -> List
         """Returns the default monitors to use for this platform.

--- a/scalyr_agent/platform_linux.py
+++ b/scalyr_agent/platform_linux.py
@@ -20,8 +20,6 @@ from __future__ import absolute_import
 
 __author__ = "czerwin@scalyr.com"
 
-from sys import platform as _platform
-
 if False:
     from typing import List
 

--- a/scalyr_agent/platform_posix.py
+++ b/scalyr_agent/platform_posix.py
@@ -283,7 +283,7 @@ class PosixPlatformController(PlatformController):
 
         debug_logger("Forking service")
 
-        # Flush standard outputs before the fork. If not flushed, then all output, that is done before fork,
+        # Flush standard outputs before the fork. If not flushed, then all output that is done before the fork
         # will be duplicated by child process.
         sys.stdout.flush()
         sys.stderr.flush()

--- a/scalyr_agent/platform_posix.py
+++ b/scalyr_agent/platform_posix.py
@@ -35,6 +35,7 @@ from io import open
 
 import six
 
+from scalyr_agent import __scalyr__
 from scalyr_agent import scalyr_logging
 from scalyr_agent.platform_controller import (
     PlatformController,
@@ -43,13 +44,6 @@ from scalyr_agent.platform_controller import (
 )
 from scalyr_agent.platform_controller import CannotExecuteAsUser, AgentNotRunning
 import scalyr_agent.util as scalyr_util
-
-from scalyr_agent.__scalyr__ import (
-    get_install_root,
-    TARBALL_INSTALL,
-    DEV_INSTALL,
-    PACKAGE_INSTALL,
-)
 
 # Based on code by Sander Marechal posted at
 # http://web.archive.org/web/20131017130434/http://www.jejik.com/articles/2007/02/a_simple_unix_linux_daemon_in_python/
@@ -98,9 +92,7 @@ class PosixPlatformController(PlatformController):
         @return:  True if this platform instance can handle the current server.
         @rtype: bool
         """
-        # TODO:  For now, we only support POSIX.  Once we get Windows support in, will need to change this to
-        # not return True when we should be using Windows.
-        return True
+        return __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.POSIX
 
     def add_options(self, options_parser):
         """Invoked by the main method to allow the platform to add in platform-specific options to the
@@ -173,21 +165,21 @@ class PosixPlatformController(PlatformController):
         """
         # TODO: Change this to something that is not Linux-specific.  Maybe we should always just default
         # to the home directory location.
-        if self._install_type == PACKAGE_INSTALL:
+        if self._install_type == __scalyr__.InstallType.PACKAGE_INSTALL:
             return DefaultPaths(
                 "/var/log/scalyr-agent-2",
                 "/etc/scalyr-agent-2/agent.json",
                 "/var/lib/scalyr-agent-2",
             )
-        elif self._install_type == TARBALL_INSTALL:
-            install_location = get_install_root()
+        elif self._install_type == __scalyr__.InstallType.TARBALL_INSTALL:
+            install_location = __scalyr__.get_install_root()
             return DefaultPaths(
                 os.path.join(install_location, "log"),
                 os.path.join(install_location, "config", "agent.json"),
                 os.path.join(install_location, "data"),
             )
         else:
-            assert self._install_type == DEV_INSTALL
+            assert self._install_type == __scalyr__.InstallType.DEV_INSTALL
             # For developers only.  We default to a directory ~/scalyr-agent-dev for storing
             # all log/data information, and then require a log, config, and data subdirectory in each of those.
             base_dir = os.path.join(os.path.expanduser("~"), "scalyr-agent-dev")
@@ -290,6 +282,11 @@ class PosixPlatformController(PlatformController):
         # Do the first fork.
 
         debug_logger("Forking service")
+
+        # Flush standard outputs before the fork. If not flushed, then all output, that is done before fork,
+        # will be duplicated by child process.
+        sys.stdout.flush()
+        sys.stderr.flush()
         try:
             pid = os.fork()
             if pid > 0:

--- a/scalyr_agent/platform_windows.py
+++ b/scalyr_agent/platform_windows.py
@@ -84,27 +84,14 @@ except ImportError:
         "the following command:  pip install psutil"
     )
 
-# [start of 2->TODO]
-# Check for suitability.
-# This file can be executed as script and imported as module.
-if __name__ == "__main__":
-    # run as script, can not import __scalyr__.py as part of the package.
-    from __scalyr__ import get_install_root, scalyr_init
-else:
-    # run as package module.
-    # Python3 does not allow to import __scalyr__.py file within the same package just by its name. (PEP 328)
-    from scalyr_agent.__scalyr__ import get_install_root, scalyr_init
-# [end of 2->TOD0]
-
-scalyr_init()
+import six
 
 # [start of 2->TODO]
 # Check for suitability.
 # Important. Import six as any other dependency from "third_party" libraries after "__scalyr__.scalyr_init"
 from six.moves import input
 
-# [end of 2->TOD0]t
-
+from scalyr_agent import __scalyr__
 from scalyr_agent.json_lib import JsonObject
 from scalyr_agent.util import RedirectorServer, RedirectorClient, RedirectorError
 from scalyr_agent.platform_controller import (
@@ -295,7 +282,7 @@ class WindowsPlatformController(PlatformController):
         @return: True if this platform instance can handle the current server.
         @rtype: bool
         """
-        return "win32" == sys.platform
+        return __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.WINDOWS
 
     @property
     def default_paths(self):
@@ -306,7 +293,7 @@ class WindowsPlatformController(PlatformController):
         """
         # NOTE: For this module, it is assumed that the 'install_type' is always PACKAGE_INSTALL
 
-        root = get_install_root()
+        root = __scalyr__.get_install_root()
         logdir = os.path.join(root, "log")
         libdir = os.path.join(root, "data")
         config = os.path.join(root, "config", "agent.json")

--- a/scalyr_agent/requests_connection.py
+++ b/scalyr_agent/requests_connection.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 
 __author__ = "imron@scalyr.com"
 
-import scalyr_agent.third_party.requests as requests
+import requests
 
 from scalyr_agent.connection import Connection
 

--- a/scalyr_agent/run_monitor.py
+++ b/scalyr_agent/run_monitor.py
@@ -43,20 +43,20 @@ from __future__ import print_function
 
 __author__ = "czerwin@scalyr.com"
 
+import pathlib as pl
+import os
 import signal
 import sys
 import time
 
 from optparse import OptionParser
 
-try:
-    from __scalyr__ import scalyr_init
-except ImportError:
-    from scalyr_agent.__scalyr__ import scalyr_init
-
-scalyr_init()
-
 import six
+
+
+# Since this file can be executes as script, add the source root to the PYTHONPATH in case if it isn't there.
+# If it is not there, then the further import of the 'scalyr_agent' package will fail.
+sys.path.append(str(pl.Path(os.path.realpath(__file__)).parent.parent))
 
 import scalyr_agent.scalyr_logging as scalyr_logging
 import scalyr_agent.util as scalyr_util

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -41,6 +41,7 @@ from six.moves import map
 from six.moves import range
 import six.moves.http_client
 
+
 from scalyr_agent.util import verify_and_get_compress_func
 from scalyr_agent.configuration import Configuration
 
@@ -89,11 +90,10 @@ def verify_server_certificate(config):
     :param config:
     :return:
     """
-    is_dev_install = __scalyr__.INSTALL_TYPE == __scalyr__.DEV_INSTALL
-    is_dev_or_msi_install = __scalyr__.INSTALL_TYPE in [
-        __scalyr__.DEV_INSTALL,
-        __scalyr__.MSI_INSTALL,
-    ]
+    is_dev_install = __scalyr__.INSTALL_TYPE == __scalyr__.InstallType.DEV_INSTALL
+    is_dev_or_windows_install = (
+        is_dev_install or __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.WINDOWS
+    )
 
     ca_file = config.ca_cert_path
     intermediate_certs_file = config.intermediate_certs_path
@@ -108,7 +108,7 @@ def verify_server_certificate(config):
 
     # NOTE: We don't include intermediate certs in the Windows binary so we skip that check
     # under the MSI / Windows install
-    if not is_dev_or_msi_install and not os.path.isfile(intermediate_certs_file):
+    if not is_dev_or_windows_install and not os.path.isfile(intermediate_certs_file):
         raise ValueError(
             'Invalid path "%s" specified for the '
             '"intermediate_certs_path" config '
@@ -997,7 +997,7 @@ class ScalyrClientSession(object):
             parts.append(sharded_copy_manager_string)
 
         if self.__use_requests:
-            import scalyr_agent.third_party.requests as requests
+            import requests
 
             parts.append("requests-%s" % (requests.__version__))
 

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -896,7 +896,9 @@ class ScalyrClientSession(object):
         platform_value = None
         # noinspection PyBroadException
         try:
-            distribution = platform.dist()
+            import distro  # pylint: disable=import-error
+
+            distribution = distro.linux_distribution()
             if len(distribution[0]) > 0:
                 platform_value = "Linux-%s-%s" % (distribution[0], distribution[1])
         except Exception:

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -20,6 +20,7 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
+import platform
 import re
 
 if False:  # NOSONAR
@@ -38,6 +39,7 @@ import locale
 import collections
 import subprocess
 import signal
+import importlib.util
 from io import open
 
 if sys.version_info < (3, 5):
@@ -65,10 +67,7 @@ import time
 import uuid
 import multiprocessing.managers
 
-try:
-    from __scalyr__ import SCALYR_VERSION
-except ImportError:
-    from scalyr_agent.__scalyr__ import SCALYR_VERSION
+from scalyr_agent import __scalyr__
 
 import scalyr_agent.json_lib as json_lib
 from scalyr_agent.json_lib import JsonParseException
@@ -363,27 +362,26 @@ def set_json_lib(lib_name):
     _json_lib, _json_encode, _json_decode = get_json_implementation(lib_name)
 
 
-# Set default json library we will use. We start with the most efficient and falling back to less
-# efficient library as a fallback.
-# We default to orjson under Python 3 (if available), since it's substantially faster than ujson for
-# encoding
-if six.PY3:
-    JSON_LIBS_TO_USE = ["orjson", "ujson", "json"]
-else:
-    JSON_LIBS_TO_USE = ["ujson", "json"]
+def _determine_json_lib() -> str:
+    """
+    Determines default json library to use. We start with the most efficient and falling back to less
+    efficient library as a fallback.
+    """
+    json_libs_to_use = ["orjson", "ujson", "json"]
 
+    for json_lib_name in json_libs_to_use:
+        # if module is available, then the result of the function has to be not None.
+        json_spec = importlib.util.find_spec(json_lib_name)
+        if json_spec is not None:
+            return json_lib_name
+
+
+# Set default json library we will use.
 last_error = None
-for json_lib_to_use in JSON_LIBS_TO_USE:
-    try:
-        set_json_lib(json_lib_to_use)
-    except ImportError as e:
-        last_error = e
-    else:
-        last_error = None
-        break
 
-# Note, we cannot use a logger here because of dependency issues with this file and scalyr_logging.py
-if last_error:
+_json_lib_to_use = _determine_json_lib()
+
+if _json_lib_to_use is None:
     # Note, we cannot use a logger here because of dependency issues with this file and scalyr_logging.py
     print(
         "No default json library found which should be present in all Python >= 2.6. "
@@ -391,6 +389,18 @@ if last_error:
         file=sys.stderr,
     )
     sys.exit(1)
+
+try:
+    set_json_lib(_json_lib_to_use)
+except ImportError as e:
+    # Note, we cannot use a logger here because of dependency issues with this file and scalyr_logging.py
+    print(
+        "The json library '{}' is found but can not be imported. Error: ".format(
+            _json_lib_to_use
+        ),
+        file=sys.stderr,
+    )
+    exit(1)
 
 
 def get_json_lib():
@@ -2196,9 +2206,10 @@ def get_agent_start_up_message():
         used_locale,
     ) = get_language_code_coding_and_locale()
 
-    msg = "Starting scalyr agent... (version=%s) (revision=%s) %s (Python version: %s) " "(OpenSSL version: %s) (default fs encoding: %s) (locale: %s) (LANG env variable: %s)" % (
-        SCALYR_VERSION,
+    msg = "Starting scalyr agent... (version=%s) (revision=%s) (arch=%s) %s (Python version: %s)" "(OpenSSL version: %s) (default fs encoding: %s) (locale: %s) (LANG env variable: %s)" % (
+        __scalyr__.SCALYR_VERSION,
         build_revision,
+        platform.processor(),
         get_pid_tid(),
         python_version_str,
         openssl_version,

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -279,13 +279,17 @@ def get_json_implementation(lib_name):
 
             def dump():
                 if fp is not None:
-                    return orjson.dump(obj, fp, default=default)
+                    return orjson.dump(  # pylint: disable=no-member
+                        obj, fp, default=default
+                    )
                 else:
-                    return orjson.dumps(obj, default=default)
+                    return orjson.dumps(  # pylint: disable=no-member
+                        obj, default=default
+                    )
 
             try:
                 return dump()
-            except orjson.JSONEncodeError as e:
+            except orjson.JSONEncodeError as e:  # pylint: disable=no-member
                 # if there is an integer size error, fall back to native json
                 if str(e) == "Integer exceeds 64-bit range":
                     _, _json_dumps, _ = get_json_implementation("json")
@@ -300,7 +304,7 @@ def get_json_implementation(lib_name):
 
         def orjson_loads_custom(data, *args, **kwargs):
             try:
-                return orjson.loads(data, *args, **kwargs)
+                return orjson.loads(data, *args, **kwargs)  # pylint: disable=no-member
             except Exception as e:
                 if "leading surrogate" in str(e) or "surrogates not allowed" in str(e):
                     _, _, _json_loads = get_json_implementation("json")
@@ -392,7 +396,7 @@ if _json_lib_to_use is None:
 
 try:
     set_json_lib(_json_lib_to_use)
-except ImportError as e:
+except ImportError:
     # Note, we cannot use a logger here because of dependency issues with this file and scalyr_logging.py
     print(
         "The json library '{}' is found but can not be imported. Error: ".format(

--- a/scripts/generate-docs-for-all-monitors.sh
+++ b/scripts/generate-docs-for-all-monitors.sh
@@ -69,7 +69,7 @@ for FILE in ${MONITOR_FILES[@]}; do
         continue
     fi
 
-    AUTO_GENERATED_CONTENT=$(python "${SCRIPT_DIR}/print_monitor_doc.py" "${MONITOR_MODULE}" --no-warning --include-sections='description,configuration_reference,log_reference,metrics')
+    AUTO_GENERATED_CONTENT=$(python3 "${SCRIPT_DIR}/print_monitor_doc.py" "${MONITOR_MODULE}" --no-warning --include-sections='description,configuration_reference,log_reference,metrics')
     CONTENT_WITHOUT_AUTO_GENERATED_PART=$(perl -0777 -p -e 's/(.*'"${AUTO_GENERATED_SECTION_MARKER}"').*/$1/s' "${DOC_FILE}")
     NEW_CONTENT=$(echo -e "${CONTENT_WITHOUT_AUTO_GENERATED_PART}\n\n${AUTO_GENERATED_CONTENT}")
     echo -e "${NEW_CONTENT}" > "${DOC_FILE}"

--- a/scripts/print_monitor_doc.py
+++ b/scripts/print_monitor_doc.py
@@ -33,17 +33,7 @@ import sys
 
 from optparse import OptionParser
 
-from scalyr_agent.__scalyr__ import scalyr_init
-
-scalyr_init()
-
-# [start of 2->TODO]
-# Check for suitability.
-# Important. Import six as any other dependency from "third_party" libraries after "__scalyr__.scalyr_init"
 import six
-from six.moves import range
-
-# [end of 2->TOD0]
 
 from scalyr_agent.monitors_manager import load_monitor_class
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -21,7 +21,6 @@ if False:  # NOSONAR
     from typing import Union
     from typing import Tuple
 
-import platform
 import subprocess
 
 import six
@@ -72,7 +71,12 @@ def _is_ubuntu_14_04():
     """
     Return True if we are running on Ubuntu 14.04.
     """
-    distro = platform.linux_distribution()
+    try:
+        import distro
+    except ImportError:
+        return False
+
+    distro = distro.linux_distribution()
 
     return distro[0].lower() == "ubuntu" and distro[1] == "14.04"
 

--- a/tests/distribution/basic_sanity_deb.py
+++ b/tests/distribution/basic_sanity_deb.py
@@ -25,10 +25,10 @@ import time
 
 import pytest
 
+from scalyr_agent import __scalyr__
 from tests.common import install_deb
 from tests.utils.dockerized import dockerized_case
 from tests.utils.agent_runner import AgentRunner
-from tests.utils.agent_runner import PACKAGE_INSTALL
 from tests.image_builder.distributions.ubuntu1804 import UbuntuBuilder
 
 
@@ -38,7 +38,7 @@ from tests.image_builder.distributions.ubuntu1804 import UbuntuBuilder
     __file__,
 )
 def test_default_compression_algorithm(request):
-    runner = AgentRunner(PACKAGE_INSTALL, send_to_server=False)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL, send_to_server=False)
 
     # deflate is the default
     install_deb()

--- a/tests/distribution/basic_sanity_rpm.py
+++ b/tests/distribution/basic_sanity_rpm.py
@@ -25,10 +25,10 @@ import time
 
 import pytest
 
+from scalyr_agent import __scalyr__
 from tests.common import install_rpm
 from tests.utils.dockerized import dockerized_case
 from tests.utils.agent_runner import AgentRunner
-from tests.utils.agent_runner import PACKAGE_INSTALL
 from tests.image_builder.distributions.amazonlinux2 import AmazonlinuxBuilder
 
 
@@ -38,7 +38,7 @@ from tests.image_builder.distributions.amazonlinux2 import AmazonlinuxBuilder
     __file__,
 )
 def test_default_compression_algorithm(request):
-    runner = AgentRunner(PACKAGE_INSTALL, send_to_server=False)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL, send_to_server=False)
 
     # deflate is the default
     install_rpm()

--- a/tests/distribution/python_version_change_tests/amazonlinux2_test.py
+++ b/tests/distribution/python_version_change_tests/amazonlinux2_test.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import pytest
 
+from scalyr_agent import __scalyr__
 from tests.image_builder.distributions.amazonlinux2 import AmazonlinuxBuilder
 
 from tests.utils.dockerized import dockerized_case
@@ -35,13 +36,13 @@ from tests.distribution.python_version_change_tests.common import (
 )
 from tests.common import install_rpm, install_next_version_rpm, remove_rpm
 
-from tests.utils.agent_runner import AgentRunner, PACKAGE_INSTALL
+from tests.utils.agent_runner import AgentRunner
 
 
 @pytest.mark.usefixtures("agent_environment")
 @dockerized_case(AmazonlinuxBuilder, __file__, file_paths_to_copy=["/scalyr-agent.rpm"])
 def test_amazonlinux_test_versions(request):
-    runner = AgentRunner(PACKAGE_INSTALL)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL)
     common_version_test(
         runner,
         install_rpm,

--- a/tests/distribution/python_version_change_tests/centos7/centos7_with_py3_test.py
+++ b/tests/distribution/python_version_change_tests/centos7/centos7_with_py3_test.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import pytest
 
+from scalyr_agent import __scalyr__
 from tests.image_builder.distributions.centos7 import CentOSBuilder
 
 from tests.utils.dockerized import dockerized_case
@@ -34,13 +35,13 @@ from tests.distribution.python_version_change_tests.common import (
     common_version_test,
 )
 from tests.common import install_rpm, install_next_version_rpm, remove_rpm
-from tests.utils.agent_runner import AgentRunner, PACKAGE_INSTALL
+from tests.utils.agent_runner import AgentRunner
 
 
 @pytest.mark.usefixtures("agent_environment")
 @dockerized_case(CentOSBuilder, __file__)
 def test_centos_test_versions(request):
-    runner = AgentRunner(PACKAGE_INSTALL)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL)
     common_version_test(
         runner,
         install_rpm,

--- a/tests/distribution/python_version_change_tests/centos8_test.py
+++ b/tests/distribution/python_version_change_tests/centos8_test.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import pytest
 
+from scalyr_agent import __scalyr__
 from tests.image_builder.distributions.centos8 import CentOSBuilder
 
 from tests.utils.dockerized import dockerized_case
@@ -34,13 +35,13 @@ from tests.distribution.python_version_change_tests.common import (
     common_version_test,
 )
 from tests.common import install_rpm, install_next_version_rpm, remove_rpm
-from tests.utils.agent_runner import AgentRunner, PACKAGE_INSTALL
+from tests.utils.agent_runner import AgentRunner
 
 
 @pytest.mark.usefixtures("agent_environment")
 @dockerized_case(CentOSBuilder, __file__, file_paths_to_copy=["/scalyr-agent.rpm"])
 def test_centos_test_versions(request):
-    runner = AgentRunner(PACKAGE_INSTALL)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL)
     common_version_test(
         runner,
         install_rpm,

--- a/tests/distribution/python_version_change_tests/common.py
+++ b/tests/distribution/python_version_change_tests/common.py
@@ -30,9 +30,10 @@ import pytest
 
 from scalyr_agent import compat
 
+from scalyr_agent import __scalyr__
 from tests.utils.compat import Path
 from tests.utils.common import get_shebang_from_file
-from tests.utils.agent_runner import AgentRunner, PACKAGE_INSTALL
+from tests.utils.agent_runner import AgentRunner
 from tests.common import PackageInstallationError
 from tests.common import install_deb, remove_deb
 
@@ -128,7 +129,7 @@ def _mock_binaries(python, python2, python3):
 
 
 def common_test_ubuntu_versions():
-    runner = AgentRunner(PACKAGE_INSTALL)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL)
     common_version_test(
         runner,
         install_deb,
@@ -244,7 +245,7 @@ def common_test_only_python_mapped_to_python2(
     # 'scalyr-agent-2-config' command must be a symlink to config_main.py
     assert _get_current_config_script_name() == "config_main.py"
 
-    runner = AgentRunner(PACKAGE_INSTALL)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL)
     runner.start()
     time.sleep(1)
 
@@ -280,7 +281,7 @@ def common_test_only_python_mapped_to_python3(
     # 'scalyr-agent-2-config' command must be a symlink to config_main.py
     assert _get_current_config_script_name() == "config_main.py"
 
-    runner = AgentRunner(PACKAGE_INSTALL)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL)
     runner.start()
     time.sleep(1)
 
@@ -321,7 +322,7 @@ def common_test_python2(install_package_fn, install_next_version_fn):
     # 'scalyr-agent-2-config' command must be a symlink to config_main_py2.py
     assert _get_current_config_script_name() == "config_main_py2.py"
 
-    runner = AgentRunner(PACKAGE_INSTALL)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL)
     runner.start()
 
     time.sleep(1)
@@ -361,7 +362,7 @@ def common_test_python3(install_package_fn, install_next_version_fn):
     # 'scalyr-agent-2-config' command must be a symlink to config_main_py3.py
     assert _get_current_config_script_name() == "config_main_py3.py"
 
-    runner = AgentRunner(PACKAGE_INSTALL)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL)
 
     runner.start()
     time.sleep(1)
@@ -394,7 +395,7 @@ def common_test_switch_default_to_python2(install_package_fn, install_next_versi
 
     assert _get_current_config_script_name() == "config_main.py"
 
-    runner = AgentRunner(PACKAGE_INSTALL)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL)
     runner.start()
     time.sleep(1)
 
@@ -442,7 +443,7 @@ def common_test_switch_default_to_python3(install_package_fn, install_next_versi
 
     assert _get_current_config_script_name() == "config_main.py"
 
-    runner = AgentRunner(PACKAGE_INSTALL)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL)
     runner.start()
     time.sleep(1)
 
@@ -485,7 +486,7 @@ def common_test_switch_command_works_without_agent_config(install_package_fn):
     """
     install_package_fn()
 
-    runner = AgentRunner(PACKAGE_INSTALL)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL)
 
     # Make sure the config is not present
     agent_config_path = "/etc/scalyr-agent-2/agent.json"
@@ -585,7 +586,7 @@ def common_test_switch_python2_to_python3(install_package_fn, install_next_versi
     install_package_fn()
     assert _get_current_config_script_name() == "config_main_py2.py"
 
-    runner = AgentRunner(PACKAGE_INSTALL)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL)
     runner.start()
     time.sleep(1)
 

--- a/tests/distribution/python_version_change_tests/ubuntu1404/ubuntu1404_test.py
+++ b/tests/distribution/python_version_change_tests/ubuntu1404/ubuntu1404_test.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import pytest
 
+from scalyr_agent import __scalyr__
 from tests.image_builder.distributions.ubuntu1404 import UbuntuBuilder
 
 from tests.utils.dockerized import dockerized_case
@@ -30,13 +31,13 @@ from tests.distribution.python_version_change_tests.common import (
     common_version_test,
 )
 from tests.common import install_deb, install_next_version_deb, remove_deb
-from tests.utils.agent_runner import PACKAGE_INSTALL, AgentRunner
+from tests.utils.agent_runner import AgentRunner
 
 
 @pytest.mark.usefixtures("agent_environment")
 @dockerized_case(UbuntuBuilder, __file__, python_executable="python_for_tests")
 def test_ubuntu_test_versions(request):
-    runner = AgentRunner(PACKAGE_INSTALL)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL)
     common_version_test(
         runner,
         install_deb,

--- a/tests/distribution/python_version_change_tests/ubuntu1604/ubuntu1604_test.py
+++ b/tests/distribution/python_version_change_tests/ubuntu1604/ubuntu1604_test.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import pytest
 
+from scalyr_agent import __scalyr__
 from tests.image_builder.distributions.ubuntu1604 import UbuntuBuilder
 
 from tests.utils.dockerized import dockerized_case
@@ -29,13 +30,13 @@ from tests.distribution.python_version_change_tests.common import (
     common_version_test,
 )
 from tests.common import install_deb, install_next_version_deb, remove_deb
-from tests.utils.agent_runner import PACKAGE_INSTALL, AgentRunner
+from tests.utils.agent_runner import AgentRunner
 
 
 @pytest.mark.usefixtures("agent_environment")
 @dockerized_case(UbuntuBuilder, __file__, python_executable="python_for_tests")
 def test_ubuntu_test_versions(request):
-    runner = AgentRunner(PACKAGE_INSTALL)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL)
     common_version_test(
         runner,
         install_deb,

--- a/tests/distribution/python_version_change_tests/ubuntu1804/ubuntu1804_test.py
+++ b/tests/distribution/python_version_change_tests/ubuntu1804/ubuntu1804_test.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import pytest
 
+from scalyr_agent import __scalyr__
 from tests.image_builder.distributions.ubuntu1804 import UbuntuBuilder
 
 from tests.utils.dockerized import dockerized_case
@@ -29,7 +30,7 @@ from tests.distribution.python_version_change_tests.common import (
     common_version_test,
 )
 from tests.common import install_deb, install_next_version_deb, remove_deb
-from tests.utils.agent_runner import PACKAGE_INSTALL, AgentRunner
+from tests.utils.agent_runner import AgentRunner
 
 
 @pytest.mark.usefixtures("agent_environment")
@@ -40,7 +41,7 @@ from tests.utils.agent_runner import PACKAGE_INSTALL, AgentRunner
     file_paths_to_copy=["/scalyr-agent.deb"],
 )
 def test_ubuntu_test_versions(request):
-    runner = AgentRunner(PACKAGE_INSTALL)
+    runner = AgentRunner(__scalyr__.InstallType.PACKAGE_INSTALL)
     common_version_test(
         runner,
         install_deb,

--- a/tests/smoke_tests/common.py
+++ b/tests/smoke_tests/common.py
@@ -20,11 +20,12 @@ import os
 import time
 from io import open
 import json
+import pathlib as pl
 
 import six
 
 from scalyr_agent import compat
-from scalyr_agent.__scalyr__ import DEV_INSTALL, get_package_root
+from scalyr_agent import __scalyr__
 from tests.smoke_tests.verifier import (
     AgentLogVerifier,
     DataJsonVerifier,
@@ -34,6 +35,11 @@ from tests.smoke_tests.verifier import (
     AgentWorkerSessionLogVerifier,
 )
 from tests.utils.agent_runner import AgentRunner
+
+# This has to be a DEV installation so we can use install root as source root
+_SOURCE_ROOT = __scalyr__.get_install_root()
+
+_AGENT_PACKAGE_PATH = pl.Path(_SOURCE_ROOT, "scalyr_agent")
 
 
 def _create_data_json_file(runner, data_json_verifier):
@@ -64,8 +70,8 @@ def _test_standalone_smoke(
     """
     Agent standalone test to run within the same machine.
     """
-    if agent_installation_type == DEV_INSTALL:
-        os.chdir(get_package_root())
+    if agent_installation_type == __scalyr__.InstallType.DEV_INSTALL:
+        os.chdir(_AGENT_PACKAGE_PATH)
 
     print("Agent host name: {0}".format(compat.os_environ_unicode["AGENT_HOST_NAME"]))
 

--- a/tests/smoke_tests/package_test.py
+++ b/tests/smoke_tests/package_test.py
@@ -18,9 +18,8 @@ from __future__ import absolute_import
 
 import pytest
 
+from scalyr_agent import __scalyr__
 from tests.smoke_tests.common import _test_standalone_smoke
-from tests.utils.agent_runner import PACKAGE_INSTALL
-
 from tests.utils.dockerized import dockerized_case
 from tests.image_builder.distributions.amazonlinux2 import AmazonlinuxBuilder
 from tests.image_builder.distributions.ubuntu import UbuntuBuilder

--- a/tests/smoke_tests/package_test.py
+++ b/tests/smoke_tests/package_test.py
@@ -31,7 +31,9 @@ from tests.common import install_rpm, install_deb
 @dockerized_case(AmazonlinuxBuilder, __file__)
 def test_smoke_package_rpm_python2(request):
     install_rpm()
-    _test_standalone_smoke(PACKAGE_INSTALL, python_version="python2")
+    _test_standalone_smoke(
+        __scalyr__.InstallType.PACKAGE_INSTALL, python_version="python2"
+    )
 
 
 @pytest.mark.usefixtures("agent_environment")
@@ -39,7 +41,9 @@ def test_smoke_package_rpm_python2(request):
 @dockerized_case(AmazonlinuxBuilder, __file__)
 def test_smoke_package_rpm_python3(request):
     install_rpm()
-    _test_standalone_smoke(PACKAGE_INSTALL, python_version="python3")
+    _test_standalone_smoke(
+        __scalyr__.InstallType.PACKAGE_INSTALL, python_version="python3"
+    )
 
 
 @pytest.mark.usefixtures("agent_environment")
@@ -47,7 +51,9 @@ def test_smoke_package_rpm_python3(request):
 @dockerized_case(UbuntuBuilder, __file__)
 def test_smoke_package_deb_python2(request):
     install_deb()
-    _test_standalone_smoke(PACKAGE_INSTALL, python_version="python2")
+    _test_standalone_smoke(
+        __scalyr__.InstallType.PACKAGE_INSTALL, python_version="python2"
+    )
 
 
 @pytest.mark.usefixtures("agent_environment")
@@ -55,4 +61,6 @@ def test_smoke_package_deb_python2(request):
 @dockerized_case(UbuntuBuilder, __file__)
 def test_smoke_package_deb_python3(request):
     install_deb()
-    _test_standalone_smoke(PACKAGE_INSTALL, python_version="python3")
+    _test_standalone_smoke(
+        __scalyr__.InstallType.PACKAGE_INSTALL, python_version="python3"
+    )

--- a/tests/smoke_tests/standalone_test/basic_test.py
+++ b/tests/smoke_tests/standalone_test/basic_test.py
@@ -31,7 +31,7 @@ if False:
 import psutil
 import pytest
 
-from scalyr_agent.__scalyr__ import DEV_INSTALL
+from scalyr_agent import __scalyr__
 from tests.utils.agent_runner import AgentRunner
 
 
@@ -126,7 +126,7 @@ def _check_workers_gracefull_stop(runner, worker_pids, occurrences=1):
 @pytest.mark.timeout(300)
 def test_standalone_agent_kill():
     runner = AgentRunner(
-        DEV_INSTALL,
+        __scalyr__.InstallType.DEV_INSTALL,
         enable_debug_log=True,
         workers_type="process",
         workers_session_count=2,
@@ -177,7 +177,7 @@ def test_standalone_agent_kill():
 @pytest.mark.timeout(300)
 def test_standalone_agent_stop():
     runner = AgentRunner(
-        DEV_INSTALL,
+        __scalyr__.InstallType.DEV_INSTALL,
         enable_debug_log=True,
         workers_type="process",
         workers_session_count=2,
@@ -200,7 +200,7 @@ def test_standalone_agent_stop():
 @pytest.mark.timeout(300)
 def test_standalone_agent_restart():
     runner = AgentRunner(
-        DEV_INSTALL,
+        __scalyr__.InstallType.DEV_INSTALL,
         enable_debug_log=True,
         workers_type="process",
         workers_session_count=2,
@@ -248,7 +248,7 @@ def test_standalone_agent_restart():
 @pytest.mark.timeout(300)
 def test_standalone_agent_config_reload():
     runner = AgentRunner(
-        DEV_INSTALL,
+        __scalyr__.InstallType.DEV_INSTALL,
         enable_debug_log=True,
         workers_type="process",
         workers_session_count=2,

--- a/tests/smoke_tests/standalone_test/smoke_test.py
+++ b/tests/smoke_tests/standalone_test/smoke_test.py
@@ -21,14 +21,14 @@ import sys
 
 import pytest
 
-from scalyr_agent.__scalyr__ import DEV_INSTALL
+from scalyr_agent import __scalyr__
 from tests.smoke_tests.common import _test_standalone_smoke
 
 
 @pytest.mark.usefixtures("agent_environment")
 @pytest.mark.timeout(300)
 def test_standalone_smoke():
-    _test_standalone_smoke(DEV_INSTALL)
+    _test_standalone_smoke(__scalyr__.InstallType.DEV_INSTALL)
 
 
 @pytest.mark.skipif(
@@ -38,5 +38,5 @@ def test_standalone_smoke():
 @pytest.mark.timeout(300)
 def test_standalone_smoke_with_process_workers():
     _test_standalone_smoke(
-        DEV_INSTALL, workers_type="process", workers_sessions_count=2
+        __scalyr__.InstallType.DEV_INSTALL, workers_type="process", workers_sessions_count=2
     )

--- a/tests/smoke_tests/standalone_test/smoke_test.py
+++ b/tests/smoke_tests/standalone_test/smoke_test.py
@@ -38,5 +38,7 @@ def test_standalone_smoke():
 @pytest.mark.timeout(300)
 def test_standalone_smoke_with_process_workers():
     _test_standalone_smoke(
-        __scalyr__.InstallType.DEV_INSTALL, workers_type="process", workers_sessions_count=2
+        __scalyr__.InstallType.DEV_INSTALL,
+        workers_type="process",
+        workers_sessions_count=2,
     )

--- a/tests/smoke_tests/standalone_test_rate_limited.py
+++ b/tests/smoke_tests/standalone_test_rate_limited.py
@@ -19,11 +19,11 @@ from __future__ import absolute_import
 
 import pytest
 
-from scalyr_agent.__scalyr__ import DEV_INSTALL
+from scalyr_agent import __scalyr__
 from tests.smoke_tests.common import _test_standalone_smoke
 
 
 @pytest.mark.usefixtures("agent_environment")
 @pytest.mark.timeout(300)
 def test_standalone_smoke():
-    _test_standalone_smoke(DEV_INSTALL, rate_limited=True)
+    _test_standalone_smoke(__scalyr__.InstallType.DEV_INSTALL, rate_limited=True)

--- a/tests/unit/__scalyr__test.py
+++ b/tests/unit/__scalyr__test.py
@@ -22,7 +22,7 @@ __author__ = "czerwin@scalyr.com"
 
 import os
 
-from scalyr_agent.__scalyr__ import get_install_root, get_package_root, SCALYR_VERSION
+from scalyr_agent.__scalyr__ import get_install_root, SCALYR_VERSION
 from scalyr_agent.test_base import ScalyrTestCase
 
 
@@ -32,6 +32,3 @@ class TestUtil(ScalyrTestCase):
 
     def test_get_install_root(self):
         self.assertEquals(os.path.basename(get_install_root()), "scalyr-agent-2")
-
-    def test_get_package_root(self):
-        self.assertEquals(os.path.basename(get_package_root()), "scalyr_agent")

--- a/tests/unit/agent_main_test.py
+++ b/tests/unit/agent_main_test.py
@@ -23,6 +23,7 @@ import tempfile
 import json
 
 import mock
+import pytest
 
 from scalyr_agent import __scalyr__
 from scalyr_agent.test_base import BaseScalyrLogCaptureTestCase
@@ -45,7 +46,13 @@ CORRECT_INIT_PRAGMA = """
 
 
 class AgentMainTestCase(BaseScalyrLogCaptureTestCase):
-    @mock.patch("scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.PACKAGE_INSTALL)
+    @pytest.mark.skipif(
+        __scalyr__.PLATFORM_TYPE != __scalyr__.PlatformType.POSIX,
+        reason="Both ca and intermediate cert files are checked only on Unix"
+    )
+    @mock.patch(
+        "scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.InstallType.PACKAGE_INSTALL
+    )
     def test_create_client_ca_file_and_intermediate_certs_file_doesnt_exist(self):
         from scalyr_agent.agent_main import ScalyrAgent
         from scalyr_agent.platform_controller import PlatformController
@@ -105,7 +112,9 @@ class AgentMainTestCase(BaseScalyrLogCaptureTestCase):
         from scalyr_agent.platform_controller import PlatformController
 
         # 1. Dev install (boths checks should be skipped)
-        with mock.patch("scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.DEV_INSTALL):
+        with mock.patch(
+            "scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.InstallType.DEV_INSTALL
+        ):
 
             # ca_cert_path file doesn't exist
             config = mock.Mock()
@@ -128,9 +137,15 @@ class AgentMainTestCase(BaseScalyrLogCaptureTestCase):
 
             self.assertTrue(create_client(config=config))
 
-        # 2. MSI install (only intermediate_certs_path check should be skipped)
-        with mock.patch("scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.MSI_INSTALL):
-
+        # 2. MSI(Windows) install (only intermediate_certs_path check should be skipped)
+        with mock.patch(
+            "scalyr_agent.__scalyr__.INSTALL_TYPE",
+            __scalyr__.InstallType.PACKAGE_INSTALL,
+        ), mock.patch(
+            # Monkeypatch the platform to Windows to fool the test.
+            "scalyr_agent.__scalyr__.PLATFORM_TYPE",
+            __scalyr__.PlatformType.WINDOWS,
+        ):
             config = mock.Mock()
             config.scalyr_server = "foo.bar.com"
             config.compression_level = 1
@@ -183,7 +198,9 @@ class AgentMainTestCase(BaseScalyrLogCaptureTestCase):
         from scalyr_agent.agent_main import ScalyrAgent
         from scalyr_agent.platform_controller import PlatformController
 
-        with mock.patch("scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.DEV_INSTALL):
+        with mock.patch(
+            "scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.InstallType.DEV_INSTALL
+        ):
 
             config = mock.Mock()
             config.scalyr_server = "foo.bar.com"
@@ -236,7 +253,7 @@ class AgentMainTestCase(BaseScalyrLogCaptureTestCase):
         from scalyr_agent.agent_main import ScalyrAgent
         from scalyr_agent.platform_controller import PlatformController
 
-        with mock.patch("scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.DEV_INSTALL):
+        with mock.patch("scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.InstallType.DEV_INSTALL):
             config = mock.Mock()
             config.scalyr_server = "foo.bar.com"
             config.server_attributes = {"serverHost": "test"}
@@ -285,7 +302,7 @@ class AgentMainTestCase(BaseScalyrLogCaptureTestCase):
         from scalyr_agent.agent_main import ScalyrAgent
         from scalyr_agent.platform_controller import PlatformController
 
-        with mock.patch("scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.DEV_INSTALL):
+        with mock.patch("scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.InstallType.DEV_INSTALL):
             config = mock.Mock()
             config.scalyr_server = "foo.bar.com"
             config.server_attributes = {"serverHost": "test"}

--- a/tests/unit/agent_main_test.py
+++ b/tests/unit/agent_main_test.py
@@ -48,7 +48,7 @@ CORRECT_INIT_PRAGMA = """
 class AgentMainTestCase(BaseScalyrLogCaptureTestCase):
     @pytest.mark.skipif(
         __scalyr__.PLATFORM_TYPE != __scalyr__.PlatformType.POSIX,
-        reason="Both ca and intermediate cert files are checked only on Unix"
+        reason="Both ca and intermediate cert files are checked only on Unix",
     )
     @mock.patch(
         "scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.InstallType.PACKAGE_INSTALL
@@ -253,7 +253,9 @@ class AgentMainTestCase(BaseScalyrLogCaptureTestCase):
         from scalyr_agent.agent_main import ScalyrAgent
         from scalyr_agent.platform_controller import PlatformController
 
-        with mock.patch("scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.InstallType.DEV_INSTALL):
+        with mock.patch(
+            "scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.InstallType.DEV_INSTALL
+        ):
             config = mock.Mock()
             config.scalyr_server = "foo.bar.com"
             config.server_attributes = {"serverHost": "test"}
@@ -302,7 +304,9 @@ class AgentMainTestCase(BaseScalyrLogCaptureTestCase):
         from scalyr_agent.agent_main import ScalyrAgent
         from scalyr_agent.platform_controller import PlatformController
 
-        with mock.patch("scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.InstallType.DEV_INSTALL):
+        with mock.patch(
+            "scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.InstallType.DEV_INSTALL
+        ):
             config = mock.Mock()
             config.scalyr_server = "foo.bar.com"
             config.server_attributes = {"serverHost": "test"}

--- a/tests/unit/builtin_monitors/kubernetes_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_monitor_test.py
@@ -27,6 +27,9 @@ from collections import OrderedDict
 
 import sys
 
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+from six import StringIO
+
 from scalyr_agent import AgentLogger
 from scalyr_agent.monitor_utils.k8s import (
     KubeletApi,
@@ -35,10 +38,6 @@ from scalyr_agent.monitor_utils.k8s import (
     K8sNamespaceFilter,
     PodInfo,
 )
-from scalyr_agent.third_party.requests.packages.urllib3.exceptions import (
-    InsecureRequestWarning,
-)
-from scalyr_agent.third_party.six import StringIO
 
 __author__ = "echee@scalyr.com"
 

--- a/tests/unit/builtin_monitors/kubernetes_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_monitor_test.py
@@ -27,7 +27,9 @@ from collections import OrderedDict
 
 import sys
 
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
+from requests.packages.urllib3.exceptions import (  # pylint: disable=import-error
+    InsecureRequestWarning,
+)
 from six import StringIO
 
 from scalyr_agent import AgentLogger

--- a/tests/unit/builtin_monitors/linux_process_metrics_test.py
+++ b/tests/unit/builtin_monitors/linux_process_metrics_test.py
@@ -16,7 +16,6 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 import os
-import sys
 import platform
 
 import mock
@@ -72,7 +71,8 @@ class LinuxProcessMetricsMonitorTest(ScalyrTestCase):
         monitor_config = {
             "module": "linux_process_metrics",
             "id": "my-id",
-            "commandline": ".*%s.*" % (" ".join(sys.argv)),
+            # just put the cmdline property of the current process, so the monitor will have to find it.
+            "commandline": ".*%s.*" % (" ".join(psutil.Process(os.getpid()).cmdline())),
         }
         mock_logger = mock.Mock()
         monitor = ProcessMonitor(monitor_config, mock_logger)

--- a/tests/unit/builtin_monitors/test_tcollectors.py
+++ b/tests/unit/builtin_monitors/test_tcollectors.py
@@ -20,12 +20,10 @@ import platform
 
 import mock
 
-from scalyr_agent.__scalyr__ import scalyr_init
-
-scalyr_init()
-
 if platform.system() != "Windows":
-    from tcollector import tcollector  # pylint: disable=import-error
+    from scalyr_agent.third_party.tcollector import (
+        tcollector,
+    )  # pylint: disable=import-error
 else:
     tcollector = None  # type: ignore
 
@@ -34,8 +32,10 @@ from scalyr_agent.test_base import skipIf
 
 class TcollectorCollectorsTestCase(unittest.TestCase):
     @skipIf(platform.system() == "Windows", "Skipping Linux platform tests on Windows")
-    @mock.patch("tcollector.tcollector.set_nonblocking", mock.Mock())
-    @mock.patch("tcollector.tcollector.subprocess.Popen")
+    @mock.patch(
+        "scalyr_agent.third_party.tcollector.tcollector.set_nonblocking", mock.Mock()
+    )
+    @mock.patch("scalyr_agent.third_party.tcollector.tcollector.subprocess.Popen")
     def test_correct_python_binary_is_used_for_subprocess(self, mock_popen):
         col = mock.Mock()
         col.name = "foo"

--- a/tests/unit/connection_test.py
+++ b/tests/unit/connection_test.py
@@ -97,7 +97,10 @@ class ScalyrNativeHttpConnectionTestCase(ScalyrTestCase):
             socket.create_connection = ORIGINAL_SOCKET_CREATE_CONNECTION
 
     # TODO: Find out why desired certificate error does not occur on Mac and enable this test.
-    @pytest.mark.skipif(platform.system() == "Darwin", reason="Request still successful on Mac even with invalid cert.")
+    @pytest.mark.skipif(
+        platform.system() == "Darwin",
+        reason="Request still successful on Mac even with invalid cert.",
+    )
     def test_connect_invalid_cert_failure(self):
         if PY26:
             # Under Python 2.6, error looks like this:
@@ -186,7 +189,10 @@ class ScalyrRequestsHttpConnectionTestCase(ScalyrTestCase):
             socket.getaddrinfo = ORIGINAL_SOCKET_CREATE_CONNECTION
 
     # TODO: Find out why desired certificate error does not occur on Mac and enable this test.
-    @pytest.mark.skipif(platform.system() == "Darwin", reason="Request still successful on Mac even with invalid cert.")
+    @pytest.mark.skipif(
+        platform.system() == "Darwin",
+        reason="Request still successful on Mac even with invalid cert.",
+    )
     def test_connect_invalid_cert_failure(self):
         if requests.__version__ < "2.26.0":
             if PY26:

--- a/tests/unit/copying_manager_tests/copying_manager_new_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_new_test.py
@@ -35,6 +35,7 @@ except ImportError:
 import pytest
 
 from scalyr_agent import scalyr_logging
+from scalyr_agent import __scalyr__
 
 from tests.unit.copying_manager_tests.common import (
     CopyingManagerCommonTest,
@@ -67,8 +68,10 @@ def pytest_generate_tests(metafunc):
     """
     if "worker_type" in metafunc.fixturenames:
         test_params = [["thread", 1, 1], ["thread", 2, 2]]
-        # if the OS is not Windows and python version > 2.7 then also do the multiprocess workers testing.
-        if platform.system() != "Windows" and sys.version_info >= (2, 7):
+        # if the OS is not Linux and python version > 2.7 then also do the multiprocess workers testing.
+        # Windows and Mac systems can not work with multiprocess workers since their process method is 'spawn'
+        # and the copying manager relies on 'fork'
+        if __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.LINUX and sys.version_info >= (2, 7):
             test_params.extend([["process", 1, 1], ["process", 2, 2]])
 
         metafunc.parametrize(

--- a/tests/unit/copying_manager_tests/copying_manager_new_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_new_test.py
@@ -19,7 +19,6 @@ from __future__ import absolute_import
 
 import time
 import os
-import platform
 import sys
 
 

--- a/tests/unit/copying_manager_tests/copying_manager_new_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_new_test.py
@@ -71,7 +71,10 @@ def pytest_generate_tests(metafunc):
         # if the OS is not Linux and python version > 2.7 then also do the multiprocess workers testing.
         # Windows and Mac systems can not work with multiprocess workers since their process method is 'spawn'
         # and the copying manager relies on 'fork'
-        if __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.LINUX and sys.version_info >= (2, 7):
+        if (
+            __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.LINUX
+            and sys.version_info >= (2, 7)
+        ):
             test_params.extend([["process", 1, 1], ["process", 2, 2]])
 
         metafunc.parametrize(

--- a/tests/unit/copying_manager_tests/copying_manager_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_test.py
@@ -43,10 +43,8 @@ formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(messag
 ch.setFormatter(formatter)
 root.addHandler(ch)
 
-from scalyr_agent import scalyr_init
 from scalyr_agent import util as scalyr_util
-
-scalyr_init()
+from scalyr_agent import __scalyr__
 
 from scalyr_agent import scalyr_logging
 from tests.unit.copying_manager_tests.copying_manager_new_test import CopyingManagerTest
@@ -64,8 +62,10 @@ def pytest_generate_tests(metafunc):
     """
     if "worker_type" in metafunc.fixturenames:
         test_params = [["thread", 1, 1], ["thread", 2, 2]]
-        # if the OS is not Windows and python version > 2.7 then also do the multiprocess workers testing.
-        if platform.system() != "Windows" and sys.version_info >= (2, 7):
+        # if the OS is not Linux and python version > 2.7 then also do the multiprocess workers testing.
+        # Windows and Mac systems can not work with multiprocess workers since their process method is 'spawn'
+        # and the copying manager relies on 'fork'
+        if __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.LINUX and sys.version_info >= (2, 7):
             test_params.extend([["process", 1, 1], ["process", 2, 2]])
 
         metafunc.parametrize(

--- a/tests/unit/copying_manager_tests/copying_manager_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_test.py
@@ -28,7 +28,6 @@ __author__ = "czerwin@scalyr.com"
 
 import sys
 import logging
-import platform
 import os
 import re
 

--- a/tests/unit/copying_manager_tests/copying_manager_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_test.py
@@ -65,7 +65,10 @@ def pytest_generate_tests(metafunc):
         # if the OS is not Linux and python version > 2.7 then also do the multiprocess workers testing.
         # Windows and Mac systems can not work with multiprocess workers since their process method is 'spawn'
         # and the copying manager relies on 'fork'
-        if __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.LINUX and sys.version_info >= (2, 7):
+        if (
+            __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.LINUX
+            and sys.version_info >= (2, 7)
+        ):
             test_params.extend([["process", 1, 1], ["process", 2, 2]])
 
         metafunc.parametrize(

--- a/tests/unit/copying_manager_tests/copying_manager_worker_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_worker_test.py
@@ -30,6 +30,7 @@ if False:
 
 import pytest
 
+from scalyr_agent import __scalyr__
 from scalyr_agent.test_base import skipIf
 from tests.unit.copying_manager_tests.common import (
     TestableCopyingManagerWorkerSession,
@@ -60,8 +61,10 @@ log.setLevel(scalyr_logging.DEBUG_LEVEL_5)
 def pytest_generate_tests(metafunc):
     if "worker_type" in metafunc.fixturenames:
         test_params = ["thread"]
-        # if the OS is not Windows and python version > 2.7 then also do the multiprocess workers testing.
-        if platform.system() != "Windows" and sys.version_info >= (2, 7):
+        # if the OS is not Linux and python version > 2.7 then also do the multiprocess workers testing.
+        # Windows and Mac systems can not work with multiprocess workers since their process method is 'spawn'
+        # and the copying manager relies on 'fork'
+        if __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.LINUX and sys.version_info >= (2, 7):
             test_params.append("process")
 
         metafunc.parametrize("worker_type", test_params)

--- a/tests/unit/copying_manager_tests/copying_manager_worker_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_worker_test.py
@@ -64,7 +64,10 @@ def pytest_generate_tests(metafunc):
         # if the OS is not Linux and python version > 2.7 then also do the multiprocess workers testing.
         # Windows and Mac systems can not work with multiprocess workers since their process method is 'spawn'
         # and the copying manager relies on 'fork'
-        if __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.LINUX and sys.version_info >= (2, 7):
+        if (
+            __scalyr__.PLATFORM_TYPE == __scalyr__.PlatformType.LINUX
+            and sys.version_info >= (2, 7)
+        ):
             test_params.append("process")
 
         metafunc.parametrize("worker_type", test_params)

--- a/tests/unit/monitor_utils/k8s_test.py
+++ b/tests/unit/monitor_utils/k8s_test.py
@@ -16,9 +16,12 @@
 # author: Steven Czerwinski <czerwin@scalyr.com>
 from __future__ import unicode_literals
 from __future__ import absolute_import
-import threading
 
 __author__ = "czerwin@scalyr.com"
+
+import threading
+
+import requests
 
 from scalyr_agent.test_base import ScalyrTestCase
 from scalyr_agent.monitor_utils.k8s import DockerMetricFetcher
@@ -35,7 +38,6 @@ from scalyr_agent.monitor_utils.k8s import (
 )
 from scalyr_agent.json_lib import JsonObject
 from scalyr_agent.monitor_utils.blocking_rate_limiter import BlockingRateLimiter
-import scalyr_agent.third_party.requests as requests
 from scalyr_agent.util import FakeClock, md5_hexdigest
 import scalyr_agent.scalyr_logging as scalyr_logging
 from scalyr_agent.configuration import Configuration

--- a/tests/unit/scalyr_client_test.py
+++ b/tests/unit/scalyr_client_test.py
@@ -1038,7 +1038,7 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
 
         user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
         split = user_agent.split(";")
-        self.assertEqual(split[-1], "requests-2.15.1")
+        self.assertEqual(split[-1], "requests-2.26.0")
         self.assertEqual(split[-4], "o-1.0.2-13")
         self.assertTrue(split[1].startswith("python-"))
 

--- a/tests/unit/test_build_info.py
+++ b/tests/unit/test_build_info.py
@@ -19,7 +19,7 @@ import unittest
 
 import mock
 
-from scalyr_agent.__scalyr__ import DEV_INSTALL
+from scalyr_agent import __scalyr__
 from scalyr_agent.build_info import get_build_info
 from scalyr_agent.build_info import get_build_revision
 
@@ -32,8 +32,7 @@ MOCK_BUILD_INFO_PATH = os.path.abspath(
 
 
 class BuildInfoUtilTestCase(unittest.TestCase):
-    @mock.patch("scalyr_agent.build_info.BUILD_INFO_PATH_LINUX", MOCK_BUILD_INFO_PATH)
-    @mock.patch("scalyr_agent.build_info.BUILD_INFO_PATH_WINDOWS", MOCK_BUILD_INFO_PATH)
+    @mock.patch("scalyr_agent.build_info.BUILD_INFO_FILE_PATH", MOCK_BUILD_INFO_PATH)
     def test_get_build_info_success(self):
         build_info = get_build_info()
         self.assertEqual(build_info["packaged_by"], "jenkins@scalyr.com")
@@ -43,22 +42,23 @@ class BuildInfoUtilTestCase(unittest.TestCase):
         self.assertEqual(build_info["from_branch"], "release")
         self.assertEqual(build_info["build_time"], "2020-05-06 17:59:21 UTC")
 
-    @mock.patch("scalyr_agent.build_info.BUILD_INFO_PATH_LINUX", "/tmp/doesnt.exist")
-    @mock.patch("scalyr_agent.build_info.BUILD_INFO_PATH_WINDOWS", "/tmp/doesnt.exist")
+    @mock.patch("scalyr_agent.build_info.BUILD_INFO_FILE_PATH", "/tmp/doesnt.exist")
     def test_get_build_info_build_info_file_doesnt_exist(self):
         build_info = get_build_info()
         self.assertEqual(build_info, {})
 
-    @mock.patch("scalyr_agent.build_info.BUILD_INFO_PATH_LINUX", MOCK_BUILD_INFO_PATH)
-    @mock.patch("scalyr_agent.build_info.BUILD_INFO_PATH_WINDOWS", MOCK_BUILD_INFO_PATH)
-    @mock.patch("scalyr_agent.__scalyr__.INSTALL_TYPE", DEV_INSTALL)
+    @mock.patch("scalyr_agent.build_info.BUILD_INFO_FILE_PATH", MOCK_BUILD_INFO_PATH)
+    @mock.patch(
+        "scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.InstallType.DEV_INSTALL
+    )
     def test_get_build_revision_from_build_info_success(self):
         build_revision = get_build_revision()
         self.assertEqual(build_revision, "7d4c4e2e94242ee25320a75c510d52967cfe50eb")
 
-    @mock.patch("scalyr_agent.build_info.BUILD_INFO_PATH_LINUX", "/tmp/doesnt.exist")
-    @mock.patch("scalyr_agent.build_info.BUILD_INFO_PATH_WINDOWS", "/tmp/doesnt.exist")
-    @mock.patch("scalyr_agent.__scalyr__.INSTALL_TYPE", DEV_INSTALL)
+    @mock.patch("scalyr_agent.build_info.BUILD_INFO_FILE_PATH", "/tmp/doesnt.exist")
+    @mock.patch(
+        "scalyr_agent.__scalyr__.INSTALL_TYPE", __scalyr__.InstallType.DEV_INSTALL
+    )
     @mock.patch("scalyr_agent.build_info.GIT_GET_HEAD_REVISION_CMD", "echo revision")
     def test_get_build_revision_from_git_success(self):
         build_revision = get_build_revision()

--- a/tests/unit/test_util_test.py
+++ b/tests/unit/test_util_test.py
@@ -205,7 +205,7 @@ class MiscUtilsTestCase(ScalyrTestCase):
         self.assertEqual(used_locale, "unable to retrieve locale")
 
     def test_get_agent_start_up_message(self):
-        from scalyr_agent.agent_main import SCALYR_VERSION
+        from scalyr_agent import __scalyr__
 
         msg = scalyr_util.get_agent_start_up_message()
 
@@ -216,7 +216,7 @@ class MiscUtilsTestCase(ScalyrTestCase):
         lang_env_var = compat.os_environ_unicode.get("LANG", "notset")
 
         self.assertTrue("Starting scalyr agent..." in msg)
-        self.assertTrue("version=%s" % (SCALYR_VERSION) in msg)
+        self.assertTrue("version=%s" % (__scalyr__.SCALYR_VERSION) in msg)
         self.assertTrue("Python version: %s" % (python_version_str) in msg)
         self.assertTrue("OpenSSL version: %s" % (openssl_version) in msg)
         self.assertTrue(

--- a/tests/unit/util/json_util_test.py
+++ b/tests/unit/util/json_util_test.py
@@ -87,10 +87,13 @@ class EncodeDecodeTest(ScalyrTestCase):
         # siigned and unsigned 64 bit ints
         if six.PY3:
             if sys.version_info >= (3, 6, 0):
-                orjson.dumps(18446744073709551615)
+                orjson.dumps(18446744073709551615)  # pylint: disable=no-member
+
             else:
-                with self.assertRaises(orjson.JSONEncodeError):
-                    orjson.dumps(18446744073709551615)
+                with self.assertRaises(
+                    orjson.JSONEncodeError  # pylint: disable=no-member
+                ):
+                    orjson.dumps(18446744073709551615)  # pylint: disable=no-member
 
         # here we do the regular json tests to be sure that
         # we fall back to native json library in case of too bit integer.

--- a/tests/unit/util/util_test.py
+++ b/tests/unit/util/util_test.py
@@ -25,10 +25,6 @@ __author__ = "czerwin@scalyr.com"
 from io import open
 import re
 
-from scalyr_agent import scalyr_init
-
-scalyr_init()
-
 import sys
 import datetime
 import os
@@ -42,7 +38,6 @@ import six
 import scalyr_agent.util as scalyr_util
 
 from scalyr_agent.util import (
-    JsonReadFileException,
     RateLimiter,
     FakeRunState,
     ScriptEscalator,
@@ -193,13 +188,17 @@ class TestUtil(ScalyrTestCase):
         self.assertEquals(json_object, JsonObject(a="hi"))
 
     def test_read_file_as_json_no_file(self):
-        self.assertRaises(JsonReadFileException, scalyr_util.read_file_as_json, "foo")
+        self.assertRaises(
+            scalyr_util.JsonReadFileException, scalyr_util.read_file_as_json, "foo"
+        )
 
     def test_read_file_as_json_with_bad_json(self):
         self.__create_file(self.__path, "{ a: hi}")
 
         self.assertRaises(
-            JsonReadFileException, scalyr_util.read_file_as_json, self.__path
+            scalyr_util.JsonReadFileException,
+            scalyr_util.read_file_as_json,
+            self.__path,
         )
 
     def test_read_file_as_json_with_strict_utf8_json(self):
@@ -208,7 +207,10 @@ class TestUtil(ScalyrTestCase):
             f.write(b'{ a: "\x96"}')
 
         self.assertRaises(
-            JsonReadFileException, scalyr_util.read_file_as_json, self.__path, True
+            scalyr_util.JsonReadFileException,
+            scalyr_util.read_file_as_json,
+            self.__path,
+            True,
         )
 
     def test_atomic_write_dict_as_json_file(self):

--- a/tests/utils/agent_runner.py
+++ b/tests/utils/agent_runner.py
@@ -84,7 +84,7 @@ class AgentRunner(object):
         send_to_server=True,
         workers_type="thread",
         workers_session_count=1,
-    ):  # type: (int, bool, bool, bool, six.text_type, int) -> None
+    ):  # type: (__scalyr__.InstallType, bool, bool, bool, six.text_type, int) -> None
 
         if enable_coverage and installation_type != __scalyr__.InstallType.DEV_INSTALL:
             raise ValueError("Coverage is only supported for dev installs")

--- a/tests/utils/agent_runner.py
+++ b/tests/utils/agent_runner.py
@@ -28,10 +28,11 @@ import copy
 import json
 import pprint
 import subprocess
+import pathlib as pl
 
 from distutils.spawn import find_executable
 
-from scalyr_agent.__scalyr__ import PACKAGE_INSTALL, DEV_INSTALL, get_package_root
+from scalyr_agent import __scalyr__
 from scalyr_agent import compat
 from scalyr_agent.platform_controller import PlatformController
 from scalyr_agent.configuration import Configuration
@@ -41,8 +42,15 @@ from tests.utils.common import get_env
 
 import six
 
-_AGENT_MAIN_PATH = Path(get_package_root(), "agent_main.py")
-_CONFIG_MAIN_PATH = Path(get_package_root(), "config_main.py")
+
+# This has to be a DEV installation so we can use install root as source root
+_SOURCE_ROOT = __scalyr__.get_install_root()
+
+_AGENT_PACKAGE_PATH = pl.Path(_SOURCE_ROOT, "scalyr_agent")
+
+
+_AGENT_MAIN_PATH = Path(_AGENT_PACKAGE_PATH, "agent_main.py")
+_CONFIG_MAIN_PATH = Path(_AGENT_PACKAGE_PATH, "agent_config.py")
 
 
 def _make_or_clear_directory(path):  # type: (Path) -> None
@@ -70,7 +78,7 @@ class AgentRunner(object):
 
     def __init__(
         self,
-        installation_type=DEV_INSTALL,
+        installation_type=__scalyr__.InstallType.DEV_INSTALL,
         enable_coverage=False,
         enable_debug_log=False,
         send_to_server=True,
@@ -78,7 +86,7 @@ class AgentRunner(object):
         workers_session_count=1,
     ):  # type: (int, bool, bool, bool, six.text_type, int) -> None
 
-        if enable_coverage and installation_type != DEV_INSTALL:
+        if enable_coverage and installation_type != __scalyr__.InstallType.DEV_INSTALL:
             raise ValueError("Coverage is only supported for dev installs")
 
         # agent data directory path.
@@ -187,12 +195,12 @@ class AgentRunner(object):
             self._agent_config_path, json.dumps(self._agent_config, indent=4)
         )
 
-    def start(self, executable="python"):
+    def start(self, executable="python3"):
         self.clear_agent_logs()
         # important to call this function before agent was started.
         self._create_agent_files()
 
-        if self._installation_type == PACKAGE_INSTALL:
+        if self._installation_type == __scalyr__.InstallType.PACKAGE_INSTALL:
             # use service command to start agent, because stop command hands on some of the RHEL based distributions
             # if agent is started differently.
             service_executable = find_executable("service")
@@ -246,10 +254,10 @@ class AgentRunner(object):
         atexit.register(self.stop)
 
     def status(self):
-        if self._installation_type == PACKAGE_INSTALL:
+        if self._installation_type == __scalyr__.InstallType.PACKAGE_INSTALL:
             cmd = "/usr/sbin/scalyr-agent-2 status -v"
         else:
-            cmd = "python {0} status -v".format(_AGENT_MAIN_PATH)
+            cmd = "python3 {0} status -v".format(_AGENT_MAIN_PATH)
 
         output = compat.subprocess_check_output(cmd=cmd, shell=True)
         output = six.ensure_text(output)
@@ -260,10 +268,10 @@ class AgentRunner(object):
         """
         :param parse_json: True to parse result as json and return a dict.
         """
-        if self._installation_type == PACKAGE_INSTALL:
+        if self._installation_type == __scalyr__.InstallType.PACKAGE_INSTALL:
             cmd = "/usr/sbin/scalyr-agent-2 status -v --format=json"
         else:
-            cmd = "python {0} status -v --format=json".format(_AGENT_MAIN_PATH)
+            cmd = "python3 {0} status -v --format=json".format(_AGENT_MAIN_PATH)
 
         output = compat.subprocess_check_output(cmd=cmd, shell=True)
         output = six.ensure_text(output)
@@ -285,7 +293,7 @@ class AgentRunner(object):
             kwargs = {"env": env}
         else:
             kwargs = {}
-        if self._installation_type == PACKAGE_INSTALL:
+        if self._installation_type == __scalyr__.InstallType.PACKAGE_INSTALL:
             subprocess.check_call(
                 "/usr/sbin/scalyr-agent-2-config --set-python {0}".format(version),
                 shell=True,
@@ -293,12 +301,12 @@ class AgentRunner(object):
             )
         else:
             subprocess.check_call(
-                "python {0} --set-python {1}".format(_CONFIG_MAIN_PATH, version),
+                "python3 {0} --set-python {1}".format(_CONFIG_MAIN_PATH, version),
                 shell=True,
                 **kwargs  # type: ignore
             )
 
-    def stop(self, executable="python"):
+    def stop(self, executable="python3"):
         if six.PY3:
             atexit.unregister(self.stop)
 
@@ -307,7 +315,7 @@ class AgentRunner(object):
 
         print("Stopping agent process...")
 
-        if self._installation_type == PACKAGE_INSTALL:
+        if self._installation_type == __scalyr__.InstallType.PACKAGE_INSTALL:
             service_executable = find_executable("service")
             if service_executable:
                 cmd = "%s scalyr-agent-2 stop" % (service_executable)
@@ -347,10 +355,10 @@ class AgentRunner(object):
         print("Agent stopped.")
         self._stopped = True
 
-    def restart(self, executable="python"):
+    def restart(self, executable="python3"):
         print("Restarting agent process...")
 
-        if self._installation_type == PACKAGE_INSTALL:
+        if self._installation_type == __scalyr__.InstallType.PACKAGE_INSTALL:
             service_executable = find_executable("service")
             if service_executable:
                 cmd = "%s scalyr-agent-2 restart" % (service_executable)

--- a/tests/utils/image_builder.py
+++ b/tests/utils/image_builder.py
@@ -20,6 +20,7 @@ import shutil
 import docker
 import argparse
 import hashlib
+import pathlib as pl
 
 if False:  # NOSONAR
     from typing import Optional
@@ -32,9 +33,14 @@ from abc import ABCMeta
 
 import six
 
-from scalyr_agent.__scalyr__ import get_package_root
+from scalyr_agent import __scalyr__
 from tests.utils.common import create_tmp_directory
 from tests.utils.compat import Path
+
+# This has to be a DEV installation so we can use install root as source root
+_SOURCE_ROOT = __scalyr__.get_install_root()
+
+_AGENT_PACKAGE_PATH = pl.Path(_SOURCE_ROOT, "scalyr_agent")
 
 
 def _copy_agent_source(src_path, dest_path):
@@ -84,7 +90,7 @@ class AgentImageBuilder(object):
 
         # copy agent course code if needed.
         if type(self).COPY_AGENT_SOURCE:
-            root_path = Path(get_package_root()).parent
+            root_path = Path(_AGENT_PACKAGE_PATH).parent
             self.add_to_build_context(
                 root_path, "agent_source", custom_copy_function=_copy_agent_source
             )

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ basepython =
 # NOTE: We pass the TERM env to preserve colors
 passenv = TERM XDG_CACHE_HOME PYTEST_BENCH_FORCE_UNIT
 setenv =
-  LINT_FILES_TO_CHECK={env:LINT_FILES_TO_CHECK:*.py scripts/*.py scripts/circleci/*.py benchmarks/scripts/*.py tests/ pylint_plugins/*.py .circleci/*.py .circleci/modernize/ scalyr_agent/ scalyr_agent/third_party/tcollector/ win32/scalyr-agent.spec}
+  LINT_FILES_TO_CHECK={env:LINT_FILES_TO_CHECK:*.py scripts/*.py scripts/circleci/*.py benchmarks/scripts/*.py tests/ pylint_plugins/*.py .circleci/*.py scalyr_agent/ scalyr_agent/third_party/tcollector/ win32/scalyr-agent.spec}
   # Which Python binary to use for various lint targets
   LINT_PYTHON_BINARY={env:LINT_PYTHON_BINARY:python3.8}
   PYTHONPATH={toxinidir}
@@ -84,7 +84,7 @@ commands =
     # NOTE 2: We run Windows platform tests separately since they cause issues when running them with other unit tests
     py.test tests/unit/test_platform_windows.py -s -vv --durations=5 -m "not memory_leak and not json_lib" --cov=scalyr_agent --cov=tests/ --cov-append --junitxml=test-results/junit-4.xml
 
-# Lint target which runs all the linting tools such as black, modernize, pylint, flake8, mypy, etc.
+# Lint target which runs all the linting tools such as black, pylint, flake8, mypy, etc.
 # NOTE: We use bash -c since we don't want tox to quote all the arguments, we want globs to
 # be expaded
 # NOTE: If you update any of the lint targets or the lint target itself, make sure you also update
@@ -101,7 +101,6 @@ deps =
 commands =
     bash -c "python ./scripts/check-bundled-ca-certs-expirations.py"
     bash -c 'black --check --config pyproject.toml {env:LINT_FILES_TO_CHECK}'
-    python .circleci/modernize/modernize.py -j 2
     bash -c 'flake8 --config lint-configs/python/.flake8 {env:LINT_FILES_TO_CHECK}'
     bash -c 'pylint -E --rcfile=./lint-configs/python/.pylintrc {env:LINT_FILES_TO_CHECK}'
     bash -c 'bandit --configfile lint-configs/python/bandit.yaml -lll -r scalyr_agent/'

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ requires =
 basepython =
     {py2.7-unit-tests,py2.7-smoke-tests,coverage}: python2.7
     {py3.5-unit-tests,py3.5-smoke-tests}: python3.5
-    {py3.6-unit-tests,py3.6-smoke-tests,lint,black,modernize,flake8,pylint,mypy,generate-monitor-docs}: python3.6
+    {py3.6-unit-tests,py3.6-smoke-tests,lint,black,flake8,pylint,mypy,generate-monitor-docs}: python3.8
     {lint,black,modernize,flake8,pylint,mypy}: {env:LINT_PYTHON_BINARY}
     {py3.7-unit-tests,py3.7-smoke-tests}: python3.7
     {py3.8-unit-tests,py3.8-smoke-tests}: python3.8
@@ -24,7 +24,7 @@ passenv = TERM XDG_CACHE_HOME PYTEST_BENCH_FORCE_UNIT
 setenv =
   LINT_FILES_TO_CHECK={env:LINT_FILES_TO_CHECK:*.py scripts/*.py scripts/circleci/*.py benchmarks/scripts/*.py tests/ pylint_plugins/*.py .circleci/*.py .circleci/modernize/ scalyr_agent/ scalyr_agent/third_party/tcollector/ win32/scalyr-agent.spec}
   # Which Python binary to use for various lint targets
-  LINT_PYTHON_BINARY={env:LINT_PYTHON_BINARY:python3.6}
+  LINT_PYTHON_BINARY={env:LINT_PYTHON_BINARY:python3.8}
   PYTHONPATH={toxinidir}
   PY_COLORS=1
   PYTEST_COMMON_OPTS=-vv -s
@@ -201,7 +201,7 @@ passenv =
 commands =
     py.test tests/smoke_tests/standalone_test -s -vv --durations=5
 
-[testenv:py3.5-smoke-tests-rate-limit]
+[testenv:py3.8-smoke-tests-rate-limit]
 setenv =
     SCALYR_MAX_SEND_RATE_ENFORCEMENT="500KB/s" SCALYR_DISABLE_MAX_SEND_RATE_ENFORCEMENT_OVERRIDES="true" SCALYR_MIN_ALLOWED_REQUEST_SIZE="100" SCALYR_MAX_ALLOWED_REQUEST_SIZE="500000" SCALYR_MIN_REQUEST_SPACING_INTERVAL="0.0" SCALYR_MAX_REQUEST_SPACING_INTERVAL="0.5"
 passenv =
@@ -293,7 +293,7 @@ commands =
     py.test tests/distribution/rpm_package.py -s -vv --tb=short --durations=5 {posargs}
 
 [testenv:agent_monitors_ubuntu]
-basepython = python3.6
+basepython = python3.8
 passenv =
     TERM SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
 commands =


### PR DESCRIPTION
This is the first "frozen binary" PR that contains initial refactoring for the frozen binaries.  
The main changes are in the `__scalyr__.py` module. The main changes:
* It contains a new logic on how to determine the installation type. In order to determine the package type correctly, it relies on a special file that has to be placed in the "scalyr_agent" package directory.
* It does not import third party libraries anymore, except `tcollectors`

Changes in the majority of other files are mostly the result of the changes in `__scalyr__.py`.

There are also changes in unit tests since they are also affected by main changes. 

Unit tests added to the Github Actions. (Most of the CircleCI tests are commented for now, but they will be also moved to the Github action in further PR's)
