### PR TITLE
Docker imate support for linux/armv7 platform

### DIFF
--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -3,28 +3,10 @@ name: Scalyr Agent Build.
 
 on: [push]
 
-# Agent image tests.
+# Agent Docker image tests
 jobs:
-  match-branches:
-    runs-on: ubuntu-20.04
-
-    steps:
-      - name: Check branches.
-        env:
-          TARGET_BRANCH: master
-
-        # Because of the issue https://github.community/t/ref-head-in-reusable-workflows/203690
-        # there's no way to specify local re-usable workflow. The branch of the workflow has to be specified manually and statically
-        # To avoid confusion, run this check that will fail if the current branch does not match the branch of the workflow.
-        # TODO: Create pre-commit hook that verifies branch name and changes it if needed. That may be a good workaround
-        # until Github add needed feature.
-        if: ${{ github.ref_type == 'branch' && github.ref_name != 'master' && github.ref_name != 'armv7_docker_support' }}
-        uses: actions/github-script@v3
-        with:
-          script: |
-              core.setFailed("The current branch is '${{ github.ref_name }}' but it has to be 'master'")
-
   docker-json:
+    if: ${{ github.ref == 'refs/heads/master' || github.ref_name == 'master' }}
     uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
     with:
       image-type: docker-json
@@ -33,6 +15,7 @@ jobs:
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
 
   docker-syslog:
+    if: ${{ github.ref == 'refs/heads/master' || github.ref_name == 'master' }}
     uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
     with:
       image-type: docker-syslog
@@ -41,6 +24,7 @@ jobs:
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
 
   docker-api:
+    if: ${{ github.ref == 'refs/heads/master' || github.ref_name == 'master' }}
     uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
     with:
       image-type: docker-api
@@ -50,6 +34,7 @@ jobs:
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
 
   k8s:
+    if: ${{ github.ref == 'refs/heads/master' || github.ref_name == 'master' }}
     uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
     with:
       image-type: k8s

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -1,5 +1,5 @@
 # The main "setup" workflow, that calls other workflows.
-name: Scalyr Agent Build.
+name: Docker Images Build
 
 on: [push]
 

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -6,7 +6,7 @@ on: [push]
 # Agent Docker image tests
 jobs:
   docker-json:
-    if: ${{ github.ref == 'refs/heads/master' || github.ref_name == 'master' }}
+    if: ${{ github.ref == 'refs/heads/master' || github.ref_name == 'master' || github.ref_name == 'armv7_docker_support' }}
     uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
     with:
       image-type: docker-json
@@ -15,7 +15,7 @@ jobs:
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
 
   docker-syslog:
-    if: ${{ github.ref == 'refs/heads/master' || github.ref_name == 'master' }}
+    if: ${{ github.ref == 'refs/heads/master' || github.ref_name == 'master' || github.ref_name == 'armv7_docker_support' }}
     uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
     with:
       image-type: docker-syslog
@@ -24,7 +24,7 @@ jobs:
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
 
   docker-api:
-    if: ${{ github.ref == 'refs/heads/master' || github.ref_name == 'master' }}
+    if: ${{ github.ref == 'refs/heads/master' || github.ref_name == 'master' || github.ref_name == 'armv7_docker_support' }}
     uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
     with:
       image-type: docker-api
@@ -34,7 +34,7 @@ jobs:
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
 
   k8s:
-    if: ${{ github.ref == 'refs/heads/master' || github.ref_name == 'master' }}
+    if: ${{ github.ref == 'refs/heads/master' || github.ref_name == 'master' || github.ref_name == 'armv7_docker_support' }}
     uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
     with:
       image-type: k8s

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -18,7 +18,7 @@ jobs:
         # To avoid confusion, run this check that will fail if the current branch does not match the branch of the workflow.
         # TODO: Create pre-commit hook that verifies branch name and changes it if needed. That may be a good workaround
         # until Github add needed feature.
-        if: ${{ github.ref_type == 'branch' && github.ref_name != 'master' }}
+        if: ${{ github.ref_type == 'branch' && github.ref_name != 'master' && github.ref_name != 'armv7_docker_support' }}
         uses: actions/github-script@v3
         with:
           script: |

--- a/.github/workflows/docker-and-k8s.yml
+++ b/.github/workflows/docker-and-k8s.yml
@@ -26,7 +26,6 @@ on:
 env:
   DOCKER_BUILDKIT: 1
 
-
 jobs:
   # TODO move here tests from the CicleCi.
   test:
@@ -71,7 +70,6 @@ jobs:
         run: |
           python3 build_package_new.py ${{ inputs.image-type }} --files-checksum > image_files_checksum.txt
 
-
       - name: Check for the docker buildx cache.
         uses: actions/cache@v2
         with:
@@ -95,8 +93,6 @@ jobs:
             --name-suffix "_${{ github.run_number }}${{ github.run_attempt }}" \
             --cache-from-dir ~/docker-test-image-build-cache-in \
             --cache-to-dir ~/docker-test-image-build-cache
-
-
 
 #  publish:
 #    needs: [test]
@@ -127,6 +123,3 @@ jobs:
 #          python3 build_package_new.py ${{ inputs.image-type }} \
 #            --push \
 #            --tag ${{ github.sha }}
-
-
-

--- a/.github/workflows/docker-and-k8s.yml
+++ b/.github/workflows/docker-and-k8s.yml
@@ -1,4 +1,4 @@
-name: Build agent packages.
+name: Build Agent Images
 
 on:
   workflow_call:
@@ -96,7 +96,7 @@ jobs:
 
 #  publish:
 #    needs: [test]
-#    name: Publish image.
+#    name: Publish Docker Image
 #    if: ${{ inputs.publish == true &&  (github.ref == 'refs/heads/master' || github.ref_type == 'tag') }}
 #    runs-on: ubuntu-latest
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,12 @@ Improvements:
 * Add support for specifying new ``server_url`` config option for each session worker. This allows user to configure different session workers to use different server urls (e.g. some workers send data to agent.scalyr.com and other send data to eu.scalyr.com).
 
 Other:
-* Update agent Docker image to include ``pympler`` dependency by default. This means memory profiling can be enabled via the agent configuration option without the need to modify and re-build the Docker image.
 * Update agent to also log response ``message`` field value when we receive ``error/client/badParam`` status code from the API to make troubleshooting easier.
+
+Docker Images:
+* Docker images now utilize Python 3.8 (in the past they used Python 2.7).
+* Docker images are now also produced and pushed to the registry for the ``linux/arm64`` and ``linux/arm/v7`` architecture.
+* Docker image now includes ``pympler`` dependency by default. This means memory profiling can be enabled via the agent configuration option without the need to modify and re-build the Docker image.
 
 ## 2.1.25 "Hamarus" - Nov 17, 2021
 

--- a/agent_build/package_builders.py
+++ b/agent_build/package_builders.py
@@ -893,7 +893,8 @@ class ContainerPackageBuilder(
             command_options.append(
                 constants.Architecture.ARM64.as_docker_platform.value
             )
-
+            command_options.append("--platform")
+            command_options.append(constants.Architecture.ARM.as_docker_platform.value)
         if with_coverage:
             logging.info("Code coverage enabled.")
             # Build image with enabled coverage measuring.

--- a/agent_build/package_builders.py
+++ b/agent_build/package_builders.py
@@ -776,6 +776,7 @@ class ContainerPackageBuilder(
         cache_to_path: str = None,
         with_coverage: bool = False,
         reuse_local_cache: bool = False,
+        remove_image_name_prefix: bool = False,
     ):
         """
         This function builds Agent docker image by using the dockerfile - 'docker/Docker.unified'.
@@ -796,6 +797,8 @@ class ContainerPackageBuilder(
             library). Used only for testing.
         :param reuse_local_cache: Set to True to re-use local cache and not pass CACHE_BUST build arg
             to the docker command. Useful for local (non-CI) builds.
+        :param remove_image_name_prefix: True to remove user / org prefix when using a custom registry.
+            For example: scalyr/scalyr-agent-2 -> scalyr-agent-2.
         """
 
         registries = registries or [""]
@@ -851,9 +854,10 @@ class ContainerPackageBuilder(
                     else:
                         registry_prefix = ""
                     # NOTE: If we are using custom registry and image name already contains user
-                    # prefix, we remove that so it works corectly.
+                    # prefix, we remove it in case remove_image_prefix argument is provided (
+                    # this is desired in a lot of cases when using custom registry)
                     # e.g. scalyr/scalyr-agent-2 -> scalyr-agent-2
-                    if "/" in image_name:
+                    if remove_image_name_prefix and "/" in image_name:
                         image_name = image_name.split("/")[1]
                     tag_options.append(f"{registry_prefix}{image_name}:{tag}")
 

--- a/agent_build/package_builders.py
+++ b/agent_build/package_builders.py
@@ -850,6 +850,11 @@ class ContainerPackageBuilder(
                         registry_prefix = f"{registry}/"
                     else:
                         registry_prefix = ""
+                    # NOTE: If we are using custom registry and image name already contains user
+                    # prefix, we remove that so it works corectly.
+                    # e.g. scalyr/scalyr-agent-2 -> scalyr-agent-2
+                    if "/" in image_name:
+                        image_name = image_name.split("/")[1]
                     tag_options.append(f"{registry_prefix}{image_name}:{tag}")
 
         command_options = [

--- a/agent_build/tools/constants.py
+++ b/agent_build/tools/constants.py
@@ -22,6 +22,8 @@ SOURCE_ROOT = pl.Path(__file__).parent.parent.parent.absolute()
 class DockerPlatform(enum.Enum):
     AMD64 = "linux/amd64"
     ARM64 = "linux/arm64"
+    # For Raspberry Pi and other lowe armv7 based ARM platforms
+    ARM = "linux/arm"
 
 
 class Architecture(enum.Enum):
@@ -31,6 +33,7 @@ class Architecture(enum.Enum):
 
     X86_64 = "x86_64"
     ARM64 = "arm64"
+    ARM = "arm"
     UNKNOWN = "unknown"
 
     @property
@@ -42,6 +45,7 @@ class Architecture(enum.Enum):
 _ARCHITECTURE_TO_DOCKER_PLATFORM = {
     Architecture.X86_64: DockerPlatform.AMD64,
     Architecture.ARM64: DockerPlatform.ARM64,
+    Architecture.ARM: DockerPlatform.ARM,
     # Handle unknown architecture value as x86_64
     Architecture.UNKNOWN: DockerPlatform.AMD64,
 }

--- a/agent_build/tools/constants.py
+++ b/agent_build/tools/constants.py
@@ -22,8 +22,9 @@ SOURCE_ROOT = pl.Path(__file__).parent.parent.parent.absolute()
 class DockerPlatform(enum.Enum):
     AMD64 = "linux/amd64"
     ARM64 = "linux/arm64"
-    # For Raspberry Pi and other lowe armv7 based ARM platforms
+    # For Raspberry Pi and other lower powered armv7 based ARM platforms
     ARM = "linux/arm"
+    ARM = "linux/armv7"
 
 
 class Architecture(enum.Enum):

--- a/agent_build/tools/constants.py
+++ b/agent_build/tools/constants.py
@@ -24,7 +24,8 @@ class DockerPlatform(enum.Enum):
     ARM64 = "linux/arm64"
     # For Raspberry Pi and other lower powered armv7 based ARM platforms
     ARM = "linux/arm"
-    ARM = "linux/armv7"
+    ARMv7 = "linux/armv7"
+    ARMv8 = "linux/armv8"
 
 
 class Architecture(enum.Enum):

--- a/build_package_new.py
+++ b/build_package_new.py
@@ -99,6 +99,10 @@ if __name__ == "__main__":
             )
 
             package_parser.add_argument(
+                "--reuse-local-cache", action="store_true", help="Set to true to enable cache re-use (e.g. when building locally and not on CI)."
+            )
+
+            package_parser.add_argument(
                 "--push", action="store_true", help="Push the result docker image."
             )
 
@@ -152,6 +156,7 @@ if __name__ == "__main__":
             tags=args.tag or [],
             cache_from_path=args.cache_from_dir,
             cache_to_path=args.cache_to_dir,
+            reuse_local_cache=args.reuse_local_cache,
         )
         exit(0)
 

--- a/build_package_new.py
+++ b/build_package_new.py
@@ -99,7 +99,9 @@ if __name__ == "__main__":
             )
 
             package_parser.add_argument(
-                "--reuse-local-cache", action="store_true", help="Set to true to enable cache re-use (e.g. when building locally and not on CI)."
+                "--reuse-local-cache",
+                action="store_true",
+                help="Set to true to enable cache re-use (e.g. when building locally and not on CI).",
             )
 
             package_parser.add_argument(

--- a/build_package_new.py
+++ b/build_package_new.py
@@ -101,7 +101,18 @@ if __name__ == "__main__":
             package_parser.add_argument(
                 "--reuse-local-cache",
                 action="store_true",
-                help="Set to true to enable cache re-use (e.g. when building locally and not on CI).",
+                help="Enable Docker image cache re-use (e.g. when building locally and not on CI).",
+            )
+
+            package_parser.add_argument(
+                "--remove-image-name-prefix",
+                action="store_true",
+                help=(
+                    "True to remove user / org name prefix from the image name when using a custom registry. This "
+                    "is usually a desired behavior when using a custom registry url where the user or "
+                    "the organization name doesn't match one specified in the Docker image name. E.g. "
+                    "scalyr/scalyr-k8s-agent -> scalyr-k8s-agent."
+                ),
             )
 
             package_parser.add_argument(
@@ -159,6 +170,7 @@ if __name__ == "__main__":
             cache_from_path=args.cache_from_dir,
             cache_to_path=args.cache_to_dir,
             reuse_local_cache=args.reuse_local_cache,
+            remove_image_name_prefix=args.remove_image_name_prefix,
         )
         exit(0)
 

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -19,4 +19,5 @@ pympler==0.8
 # to prevent versions conflict, install the appropriate version of 'requests', to force 'docker' to reuse it.
 requests==2.20.0
 docker==4.1.0
-zstandard==0.16.0
+zstandard==0.16.0; python_version >= '3.5'
+zstandard==0.14.1; python_version < '3.5'

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -19,3 +19,4 @@ pympler==0.8
 # to prevent versions conflict, install the appropriate version of 'requests', to force 'docker' to reuse it.
 requests==2.20.0
 docker==4.1.0
+zstandard==0.16.0

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,7 +1,14 @@
 # dependencies for docker images.
-ujson==1.35
-orjson==3.5.2; python_version >= '3.6'
-orjson==2.0.11; python_version == '3.5'
+# NOTE: ujson and orjson don't include pre-built wheels for ARMv7 so we don't
+# include those for armv7 builds and simply fall back to json.
+# Alernative would be to install rust + arm toolchain in the build docker image
+# and instead of using pre-built wheel we would compile wheel in docker image
+# (slow)
+# Keep in mind that wheels are available for ARM64 (e.g. graviton) so we do use
+# those on linux/arm64
+ujson==1.35; 'armv7' not in platform_machine
+orjson==3.5.2; python_version >= '3.6' and 'armv7' not in platform_machine
+orjson==2.0.11; python_version == '3.5' and 'armv7' not in platform_machine
 # Two dependencies below are used for CPU and memory profiling which is opt-in and disabled by
 # default. We include it in the Docker image to make  troubleshooting (profiling) easier for the
 # end user (no need to rebuild Docker image - user can simply enable the corresponding agent config


### PR DESCRIPTION
This pull request adds support for ``linux/arm`` architecture.

This architecture includes ``linux/armv7`` which is an architecture used by Raspberry Pi and some other lower powered embedded ARM and IoT devices.

Older versions of Raspberry Pi used ``armv6``, but not many places support this architecture anymore so I didn't add support for it.

Overall, this PR includes the following changes:

- Support for building and pushing ``linux/armv7`` images
- Add new ``--reuse-local-cache`` argument to the build script. This comes handy when building the image locally (outside CI) to speed up the builds.
- Fix tag name when using custom registry. Previous code wouldn't not work correctly when using custom registry when the user / org name is not ``scalyr``. Constructed URL would end up being ``<registry url>/<user>scalyr/scalyr-agent-2:tag``, but we want ``<registry url>/<user>/scalyr-agent-2:tag``. @ArthurKamalov can you please review this change? I just did a quick solution which works, but there are likely other possible solutions (e.g. remove user / org name from the "image_name", etc.)
- Update docker image requirements file so we don't bundle ``orjson`` and ``ujson`` dependency. Those dependencies don't offer armv7 compatible pre-built wheels at this point. This means we would need to build them inside the Docker image. To do that, we would need to install rust, etc. Since the building is slow, I decided to skip it for now and simply exclude those dependencies on armv7 (we still use those dependencies on arm64 for which wheels are available). It means that we will simply fall back to stdlib json library.

Example I used to build the image locally:

```bash
python3 build_package_new.py k8s --tag "$(date +%s)-dev" --registry kami007 --reuse-local-cache --remove-image-name-prefix --push
```