### PR TITLE
Use self hosted runners for Docker build jobs

### DIFF
--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -11,12 +11,16 @@ on: [push]
 
 # 2. In this workflow, change docker hub secrets to utilize testing and not prod account so images
 #    get pushed to testing account. Change ``_PROD_` in the secret name to ``_TEST``,
-#    e.g. ``DOCKER_HUB_USERNAME_TEST_ACCOUNT`` ``DOCKER_HUB_PASSWORD_TEST_ACCOUNT``
+#    e.g. ``DOCKER_HUB_USERNAME_TEST_ACCOUNT`` ``DOCKER_HUB_PASSWORD_TEST_ACCOUNT``.
+#    Images for test account will get pushed to https://hub.docker.com/r/test4scalyr/.
 #
 # 3. Inside .github/workflows/docker-and-k8s.yml workflow, change if ``publish`` job conditional to:
 #    if: ${{ inputs.publish == true && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' || github.ref == 'refs/heads/YOUR_BRANCH_NAME') }}
 #
-# For example:
+#    And the "Push image" step conditional to:
+#        if: ${{ github.ref == 'refs/heads/YOUR_BRANCH_NAME' }}
+#
+# For example: https://github.com/scalyr/scalyr-agent-2/pull/804/commits/b51f55bb5dd12d60c7d9516c77ad13c39ee902e7
 jobs:
   docker-json:
     uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@use_self_hosted_runners

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -20,7 +20,7 @@ on: [push]
 #    And the "Push image" step conditional to:
 #        if: ${{ github.ref == 'refs/heads/YOUR_BRANCH_NAME' }}
 #
-# For example: https://github.com/scalyr/scalyr-agent-2/pull/804/commits/b51f55bb5dd12d60c7d9516c77ad13c39ee902e7
+# For example: https://github.com/scalyr/scalyr-agent-2/pull/804/commits/0eccf278623552b51d9289d75a47794e88f02862
 jobs:
   docker-json:
     uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@use_self_hosted_runners

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -4,6 +4,19 @@ name: Docker Images Build
 on: [push]
 
 # Agent Docker image tests
+#
+# To test this workflow with your branch, make the following changes:
+#
+# 1. In this workflow, change ``@master`` to ``@your_branch_name`` - e.g. ``@docker_image_alpine``
+
+# 2. In this workflow, change docker hub secrets to utilize testing and not prod account so images
+#    get pushed to testing account. Change ``_PROD_` in the secret name to ``_TEST``,
+#    e.g. ``DOCKER_HUB_USERNAME_TEST_ACCOUNT`` ``DOCKER_HUB_PASSWORD_TEST_ACCOUNT``
+#
+# 3. Inside .github/workflows/docker-and-k8s.yml workflow, change if ``publish`` job conditional to:
+#    if: ${{ inputs.publish == true && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' || github.ref == 'refs/heads/YOUR_BRANCH_NAME') }}
+#
+# For example:
 jobs:
   docker-json:
     uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -19,45 +19,45 @@ on: [push]
 # For example:
 jobs:
   docker-json:
-    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
+    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@use_self_hosted_runners
     with:
       image-type: docker-json
       publish: true
     secrets:
       SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_PROD_ACCOUNT }}
-      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_PROD_ACCOUNT }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_TEST_ACCOUNT }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_TEST_ACCOUNT }}
 
   docker-syslog:
-    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
+    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@use_self_hosted_runners
     with:
       image-type: docker-syslog
       publish: true
     secrets:
       SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_PROD_ACCOUNT }}
-      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_PROD_ACCOUNT }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_TEST_ACCOUNT }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_TEST_ACCOUNT }}
 
   docker-api:
-    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
+    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@use_self_hosted_runners
     with:
       image-type: docker-api
       publish: false
     secrets:
       SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_PROD_ACCOUNT }}
-      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_PROD_ACCOUNT }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_TEST_ACCOUNT }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_TEST_ACCOUNT }}
 
   k8s:
-    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
+    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@use_self_hosted_runners
     with:
       image-type: k8s
       publish: true
     secrets:
       SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_PROD_ACCOUNT }}
-      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_PROD_ACCOUNT }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_TEST_ACCOUNT }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_TEST_ACCOUNT }}

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -23,45 +23,45 @@ on: [push]
 # For example: https://github.com/scalyr/scalyr-agent-2/pull/804/commits/0eccf278623552b51d9289d75a47794e88f02862
 jobs:
   docker-json:
-    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@use_self_hosted_runners
+    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
     with:
       image-type: docker-json
       publish: true
     secrets:
       SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_TEST_ACCOUNT }}
-      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_TEST_ACCOUNT }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_PROD_ACCOUNT }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_PROD_ACCOUNT }}
 
   docker-syslog:
-    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@use_self_hosted_runners
+    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
     with:
       image-type: docker-syslog
       publish: true
     secrets:
       SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_TEST_ACCOUNT }}
-      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_TEST_ACCOUNT }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_PROD_ACCOUNT }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_PROD_ACCOUNT }}
 
   docker-api:
-    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@use_self_hosted_runners
+    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
     with:
       image-type: docker-api
       publish: false
     secrets:
       SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_TEST_ACCOUNT }}
-      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_TEST_ACCOUNT }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_PROD_ACCOUNT }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_PROD_ACCOUNT }}
 
   k8s:
-    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@use_self_hosted_runners
+    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
     with:
       image-type: k8s
       publish: true
     secrets:
       SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_TEST_ACCOUNT }}
-      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_TEST_ACCOUNT }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_PROD_ACCOUNT }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_PROD_ACCOUNT }}

--- a/.github/workflows/docker-and-k8s.yml
+++ b/.github/workflows/docker-and-k8s.yml
@@ -33,8 +33,27 @@ env:
 jobs:
   # TODO move here tests from the CicleCi.
 
+  pre_job:
+    name: Skip Duplicate Jobs Pre Job
+    # NOTE: We intentionally run this job on cloud so it can always run and cancel any other jobs.
+    # If we use self-hosted runner, it may be queued behind other jobs if there are no free runners
+    # available which defeats the purpose of this job.
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@ea548f2a2a08c55dcb111418ca62181f7887e297 # v3.3.0
+        with:
+          github_token: ${{ github.token }}
+
   test:
     runs-on: self-hosted
+
+    needs: pre_job
+    # NOTE: We always want to run this job on master
+    if: ${{ needs.pre_job.outputs.should_skip == 'false' || github.ref == 'refs/heads/master' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docker-and-k8s.yml
+++ b/.github/workflows/docker-and-k8s.yml
@@ -111,7 +111,7 @@ jobs:
   publish:
     needs: [test]
     name: Publish Docker Image
-    if: ${{ inputs.publish == true && (github.ref == 'refs/heads/master' || github.ref_type == 'tag') }}
+    if: ${{ inputs.publish == true && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' || github.ref == 'refs/heads/use_self_hosted_runners') }}
     runs-on: self-hosted
 
     strategy:
@@ -171,7 +171,7 @@ jobs:
           mkdir -p ~/docker-image-build-cache
 
       - name: Push image using the master branch commit SHA.
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/use_self_hosted_runners' }}
         run: |
           # NOTE: --remove-image-name-prefix is needed in case Docker hub usename is not scalyr
           python3 build_package_new.py "${{ inputs.image-type }}-${{ matrix.image_distro_name }}" \

--- a/.github/workflows/docker-and-k8s.yml
+++ b/.github/workflows/docker-and-k8s.yml
@@ -34,7 +34,7 @@ jobs:
   # TODO move here tests from the CicleCi.
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     strategy:
       fail-fast: false
@@ -112,7 +112,7 @@ jobs:
     needs: [test]
     name: Publish Docker Image
     if: ${{ inputs.publish == true && (github.ref == 'refs/heads/master' || github.ref_type == 'tag') }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docker-and-k8s.yml
+++ b/.github/workflows/docker-and-k8s.yml
@@ -130,7 +130,7 @@ jobs:
   publish:
     needs: [test]
     name: Publish Docker Image
-    if: ${{ inputs.publish == true && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' || github.ref == 'refs/heads/use_self_hosted_runners') }}
+    if: ${{ inputs.publish == true && (github.ref == 'refs/heads/master' || github.ref_type == 'tag') }}
     runs-on: self-hosted
 
     strategy:

--- a/.github/workflows/docker-and-k8s.yml
+++ b/.github/workflows/docker-and-k8s.yml
@@ -103,7 +103,7 @@ jobs:
           python3 build_package_new.py "${{ inputs.image-type }}-${{ matrix.image_distro_name }}" --files-checksum --debug
           python3 build_package_new.py "${{ inputs.image-type }}-${{ matrix.image_distro_name }}" --files-checksum > image_files_checksum.txt
 
-      - name: Check for the docker buildx cache.
+      - name: Check for the docker buildx cache
         uses: actions/cache@v2
         with:
           path: ~/docker-test-image-build-cache
@@ -174,13 +174,13 @@ jobs:
           python3 build_package_new.py "${{ inputs.image-type }}-${{ matrix.image_distro_name }}" --files-checksum --debug
           python3 build_package_new.py "${{ inputs.image-type }}-${{ matrix.image_distro_name }}" --files-checksum > image_files_checksum.txt
 
-      - name: Check for the docker buildx cache.
+      - name: Check for the docker buildx cache
         uses: actions/cache@v2
         with:
           path: ~/docker-image-build-cache
           key: agent-docker-image-buildx-cache-${{ inputs.image-type }}-${{ matrix.image_distro_name }}-${{ hashFiles('image_files_checksum.txt') }}
 
-      - name: Prepare build cache directories.
+      - name: Prepare build cache directories
         run: |
           mkdir -p ~/docker-image-build-cache
           # If cache exists, then it goes to the input of the build.
@@ -189,7 +189,7 @@ jobs:
           # where a new build cache will be stored.
           mkdir -p ~/docker-image-build-cache
 
-      - name: Push image using the master branch commit SHA.
+      - name: Push image using the master branch commit SHA
         if: ${{ github.ref == 'refs/heads/use_self_hosted_runners' }}
         run: |
           # NOTE: --remove-image-name-prefix is needed in case Docker hub usename is not scalyr
@@ -201,7 +201,7 @@ jobs:
             --cache-from-dir ~/docker-image-build-cache-in \
             --cache-to-dir ~/docker-image-build-cache
 
-      - name: Push image using the tag.
+      - name: Push image using the tag
         if: ${{ github.ref_type == 'tag' }}
         run: |
           tag_options=$(python3 scripts/cicd/verify_and_get_image_tag_to_publish.py "${{ github.ref_name }})" --sufix "${{ matrix.image_tag_suffix }}"
@@ -213,7 +213,3 @@ jobs:
             --cache-from-dir ~/docker-image-build-cache-in \
             --cache-to-dir ~/docker-image-build-cache \
             ${tag_options}
-
-          # Check the cache directory size post build
-          du -hs ~/docker-image-build-cache
-          ls -lah ~/docker-image-build-cache

--- a/tests/package_tests/internals/common.py
+++ b/tests/package_tests/internals/common.py
@@ -189,6 +189,8 @@ class LogVerifier:
 
                 # The result has been failed. Stop the verifier with error.
                 elif result == LogVerifierCheckResult.FAIL:
+                    # TODO:  Retry on temporary connection errors or similar, e.g.
+                    #  Agent log contains error line : 2021-12-22 12:14:31.879Z ERROR [core] [scalyr_logging.py:621] [error="client/connectionFailed"] Failed to connect to "https://agent.scalyr.com" due to exception.  Exception was "timed out".  Closing connection, will re-attempt :stack_trace:
                     error_message = f"The check '{line_check.description}' has failed."
                     if message:
                         error_message = message

--- a/tests/package_tests/internals/k8s_test.py
+++ b/tests/package_tests/internals/k8s_test.py
@@ -150,7 +150,7 @@ def _test(image_name: str, architecture: constants.Architecture, scalyr_api_key:
     )
 
     # Wait a little.
-    time.sleep(3)
+    time.sleep(10)
 
     # Execute tail -f command on the agent.log inside the pod to read its content.
     agent_log_tail_process = subprocess.Popen(


### PR DESCRIPTION
Change to use self hosted runners for new Docker image build jobs.