### PR TITLE
Add "logger_include_node_name" config option to K8s Open Metrics Monitor

### DIFF
--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -81,6 +81,39 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
         if "SCALYR_K8S_NODE_NAME" in os.environ:
             del os.environ["SCALYR_K8S_NODE_NAME"]
 
+    def test_logger_include_node_name_config_option(self):
+        monitor_config = {
+            "module": "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor",
+        }
+        global_config = mock.Mock()
+        global_config.agent_log_path = MOCK_AGENT_LOG_PATH
+        mock_logger = mock.Mock()
+
+        monitor = KubernetesOpenMetricsMonitor(
+            monitor_config=monitor_config,
+            logger=mock_logger,
+            global_config=global_config,
+        )
+        self.assertEqual(
+            monitor._logger.name,
+            "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor(test-node-name)",
+        )
+
+        monitor_config = {
+            "module": "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor",
+            "logger_include_node_name": False,
+        }
+        global_config = mock.Mock()
+        global_config.agent_log_path = MOCK_AGENT_LOG_PATH
+        mock_logger = mock.Mock()
+
+        monitor = KubernetesOpenMetricsMonitor(
+            monitor_config=monitor_config,
+            logger=mock_logger,
+            global_config=global_config,
+        )
+        self.assertTrue(isinstance(monitor._logger.name, mock.Mock))
+
     def test_get_monitor_and_log_config(self):
         monitor_config = {
             "module": "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor",

--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -72,6 +72,15 @@ for index, pod in enumerate(
 
 
 class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
+    @classmethod
+    def setUpClass(cls):
+        os.environ["SCALYR_K8S_NODE_NAME"] = "test-node-name"
+
+    @classmethod
+    def tearDownClass(cls):
+        if "SCALYR_K8S_NODE_NAME" in os.environ:
+            del os.environ["SCALYR_K8S_NODE_NAME"]
+
     def test_get_monitor_and_log_config(self):
         monitor_config = {
             "module": "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor",
@@ -104,7 +113,7 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
         )
         expected_monitor_config = {
             "ca_file": None,
-            "extra_fields": JsonObject({"node": None}),
+            "extra_fields": JsonObject({"node": "test-node-name"}),
             "headers": JsonObject({}),
             "id": "one",
             "log_path": "scalyr_agent.builtin_monitors.openmetrics_monitor.log",


### PR DESCRIPTION
This config option allows us to enable debug level using new ``debug_level_logger_names`` global config option for all the monitor instances without needing to know the node name up front.