### PR TITLE
Ingest memory profiling data by default when profiling is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Packaged by Arthur Kamalov <arthurk@sentinelone.com> on Feb 12, 2022 23:04 -0800
 
 Improvements:
 * Add new ``debug_level_logger_names`` config option. With this config option user can specify a list of logger names for which to set debug log level for. Previously user could only set debug level for all the loggers. This comes handy when we want to set debug level for a single of subset of loggers (e.g. for a single monitor).
+* If profiling is enabled (``enable_profiling`` configuration option), memory profiling data will be ingested by default (CPU profiling data was already being ingested when profiling was enabled, but not memory one).
 
 Docker images:
 * Upgrade Python used by Docker images from 3.8.10 to 3.8.12.

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -440,7 +440,6 @@ class Configuration(object):
                 )
                 self.__log_configs.append(profile_config)
 
-
             self.__monitor_configs = list(self.__config.get_json_array("monitors"))
 
             # Perform validation for k8s_logs option

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -416,6 +416,14 @@ class Configuration(object):
 
             # add in the profile logs if we have enabled profiling
             if self.enable_profiling:
+                self.__logger.info(
+                    "Profiling is enabled, will ingest CPU profiling (%s) and memory "
+                    "profiling (%s) data by default"
+                    % (self.profile_log_name, self.memory_profile_log_name),
+                    limit_once_per_x_secs=86400,
+                    limit_key="profiling-enabled-ingest",
+                )
+
                 # 1. CPU profiling
                 profile_config = JsonObject(
                     path=self.profile_log_name,

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -414,18 +414,32 @@ class Configuration(object):
 
             self.__k8s_log_configs = list(self.__config.get_json_array("k8s_logs"))
 
-            # add in the profile log if we have enabled profiling
+            # add in the profile logs if we have enabled profiling
             if self.enable_profiling:
+                # 1. CPU profiling
                 profile_config = JsonObject(
                     path=self.profile_log_name,
                     copy_from_start=True,
                     staleness_threshold_secs=20 * 60,
-                    parser="scalyrAgentProfiling",
+                    parser="scalyrAgentCpuProfiling",
                 )
                 self.__verify_log_entry_and_set_defaults(
                     profile_config, description="CPU profile log config"
                 )
                 self.__log_configs.append(profile_config)
+
+                # 2. Memory profiling
+                profile_config = JsonObject(
+                    path=self.memory_profile_log_name,
+                    copy_from_start=True,
+                    staleness_threshold_secs=20 * 60,
+                    parser="scalyrAgentMemoryProfiling",
+                )
+                self.__verify_log_entry_and_set_defaults(
+                    profile_config, description="CPU profile log config"
+                )
+                self.__log_configs.append(profile_config)
+
 
             self.__monitor_configs = list(self.__config.get_json_array("monitors"))
 


### PR DESCRIPTION
This pull request updates the code so we ingest memory profiling dump / data by default when profiling is enabled (``enable_profiling`` configuration option).

We already do that by default for CPU profiling data, but we haven't do it for memory profiling data. This way the behavior should be consistent and it should also help with the end user experience.

NOTE: I also changed the parser name we attach to the profiler data - I checked the (server side code) and it doesn't seem we define any parser for this name on the server side, but in case I missed something, please let me know.

On a somewhat related note - in the future it may make sense for us to define server side parser / line join rule for those two parsers to provide a better user experience.