### PR TITLE
Fix URL monitor handling of request data for POST requests under Python 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Docker images:
 * Upgrade Python used by Docker images from 3.8.10 to 3.8.12.
 * Base distribution version for non slim Alpine Linux based images has been upgraded from Debian Buster (10) to Debian Bullseye.
 
+Bug fixes:
+* Fix a bug with the URL monitor not working correctly with POST methods when ``request_data`` was specified under Python 3.
+
 ## 2.1.26 "Yavin" - Jan 12, 2022
 
 <!---

--- a/scalyr_agent/builtin_monitors/url_monitor.py
+++ b/scalyr_agent/builtin_monitors/url_monitor.py
@@ -284,11 +284,11 @@ class UrlMonitor(ScalyrMonitor):
         @type e: Exception
         @type error_type: str
         """
-        # Convert the exception to a string, truncated to 20 chars.
+        # Convert the exception to a string, truncated to 30 chars.
         e_to_str = six.text_type(e)
 
-        if len(e_to_str) > 20:
-            e_to_str = e_to_str[0:20]
+        if len(e_to_str) > 30:
+            e_to_str = e_to_str[0:30] + "..."
 
         extra_fields = {
             "url": self.url,

--- a/scalyr_agent/builtin_monitors/url_monitor.py
+++ b/scalyr_agent/builtin_monitors/url_monitor.py
@@ -198,15 +198,19 @@ class UrlMonitor(ScalyrMonitor):
         Builds the HTTP request based on the request URL, HTTP headers and method
         @return: Request object
         """
+        # TODO: Switch to requests
+        request_data = self.request_data
 
-        request = six.moves.urllib.request.Request(self.url, data=self.request_data)
+        if six.PY3 and request_data:
+            request_data = six.ensure_binary(request_data)
+
+        request = six.moves.urllib.request.Request(self.url, data=request_data)
 
         for header_key, header_value in six.iteritems(self._base_headers):
             request.add_header(header_key, header_value)
 
         if self.request_headers:
             for header in self.request_headers:
-                print(header)
                 request.add_header(header["header"], header["value"])
 
         # seems awkward to override the GET method, but internally it flips

--- a/tests/unit/url_monitor_test.py
+++ b/tests/unit/url_monitor_test.py
@@ -31,6 +31,7 @@ from scalyr_agent.builtin_monitors.url_monitor import UrlMonitor
 from scalyr_agent.scalyr_monitor import MonitorConfig
 from scalyr_agent.json_lib.objects import JsonArray, JsonObject
 
+import six
 import mock
 
 EXPECTED_BASE_HEADERS = list(
@@ -105,7 +106,12 @@ class UrlMonitorTestRequest(unittest.TestCase):
         url_monitor = UrlMonitor(monitor_config=config, logger=mock_logger)
         actual_request = url_monitor.build_request()
         self.assertEqual(actual_request.get_method(), "POST")
-        self.assertEqual(actual_request.data, "{fakejsonthatisnotlegit}")
+
+        if six.PY3:
+            self.assertEqual(actual_request.data, b"{fakejsonthatisnotlegit}")
+        else:
+            self.assertEqual(actual_request.data, "{fakejsonthatisnotlegit}")
+
         self.assertEqual(
             sorted(actual_request.header_items()),
             sorted(
@@ -122,6 +128,9 @@ class UrlMonitorTestRequest(unittest.TestCase):
             "request_headers": "not legit headers",
             "module": self.module,
         }
+
+        if six.PY3:
+            config_data["request_data"] = b"{fakejsonthatisnotlegit}"
 
         config = MonitorConfig(content=config_data)
         self.assertRaises(


### PR DESCRIPTION
This pull request fixes URL monitor so it works correctly under Python 3 when the POST method is used and the request data is specified.

Previously under Python 3, user would see errors like this when specifying POST data:

```bash
'failed', extra_fields={'url': 'http://127.0.0.1:11505/200_post', 'status': 0, 'length': 0, 'unknown_error': 'POST data should be '}
```

In addition to that, I also included two other improvements:

* If the error message is truncated, indicate that with ``...`` and include 30 characters instead of 20 by default. Previously we didn't indicate that a message has been truncated which would result in "weird" errors such as``'POST data should be '``.
* On unknown errors, also log the whole traceback. This should help with troubleshooting (and unknown errors would indicate some kind of fatal error or a bug like in this case so it's not something which would get logged during normal use so it won't result in a log volume increase)

NOTE: Long term (after we drop support for Python 2) we should migrate all that home grown glue code for handling HTTP requests to the requests library.