### PR TITLE
 Fix typo in the agent start up message

### DIFF
--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -2204,7 +2204,7 @@ def get_agent_start_up_message():
 
     msg = (
         "Starting scalyr agent... (version=%s) (revision=%s) %s (Python version: %s) "
-        "(OpenSSL version: %s) (default fs encoding: %s) (locale: %s) (LANG env variable: %s)"
+        "(OpenSSL version: %s) (default fs encoding: %s) (locale: %s) (LANG env variable: %s) "
         "(date parsing library: %s)"
         % (
             SCALYR_VERSION,


### PR DESCRIPTION
This pull request fixes a small formatting / typo (missing whitespace) in the agent start up line.