### PR TITLE
Improve caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2312,193 +2312,193 @@ jobs:
     steps:
       - ami-tests:
           test_type: "development"
-
-workflows:
- version: 2
- static-analysis:
-   <<: *skip_release_build_branch_push
-   jobs:
-     - lint-checks:
-         context: scalyr-agent
- unit-tests:
-   <<: *skip_release_build_branch_push
-   # NOTE: To avoid massive and inflated build matrix, we currently don't run tests under multiple
-   # Python 3 versions
-   jobs:
-     - unittest-27:
-         context: scalyr-agent
-     - unittest-35:
-         context: scalyr-agent
-     - unittest-35-osx:
-         context: scalyr-agent
-     - unittest-38-windows:
-         context: scalyr-agent
- smoke-tests:
-   <<: *skip_release_build_branch_push
-   jobs:
-     - smoke-standalone-27:
-         context: scalyr-agent
-     - smoke-standalone-35:
-         context: scalyr-agent
-     - smoke-standalone-35-rate-limit:
-         context: scalyr-agent
-      # NOTE: smoke test jobs below still use old smoke tests framework
-     - smoke-docker-json:
-         context: scalyr-agent
-     - smoke-docker-api-raw-logs-disabled:
-         context: scalyr-agent
-     - smoke-docker-syslog:
-         context: scalyr-agent
-     - smoke-k8s:
-         context: scalyr-agent
-     - smoke-monitors-tests:
-         context: scalyr-agent
-     - sonarcloud-scan:
-         requires:
-           # NOTE: This is not ideal, but Circle CI doesn't support cross
-           # workflow dependencies (we can't wait on unittest-27 here) so we just wait on the
-           # slowest jobs
-           - smoke-docker-json
-           - smoke-docker-api-raw-logs-disabled
-           - smoke-docker-syslog
-           - smoke-k8s
-           - smoke-monitors-tests
- package-tests:
-   <<: *skip_release_build_branch_push
-   jobs:
-     - build-linux-packages-and-installer-script
-     - build-windows-package
-     - package-test-rpm:
-         context: scalyr-agent
-         <<: *master_and_release_only
-     - package-test-deb:
-         context: scalyr-agent
-         <<: *master_and_release_only
-     - smoke-rpm-package-py2:
-         context: scalyr-agent
-         requires:
-           - package-test-rpm
-         <<: *master_and_release_only
-     - smoke-rpm-package-py3:
-         context: scalyr-agent
-         requires:
-           - package-test-rpm
-         <<: *master_and_release_only
-     - smoke-deb-package-py2:
-         context: scalyr-agent
-         requires:
-           - package-test-deb
-         <<: *master_and_release_only
-     - smoke-deb-package-py3:
-         context: scalyr-agent
-         requires:
-           - package-test-deb
-         <<: *master_and_release_only
-     - ami-tests-development:
-          context: scalyr-agent
-          requires:
-            - build-windows-package
-            - build-linux-packages-and-installer-script
-     - ami-tests-stable:
-          context: scalyr-agent
-          <<: *master_and_release_only
- benchmarks:
-   <<: *skip_release_build_branch_push
-   jobs:
-     - benchmarks-micro-py-27
-     - benchmarks-micro-py-35
-     - benchmarks-idle-agent-py-27:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-idle-agent-py-35:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-idle-agent-no-monitors-py-27:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-idle-agent-no-monitors-py-35:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27:
-         <<: *benchmarks_master_and_release_only
-     - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35:
-         <<: *benchmarks_master_and_release_only
-     # - send-benchmark-results-and-graphs-to-slack:
-     #     requires:
-     #       - benchmarks-idle-agent-py-27
-     #       - benchmarks-idle-agent-py-35
-     #       - benchmarks-idle-agent-no-monitors-py-27
-     #       - benchmarks-idle-agent-no-monitors-py-35
-     #       - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27
-     #       - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35
-     #       - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27
-     #       - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35
-     #       - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27
-     #       - benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35
-     #       - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27
-     #       - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35
-     #     <<: *benchmarks_master_and_release_only
- weekly-circle-ci-usage-report:
-   triggers:
-     - schedule:
-         cron: "0 0 * * 0"
-         filters:
-           branches:
-             only:
-               - master
-   jobs:
-     - send-circle-ci-usage-report
-
- # We run AMI based package install tests which utilize installer script on
- # daily basis.
- # This helps us detect various installer script and other potential upstream
- # issues.
- daily-stable-ami-package-install-tests:
-   triggers:
-     - schedule:
-         cron: "0 2 * * *"
-         filters:
-           branches:
-             only:
-               - master
-   jobs:
-     - ami-tests-stable:
-         context: scalyr-agent
-     - unittest-27:
-         context: scalyr-agent
-     - unittest-35:
-         context: scalyr-agent
-     - unittest-35-osx:
-         context: scalyr-agent
-     - unittest-38-windows:
-         context: scalyr-agent
-     - build-linux-packages-and-installer-script
-     - build-windows-package
-     - package-test-rpm:
-         context: scalyr-agent
-     - package-test-deb:
-         context: scalyr-agent
-     - smoke-rpm-package-py2:
-         context: scalyr-agent
-         requires:
-           - package-test-rpm
-     - smoke-rpm-package-py3:
-         context: scalyr-agent
-         requires:
-           - package-test-rpm
-     - smoke-deb-package-py2:
-         context: scalyr-agent
-         requires:
-           - package-test-deb
-     - smoke-deb-package-py3:
-         context: scalyr-agent
-         requires:
-           - package-test-deb
+#
+#workflows:
+# version: 2
+# static-analysis:
+#   <<: *skip_release_build_branch_push
+#   jobs:
+#     - lint-checks:
+#         context: scalyr-agent
+# unit-tests:
+#   <<: *skip_release_build_branch_push
+#   # NOTE: To avoid massive and inflated build matrix, we currently don't run tests under multiple
+#   # Python 3 versions
+#   jobs:
+#     - unittest-27:
+#         context: scalyr-agent
+#     - unittest-35:
+#         context: scalyr-agent
+#     - unittest-35-osx:
+#         context: scalyr-agent
+#     - unittest-38-windows:
+#         context: scalyr-agent
+# smoke-tests:
+#   <<: *skip_release_build_branch_push
+#   jobs:
+#     - smoke-standalone-27:
+#         context: scalyr-agent
+#     - smoke-standalone-35:
+#         context: scalyr-agent
+#     - smoke-standalone-35-rate-limit:
+#         context: scalyr-agent
+#      # NOTE: smoke test jobs below still use old smoke tests framework
+#     - smoke-docker-json:
+#         context: scalyr-agent
+#     - smoke-docker-api-raw-logs-disabled:
+#         context: scalyr-agent
+#     - smoke-docker-syslog:
+#         context: scalyr-agent
+#     - smoke-k8s:
+#         context: scalyr-agent
+#     - smoke-monitors-tests:
+#         context: scalyr-agent
+#     - sonarcloud-scan:
+#         requires:
+#           # NOTE: This is not ideal, but Circle CI doesn't support cross
+#           # workflow dependencies (we can't wait on unittest-27 here) so we just wait on the
+#           # slowest jobs
+#           - smoke-docker-json
+#           - smoke-docker-api-raw-logs-disabled
+#           - smoke-docker-syslog
+#           - smoke-k8s
+#           - smoke-monitors-tests
+# package-tests:
+#   <<: *skip_release_build_branch_push
+#   jobs:
+#     - build-linux-packages-and-installer-script
+#     - build-windows-package
+#     - package-test-rpm:
+#         context: scalyr-agent
+#         <<: *master_and_release_only
+#     - package-test-deb:
+#         context: scalyr-agent
+#         <<: *master_and_release_only
+#     - smoke-rpm-package-py2:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-rpm
+#         <<: *master_and_release_only
+#     - smoke-rpm-package-py3:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-rpm
+#         <<: *master_and_release_only
+#     - smoke-deb-package-py2:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-deb
+#         <<: *master_and_release_only
+#     - smoke-deb-package-py3:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-deb
+#         <<: *master_and_release_only
+#     - ami-tests-development:
+#          context: scalyr-agent
+#          requires:
+#            - build-windows-package
+#            - build-linux-packages-and-installer-script
+#     - ami-tests-stable:
+#          context: scalyr-agent
+#          <<: *master_and_release_only
+# benchmarks:
+#   <<: *skip_release_build_branch_push
+#   jobs:
+#     - benchmarks-micro-py-27
+#     - benchmarks-micro-py-35
+#     - benchmarks-idle-agent-py-27:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-idle-agent-py-35:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-idle-agent-no-monitors-py-27:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-idle-agent-no-monitors-py-35:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27:
+#         <<: *benchmarks_master_and_release_only
+#     - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35:
+#         <<: *benchmarks_master_and_release_only
+#     # - send-benchmark-results-and-graphs-to-slack:
+#     #     requires:
+#     #       - benchmarks-idle-agent-py-27
+#     #       - benchmarks-idle-agent-py-35
+#     #       - benchmarks-idle-agent-no-monitors-py-27
+#     #       - benchmarks-idle-agent-no-monitors-py-35
+#     #       - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27
+#     #       - benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35
+#     #       - benchmarks-loaded-agent-single-growing-log-file-20mb-py-27
+#     #       - benchmarks-loaded-agent-single-growing-log-file-20mb-py-35
+#     #       - benchmarks-loaded-agent-single-growing-log-file-180mb-py-27
+#     #       - benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35
+#     #       - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27
+#     #       - benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35
+#     #     <<: *benchmarks_master_and_release_only
+# weekly-circle-ci-usage-report:
+#   triggers:
+#     - schedule:
+#         cron: "0 0 * * 0"
+#         filters:
+#           branches:
+#             only:
+#               - master
+#   jobs:
+#     - send-circle-ci-usage-report
+#
+# # We run AMI based package install tests which utilize installer script on
+# # daily basis.
+# # This helps us detect various installer script and other potential upstream
+# # issues.
+# daily-stable-ami-package-install-tests:
+#   triggers:
+#     - schedule:
+#         cron: "0 2 * * *"
+#         filters:
+#           branches:
+#             only:
+#               - master
+#   jobs:
+#     - ami-tests-stable:
+#         context: scalyr-agent
+#     - unittest-27:
+#         context: scalyr-agent
+#     - unittest-35:
+#         context: scalyr-agent
+#     - unittest-35-osx:
+#         context: scalyr-agent
+#     - unittest-38-windows:
+#         context: scalyr-agent
+#     - build-linux-packages-and-installer-script
+#     - build-windows-package
+#     - package-test-rpm:
+#         context: scalyr-agent
+#     - package-test-deb:
+#         context: scalyr-agent
+#     - smoke-rpm-package-py2:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-rpm
+#     - smoke-rpm-package-py3:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-rpm
+#     - smoke-deb-package-py2:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-deb
+#     - smoke-deb-package-py3:
+#         context: scalyr-agent
+#         requires:
+#           - package-test-deb

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 debug
 build
+/agent_build_output
 .vagrant
 .idea
 .run

--- a/.github/actions/perform-deployment/dist/index.js
+++ b/.github/actions/perform-deployment/dist/index.js
@@ -57997,7 +57997,11 @@ async function performDeployment() {
 
     const deploymentName = core.getInput("deployment-name")
     const cacheVersionSuffix = core.getInput("cache-version-suffix")
-    const cacheDir = "deployment_caches"
+    const cacheDir = path.resolve(path.join("agent_build_output", "deployment_cache", deploymentName))
+
+    if (!fs.existsSync(cacheDir)) {
+        fs.mkdirSync(cacheDir,{recursive: true})
+    }
 
     // Get json list with names of all deployments which are needed for this deployment.
     const deployment_helper_script_path = path.join("agent_build", "scripts", "run_deployment.py")
@@ -58027,7 +58031,7 @@ async function performDeployment() {
     // has to reuse them.
     child_process.execFileSync(
         "python3",
-        [deployment_helper_script_path, "deployment", deploymentName, "deploy", "--cache-dir", cacheDir],
+        [deployment_helper_script_path, "deployment", deploymentName, "deploy"],
         {stdio: 'inherit'}
     );
 

--- a/.github/actions/perform-deployment/index.js
+++ b/.github/actions/perform-deployment/index.js
@@ -105,7 +105,11 @@ async function performDeployment() {
 
     const deploymentName = core.getInput("deployment-name")
     const cacheVersionSuffix = core.getInput("cache-version-suffix")
-    const cacheDir = "deployment_caches"
+    const cacheDir = path.resolve(path.join("agent_build_output", "deployment_cache", deploymentName))
+
+    if (!fs.existsSync(cacheDir)) {
+        fs.mkdirSync(cacheDir,{recursive: true})
+    }
 
     // Get json list with names of all deployments which are needed for this deployment.
     const deployment_helper_script_path = path.join("agent_build", "scripts", "run_deployment.py")
@@ -135,7 +139,7 @@ async function performDeployment() {
     // has to reuse them.
     child_process.execFileSync(
         "python3",
-        [deployment_helper_script_path, "deployment", deploymentName, "deploy", "--cache-dir", cacheDir],
+        [deployment_helper_script_path, "deployment", deploymentName, "deploy"],
         {stdio: 'inherit'}
     );
 

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -5,46 +5,10 @@ on: [push]
 
 # Agent Docker image tests
 jobs:
-  docker-json:
-    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
-    with:
-      image-type: docker-json
-      publish: true
+  build-images:
+    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@refactor-deployment-caching
     secrets:
       SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_PROD_ACCOUNT }}
-      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_PROD_ACCOUNT }}
-
-  docker-syslog:
-    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
-    with:
-      image-type: docker-syslog
-      publish: true
-    secrets:
-      SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
-      SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_PROD_ACCOUNT }}
-      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_PROD_ACCOUNT }}
-
-  docker-api:
-    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
-    with:
-      image-type: docker-api
-      publish: false
-    secrets:
-      SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
-      SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_PROD_ACCOUNT }}
-      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_PROD_ACCOUNT }}
-
-  k8s:
-    uses: scalyr/scalyr-agent-2/.github/workflows/docker-and-k8s.yml@master
-    with:
-      image-type: k8s
-      publish: true
-    secrets:
-      SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
-      SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_PROD_ACCOUNT }}
-      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_PROD_ACCOUNT }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_TEST_ACCOUNT }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_TEST_ACCOUNT }}

--- a/.github/workflows/docker-and-k8s.yml
+++ b/.github/workflows/docker-and-k8s.yml
@@ -3,19 +3,10 @@ name: Build Agent Images
 on:
   workflow_call:
     inputs:
-      image-type:
-        description: "Name of the image build type (docker-json, docker-syslog, docker-api, k8s)."
-        required: true
-        type: string
       python-version:
         required: false
         type: string
         default: 3.8.10
-      publish:
-        description: "If true, then the result image will be published on master branch or any tag."
-        type: boolean
-        required: false
-        default: false
 
     secrets:
       SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN:
@@ -39,9 +30,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - image_distro_name: "buster"
-          - image_distro_name: "alpine"
+        image-type: ["docker-json", "docker-syslog", "docker-api", "k8s"]
+        image-distro-name: ["buster", "alpine"]
+
+    env:
+      # Set this variable to tell the agent build code that it runs in CI/CD and it needs to use caching.
+      AGENT_BUILD_IN_CICD: "1"
 
     steps:
       - name: Checkout repository
@@ -68,133 +62,118 @@ jobs:
           image: tonistiigi/binfmt:qemu-v6.1.0
           platforms: all
 
+      - name: Perform the build of the base docker image in the deployment.
+        uses: ./.github/actions/perform-deployment
+        with:
+          deployment-name: ${{ matrix.image-type }}-${{ matrix.image-distro-name }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
           driver-opts: network=host
 
       - name: Start minikube for the test of the kubernetes build
-        if: inputs.image-type == 'k8s'
+        if: matrix.image-type == 'k8s'
         shell: bash
         run: |
           minikube start
-
-      - name: Get checksum of the base image files
-        run: |
-          python3 build_package_new.py "${{ inputs.image-type }}-${{ matrix.image_distro_name }}" --files-checksum --debug
-          python3 build_package_new.py "${{ inputs.image-type }}-${{ matrix.image_distro_name }}" --files-checksum > image_files_checksum.txt
-
-      - name: Check for the docker buildx cache.
-        uses: actions/cache@v2
-        with:
-          path: ~/docker-test-image-build-cache
-          key: agent-docker-test-image-buildx-cache-${{ inputs.image-type }}-${{ matrix.image_distro_name }}-${{ hashFiles('image_files_checksum.txt') }}
 
       - name: Run image test
         env:
             SCALYR_API_KEY: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
         run: |
 
-          mkdir -p ~/docker-test-image-build-cache
-          # If cache exists, then it goes to the input of the build.
-          mv ~/docker-test-image-build-cache ~/docker-test-image-build-cache-in
-          # If cache does not exist, then create a new epty cache directory,
-          # where a new build cache will be stored.
-          mkdir -p ~/docker-test-image-build-cache
-
           python3 tests/package_tests/run_package_test.py package-test \
-           "${{ inputs.image-type }}-${{ matrix.image_distro_name }}_test" \
+           "${{ matrix.image-type }}-${{ matrix.image-distro-name }}_test" \
             --name-suffix "_${{ github.run_number }}${{ github.run_attempt }}" \
-            --cache-from-dir ~/docker-test-image-build-cache-in \
-            --cache-to-dir ~/docker-test-image-build-cache
 
-  publish:
-    needs: [test]
-    name: Publish Docker Image
-    if: ${{ inputs.publish == true && (github.ref == 'refs/heads/master' || github.ref_type == 'tag') }}
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # We build 2 type of images - one based on Debian Buster Slim image and another set based
-          # on Alpine Linux
-          - image_distro_name: "buster"
-            image_tag_suffix: ""
-            image_tag_suffix_full: ""
-          # NOTE: For non empty suffixes, "image_tag_suffix_full" version needs to contain leading "-"
-          - image_distro_name: "alpine"
-            image_tag_suffix: "alpine"
-            image_tag_suffix_full: "-alpine"
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v1
-        with:
-          image: tonistiigi/binfmt:qemu-v6.1.0
-          platforms: all
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          driver-opts: network=host
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-
-      - name: Get checksum of the base image files
-        run: |
-          python3 build_package_new.py "${{ inputs.image-type }}-${{ matrix.image_distro_name }}" --files-checksum --debug
-          python3 build_package_new.py "${{ inputs.image-type }}-${{ matrix.image_distro_name }}" --files-checksum > image_files_checksum.txt
-
-      - name: Check for the docker buildx cache.
-        uses: actions/cache@v2
-        with:
-          path: ~/docker-image-build-cache
-          key: agent-docker-image-buildx-cache-${{ inputs.image-type }}-${{ matrix.image_distro_name }}-${{ hashFiles('image_files_checksum.txt') }}
-
-      - name: Prepare build cache directories.
-        run: |
-          mkdir -p ~/docker-image-build-cache
-          # If cache exists, then it goes to the input of the build.
-          mv ~/docker-image-build-cache ~/docker-image-build-cache-in
-          # If cache does not exist, then create a new empty cache directory,
-          # where a new build cache will be stored.
-          mkdir -p ~/docker-image-build-cache
-
-      - name: Push image using the master branch commit SHA.
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: |
-          # NOTE: --remove-image-name-prefix is needed in case Docker hub usename is not scalyr
-          python3 build_package_new.py "${{ inputs.image-type }}-${{ matrix.image_distro_name }}" \
-            --registry "${{ secrets.DOCKER_HUB_USERNAME }}" \
-            --remove-image-name-prefix \
-            --push \
-            --tag "${{ github.sha }}${{ matrix.image_tag_suffix_full }}" \
-            --cache-from-dir ~/docker-image-build-cache-in \
-            --cache-to-dir ~/docker-image-build-cache
-
-      - name: Push image using the tag.
-        if: ${{ github.ref_type == 'tag' }}
-        run: |
-          tag_options=$(python3 scripts/cicd/verify_and_get_image_tag_to_publish.py "${{ github.ref_name }})" --sufix "${{ matrix.image_tag_suffix }}"
-
-          python3 build_package_new.py ${{ inputs.image-type }} \
-            --registry "${{ secrets.DOCKER_HUB_USERNAME }}" \
-            --remove-image-name-prefix \
-            --push \
-            --cache-from-dir ~/docker-image-build-cache-in \
-            --cache-to-dir ~/docker-image-build-cache \
-            ${tag_options}
-
-          # Check the cache directory size post build
-          du -hs ~/docker-image-build-cache
-          ls -lah ~/docker-image-build-cache
+#  publish:
+#    needs: [test]
+#    name: Publish Docker Image
+#    if: ${{ inputs.publish == true && (github.ref == 'refs/heads/master' || github.ref_type == 'tag') }}
+#    runs-on: ubuntu-latest
+#
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        include:
+#          # We build 2 type of images - one based on Debian Buster Slim image and another set based
+#          # on Alpine Linux
+#          - image-distro-name: "buster"
+#            image_tag_suffix: ""
+#            image_tag_suffix_full: ""
+#          # NOTE: For non empty suffixes, "image_tag_suffix_full" version needs to contain leading "-"
+#          - image-distro-name: "alpine"
+#            image_tag_suffix: "alpine"
+#            image_tag_suffix_full: "-alpine"
+#
+#    steps:
+#      - name: Checkout repository
+#        uses: actions/checkout@v2
+#
+#      - name: Set up QEMU
+#        id: qemu
+#        uses: docker/setup-qemu-action@v1
+#        with:
+#          image: tonistiigi/binfmt:qemu-v6.1.0
+#          platforms: all
+#
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v1
+#        with:
+#          driver-opts: network=host
+#
+#      - name: Log in to Docker Hub
+#        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+#        with:
+#          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+#          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+#
+#      - name: Get checksum of the base image files
+#        run: |
+#          python3 build_package_new.py "${{ inputs.image-type }}-${{ matrix.image-distro-name }}" --files-checksum --debug
+#          python3 build_package_new.py "${{ inputs.image-type }}-${{ matrix.image-distro-name }}" --files-checksum > image_files_checksum.txt
+#
+#      - name: Check for the docker buildx cache.
+#        uses: actions/cache@v2
+#        with:
+#          path: ~/docker-image-build-cache
+#          key: agent-docker-image-buildx-cache-${{ inputs.image-type }}-${{ matrix.image-distro-name }}-${{ hashFiles('image_files_checksum.txt') }}
+#
+#      - name: Prepare build cache directories.
+#        run: |
+#          mkdir -p ~/docker-image-build-cache
+#          # If cache exists, then it goes to the input of the build.
+#          mv ~/docker-image-build-cache ~/docker-image-build-cache-in
+#          # If cache does not exist, then create a new empty cache directory,
+#          # where a new build cache will be stored.
+#          mkdir -p ~/docker-image-build-cache
+#
+#      - name: Push image using the master branch commit SHA.
+#        if: ${{ github.ref == 'refs/heads/master' }}
+#        run: |
+#          # NOTE: --remove-image-name-prefix is needed in case Docker hub usename is not scalyr
+#          python3 build_package_new.py "${{ inputs.image-type }}-${{ matrix.image-distro-name }}" \
+#            --registry "${{ secrets.DOCKER_HUB_USERNAME }}" \
+#            --remove-image-name-prefix \
+#            --push \
+#            --tag "${{ github.sha }}${{ matrix.image_tag_suffix_full }}" \
+#            --cache-from-dir ~/docker-image-build-cache-in \
+#            --cache-to-dir ~/docker-image-build-cache
+#
+#      - name: Push image using the tag.
+#        if: ${{ github.ref_type == 'tag' }}
+#        run: |
+#          tag_options=$(python3 scripts/cicd/verify_and_get_image_tag_to_publish.py "${{ github.ref_name }})" --sufix "${{ matrix.image_tag_suffix }}"
+#
+#          python3 build_package_new.py ${{ inputs.image-type }} \
+#            --registry "${{ secrets.DOCKER_HUB_USERNAME }}" \
+#            --remove-image-name-prefix \
+#            --push \
+#            --cache-from-dir ~/docker-image-build-cache-in \
+#            --cache-to-dir ~/docker-image-build-cache \
+#            ${tag_options}
+#
+#          # Check the cache directory size post build
+#          du -hs ~/docker-image-build-cache
+#          ls -lah ~/docker-image-build-cache

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ scalyr-agent-2-*/
 tests/package_tests/credentials.json
 !.github/actions/perform-deployment/dist
 .github/actions/perform-deployment/node_modules
+/agent_build_output
 
 # Installer logs
 pip-log.txt

--- a/agent_build/DEPLOYMENTS.md
+++ b/agent_build/DEPLOYMENTS.md
@@ -50,19 +50,24 @@ In the example we use step class ``ExampleStep``:
 
 ``` 
 
-class ExampleStep(ShellScriptDeploymentStep):
-    SCRIPT_PATH = _DEPLOYMENT_STEPS_PATH / "example/install-requirements-and-download-webdriver.sh"
-    USED_FILES = [
-        _DEPLOYMENT_STEPS_PATH / "example/requirements-1.txt",
-        _DEPLOYMENT_STEPS_PATH / "example/requirements-2.txt",
+class ExampleStep(deployments.ShellScriptDeploymentStep):
+    @property
+    def script_path(self) -> pl.Path:
+        return _REL_EXAMPLE_DEPLOYMENT_STEPS_PATH / "install-requirements-and-download-webdriver.sh"
+
+    @property
+    def _tracked_file_globs(self) -> List[pl.Path]:
+        return [
+            *super(ExampleStep, self)._tracked_file_globs,
+            _REL_EXAMPLE_DEPLOYMENT_STEPS_PATH / "requirements-*.txt",
     ]
 ```
 
 Here in the example we declare class `ExampleStep` as a child of the `ShellScriptDeploymentStep`
 class. The ``ShellScriptDeploymentStep`` base class is a `DeploymentStep` that runs some shell script in order to perform
-the step, and the script is specified in the ``SCRIPT_PATH`` class attribute. In our case, the shell script is 
-``install-requirements-and-download-webdriver.sh``. The needed requirement files are reflected in the ``USED_FILES`` -
-another class attribute, which is the list of paths to the files, that are somehow used in the deployment step.
+the step, and the script is specified in its ``script_path`` property method. In our case, the shell script is 
+``install-requirements-and-download-webdriver.sh``. The needed requirement files are reflected in the ``tracked_file_globs`` -
+another property method, which is the list of paths to the files, that are somehow used in the deployment step.
 
 The script file ``install-requirements-and-download-webdriver.sh`` does the main work of the step, and it can also cache 
 some intermediate results by calling special cache functions, which are sourced before the script:
@@ -76,7 +81,7 @@ some intermediate results by calling special cache functions, which are sourced 
     save_to_cache <cache_key> <path>
     ```
 
-NOTE: You can find those example files in the ``agent_build/tools/environment_deployments/steps/example`` directory.
+NOTE: You can find those example files in tests in file ``agent_build/tools/tests/test_deployments.py``
 
 After the deployment and its steps are defined, we can use it in the GitHub Actions.
 To do that, we just have to call a local GitHub action `github/actions/perform-deployment`

--- a/agent_build/docker/Dockerfile
+++ b/agent_build/docker/Dockerfile
@@ -1,0 +1,87 @@
+# Final Scalyr Agent docker image that uses the previously built base image.
+# NOTE: multi-stage builds require Docker 17.05 or greater
+
+# Type of the image build, e.g: docker-json, docker-syslog, k8s
+ARG BUILD_TYPE
+
+# Name of the base image to use.
+ARG BASE_IMAGE
+
+ARG MODE="normal"
+
+
+FROM $BASE_IMAGE as scalyr-build
+MAINTAINER Scalyr Inc <support@scalyr.com>
+
+# If specified then the package build command will produce additional debug logging.
+ARG AGENT_BUILD_DEBUG
+ENV AGENT_BUILD_DEBUG=$AGENT_BUILD_DEBUG
+# Special env. variable that will enable addional logging info about that command runs in docker.
+ENV AGENT_BUILD_IN_DOCKER=1
+# e.g. k8s, docker-json
+ARG BUILD_TYPE
+# e.g. k8s-buster, docker-json-buster, k8s-alpine
+ARG BUILDER_NAME
+ADD . /scalyr-agent-2
+
+# Build the tarball with Agent's files.
+RUN python3 /scalyr-agent-2/build_package_new.py ${BUILDER_NAME} --only-filesystem-tarball /tmp/build/scalyr-agent.tar.gz
+
+# Extract tarball to the special place that can be reused by next stages.
+WORKDIR /tmp/container-fs
+RUN tar -xf /tmp/build/scalyr-agent.tar.gz
+
+WORKDIR /
+
+# Copy result files to a new base stage.
+FROM python:3.8.10-slim as scalyr-base
+MAINTAINER Scalyr Inc <support@scalyr.com>
+# Copy Agent's Python dependencies. Those dependencies were built in the base image,
+# which is given by 'BASE_IMAGE' arg.
+COPY --from=scalyr-build  /tmp/dependencies/ /
+# Copy Agent files.
+COPY --from=scalyr-build /tmp/container-fs /
+
+
+# Optional stage for docker-json.
+FROM scalyr-base as build-docker-json
+MAINTAINER Scalyr Inc <support@scalyr.com>
+# Nothing to add
+
+# Optional stage for docker-api.
+FROM scalyr-base as build-docker-api
+MAINTAINER Scalyr Inc <support@scalyr.com>
+# Nothing to add
+
+
+# Optional stage for docker-syslog.
+FROM scalyr-base as build-docker-syslog
+MAINTAINER Scalyr Inc <support@scalyr.com>
+# expose syslog ports
+EXPOSE 601/tcp
+# Please note Syslog UDP 1024 max packet length (rfc3164)
+EXPOSE 514/udp
+
+
+# Optional stage for k8s.
+FROM scalyr-base as build-k8s
+MAINTAINER Scalyr Inc <support@scalyr.com>
+ENV SCALYR_STDOUT_SEVERITY ERROR
+
+
+# Noraml result image.
+FROM build-$BUILD_TYPE as scalyr-normal
+MAINTAINER Scalyr Inc <support@scalyr.com>
+
+CMD ["/usr/sbin/scalyr-agent-2", "--no-fork", "--no-change-user", "start"]
+
+
+# Result image stage for testing.
+FROM build-$BUILD_TYPE as scalyr-testing
+MAINTAINER Scalyr Inc <support@scalyr.com>
+# Since test version of the image uses coverage, add command that runs the Agent with enabled coverage.
+CMD ["coverage", "run", "--branch", "/usr/share/scalyr-agent-2/py/scalyr_agent/agent_main.py", "--no-fork", "--no-change-user", "start"]
+
+# Use stage with needed mode as a final image.
+FROM scalyr-$MODE as scalyr
+MAINTAINER Scalyr Inc <support@scalyr.com>

--- a/agent_build/docker/Dockerfile.base
+++ b/agent_build/docker/Dockerfile.base
@@ -1,0 +1,81 @@
+# Base image that creates all necessary dependencies for the scalyr-agent docker image.
+# NOTE: multi-stage builds require Docker 17.05 or greater
+
+# Suffix for the python dockerhub image. For now can be:
+#   - 'slim' for buster based image
+#   - 'alpine' for alpine based image.
+ARG BASE_IMAGE_SUFFIX
+
+# Install dependency packages for buster.
+FROM python:3.8.10-slim as scalyr-dependencies-slim
+MAINTAINER Scalyr Inc <support@scalyr.com>
+
+RUN apt-get update && apt-get install -y build-essential git tar curl
+
+
+# Install dependency packages for alpine.
+FROM python:3.8.10-alpine as scalyr-dependencies-alpine
+MAINTAINER Scalyr Inc <support@scalyr.com>
+
+RUN apk update && apk add --virtual build-dependencies \
+    binutils \
+    build-base \
+    gcc \
+    g++ \
+    make \
+    curl \
+    python3-dev \
+    patchelf \
+    git
+
+# Install rust and cargo. It is needed to build some of the Python dependencies of the agent.
+FROM scalyr-dependencies-$BASE_IMAGE_SUFFIX as scalyr-dependencies-rust-
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup toolchain install nightly
+RUN rustup default nightly
+
+# There's no precompiled rust installation for armv7 so we replase the previous stage with this and do nothing.
+FROM scalyr-dependencies-$BASE_IMAGE_SUFFIX as scalyr-dependencies-rust-v7
+# Do nothing
+
+# Use one of the two previous stages according to the TARGETVARIANT suffix.
+# if TARGETVARIANT is 'v7', then we use stage without rust.
+# IMPORTANT: that may be needed to revise if new architectres are added.
+FROM scalyr-dependencies-rust-$TARGETVARIANT as scalyr-dependencies
+
+ARG TARGETVARIANT
+ARG COVERAGE_VERSION
+
+ADD agent_build/requirement-files/docker-image-requirements.txt agent_build/requirement-files/docker-image-requirements.txt
+ADD agent_build/requirement-files/compression-requirements.txt agent_build/requirement-files/compression-requirements.txt
+ADD agent_build/requirement-files/main-requirements.txt agent_build/requirement-files/main-requirements.txt
+
+# Install agent dependencies.
+RUN pip3 install --upgrade pip
+RUN pip3 --no-cache-dir install --root /tmp/dependencies -r agent_build/requirement-files/docker-image-requirements.txt
+
+# Install coverage if its version if specified. Only used in testing.
+RUN if [ -n "${COVERAGE_VERSION}" ]; then pip3 install --root /tmp/dependencies coverage=="${COVERAGE_VERSION}"; fi
+
+
+# Install packages and tools that will be required during the final image build.
+
+# Install tools for alpine
+FROM python:3.8.10-alpine as ready-base-alpine
+MAINTAINER Scalyr Inc <support@scalyr.com>
+
+RUN apk update && apk add --virtual curl git
+
+# Install tools for buster.
+FROM python:3.8.10-slim as ready-base-slim
+MAINTAINER Scalyr Inc <support@scalyr.com>
+
+RUN apt-get update && apt-get install -y git tar curl
+
+# Create a final base stage from one of the prefious OS-specific stages.
+FROM ready-base-$BASE_IMAGE_SUFFIX
+
+# Copy Agent's Python dependencies, so they also can be used in the final image build.
+COPY --from=scalyr-dependencies  /tmp/dependencies/ /tmp/dependencies/
+WORKDIR /

--- a/agent_build/package_builders.py
+++ b/agent_build/package_builders.py
@@ -175,14 +175,14 @@ class PackageBuilder(abc.ABC):
         :param no_versioned_file_name:  True if the version number should not be embedded in the artifact's file name.
         """
         # The path where the build output will be stored.
-        self._build_output_path: Optional[pl.Path] = None
-
+        self._build_output_path: Optional[pl.Path] = constants.PACKAGE_BUILDER_OUTPUT / self.name
         # Folder with intermediate and temporary results of the build.
-        self._intermediate_results_path: Optional[pl.Path] = None
-
+        self._intermediate_results_path = (
+                self._build_output_path / "intermediate_results"
+        )
         # The path of the folder where all files of the package will be stored.
-        # May be help full for the debug purposes.
-        self._package_files_path: Optional[pl.Path] = None
+        # Also may be helpful for the debug purposes.
+        self._package_root_path = self._build_output_path / "package_root"
 
         self._variant = variant
         self._no_versioned_file_name = no_versioned_file_name
@@ -234,31 +234,16 @@ class PackageBuilder(abc.ABC):
             arch=package_specific_arch_name
         )
 
-    def build(self, output_path: Union[str, pl.Path], locally: bool = False):
+    def build(self, locally: bool = False):
         """
         The function where the actual build of the package happens.
-        :param output_path: Path to the directory where the resulting output has to be stored.
         :param locally: Force builder to build the package on the current system, even if meant to be done inside
             docker. This is needed to avoid loop when it is already inside the docker.
         """
 
-        output_path = pl.Path(output_path).absolute()
-
-        if output_path.exists():
-            shutil.rmtree(output_path)
-
-        output_path.mkdir(parents=True)
-
         # Build right here.
         if locally or not self.deployment.in_docker:
-            self._build_output_path = pl.Path(output_path)
-            self._package_files_path = self._build_output_path / "package_root"
-            self._package_files_path.mkdir()
-            self._intermediate_results_path = (
-                self._build_output_path / "intermediate_results"
-            )
-            self._intermediate_results_path.mkdir()
-            self._build(output_path=output_path)
+            self._build()
             return
 
         # Build in docker.
@@ -290,7 +275,7 @@ class PackageBuilder(abc.ABC):
             architecture=self.architecture,
             image_name=f"agent-builder-{self.name}-{base_image_name}".lower(),
             base_image_name=base_image_name,
-            output_path_mappings={output_path: pl.Path("/tmp/build")},
+            output_path_mappings={self._build_output_path: pl.Path("/tmp/build")},
         )
 
     @property
@@ -526,9 +511,33 @@ class PackageBuilder(abc.ABC):
         output_path.mkdir(parents=True, exist_ok=True)
         shutil.copy2(frozen_binary_path, output_path)
 
-    def _build_package_files(self, output_path: Union[str, pl.Path]):
+    @property
+    def _agent_install_root_path(self) -> pl.Path:
         """
-        Build the basic structure for all packages.
+        The path to the root directory with all agent-related files.
+        By the default, the install root of the agent is the same as the root of the whole package.
+        """
+        return self._package_root_path
+
+    def _build_package_files(self):
+        """
+        This method builds all files of the package.
+        """
+
+        # Clear previously used build folder, if exists.
+        if self._build_output_path.exists():
+            shutil.rmtree(self._build_output_path)
+
+        self._build_output_path.mkdir(parents=True)
+        self._intermediate_results_path.mkdir()
+        self._package_root_path.mkdir()
+
+        # Build files in the agent's install root.
+        self._build_agent_install_root()
+
+    def _build_agent_install_root(self):
+        """
+        Build the basic structure of the install root.
 
             This creates a directory and then populates it with the basic structure required by most of the packages.
 
@@ -543,36 +552,33 @@ class PackageBuilder(abc.ABC):
                 VERSION                    -- File with current version of the agent.
                 install_type               -- File with type of the installation.
 
-
-        :param output_path: The output path where the result files are stored.
         """
-        output_path = pl.Path(output_path)
 
-        if output_path.exists():
-            shutil.rmtree(output_path)
+        if self._agent_install_root_path.exists():
+            shutil.rmtree(self._agent_install_root_path)
 
-        output_path.mkdir(parents=True)
+        self._agent_install_root_path.mkdir(parents=True)
 
         # Write build_info file.
-        build_info_path = output_path / "build_info"
+        build_info_path = self._agent_install_root_path / "build_info"
         build_info_path.write_text(self._build_info)
 
         # Copy the monitors directory.
-        monitors_path = output_path / "monitors"
+        monitors_path = self._agent_install_root_path / "monitors"
         shutil.copytree(__SOURCE_ROOT__ / "monitors", monitors_path)
-        recursively_delete_files_by_name(output_path / monitors_path, "README.md")
+        recursively_delete_files_by_name(self._agent_install_root_path / monitors_path, "README.md")
 
         # Add VERSION file.
-        shutil.copy2(__SOURCE_ROOT__ / "VERSION", output_path / "VERSION")
+        shutil.copy2(__SOURCE_ROOT__ / "VERSION", self._agent_install_root_path / "VERSION")
 
         # Create bin directory with executables.
-        bin_path = output_path / "bin"
+        bin_path = self._agent_install_root_path / "bin"
         bin_path.mkdir()
 
         if type(self).USE_FROZEN_BINARIES:
             self._build_frozen_binary(bin_path)
         else:
-            source_code_path = output_path / "py"
+            source_code_path = self._agent_install_root_path / "py"
 
             shutil.copytree(
                 __SOURCE_ROOT__ / "scalyr_agent", source_code_path / "scalyr_agent"
@@ -602,10 +608,9 @@ class PackageBuilder(abc.ABC):
             )
 
     @abc.abstractmethod
-    def _build(self, output_path: Union[str, pl.Path]):
+    def _build(self):
         """
         The implementation of the package build.
-        :param output_path: Path for the build result.
         """
         pass
 
@@ -621,21 +626,21 @@ class LinuxPackageBuilder(PackageBuilder):
         "windows_process_metrics",
     ]
 
-    def _build_package_files(self, output_path: Union[str, pl.Path]):
+    def _build_agent_install_root(self):
         """
         Add files to the agent's install root which are common for all linux packages.
         """
-        super(LinuxPackageBuilder, self)._build_package_files(output_path=output_path)
+        super(LinuxPackageBuilder, self)._build_agent_install_root()
 
         # Add certificates.
-        certs_path = output_path / "certs"
+        certs_path = self._agent_install_root_path / "certs"
         self._add_certs(certs_path)
 
         # Misc extra files needed for some features.
         # This docker file is needed by the `scalyr-agent-2-config --docker-create-custom-dockerfile` command.
         # We put it in all distributions (not just the docker_tarball) in case a customer creates an image
         # using a package.
-        misc_path = output_path / "misc"
+        misc_path = self._agent_install_root_path / "misc"
         misc_path.mkdir()
         for f in ["Dockerfile.custom_agent_config", "Dockerfile.custom_k8s_config"]:
             shutil.copy2(__SOURCE_ROOT__ / "docker" / f, misc_path / f)
@@ -650,22 +655,25 @@ class LinuxFhsBasedPackageBuilder(LinuxPackageBuilder):
 
     INSTALL_TYPE = "package"
 
-    def _build_package_files(self, output_path: Union[str, pl.Path]):
-        # The install root is located in the usr/share/scalyr-agent-2.
-        install_root = output_path / "usr/share/scalyr-agent-2"
-        super(LinuxFhsBasedPackageBuilder, self)._build_package_files(
-            output_path=install_root
-        )
+    @property
+    def _agent_install_root_path(self) -> pl.Path:
+        # The install root for FHS based packages is located in the usr/share/scalyr-agent-2.
+        original_install_root = super(LinuxFhsBasedPackageBuilder, self)._agent_install_root_path
+        return original_install_root / "usr/share/scalyr-agent-2"
 
-        pl.Path(output_path, "var/log/scalyr-agent-2").mkdir(parents=True)
-        pl.Path(output_path, "var/lib/scalyr-agent-2").mkdir(parents=True)
+    def _build_package_files(self):
 
-        bin_path = install_root / "bin"
-        usr_sbin_path = self._package_files_path / "usr/sbin"
+        super(LinuxFhsBasedPackageBuilder, self)._build_package_files()
+
+        pl.Path(self._package_root_path, "var/log/scalyr-agent-2").mkdir(parents=True)
+        pl.Path(self._package_root_path, "var/lib/scalyr-agent-2").mkdir(parents=True)
+
+        bin_path = self._agent_install_root_path / "bin"
+        usr_sbin_path = self._package_root_path / "usr/sbin"
         usr_sbin_path.mkdir(parents=True)
         for binary_path in bin_path.iterdir():
             binary_symlink_path = (
-                self._package_files_path / "usr/sbin" / binary_path.name
+                    self._package_root_path / "usr/sbin" / binary_path.name
             )
             symlink_target_path = pl.Path(
                 "..", "share", "scalyr-agent-2", "bin", binary_path.name
@@ -673,9 +681,7 @@ class LinuxFhsBasedPackageBuilder(LinuxPackageBuilder):
             binary_symlink_path.symlink_to(symlink_target_path)
 
 
-class ContainerPackageBuilder(
-    LinuxFhsBasedPackageBuilder, files_checksum_tracker.FilesChecksumTracker
-):
+class ContainerPackageBuilder(LinuxFhsBasedPackageBuilder):
     """
     The base builder for all docker and kubernetes based images . It builds an executable script in the current working
      directory that will build the container image for the various Docker and Kubernetes targets.
@@ -690,40 +696,35 @@ class ContainerPackageBuilder(
     # Names of the result image that goes to dockerhub.
     RESULT_IMAGE_NAMES: List[str]
 
-    FILE_GLOBS_USED_IN_IMAGE_BUILD: List[pl.Path]
+    FILE_GLOBS_USED_IN_IMAGE_BUILD: List[pl.Path] = []
 
     def __init__(
         self,
         config_path: pl.Path,
         name: str,
-        dockerfile_path: pl.Path = pl.Path("Dockerfile"),
+        base_image_deployment_step_cls: Type[deployments.BuildDockerBaseImageStep],
         variant: str = None,
         no_versioned_file_name: bool = False,
     ):
         """
         :param config_path: Path to the configuration directory which will be copied to the image.
-        :param dockerfile_path: Path to the Dockerfile to use. Defaults to Dockerfile.
         :param variant: Adds the specified string into the package's iteration name. This may be None if no additional
         tweak to the name is required. This is used to produce different packages even for the same package type (such
         as 'rpm').
         :param no_versioned_file_name:  True if the version number should not be embedded in the artifact's file name.
         """
         self._name = name
-        self.dockerfile_path = dockerfile_path
-
-        # NOTE: This variable must be defined here as class instance variable since it's value is
-        # dynamic and based on the dockerfile_path value.
-        self.FILE_GLOBS_USED_IN_IMAGE_BUILD = []
-        self.FILE_GLOBS_USED_IN_IMAGE_BUILD.append(pl.Path("docker/requirements.txt"))
-        self.FILE_GLOBS_USED_IN_IMAGE_BUILD.append(self.dockerfile_path)
+        self.dockerfile_path = __SOURCE_ROOT__ / "agent_build/docker/Dockerfile"
 
         super(ContainerPackageBuilder, self).__init__(
             architecture=constants.Architecture.UNKNOWN,
             variant=variant,
             no_versioned_file_name=no_versioned_file_name,
+            deployment_step_classes=[base_image_deployment_step_cls]
         )
 
-        files_checksum_tracker.FilesChecksumTracker.__init__(self)
+        self.base_image_deployment_step_cls = base_image_deployment_step_cls
+
         self.config_path = config_path
 
     @property
@@ -732,30 +733,20 @@ class ContainerPackageBuilder(
         # Dockerfile represents a different builder
         return self._name
 
-    @property
-    def _tracked_file_globs(self) -> List[pl.Path]:
-        return self.FILE_GLOBS_USED_IN_IMAGE_BUILD
-
-    @property
-    def used_files_checksum(self) -> str:
-        return self._get_files_checksum()
-
-    def _build_package_files(self, output_path: Union[str, pl.Path]):
-        super(ContainerPackageBuilder, self)._build_package_files(
-            output_path=output_path
-        )
+    def _build_package_files(self):
+        super(ContainerPackageBuilder, self)._build_package_files()
 
         # Need to create some docker specific directories.
-        pl.Path(output_path / "var/log/scalyr-agent-2/containers").mkdir()
+        pl.Path(self._package_root_path / "var/log/scalyr-agent-2/containers").mkdir()
 
         # Copy config
         self._add_config(
             config_source_path=self.config_path,
-            output_path=self._package_files_path / "etc/scalyr-agent-2",
+            output_path=self._package_root_path / "etc/scalyr-agent-2",
         )
 
-    def _build(self, output_path: Union[str, pl.Path]):
-        self._build_package_files(output_path=self._package_files_path)
+    def _build(self):
+        self._build_package_files()
 
         container_tarball_path = self._build_output_path / "scalyr-agent.tar.gz"
 
@@ -764,7 +755,7 @@ class ContainerPackageBuilder(
         # mainly Posix.
         with tarfile.open(container_tarball_path, "w:gz") as container_tar:
 
-            for root, dirs, files in os.walk(self._package_files_path):
+            for root, dirs, files in os.walk(self._package_root_path):
                 to_copy = []
                 for name in dirs:
                     to_copy.append(os.path.join(root, name))
@@ -773,7 +764,7 @@ class ContainerPackageBuilder(
 
                 for x in to_copy:
                     file_entry = container_tar.gettarinfo(
-                        x, arcname=str(pl.Path(x).relative_to(self._package_files_path))
+                        x, arcname=str(pl.Path(x).relative_to(self._package_root_path))
                     )
                     file_entry.uname = "root"
                     file_entry.gname = "root"
@@ -786,22 +777,37 @@ class ContainerPackageBuilder(
                     else:
                         container_tar.addfile(file_entry)
 
-    def build_image(
+    def build_filesystem_tarball(self, output_path: pl.Path):
+        super(ContainerPackageBuilder, self).build(
+            locally=True
+        )
+
+        # Also copy result tarball to the given path.
+        output_path.parent.mkdir(exist_ok=True, parents=True)
+        shutil.copy2(self._build_output_path / "scalyr-agent.tar.gz", output_path)
+
+    def build(
         self,
         image_names=None,
         registries: List[str] = None,
         tags: List[str] = None,
         push: bool = False,
-        cache_from_path: str = None,
-        cache_to_path: str = None,
-        with_coverage: bool = False,
-        reuse_local_cache: bool = False,
+        use_test_version: bool = False,
         remove_image_name_prefix: bool = False,
     ):
         """
         This function builds Agent docker image by using the specified dockerfile (defaults to "Dockerfile").
         It passes to dockerfile its own package type through docker build arguments, so the same package builder
         will be executed inside the docker build to prepare inner container filesystem.
+
+        The result image is built upon the base image that has to be built by the deployment of this builder.
+            Since it's not a trivial task to "transfer" a multi-platform image from one place to another, the image is
+            pushed to a local registry in the container, and the root of that registry is transferred instead.
+
+        Registry's root in /var/lib/registry is exposed to the host by using docker's mount feature and saved in the
+            deployment's output directory. This builder then spins up another local registry container and mounts root
+            of the saved registry. Now builder can refer to this local registry in order to get the base image.
+
         :param image_names: The list of image names. By default uses image names that are specified in the
             package builder.
         :param registries: List of registries to push to.
@@ -809,24 +815,22 @@ class ContainerPackageBuilder(
         :param push: If True, push result image to the registries that are specified in the 'registries' argument.
             If False, then just export the result image to the local docker. NOTE: The local docker cannot handle
             multi-platform images, so it will only get image for its  platform.
-        :param cache_from_path: Use given directory as a cache source by docker buildx (see more in '--cache-from'
-            in docker buildx docs)
-        :param cache_to_path: Use given directory as a cache destination by docker buildx (see more in
-            '--cache-to' in docker buildx docs)
-        :param with_coverage: Makes docker image to run agent with enabled coverage measuring (Python 'coverage'
-            library). Used only for testing.
-        :param reuse_local_cache: Set to True to re-use local cache and not pass CACHE_BUST build arg
-            to the docker command. Useful for local (non-CI) builds.
+        :param use_test_version: Makes testing docker image that runs agent with enabled coverage measuring (Python
+            'coverage' library). Must not be enabled in production images.
         :param remove_image_name_prefix: True to remove user / org prefix when using a custom registry.
             For example: scalyr/scalyr-agent-2 -> scalyr-agent-2.
         """
 
-        registries = registries or [""]
-        tags = tags or ["latest"]
+        if not common.IN_CICD:
+            # If there's not a CI/CD then the deployment has to be done explicitly.
+            # If there is an CI/CD, then the deployment has to be already done.
 
-        buildx_builder_name = "agent_image_buildx_builder"
+            # The ready deployment is required because it builds the base image of out result image.
+            self.deployment.deploy()
+
         # Create docker buildx builder instance. # Without it the result image won't be pushed correctly
         # to the local registry.
+        buildx_builder_name = "agent_image_buildx_builder"
 
         # check if builder already exists.
         ls_output = (
@@ -859,10 +863,21 @@ class ContainerPackageBuilder(
             ]
         )
 
-        dockerfile_path = __SOURCE_ROOT__ / self.dockerfile_path
+        logging.info("Build base image.")
 
-        if not os.path.isfile(dockerfile_path):
-            raise ValueError(f"File path {dockerfile_path} doesn't exist")
+        base_image_tag_suffix = self.base_image_deployment_step_cls.BASE_DOCKER_IMAGE_TAG_SUFFIX
+
+        if use_test_version:
+            logging.info("Build testing image version.")
+            base_image_tag_suffix = f"{base_image_tag_suffix}-testing"
+
+        base_image_name = f"agent_base_image:{base_image_tag_suffix}"
+
+        registries = registries or [""]
+        tags = tags or ["latest"]
+
+        if not os.path.isfile(self.dockerfile_path):
+            raise ValueError(f"File path {self.dockerfile_path} doesn't exist")
 
         tag_options = []
 
@@ -890,32 +905,14 @@ class ContainerPackageBuilder(
             "build",
             *tag_options,
             "-f",
-            str(dockerfile_path),
+            str(self.dockerfile_path),
             "--build-arg",
             f"BUILD_TYPE={type(self).PACKAGE_TYPE.value}",
             "--build-arg",
             f"BUILDER_NAME={self.name}",
+            "--build-arg",
+            f"BASE_IMAGE=localhost:5000/{base_image_name}"
         ]
-
-        if not reuse_local_cache:
-            command_options.extend(
-                [
-                    "--build-arg",
-                    # Pass current time to this build argument to ensure that all commands after this argument
-                    # won't use caching.
-                    f"CACHE_BUST={datetime.datetime.now().isoformat()}",
-                ]
-            )
-
-        # Add caching options if specified.
-        if cache_from_path:
-            command_options.append(
-                f"--cache-from=type=local,mode=max,src={cache_from_path}",
-            )
-        if cache_to_path:
-            command_options.append(
-                f"--cache-to=type=local,mode=max,dest={cache_to_path}",
-            )
 
         if common.DEBUG:
             # If debug, then also specify the debug mode inside the docker build.
@@ -928,23 +925,14 @@ class ContainerPackageBuilder(
 
         # If we need to push, then specify all platforms.
         if push:
-            command_options.append("--platform")
-            command_options.append(
-                constants.Architecture.X86_64.as_docker_platform.value
-            )
-            command_options.append("--platform")
-            command_options.append(
-                constants.Architecture.ARM64.as_docker_platform.value
-            )
-            command_options.append("--platform")
-            command_options.append(
-                constants.Architecture.ARMV7.as_docker_platform.value
-            )
-        if with_coverage:
-            logging.info("Code coverage enabled.")
-            # Build image with enabled coverage measuring.
+            for plat in constants.AGENT_DOCKER_IMAGE_SUPPORTED_PLATFORMS:
+                command_options.append("--platform")
+                command_options.append(plat.value)
+
+        if use_test_version:
+            # Pass special build argument to produce testing image.
             command_options.append("--build-arg")
-            command_options.append("MODE=with-coverage")
+            command_options.append("MODE=testing")
 
         if push:
             command_options.append("--push")
@@ -963,11 +951,23 @@ class ContainerPackageBuilder(
 
         logging.info(build_log_message)
 
-        common.run_command(
-            command_options,
-            # This command runs partially runs the same code, so it would be nice to see the output.
-            debug=True,
+        registry_data_path = self.deployment.output_path / "output_registry"
+
+        # Create container with local image registry. And mount existing registry root with base images.
+        registry_container = build_in_docker.LocalRegistryContainer(
+            name="output_registry_path",
+            registry_port=5000,
+            registry_data_path=registry_data_path
         )
+
+        # Start registry and run build of the final docker image. Build process will refer the the
+        # base image in the local registry.
+        with registry_container:
+            common.run_command(
+                command_options,
+                # This command runs partially runs the same code, so it would be nice to see the output.
+                debug=True,
+            )
 
 
 class K8sPackageBuilder(ContainerPackageBuilder):
@@ -1016,50 +1016,50 @@ class DockerApiPackageBuilder(ContainerPackageBuilder):
 
 
 _CONFIGS_PATH = __SOURCE_ROOT__ / "docker"
-
+_AGENT_BUILD_DOCKER_PATH = constants.SOURCE_ROOT / "agent_build" / "docker"
 
 # Create builders for each scalyr agent docker image. Those builders will be executed in the Dockerfile to
 # create the filesystem for the image.
 DOCKER_JSON_CONTAINER_BUILDER_BUSTER = DockerJsonPackageBuilder(
     name="docker-json-buster",
     config_path=_CONFIGS_PATH / "docker-json-config",
-    dockerfile_path=pl.Path("Dockerfile"),
+    base_image_deployment_step_cls=deployments.BuildBusterDockerBaseImageStep
 )
 DOCKER_JSON_CONTAINER_BUILDER_ALPINE = DockerJsonPackageBuilder(
     name="docker-json-alpine",
     config_path=_CONFIGS_PATH / "docker-json-config",
-    dockerfile_path=pl.Path("Dockerfile.alpine"),
+    base_image_deployment_step_cls=deployments.BuildAlpineDockerBaseImageStep
 )
 
 DOCKER_SYSLOG_CONTAINER_BUILDER_BUSTER = DockerSyslogPackageBuilder(
     name="docker-syslog-buster",
     config_path=_CONFIGS_PATH / "docker-syslog-config",
-    dockerfile_path=pl.Path("Dockerfile"),
+    base_image_deployment_step_cls=deployments.BuildBusterDockerBaseImageStep
 )
 DOCKER_SYSLOG_CONTAINER_BUILDER_ALPINE = DockerSyslogPackageBuilder(
     name="docker-syslog-alpine",
     config_path=_CONFIGS_PATH / "docker-syslog-config",
-    dockerfile_path=pl.Path("Dockerfile.alpine"),
+    base_image_deployment_step_cls=deployments.BuildAlpineDockerBaseImageStep
 )
 
 DOCKER_API_CONTAINER_BUILDER_BUSTER = DockerApiPackageBuilder(
     name="docker-api-buster",
     config_path=_CONFIGS_PATH / "docker-api-config",
-    dockerfile_path=pl.Path("Dockerfile"),
+    base_image_deployment_step_cls=deployments.BuildBusterDockerBaseImageStep
 )
 DOCKER_API_CONTAINER_BUILDER_ALPINE = DockerApiPackageBuilder(
     name="docker-api-alpine",
     config_path=_CONFIGS_PATH / "docker-api-config",
-    dockerfile_path=pl.Path("Dockerfile.alpine"),
+    base_image_deployment_step_cls=deployments.BuildAlpineDockerBaseImageStep
 )
 
 K8S_CONTAINER_BUILDER_BUSTER = K8sPackageBuilder(
     name="k8s-buster",
     config_path=_CONFIGS_PATH / "k8s-config",
-    dockerfile_path=pl.Path("Dockerfile"),
+    base_image_deployment_step_cls=deployments.BuildBusterDockerBaseImageStep
 )
 K8S_CONTAINER_BUILDER_ALPINE = K8sPackageBuilder(
     name="k8s-alpine",
     config_path=_CONFIGS_PATH / "k8s-config",
-    dockerfile_path=pl.Path("Dockerfile.alpine"),
+    base_image_deployment_step_cls=deployments.BuildAlpineDockerBaseImageStep
 )

--- a/agent_build/requirement-files/compression-requirements.txt
+++ b/agent_build/requirement-files/compression-requirements.txt
@@ -1,5 +1,8 @@
 # Compression libraries
-zstandard==0.15.2; python_version >= '3.5'
-zstandard==0.14.1; python_version < '3.5'
+# NOTE: zstandard don't include pre-built wheels for ARMv7 for glibc and
+# musl.
+zstandard==0.16.0; python_version >= '3.5' and 'armv7' not in platform_machine
+zstandard==0.14.1; python_version < '3.5' and 'armv7' not in platform_machine
+
 lz4==3.1.10; python_version >= '3.5'
 lz4==2.2.1; python_version < '3.5'

--- a/agent_build/requirement-files/docker-image-requirements.txt
+++ b/agent_build/requirement-files/docker-image-requirements.txt
@@ -1,0 +1,11 @@
+-r ./main-requirements.txt
+-r ./compression-requirements.txt
+
+# Two dependencies below are used for CPU and memory profiling which is opt-in and disabled by
+# default. We include it in the Docker image to make  troubleshooting (profiling) easier for the
+# end user (no need to rebuild Docker image - user can simply enable the corresponding agent config
+# option)
+yappi==1.2.3
+pympler==0.8
+
+docker==4.1.0

--- a/agent_build/requirement-files/main-requirements.txt
+++ b/agent_build/requirement-files/main-requirements.txt
@@ -1,0 +1,6 @@
+# NOTE: orjson don't include pre-built wheels for ARMv7 for glibc and
+# musl.
+orjson==3.6.5; python_version >= '3.6' and 'armv7' not in platform_machine
+orjson==2.0.11; python_version == '3.5' and 'armv7' not in platform_machine
+
+requests==2.20.0

--- a/agent_build/requirement-files/testing-requirements.txt
+++ b/agent_build/requirement-files/testing-requirements.txt
@@ -1,3 +1,7 @@
+-r ./main-requirements.txt
+-r ./compression-requirements.txt
+-r ./docker-image-requirements.txt
+
 # Testing tools and libraries
 mock==3.0.5
 psutil==5.7.0
@@ -22,10 +26,7 @@ docker==4.1.0
 # the version of 'requests' library that 'docker' uses as a dependency is higher than we use in agent,
 # to prevent versions conflict, install the appropriate version of 'requests', to force 'docker' to reuse it.
 # NOTE: We can't use requests >= 2.22.0 since we still need to support Python 2.6
-requests==2.20.0
 ujson==1.35
-orjson==3.5.2; python_version >= '3.6'
-orjson==2.0.11; python_version == '3.5'
 # Needed by MockHTTPServer class and related tests
 flask==1.1.1
 pathlib2==2.3.5; python_version <= '2.7'

--- a/agent_build/scripts/run_deployment.py
+++ b/agent_build/scripts/run_deployment.py
@@ -24,16 +24,15 @@ Usage:
 
     Perform some deployment (used by Github Action CI):
 
-        run_deployment.py deployment <deployment_name> deploy  [--cache-dir <cache_dir>]
+        run_deployment.py deployment <deployment_name> deploy
 
-        The '--cache-dir' option provides path where steps of the deployment store their cached results. Each step
-            has its own unique cache name, so our local GutHub action can cache step's results to its own, separate
-            cache in the Github Actions. That means that the step that is used by many deployments will be cached only
-            once and will be reused by those deployments.
-
-    Get names of all caches of all steps of the deployment.
+    Get names of all caches of all steps of the deployment (used by Github Action CI).
 
         run_deployment.py deployment <deployment_name> get-deployment-all-cache-names
+
+        Each step has its own unique cache name, so our local GutHub action can cache step's results to its own,
+        separate cache in the Github Actions. That means that the step that is used by many deployments will be cached
+        only once and will be reused by those deployments.
 
         Also a utility command for the Github Action CI to perform the trick with caching, that has been described
             above. The local GitHub action uses those names as cache keys for GitHub Action cache.
@@ -52,6 +51,7 @@ _SOURCE_ROOT = pl.Path(__file__).parent.parent.parent.absolute()
 sys.path.append(str(_SOURCE_ROOT))
 
 from agent_build.tools.environment_deployments import deployments
+from agent_build import package_builders
 from agent_build.tools import common
 
 
@@ -70,11 +70,6 @@ if __name__ == "__main__":
         dest="deployment_command", required=True
     )
     deploy_parser = deployment_subparsers.add_parser("deploy")
-    deploy_parser.add_argument(
-        "--cache-dir",
-        dest="cache_dir",
-        help="Cache directory to save/reuse deployment results.",
-    )
 
     get_all_deployments_parser = deployment_subparsers.add_parser(
         "get-deployment-all-cache-names"
@@ -87,16 +82,9 @@ if __name__ == "__main__":
         deployment = deployments.ALL_DEPLOYMENTS[args.deployment_name]
         if args.deployment_command == "deploy":
             # Perform the deployment with specified name.
-
-            cache_dir = None
-
-            if args.cache_dir:
-                cache_dir = pl.Path(args.cache_dir)
-
-            deployment.deploy(
-                cache_dir=cache_dir,
-            )
+            deployment.deploy()
             exit(0)
+
         if args.deployment_command == "get-deployment-all-cache-names":
             # A special command which is needed to perform the Github action located in
             # '.github/actions/perform-deployment'. The command provides names of the caches of the deployment's steps,

--- a/agent_build/tools/build_in_docker/Dockerfile
+++ b/agent_build/tools/build_in_docker/Dockerfile
@@ -4,7 +4,7 @@
 ARG BASE_IMAGE_NAME
 ARG BUILD_STAGE
 
-# This stage is used in building deployment steps (agent_build/tools/environemt_deployments.py).
+# This stage is used in building of the deployment steps (agent_build/tools/environemt_deployments.py).
 # It expects that the base image contains all needed files to perform the step.
 FROM $BASE_IMAGE_NAME as stage-step-build
 ARG WORK_DIR="/"

--- a/agent_build/tools/build_in_docker/__init__.py
+++ b/agent_build/tools/build_in_docker/__init__.py
@@ -20,7 +20,7 @@
 import pathlib as pl
 import os
 import subprocess
-from typing import Dict
+from typing import Dict, List
 
 from agent_build.tools import constants
 from agent_build.tools import common
@@ -160,3 +160,83 @@ def build_stage(
         finally:
             # Remove container.
             common.run_command(["docker", "rm", "-f", container_name])
+
+
+class DockerContainer:
+    """
+    Simple wrapper around docker container that allows to use context manager to clean up when container is not
+    needed anymore.
+    NOTE: The 'docker' library is not used on purpose, since there's only one abstraction that is needed. Using
+    docker through the docker CLI is much easier and does not require the "docker" lib as dependency.
+    """
+    def __init__(
+            self,
+            name: str,
+            image_name: str,
+            ports: List[str] = None,
+            mounts: List[str] = None,
+    ):
+        self.name = name
+        self.image_name = image_name
+        self.mounts = mounts or []
+        self.ports = ports or []
+
+    def start(self):
+
+        # Kill the previously run container, if exists.
+        self.kill()
+
+        command_args = [
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "--name",
+            self.name,
+        ]
+
+        for port in self.ports:
+            command_args.append("-p")
+            command_args.append(port)
+
+        for mount in self.mounts:
+            command_args.append("-v")
+            command_args.append(mount)
+
+        command_args.append(self.image_name)
+
+        common.check_call_with_log(
+            command_args
+        )
+
+    def kill(self):
+        common.run_command(["docker", "rm", "-f", self.name])
+
+    def __enter__(self):
+        return self.start()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.kill()
+
+
+class LocalRegistryContainer(DockerContainer):
+    """
+    Container start runs local docker registry inside.
+    """
+    def __init__(
+            self,
+            name: str,
+            registry_port: int,
+            registry_data_path: pl.Path = None
+    ):
+        """
+        :param name: Name of the container.
+        :param registry_port: Host port that will be mapped to the registry's port.
+        :param registry_data_path: Host directory that will be mapped to the registry's data root.
+        """
+        super(LocalRegistryContainer, self).__init__(
+            name=name,
+            image_name="registry:2",
+            ports=[f"{registry_port}:5000"],
+            mounts=[f"{registry_data_path}:/var/lib/registry"],
+        )

--- a/agent_build/tools/common.py
+++ b/agent_build/tools/common.py
@@ -23,6 +23,9 @@ DEBUG = bool(os.environ.get("AGENT_BUILD_DEBUG"))
 # If this env. variable is set, then the code runs inside the docker.
 IN_DOCKER = bool(os.environ.get("AGENT_BUILD_IN_DOCKER"))
 
+# If this env. variable is set, than the code runs in CI/CD (e.g. Github actions)
+IN_CICD = bool(os.environ.get("AGENT_BUILD_IN_CICD"))
+
 # A counter for all commands that have been executed since start of the program.
 # Just for more informative logging.
 _COMMAND_COUNTER = 0
@@ -112,6 +115,9 @@ def run_command(*args, debug: bool = False, **kwargs):
 
     stdout = b"\n".join(lines)
     if process.returncode != 0:
+        if not debug:
+            # Even if it's not debug print output on error.
+            print(stdout.decode(), file=sys.stderr)
         raise subprocess.CalledProcessError(
             returncode=process.returncode, cmd=cmd_args, output=stdout
         )

--- a/agent_build/tools/constants.py
+++ b/agent_build/tools/constants.py
@@ -17,6 +17,10 @@ import enum
 import pathlib as pl
 
 SOURCE_ROOT = pl.Path(__file__).parent.parent.parent.absolute()
+AGENT_BUILD_OUTPUT = SOURCE_ROOT / "agent_build_output"
+PACKAGE_BUILDER_OUTPUT = AGENT_BUILD_OUTPUT / "package"
+DEPLOYMENT_OUTPUT = AGENT_BUILD_OUTPUT / "deployment"
+DEPLOYMENT_CACHE_DIR = AGENT_BUILD_OUTPUT / "deployment_cache"
 
 
 class DockerPlatform(enum.Enum):
@@ -66,3 +70,11 @@ class PackageType(enum.Enum):
     DOCKER_API = "docker-api"
     K8S = "k8s"
     MSI = "msi"
+
+
+# CPU architectures or platforms that has to be supported by the Agent docker images,
+AGENT_DOCKER_IMAGE_SUPPORTED_PLATFORMS = [
+    DockerPlatform.AMD64,
+    DockerPlatform.ARM64,
+    DockerPlatform.ARMV7
+]

--- a/agent_build/tools/environment_deployments/deployments.py
+++ b/agent_build/tools/environment_deployments/deployments.py
@@ -14,9 +14,11 @@
 
 
 import abc
+import os
 import pathlib as pl
 import shlex
 import re
+import shutil
 import subprocess
 import logging
 from typing import Union, Optional, List, Dict, Type
@@ -72,16 +74,14 @@ class DeploymentStep(files_checksum_tracker.FilesChecksumTracker):
         CI/CD such as Github Actions.
     """
 
-    # Set of files that are somehow used during the step. Needed to calculate the checksum of the whole step, so it can
-    # be used as cache key.
-    USED_FILES: List[pl.Path] = []
-
     def __init__(
         self,
+        deployment: 'Deployment',
         architecture: constants.Architecture,
         previous_step: Union[str, "DeploymentStep"] = None,
     ):
         """
+        :param deployment: The deployment instance where this step is added.
         :param architecture: Architecture of the machine where step has to be performed.
         :param previous_step: If None then step is considered as first and it doesn't have to be performed on top
             of another step. If this is an instance of another DeploymentStep, then this step will be performed on top
@@ -92,6 +92,7 @@ class DeploymentStep(files_checksum_tracker.FilesChecksumTracker):
         super(DeploymentStep, self).__init__()
 
         self.architecture = architecture
+        self.deployment = deployment
 
         if isinstance(previous_step, DeploymentStep):
             # The previous step is specified.
@@ -107,12 +108,16 @@ class DeploymentStep(files_checksum_tracker.FilesChecksumTracker):
             self.base_docker_image = None
             self.previous_step = None
 
+        # personal cache directory of the step.
+        self.cache_directory = self.deployment.cache_directory / self.cache_key
+        self.output_directory = self.deployment.output_directory / self.unique_name
+
     @property
     def _tracked_file_globs(self) -> List[pl.Path]:
         """
         Get filed that has to be tracked by the step in order to calculate checksum, for caching.
         """
-        return type(self).USED_FILES
+        return []
 
     @property
     def name(self) -> str:
@@ -191,35 +196,22 @@ class DeploymentStep(files_checksum_tracker.FilesChecksumTracker):
         return self._get_files_checksum(additional_seed=additional_seed)
 
     def run(
-        self,
-        cache_dir: Union[str, pl.Path] = None,
+        self
     ):
         """
         Run the step. Based on its initial data, it will be performed in docker or locally, on the current system.
-
-        :param cache_dir: Path of the cache directory. If specified, then the step may save or reuse some intermediate
-            result using it.
-        :param locally: A special flag that forces a step to be performed locally on the current system, even
-            if it meant to be performed inside docker. This is needed to avoid the loop when the step is already in the
-            docker.
         """
 
-        def run_step():
-            if self.in_docker:
-                self._run_in_docker(cache_dir=cache_dir)
-            else:
-                self._run_locally(cache_dir=cache_dir)
+        if self.in_docker:
+            run_func = self._run_in_docker
+        else:
+            run_func = self._run_locally
 
-        self._run_function_in_isolated_source_directory(function=run_step)
+        self._run_function_in_isolated_source_directory(function=run_func)
 
-    def _run_in_docker(
-        self,
-        cache_dir: Union[str, pl.Path] = None,
-    ):
+    def _run_in_docker(self):
         """
         This function does the same deployment but inside the docker.
-        :param cache_dir: Path of the cache directory. If specified, then the step may save or reuse some intermediate
-            result using it. In case of docker, the whole result image of the step will be cached.
         """
 
         # Before the build, check if there is already an image with the same name. The name contains the checksum
@@ -241,10 +233,9 @@ class DeploymentStep(files_checksum_tracker.FilesChecksumTracker):
 
         save_to_cache = False
 
-        # If cache directory is specified, then check if the image file is already there and we can reuse it.
-        if cache_dir:
-            cache_dir = pl.Path(cache_dir)
-            cached_image_path = cache_dir / self.result_image_name
+        # If code runs in CI/CD, then check if the image file is already in cache and we can reuse it.
+        if common.IN_CICD:
+            cached_image_path = self.cache_directory / self.result_image_name
             if cached_image_path.is_file():
                 logging.info(
                     f"Cached image {self.result_image_name} file for the deployment step '{self.name}' has been found, "
@@ -264,9 +255,9 @@ class DeploymentStep(files_checksum_tracker.FilesChecksumTracker):
 
         self._run_in_docker_impl()
 
-        if cache_dir and save_to_cache:
-            cache_dir.mkdir(parents=True, exist_ok=True)
-            cached_image_path = cache_dir / self.result_image_name
+        if common.IN_CICD and save_to_cache:
+            self.cache_directory.mkdir(parents=True, exist_ok=True)
+            cached_image_path = self.cache_directory / self.result_image_name
             logging.info(
                 f"Saving image '{self.result_image_name}' file for the deployment step {self.name} into cache."
             )
@@ -275,27 +266,50 @@ class DeploymentStep(files_checksum_tracker.FilesChecksumTracker):
             )
 
     @abc.abstractmethod
-    def _run_locally(
-        self,
-        cache_dir: Union[str, pl.Path] = None,
-    ):
+    def _run_locally(self):
         """
         Run step locally. This has to be implemented in children classes.
-        :param cache_dir: Path of the cache directory. If specified, then the step may save or reuse some intermediate
-            result using it.
         """
         pass
 
     @abc.abstractmethod
     def _run_in_docker_impl(
-        self, cache_dir: Union[str, pl.Path] = None, locally: bool = False
+        self, locally: bool = False
     ):
         """
         Run step in docker. This has to be implemented in children classes.
-        :param cache_dir: Path of the cache directory.
         :param locally: If we are already in docker, this has to be set as True, to avoid loop.
         """
         pass
+
+    def _restore_from_cache(self, key: str, path: pl.Path) -> bool:
+        """
+        Restore file or directory by given key from the step's cache.
+        :param key: Name of the file or directory to search in cache.
+        :param path: Path where to copy the cached object if it's found.
+        :return: True if cached object is found.
+        """
+        full_path = self.cache_directory / key
+        if full_path.exists():
+            if full_path.is_dir():
+                shutil.copytree(full_path, path)
+            else:
+                shutil.copy2(full_path, path)
+            return True
+
+        return False
+
+    def _save_to_cache(self, key: str, path: pl.Path):
+        """
+
+        :param key: Name of the file or directory in cache.
+        :param path: Path from where to copy the object to the cache.
+        """
+        full_path = self.cache_directory / key
+        if path.is_dir():
+            shutil.copytree(path, full_path)
+        else:
+            shutil.copy2(path, key)
 
 
 class DockerFileDeploymentStep(DeploymentStep):
@@ -325,19 +339,15 @@ class DockerFileDeploymentStep(DeploymentStep):
         # This step is in docker by definition.
         return True
 
-    def _run_locally(
-        self,
-        cache_dir: Union[str, pl.Path] = None,
-    ):
+    def _run_locally(self):
         # This step is in docker by definition.
         raise RuntimeError("The docker based step can not be performed locally.")
 
     def _run_in_docker_impl(
-        self, cache_dir: Union[str, pl.Path] = None, locally: bool = False
+        self, locally: bool = False
     ):
         """
         Perform the actual build by calling docker build with specified dockerfile and other options.
-        :param cache_dir: Path of the cache directory.
         :param locally: This is ignored, the dockerfile based step can not be performed locally.
         """
         build_in_docker.run_docker_build(
@@ -353,41 +363,46 @@ class ShellScriptDeploymentStep(DeploymentStep):
     The deployment step class which is a wrapper around some shell script.
     """
 
-    # Path to  the script file that has to be executed during the step.
-    SCRIPT_PATH: pl.Path
-
     def __init__(
         self,
+        deployment: 'Deployment',
         architecture: constants.Architecture,
         previous_step: Union[str, "DeploymentStep"] = None,
     ):
         super(ShellScriptDeploymentStep, self).__init__(
-            architecture=architecture, previous_step=previous_step
+            deployment=deployment,
+            architecture=architecture,
+            previous_step=previous_step
         )
+
+    @property
+    @abc.abstractmethod
+    def script_path(self) -> pl.Path:
+        """
+        Path to  the script file that has to be executed during the step.
+        """
+        pass
+
 
     @property
     def _tracked_file_globs(self) -> List[pl.Path]:
         # Also add script to the used file collection, so it is included to the checksum calculation.
         script_files = [
-            type(self).SCRIPT_PATH,
+            self.script_path,
             _REL_DEPLOYMENT_STEPS_PATH / "step_runner.sh",
         ]
         return super(ShellScriptDeploymentStep, self)._tracked_file_globs + script_files
 
-    def _get_command_line_args(
-        self,
-        cache_dir: Union[str, pl.Path] = None,
-    ) -> List[str]:
+    def _get_command_line_args(self) -> List[str]:
         """
         Create list with the shell command line arguments that has to execute the shell script.
             Optionally also adds cache path to the shell script as additional argument.
-        :param cache_dir: Path to the cache dir.
         :return: String with shell command that can be executed to needed shell.
         """
 
         # Determine needed shell interpreter.
-        if type(self).SCRIPT_PATH.suffix == ".ps1":
-            command_args = ["powershell", str(type(self).SCRIPT_PATH)]
+        if self.script_path.suffix == ".ps1":
+            command_args = ["powershell", self.script_path]
         else:
             shell = "/bin/sh"
 
@@ -399,30 +414,33 @@ class ShellScriptDeploymentStep(DeploymentStep):
             command_args = [
                 shell,
                 str(step_runner_script_path),
-                str(type(self).SCRIPT_PATH),
+                str(self.script_path),
             ]
 
-        # If cache directory is presented, then we pass it as an additional argument to the
+        # Pass cache directory as an additional argument to the
         # script, so it can use the cache too.
-        if cache_dir:
-            command_args.append(str(pl.Path(cache_dir)))
+        command_args.append(str(pl.Path(self.cache_directory)))
+
+        command_args.append(str(self.deployment.output_directory))
 
         return command_args
 
-    def _run_locally(
-        self,
-        cache_dir: Union[str, pl.Path] = None,
-    ):
+    def _run_locally(self):
         """
         Run step locally by running the script on current system.
-        :param cache_dir: Path of the cache directory. If specified, then the script may save or reuse some intermediate
-            results in it.
         """
-        command_args = self._get_command_line_args(cache_dir=cache_dir)
+        command_args = self._get_command_line_args()
+
+        # Copy current environment.
+        env = os.environ.copy()
+
+        if common.IN_CICD:
+            env["IN_CICD"] = "1"
 
         try:
             output = common.run_command(
                 command_args,
+                env=env,
                 debug=True,
             ).decode()
         except subprocess.CalledProcessError as e:
@@ -431,13 +449,12 @@ class ShellScriptDeploymentStep(DeploymentStep):
         return output
 
     def _run_in_docker_impl(
-        self, cache_dir: Union[str, pl.Path] = None, locally: bool = False
+        self, locally: bool = False
     ):
         """
         Run step in docker. It uses a special logic, which is implemented in 'agent_build/tools/tools.build_in_docker'
         module,that allows to execute custom command inside docker by using 'docker build' command. It differs from
         running just in the container because we can benefit from the docker caching mechanism.
-        :param cache_dir: Path of the cache directory.
         :param locally: If we are already in docker, this has to be set as True, to avoid loop.
         """
 
@@ -483,7 +500,7 @@ class ShellScriptDeploymentStep(DeploymentStep):
             )
 
             # Get command that has to run shell script.
-            command_args = self._get_command_line_args(cache_dir=cache_dir)
+            command_args = self._get_command_line_args()
 
             # Run command in the previously created intermediate image.
             try:
@@ -529,6 +546,8 @@ class Deployment:
         self.name = name
         self.architecture = architecture
         self.base_docker_image = base_docker_image
+        self.cache_directory = constants.DEPLOYMENT_CACHE_DIR / self.name
+        self.output_directory = constants.DEPLOYMENT_OUTPUT / self.name
 
         # List with instantiated steps.
         self.steps = []
@@ -538,6 +557,7 @@ class Deployment:
 
         for step_cls in step_classes:
             step = step_cls(
+                deployment=self,
                 architecture=architecture,
                 # specify previous step for the current step.
                 previous_step=previous_step,
@@ -550,6 +570,13 @@ class Deployment:
             raise ValueError(f"The deployment with name: {self.name} already exists.")
 
         ALL_DEPLOYMENTS[self.name] = self
+
+    @property
+    def output_path(self) -> pl.Path:
+        """
+        Path to the directory where the deployment's steps can put their results.
+        """
+        return constants.DEPLOYMENT_OUTPUT / self.name
 
     @property
     def in_docker(self) -> bool:
@@ -569,33 +596,13 @@ class Deployment:
         """
         return self.steps[-1].result_image_name.lower()
 
-    def deploy(
-        self,
-        cache_dir: pl.Path = None,
-    ):
+    def deploy(self):
         """
         Perform the deployment by running all deployment steps.
-
-        :param cache_dir: Cache directory. If specified, all steps of the deployment will use it to
-            save their results in it.
-        :return:
         """
 
         for step in self.steps:
-
-            # If cache is specified, then create separate sub-folder in it for each step.
-            # NOTE: Those sub-folders are used by our special Github-Actions action that caches all such sub-folders to
-            # the Github Actions cache. See more in ".github/actions/perform-deployment"
-            if cache_dir:
-                step_cache_path = cache_dir.absolute() / step.cache_key
-                if not step_cache_path.is_dir():
-                    step_cache_path.mkdir(parents=True)
-            else:
-                step_cache_path = None
-
-            step.run(
-                cache_dir=step_cache_path,
-            )
+            step.run()
 
 
 # Special collection where all created deployments are stored. All of the  deployments are saved with unique name as
@@ -610,11 +617,193 @@ def get_deployment_by_name(name: str) -> Deployment:
 
 # Step that runs small script which installs requirements for the test/dev environment.
 class InstallTestRequirementsDeploymentStep(ShellScriptDeploymentStep):
-    SCRIPT_PATH = _REL_DEPLOYMENT_STEPS_PATH / "deploy-test-environment.sh"
-    USED_FILES = [
-        _REL_AGENT_REQUIREMENT_FILES_PATH / "testing-requirements.txt",
-        _REL_AGENT_REQUIREMENT_FILES_PATH / "compression-requirements.txt",
-    ]
+    @property
+    def script_path(self) -> pl.Path:
+        return _REL_DEPLOYMENT_STEPS_PATH / "deploy-test-environment.sh"
+
+    @property
+    def _tracked_file_globs(self) -> List[pl.Path]:
+        globs = super(InstallTestRequirementsDeploymentStep, self)._tracked_file_globs
+        globs.append(_REL_AGENT_REQUIREMENT_FILES_PATH / "*.txt")
+        return globs
+
+
+_REL_DOCKER_BASE_IMAGE_STEP_PATH = _REL_DEPLOYMENT_STEPS_PATH / "docker-base-images"
+_REL_AGENT_BUILD_DOCKER_PATH = _REL_AGENT_BUILD_PATH / "docker"
+
+
+class BuildDockerBaseImageStep2(DeploymentStep):
+    """
+    This deployment step (not this, but it's subclasses) builds base image for the agent docker images.
+
+    The builder if the agent docker images have to use this base image in order to create a final image.
+        Since it's not a trivial task to "transfer" a multi-platform image from one place to another, the image is
+        pushed to a local registry in the container, and the root of that registry is transferred instead.
+
+    Registry's root in /var/lib/registry is exposed to the host by using docker's mount feature and saved in the
+        deployment's output directory. This final image builder then spins up another local registry container and
+        mounts root of the saved registry. Now builder can refer to this local registry in order to get the base image.
+    """
+
+    # Suffix of the tag of the python dockerhub image. for example: slim, alpine.
+    BASE_IMAGE_NAME_SUFFIX: str
+
+    # Name of the base image.
+    BASE_IMAGE_NAME = "agent_docker_base"
+
+    @property
+    def _tracked_file_globs(self) -> List[pl.Path]:
+        globs = super(BuildDockerBaseImageStep, self)._tracked_file_globs
+        # Track the dockerfile...
+        globs.append(_REL_AGENT_BUILD_DOCKER_PATH / "Dockerfile.base")
+        # .. and requirement files.
+        globs.append(_REL_AGENT_REQUIREMENT_FILES_PATH / "docker-image-requirements.txt")
+        globs.append(_REL_AGENT_REQUIREMENT_FILES_PATH / "compression-requirements.txt")
+        globs.append(_REL_AGENT_REQUIREMENT_FILES_PATH / "main-requirements.txt")
+        return globs
+
+    def _run_locally(self):
+        """
+        Build the base docker image and push it to the local registry.
+        """
+
+        step_output_dir_path = self.deployment.output_path / "output_registry"
+        if step_output_dir_path.is_dir():
+            shutil.rmtree(step_output_dir_path)
+
+        hit = False
+        if common.IN_CICD:
+            hit = self._restore_from_cache("output_registry", step_output_dir_path)
+            if hit:
+                logging.info(
+                    "The local registry with base docker image is found in cache. Reuse it instead of building."
+                )
+                return
+
+        logging.info("Build docker base image.")
+        if step_output_dir_path.is_dir():
+            shutil.rmtree(step_output_dir_path)
+        step_output_dir_path.mkdir(parents=True)
+
+        def _build_base_image(
+            result_image_name: str,
+            with_coverage: bool
+        ):
+            dockerfile_path = self._isolated_source_root_path / _REL_AGENT_BUILD_DOCKER_PATH / "Dockerfile.base"
+
+            command_args = [
+                "docker",
+                "buildx",
+                "build",
+                "-t",
+                f"localhost:5000/{result_image_name}",
+                "-f",
+                str(dockerfile_path),
+                "--push",
+                "--build-arg",
+                f"BASE_IMAGE_SUFFIX={type(self).BASE_IMAGE_NAME_SUFFIX}"
+            ]
+
+            if with_coverage:
+                command_args.append("--build-arg")
+                command_args.append("COVERAGE_VERSION=4.5.4")
+
+            # Add all needed platforms to build.
+            for plat in constants.AGENT_DOCKER_IMAGE_SUPPORTED_PLATFORMS:
+                command_args.append("--platform")
+                command_args.append(plat.value)
+
+            # Add final argument of the command - build context path.
+            # Specify here our special root directory which contains only
+            # tracked files that are tracked by that step.
+            command_args.append(
+                str(self._isolated_source_root_path)
+            )
+
+            # Run build.
+            common.check_call_with_log(
+                command_args
+            )
+
+        # Create registry where the result base image is pushed.
+        registry_container = build_in_docker.LocalRegistryContainer(
+            name="output_registry_path",
+            registry_port=5000,
+            # specify directory where registry's data root is mapped.
+            registry_data_path=step_output_dir_path
+        )
+
+        # Start registry and build and push base images within while it's running.
+        with registry_container:
+            # build testing version of the base image. (with coverage)
+            _build_base_image(
+                result_image_name=f"{type(self).BASE_IMAGE_NAME}_testing",
+                with_coverage=True
+            )
+            # build prod version of the base image.
+            _build_base_image(
+                result_image_name=type(self).BASE_IMAGE_NAME,
+                with_coverage=False
+            )
+
+        if common.IN_CICD and not hit:
+            logging.info("Save registry data with base docker image in cache.")
+            self._save_to_cache("output_registry", step_output_dir_path)
+
+
+_REL_DEPLOYMENT_BUILD_BASE_IMAGE_STEP = _REL_DEPLOYMENT_STEPS_PATH / "build_base_docker_image"
+
+
+class BuildDockerBaseImageStep(ShellScriptDeploymentStep):
+    """
+    This deployment step is responsible for the building of the base image of the agent docker images.
+    It runs shell script that builds that base image and pushes it to the local registry that runs in container.
+    After push, registry is shut down, but it's data root is preserved. This step puts this
+    registry data root to the output of the deployment, so the builder of the final agent docker image can access this
+    output and fetch base images from registry root (it needs to start another registry and mount existing registry
+    root).
+    """
+
+    # Suffix of that python image, that is used as the base image for our base image.
+    # has to match one of the names from the 'agent_build/tools/environment_deployments/steps/build_base_docker_image'
+    # directory, except 'build_base_images_common_lib.sh', it is a helper library.
+    BASE_DOCKER_IMAGE_TAG_SUFFIX: str
+
+    @property
+    def script_path(self) -> pl.Path:
+        """
+        Resolve path to the base image builder script which depends on suffix on the base image.
+        """
+        return _REL_DEPLOYMENT_BUILD_BASE_IMAGE_STEP / f"{type(self).BASE_DOCKER_IMAGE_TAG_SUFFIX}.sh"
+
+    @property
+    def _tracked_file_globs(self) -> List[pl.Path]:
+        globs = super(BuildDockerBaseImageStep, self)._tracked_file_globs
+        # Track the dockerfile...
+        globs.append(_REL_AGENT_BUILD_DOCKER_PATH / "Dockerfile.base")
+        # and helper lib for base image builder.
+        globs.append(
+            _REL_DEPLOYMENT_BUILD_BASE_IMAGE_STEP / "build_base_images_common_lib.sh"
+        )
+        # .. and requirement files...
+        globs.append(_REL_AGENT_REQUIREMENT_FILES_PATH / "docker-image-requirements.txt")
+        globs.append(_REL_AGENT_REQUIREMENT_FILES_PATH / "compression-requirements.txt")
+        globs.append(_REL_AGENT_REQUIREMENT_FILES_PATH / "main-requirements.txt")
+        return globs
+
+
+class BuildBusterDockerBaseImageStep(BuildDockerBaseImageStep):
+    """
+    Subclass that builds agent's base docker image based on debian buster (slim)
+    """
+    BASE_DOCKER_IMAGE_TAG_SUFFIX = "slim"
+
+
+class BuildAlpineDockerBaseImageStep(BuildDockerBaseImageStep):
+    """
+    Subclass that builds agent's base docker image based on alpine.
+    """
+    BASE_DOCKER_IMAGE_TAG_SUFFIX = "alpine"
 
 
 # Create common test environment that will be used by GitHub Actions CI

--- a/agent_build/tools/environment_deployments/steps/build_base_docker_image/alpine.sh
+++ b/agent_build/tools/environment_deployments/steps/build_base_docker_image/alpine.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Copyright 2014-2021 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used by "ShellScriptDeploymentStep"
+# (See more in class "ShellScriptDeploymentStep" in the "agent_build/tools/environment_deployments/deployments.py"
+
+# This script is used in the deployment step that build base image for the alpine based agent docker images.
+# This file is sourced by one of the actual shell scripts that has to build the base image.
+
+# source main library, all needed functions are in there.
+. "$SOURCE_ROOT/agent_build/tools/environment_deployments/steps/build_base_docker_image/build_base_images_common_lib.sh"
+
+# Build base images are based on the python-alpine dockerhub image.
+build_all_base_images alpine

--- a/agent_build/tools/environment_deployments/steps/build_base_docker_image/build_base_images_common_lib.sh
+++ b/agent_build/tools/environment_deployments/steps/build_base_docker_image/build_base_images_common_lib.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# Copyright 2014-2021 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used by "ShellScriptDeploymentStep"
+# (See more in class "ShellScriptDeploymentStep" in the "agent_build/tools/environment_deployments/deployments.py"
+
+# This helper library that is used in the deployment step that build base image for agent docker images.
+# This file is sourced by one of the actual shell scripts that has to build the base image.
+
+
+# The builder of the agent docker images have to use this base image in order to create a final image.
+#    Since it's not a trivial task to "transfer" a multi-platform image from one place to another, the image is
+#    pushed to a local registry in the container, and the root of that registry is transferred instead.
+#
+# Registry's root in /var/lib/registry is exposed to the host by using docker's mount feature and saved in the
+#    deployment's output directory. This final image builder then spins up another local registry container and
+#    mounts root of the saved registry. Now builder can refer to this local registry in order to get the base image.
+
+
+set -e
+
+# The directory with registry's data root
+registry_output_path="$STEP_OUTPUT_PATH/output_registry"
+
+# Check if registry data root already exists in cache.
+restore_from_cache output_registry "$registry_output_path"
+
+if [ -d "$registry_output_path" ]; then
+  log "Registry data root is found in cache. Skip building of the base image and reuse it from found registry."
+  exit 0
+fi
+
+log "Registry data root is not found in cache, build image from scratch"
+sh_cs mkdir -p "$registry_output_path"
+
+container_name="agent_base_image_registry_step"
+
+kill_registry_container() {
+  sh_cs docker rm -f "$container_name"
+}
+
+trap kill_registry_container EXIT
+
+log "Spin up local registry  in container"
+sh_cs docker run -d --rm -p 5000:5000 -v "$registry_output_path:/var/lib/registry" --name "$container_name" registry:2
+
+
+buildx_builder_name="agent_image_buildx_builder"
+
+if ! sh_cs docker buildx ls | grep $buildx_builder_name ; then
+  log "Create new  buildx builder instance."
+  sh_cs docker \
+    buildx \
+    create \
+    --driver-opt=network=host \
+    --name \
+    "$buildx_builder_name"
+fi
+
+log "Use buildx builder instance."
+sh_cs docker buildx use "$buildx_builder_name"
+
+
+# Build all needed base images.
+build_all_base_images() {
+  # The argument is a tag suffix of the Python's image on dockerhub image.
+  # According to that suffix, the appropriate python image will be used.
+  # For example, for base image that is based on buster, the suffix is 'slim', so the builder will use "python:slim",
+  # or 'alpine, so builder will use 'python:alpine'
+  base_image_tag_suffix=$1
+
+  log "Build base image with Python:$base_image_tag_suffix"
+
+  build_base_image() {
+    use_test_version=$1
+
+    coverage_arg=""
+    tag_suffix=""
+    if $use_test_version ; then
+      coverage_arg="--build-arg COVERAGE_VERSION=4.5.4"
+      tag_suffix="-testing"
+    fi
+
+    # shellcheck disable=SC2086 # Intended splitting of coverage_arg
+    sh_cs docker \
+      buildx build \
+      -t "localhost:5000/agent_base_image:$base_image_tag_suffix$tag_suffix" \
+      -f "$SOURCE_ROOT/agent_build/docker/Dockerfile.base" \
+      --push \
+      --build-arg "BASE_IMAGE_SUFFIX=$base_image_tag_suffix" \
+      $coverage_arg \
+      --platform linux/amd64 \
+      --platform linux/arm64 \
+      --platform linux/arm/v7 \
+      "$SOURCE_ROOT"
+
+  }
+  # Build images
+  # test version
+  build_base_image true
+
+  # prod version
+  build_base_image false
+
+  log "Save registry's data root to cache to reuse it in future."
+  save_to_cache output_registry "$registry_output_path"
+}

--- a/agent_build/tools/environment_deployments/steps/build_base_docker_image/slim.sh
+++ b/agent_build/tools/environment_deployments/steps/build_base_docker_image/slim.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Copyright 2014-2021 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used by "ShellScriptDeploymentStep"
+# (See more in class "ShellScriptDeploymentStep" in the "agent_build/tools/environment_deployments/deployments.py"
+
+# This script is used in the deployment step that build base image for the buster(debian) based agent docker images.
+# This file is sourced by one of the actual shell scripts that has to build the base image.
+
+# source main library, all needed functions are in there.
+. "$SOURCE_ROOT/agent_build/tools/environment_deployments/steps/build_base_docker_image/build_base_images_common_lib.sh"
+
+build_all_base_images slim

--- a/agent_build/tools/environment_deployments/steps/step_runner.sh
+++ b/agent_build/tools/environment_deployments/steps/step_runner.sh
@@ -25,6 +25,7 @@
 
 STEP_SCRIPT_PATH="$1"
 CACHE_DIR="$2"
+STEP_OUTPUT_PATH="$3"
 
 set -e
 
@@ -64,22 +65,10 @@ log "=========== Run Deployment Step Script'$(basename "$STEP_SCRIPT_PATH")' ===
 
 log "SOURCE_ROOT: ${SOURCE_ROOT}"
 
-# Check if the cache directory is specified. If it doesn't, then the caching has to be disabled.
-if [ -n "$CACHE_DIR" ]; then
-  if [ ! -d "$CACHE_DIR" ]; then
-    mkdir -p "${CACHE_DIR}"
-  fi
-  log "Use directory ${CACHE_DIR} as cache."
-  use_cache=true
-else
-  use_cache=false
-fi
-
-
 
 # Function that restores data from cache if exists.
 restore_from_cache() {
-  if ! $use_cache ; then
+  if [ -z "$IN_CICD" ]; then
     log "Cache disabled."
     return 0
   fi
@@ -109,7 +98,7 @@ save_to_cache() {
   cache_key=$1
   path=$2
 
-  if ! $use_cache ; then
+  if [ -z "$IN_CICD" ]; then
     log "Cache disabled"
     return 0
   fi
@@ -137,6 +126,7 @@ save_to_cache() {
 
 # Export useful variables, so they can be used by the script.
 export SOURCE_ROOT
+export STEP_OUTPUT_PATH
 
 # Run the script.
 . "${STEP_SCRIPT_PATH}"

--- a/tests/package_tests/internals/docker_test.py
+++ b/tests/package_tests/internals/docker_test.py
@@ -56,6 +56,8 @@ def _test(
             f"SCALYR_API_KEY={scalyr_api_key}",
             "-v",
             "/var/run/docker.sock:/var/scalyr/docker.sock",
+            "-v",
+            "/var/lib/docker/containers:/var/lib/docker/containers",
             "--platform",
             architecture.as_docker_platform.value,
             image_name,

--- a/tests/package_tests/run_package_test.py
+++ b/tests/package_tests/run_package_test.py
@@ -93,14 +93,6 @@ if __name__ == "__main__":
             help="Additional suffix for the name of the agent instances.",
         )
 
-        if isinstance(package_test, all_package_tests.DockerImagePackageTest):
-            run_package_test_parser.add_argument(
-                "--cache-from-dir",
-            )
-            run_package_test_parser.add_argument(
-                "--cache-to-dir",
-            )
-
     get_tests_github_matrix_parser = subparsers.add_parser(
         "get-package-builder-tests-github-matrix"
     )
@@ -122,8 +114,6 @@ if __name__ == "__main__":
                 scalyr_api_key=scalyr_api_key,
                 name_suffix=get_option(
                     "name_suffix", default=str(datetime.datetime.now().timestamp())
-                ),
-                cache_from_path=args.cache_from_dir,
-                cache_to_path=args.cache_to_dir,
+                )
             )
         exit(0)


### PR DESCRIPTION
This PR: 
* Splits agent docker image Dockerfile into the base and final dockerfiles. Base image build does all of the hard work and then can be cached to speed up the process. All build instructions for the `buster` and `alpine` version now are in the same dockerfile - `agent_build/docker/Dockerfile.base`. The final Dockerfile does nothing except the creating of the agent files, which is a completely non-time-consuming process, so the final Dockerfile does not require caching.
* I also reorganized requirement files.  <DEBATABLE TOPIC ALERT>:  I Enabled `orjson` and `zstandard` for alpine to keep fewer requirement files.  Yeah, the build time under QEMU is terrible ( at least 40 min), but, caching has to reduce that to 1-2 min. We only have to wait that long when we change a very small set of files that can change the checksum of the deployment. 
* Cached docker images now take only a few hundred megabytes!.
* Docker images are now all built-in one workflow but in a different job by using job matrix. The next step is to add the final "publish" job that aggregates all results and pushes all images at once, from one job. That has to make the publishing process more "atomic", as we discussed earlier.