### PR TITLE
Update numpy to the latest version

### DIFF
--- a/benchmarks/scripts/requirements.txt
+++ b/benchmarks/scripts/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.20.0
-numpy==1.16.6
+numpy==1.22.0; python_version >= '3.5'
+numpy==1.16.6; python_version <= '2.7'
 psutil==5.7.0


### PR DESCRIPTION
This PR updates numpy to the latest version which includes a fix for a security issue (we only use numpy inside the tests / benchmarks).