### PR TITLE
Fix package tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2321,30 +2321,30 @@ workflows:
      - build-windows-package
      - package-test-rpm:
          context: scalyr-agent
-         <<: *master_and_release_only
+         #<<: *master_and_release_only
      - package-test-deb:
          context: scalyr-agent
-         <<: *master_and_release_only
+         #<<: *master_and_release_only
      - smoke-rpm-package-py2:
          context: scalyr-agent
          requires:
            - package-test-rpm
-         <<: *master_and_release_only
+         #<<: *master_and_release_only
      - smoke-rpm-package-py3:
          context: scalyr-agent
          requires:
            - package-test-rpm
-         <<: *master_and_release_only
+         #<<: *master_and_release_only
      - smoke-deb-package-py2:
          context: scalyr-agent
          requires:
            - package-test-deb
-         <<: *master_and_release_only
+         #<<: *master_and_release_only
      - smoke-deb-package-py3:
          context: scalyr-agent
          requires:
            - package-test-deb
-         <<: *master_and_release_only
+         #<<: *master_and_release_only
      - ami-tests-development:
           context: scalyr-agent
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2321,30 +2321,30 @@ workflows:
      - build-windows-package
      - package-test-rpm:
          context: scalyr-agent
-         #<<: *master_and_release_only
+         <<: *master_and_release_only
      - package-test-deb:
          context: scalyr-agent
-         #<<: *master_and_release_only
+         <<: *master_and_release_only
      - smoke-rpm-package-py2:
          context: scalyr-agent
          requires:
            - package-test-rpm
-         #<<: *master_and_release_only
+         <<: *master_and_release_only
      - smoke-rpm-package-py3:
          context: scalyr-agent
          requires:
            - package-test-rpm
-         #<<: *master_and_release_only
+         <<: *master_and_release_only
      - smoke-deb-package-py2:
          context: scalyr-agent
          requires:
            - package-test-deb
-         #<<: *master_and_release_only
+         <<: *master_and_release_only
      - smoke-deb-package-py3:
          context: scalyr-agent
          requires:
            - package-test-deb
-         #<<: *master_and_release_only
+         <<: *master_and_release_only
      - ami-tests-development:
           context: scalyr-agent
           requires:

--- a/build_package.py
+++ b/build_package.py
@@ -1805,7 +1805,7 @@ def get_build_info():
         if rc != 0:
             packager_email = "unknown"
 
-        __build_info__["packaged_by"] = packager_email
+        __build_info__["packaged_by"] = packager_email.strip()
 
         # Determine the last commit from the log.
         (_, commit_id) = run_command(
@@ -1814,13 +1814,13 @@ def get_build_info():
             command_name="git",
         )
 
-        __build_info__["latest_commit"] = commit_id
+        __build_info__["latest_commit"] = commit_id.strip()
 
         # Include the branch just for safety sake.
         (_, branch) = run_command(
             "git branch | cut -d ' ' -f 2", exit_on_fail=True, command_name="git"
         )
-        __build_info__["from_branch"] = branch
+        __build_info__["from_branch"] = branch.strip()
 
         # Add a timestamp.
 

--- a/build_package.py
+++ b/build_package.py
@@ -1156,7 +1156,6 @@ def build_base_files(install_type, base_configs="config"):
     os.chdir("bin")
 
     make_soft_link("../py/scalyr_agent/agent_main.py", "scalyr-agent-2")
-    # make_soft_link("../py/scalyr_agent/config_main.py", "scalyr-agent-2-config")
 
     shutil.copy(
         make_path(agent_source_root, "agent_build/linux/scalyr-agent-2-config"),

--- a/installer/scripts/scalyr-switch-python.sh
+++ b/installer/scripts/scalyr-switch-python.sh
@@ -56,4 +56,4 @@ else
   exit 2
 fi
 
-/usr/share/scalyr-agent-2/bin/scalyr-agent-2 config --set-python="${EXECUTABLE_NAME}"
+/usr/bin/env "${EXECUTABLE_NAME}" /usr/share/scalyr-agent-2/bin/scalyr-agent-2 config --set-python="${EXECUTABLE_NAME}"

--- a/installer/scripts/scalyr-switch-python.sh
+++ b/installer/scripts/scalyr-switch-python.sh
@@ -56,4 +56,4 @@ else
   exit 2
 fi
 
-/usr/bin/env "${EXECUTABLE_NAME}" /usr/share/scalyr-agent-2/bin/scalyr-agent-2-config --set-python="${EXECUTABLE_NAME}"
+/usr/share/scalyr-agent-2/bin/scalyr-agent-2-config --set-python="${EXECUTABLE_NAME}"

--- a/installer/scripts/scalyr-switch-python.sh
+++ b/installer/scripts/scalyr-switch-python.sh
@@ -56,4 +56,4 @@ else
   exit 2
 fi
 
-/usr/share/scalyr-agent-2/bin/scalyr-agent-2-config --set-python="${EXECUTABLE_NAME}"
+/usr/share/scalyr-agent-2/bin/scalyr-agent-2 config --set-python="${EXECUTABLE_NAME}"

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -76,7 +76,7 @@ else
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=upgrade --from-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1404-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=debian1003 --type=upgrade --from-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/debian1003-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=centos7 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/centos7-upgrade.log &
-  python tests/ami/packages_sanity_tests.py --distro=centos8 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/centos8-upgrade.log &
+  # python tests/ami/packages_sanity_tests.py --distro=centos8 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/centos8-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=amazonlinux2 --type=upgrade --from-version=current --to-version=/tmp/workspace/scalyr-agent-2.rpm --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/amazonlinux2-upgrade.log &
 fi
 

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -58,7 +58,8 @@ if [ "${TEST_TYPE}" == "stable" ]; then
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/ubuntu1404-install.log &
   python tests/ami/packages_sanity_tests.py --distro=debian1003 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/debian1003-install.log &
   python tests/ami/packages_sanity_tests.py --distro=centos7 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/centos7-install.log &
-  python tests/ami/packages_sanity_tests.py --distro=centos8 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/centos8-install.log &
+  # disable centos 8, because of it's EOL and the poor connection between vault repos.
+  #python tests/ami/packages_sanity_tests.py --distro=centos8 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/centos8-install.log &
   python tests/ami/packages_sanity_tests.py --distro=amazonlinux2 --type=install --to-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" &> outputs/amazonlinux2-install.log &
 else
   echo "Run sanity tests for the new packages from the current revision."

--- a/tests/distribution/python_version_change_tests/amazonlinux2_test.py
+++ b/tests/distribution/python_version_change_tests/amazonlinux2_test.py
@@ -53,20 +53,20 @@ def test_amazonlinux_test_versions(request):
         install_fails=True,
     )
     common_version_test(
-        runner, install_rpm, remove_rpm, "config_main.py", "", "2.5.1", "3.4.1"
+        runner, install_rpm, remove_rpm, "agent_main.py", "", "2.5.1", "3.4.1"
     )
     common_version_test(
-        runner, install_rpm, remove_rpm, "config_main_py2.py", "2.5.1", "", "3.4.1"
+        runner, install_rpm, remove_rpm, "agent_main_py2.py", "2.5.1", "", "3.4.1"
     )
     common_version_test(
-        runner, install_rpm, remove_rpm, "config_main_py3.py", "2.5.1", "2.5.1", ""
+        runner, install_rpm, remove_rpm, "agent_main_py3.py", "2.5.1", "2.5.1", ""
     )
-    common_version_test(runner, install_rpm, remove_rpm, "config_main.py", "", "", "")
+    common_version_test(runner, install_rpm, remove_rpm, "agent_main.py", "", "", "")
     common_version_test(
-        runner, install_rpm, remove_rpm, "config_main_py2.py", "2.5.1", "", ""
+        runner, install_rpm, remove_rpm, "agent_main_py2.py", "2.5.1", "", ""
     )
     common_version_test(
-        runner, install_rpm, remove_rpm, "config_main.py", "", "2.5.1", ""
+        runner, install_rpm, remove_rpm, "agent_main.py", "", "2.5.1", ""
     )
 
 

--- a/tests/distribution/python_version_change_tests/centos7/centos7_with_py3_test.py
+++ b/tests/distribution/python_version_change_tests/centos7/centos7_with_py3_test.py
@@ -53,17 +53,17 @@ def test_centos_test_versions(request):
     )
 
     common_version_test(
-        runner, install_rpm, remove_rpm, "config_main_py2.py", "2.5.1", "", "3.4.1"
+        runner, install_rpm, remove_rpm, "agent_main_py2.py", "2.5.1", "", "3.4.1"
     )
     common_version_test(
-        runner, install_rpm, remove_rpm, "config_main_py3.py", "2.5.1", "2.5.1", ""
+        runner, install_rpm, remove_rpm, "agent_main_py3.py", "2.5.1", "2.5.1", ""
     )
-    common_version_test(runner, install_rpm, remove_rpm, "config_main.py", "", "", "")
+    common_version_test(runner, install_rpm, remove_rpm, "agent_main.py", "", "", "")
     common_version_test(
-        runner, install_rpm, remove_rpm, "config_main_py2.py", "2.5.1", "", ""
+        runner, install_rpm, remove_rpm, "agent_main_py2.py", "2.5.1", "", ""
     )
     common_version_test(
-        runner, install_rpm, remove_rpm, "config_main.py", "", "2.5.1", ""
+        runner, install_rpm, remove_rpm, "agent_main.py", "", "2.5.1", ""
     )
 
 

--- a/tests/distribution/python_version_change_tests/centos8_test.py
+++ b/tests/distribution/python_version_change_tests/centos8_test.py
@@ -57,26 +57,26 @@ def test_centos_test_versions(request):
         runner,
         install_rpm,
         remove_rpm,
-        "config_main.py",
+        "agent_main.py",
         "",
         "2.5.1",
         "3.4.1",
         install_fails=True,
     )
     common_version_test(
-        runner, install_rpm, remove_rpm, "config_main_py2.py", "2.5.1", "", "3.4.1"
+        runner, install_rpm, remove_rpm, "agent_main_py2.py", "2.5.1", "", "3.4.1"
     )
     common_version_test(
-        runner, install_rpm, remove_rpm, "config_main_py3.py", "2.5.1", "2.5.1", ""
+        runner, install_rpm, remove_rpm, "agent_main_py3.py", "2.5.1", "2.5.1", ""
     )
     common_version_test(
-        runner, install_rpm, remove_rpm, "config_main_py2.py", "", "", ""
+        runner, install_rpm, remove_rpm, "agent_main_py2.py", "", "", ""
     )
     common_version_test(
-        runner, install_rpm, remove_rpm, "config_main_py2.py", "2.5.1", "", ""
+        runner, install_rpm, remove_rpm, "agent_main_py2.py", "2.5.1", "", ""
     )
     common_version_test(
-        runner, install_rpm, remove_rpm, "config_main_py3.py", "", "2.5.1", ""
+        runner, install_rpm, remove_rpm, "agent_main_py3.py", "", "2.5.1", ""
     )
 
 

--- a/tests/distribution/python_version_change_tests/common.py
+++ b/tests/distribution/python_version_change_tests/common.py
@@ -533,26 +533,26 @@ def common_test_switch_command_works_without_agent_config(install_package_fn):
     runner.switch_version("python3", env=env)
 
     shebang_line_main = get_shebang_from_file(scalyr_agent_2_target)
-    shebang_line_config = get_shebang_from_file(scalyr_agent_2_config_target)
+    #shebang_line_config = get_shebang_from_file(scalyr_agent_2_config_target)
     assert shebang_line_main == "#!/usr/bin/env python3"
-    assert shebang_line_config == "#!/usr/bin/env python3"
+    #assert shebang_line_config == "#!/usr/bin/env python3"
 
     # Switch back to python2
     runner.switch_version("python2", env=env)
 
     shebang_line_main = get_shebang_from_file(scalyr_agent_2_target)
-    shebang_line_config = get_shebang_from_file(scalyr_agent_2_config_target)
+    #shebang_line_config = get_shebang_from_file(scalyr_agent_2_config_target)
     assert shebang_line_main == "#!/usr/bin/env python2"
-    assert shebang_line_config == "#!/usr/bin/env python2"
+    #assert shebang_line_config == "#!/usr/bin/env python2"
 
     # Switch back to python (aka default)
     if is_python_binary_available:
         runner.switch_version("python", env=env)
 
         shebang_line_main = get_shebang_from_file(scalyr_agent_2_target)
-        shebang_line_config = get_shebang_from_file(scalyr_agent_2_config_target)
+        #shebang_line_config = get_shebang_from_file(scalyr_agent_2_config_target)
         assert shebang_line_main == "#!/usr/bin/env python"
-        assert shebang_line_config == "#!/usr/bin/env python"
+        #assert shebang_line_config == "#!/usr/bin/env python"
 
     # Write a config with invalid config, this way we ensure config is indeed not parsed by that
     # command even if it's present
@@ -568,9 +568,9 @@ def common_test_switch_command_works_without_agent_config(install_package_fn):
     runner.switch_version("python3", env=env)
 
     shebang_line_main = get_shebang_from_file(scalyr_agent_2_target)
-    shebang_line_config = get_shebang_from_file(scalyr_agent_2_config_target)
+    #shebang_line_config = get_shebang_from_file(scalyr_agent_2_config_target)
     assert shebang_line_main == "#!/usr/bin/env python3"
-    assert shebang_line_config == "#!/usr/bin/env python3"
+    #assert shebang_line_config == "#!/usr/bin/env python3"
 
 
 def common_test_switch_python2_to_python3(install_package_fn, install_next_version_fn):

--- a/tests/distribution/python_version_change_tests/common.py
+++ b/tests/distribution/python_version_change_tests/common.py
@@ -61,7 +61,7 @@ def _remove_python(command):
 
 def _get_current_config_script_name():
     return Path(
-        os.readlink(six.text_type(SCALYR_PACKAGE_BIN_PATH / "scalyr-agent-2-config"))
+        six.text_type(SCALYR_PACKAGE_BIN_PATH / "scalyr-agent-2-config")
     ).name
 
 

--- a/tests/distribution/python_version_change_tests/common.py
+++ b/tests/distribution/python_version_change_tests/common.py
@@ -190,7 +190,6 @@ def common_version_test(
         stdout, _ = install_package_fn()
 
     current_main_script_file_name = _get_current_main_script_name()
-
     assert current_main_script_file_name == expected_conf_file_name
 
     _mock_binaries("", "", "")
@@ -507,11 +506,11 @@ def common_test_switch_command_works_without_agent_config(install_package_fn):
     binary_path = os.path.join("/", "usr", "share", "scalyr-agent-2", "bin")
 
     scalyr_agent_2_target = os.path.join(binary_path, "scalyr-agent-2")
-    scalyr_agent_2_config_target = os.path.join(binary_path, "scalyr-agent-2-config")
+    #scalyr_agent_2_config_target = os.path.join(binary_path, "scalyr-agent-2-config")
 
     # Default should be python binary
     shebang_line_main = get_shebang_from_file(scalyr_agent_2_target)
-    shebang_line_config = get_shebang_from_file(scalyr_agent_2_config_target)
+    #shebang_line_config = get_shebang_from_file(scalyr_agent_2_config_target)
 
     # On some newer distros python binary is not available
     if shutil.which("python"):
@@ -525,10 +524,10 @@ def common_test_switch_command_works_without_agent_config(install_package_fn):
         expected,
         shebang_line_main,
     )
-    assert shebang_line_config == expected, "expected %s, got %s" % (
-        expected,
-        shebang_line_config,
-    )
+    # assert shebang_line_config == expected, "expected %s, got %s" % (
+    #     expected,
+    #     shebang_line_config,
+    # )
 
     # Switch to python3
     runner.switch_version("python3", env=env)

--- a/tests/distribution/python_version_change_tests/common.py
+++ b/tests/distribution/python_version_change_tests/common.py
@@ -161,7 +161,7 @@ def common_version_test(
     runner,
     install_package_fn,
     remove_package_fn,
-    expected_conf_file_name,
+    expected_main_file_name,
     *python_versions,
     **kwargs
 ):
@@ -171,7 +171,7 @@ def common_version_test(
     :param runner: The agent runner
     :param install_package_fn: callable that installs package with appropriate type to the current machine OS.
     :param remove_package_fn: callable that removes package.
-    :param expected_conf_file_name: name of the "conf_main*" file, helps to be sure that python version is switched.
+    :param expected_main_file_name: name of the "agent_main*" file, helps to be sure that python version is switched.
     :param python_versions: mock real python binaries with with dummy bash scripts, which only prints version.
     By those mocks we make installer skip those binaries as invalid for the agent.
     :param kwargs:
@@ -190,7 +190,7 @@ def common_version_test(
         stdout, _ = install_package_fn()
 
     current_main_script_file_name = _get_current_main_script_name()
-    assert current_main_script_file_name == expected_conf_file_name
+    assert current_main_script_file_name == expected_main_file_name
 
     _mock_binaries("", "", "")
 

--- a/tests/distribution/python_version_change_tests/common.py
+++ b/tests/distribution/python_version_change_tests/common.py
@@ -506,11 +506,9 @@ def common_test_switch_command_works_without_agent_config(install_package_fn):
     binary_path = os.path.join("/", "usr", "share", "scalyr-agent-2", "bin")
 
     scalyr_agent_2_target = os.path.join(binary_path, "scalyr-agent-2")
-    #scalyr_agent_2_config_target = os.path.join(binary_path, "scalyr-agent-2-config")
 
     # Default should be python binary
     shebang_line_main = get_shebang_from_file(scalyr_agent_2_target)
-    #shebang_line_config = get_shebang_from_file(scalyr_agent_2_config_target)
 
     # On some newer distros python binary is not available
     if shutil.which("python"):
@@ -524,35 +522,25 @@ def common_test_switch_command_works_without_agent_config(install_package_fn):
         expected,
         shebang_line_main,
     )
-    # assert shebang_line_config == expected, "expected %s, got %s" % (
-    #     expected,
-    #     shebang_line_config,
-    # )
 
     # Switch to python3
     runner.switch_version("python3", env=env)
 
     shebang_line_main = get_shebang_from_file(scalyr_agent_2_target)
-    #shebang_line_config = get_shebang_from_file(scalyr_agent_2_config_target)
     assert shebang_line_main == "#!/usr/bin/env python3"
-    #assert shebang_line_config == "#!/usr/bin/env python3"
 
     # Switch back to python2
     runner.switch_version("python2", env=env)
 
     shebang_line_main = get_shebang_from_file(scalyr_agent_2_target)
-    #shebang_line_config = get_shebang_from_file(scalyr_agent_2_config_target)
     assert shebang_line_main == "#!/usr/bin/env python2"
-    #assert shebang_line_config == "#!/usr/bin/env python2"
 
     # Switch back to python (aka default)
     if is_python_binary_available:
         runner.switch_version("python", env=env)
 
         shebang_line_main = get_shebang_from_file(scalyr_agent_2_target)
-        #shebang_line_config = get_shebang_from_file(scalyr_agent_2_config_target)
         assert shebang_line_main == "#!/usr/bin/env python"
-        #assert shebang_line_config == "#!/usr/bin/env python"
 
     # Write a config with invalid config, this way we ensure config is indeed not parsed by that
     # command even if it's present
@@ -568,9 +556,7 @@ def common_test_switch_command_works_without_agent_config(install_package_fn):
     runner.switch_version("python3", env=env)
 
     shebang_line_main = get_shebang_from_file(scalyr_agent_2_target)
-    #shebang_line_config = get_shebang_from_file(scalyr_agent_2_config_target)
     assert shebang_line_main == "#!/usr/bin/env python3"
-    #assert shebang_line_config == "#!/usr/bin/env python3"
 
 
 def common_test_switch_python2_to_python3(install_package_fn, install_next_version_fn):

--- a/tests/distribution/python_version_change_tests/common.py
+++ b/tests/distribution/python_version_change_tests/common.py
@@ -59,9 +59,9 @@ def _remove_python(command):
         pass
 
 
-def _get_current_config_script_name():
+def _get_current_main_script_name():
     return Path(
-        six.text_type(SCALYR_PACKAGE_BIN_PATH / "scalyr-agent-2-config")
+        os.readlink(six.text_type(SCALYR_PACKAGE_BIN_PATH / "scalyr-agent-2"))
     ).name
 
 
@@ -140,20 +140,20 @@ def common_test_ubuntu_versions():
         install_fails=True,
     )
     common_version_test(
-        runner, install_deb, remove_deb, "config_main.py", "", "2.5.1", "3.4.1"
+        runner, install_deb, remove_deb, "agent_main.py", "", "2.5.1", "3.4.1"
     )
     common_version_test(
-        runner, install_deb, remove_deb, "config_main_py2.py", "2.5.1", "", "3.4.1"
+        runner, install_deb, remove_deb, "agent_main_py2.py", "2.5.1", "", "3.4.1"
     )
     common_version_test(
-        runner, install_deb, remove_deb, "config_main_py3.py", "2.5.1", "2.5.1", ""
+        runner, install_deb, remove_deb, "agent_main_py3.py", "2.5.1", "2.5.1", ""
     )
-    common_version_test(runner, install_deb, remove_deb, "config_main.py", "", "", "")
+    common_version_test(runner, install_deb, remove_deb, "agent_main.py", "", "", "")
     common_version_test(
-        runner, install_deb, remove_deb, "config_main_py2.py", "2.5.1", "", ""
+        runner, install_deb, remove_deb, "agent_main_py2.py", "2.5.1", "", ""
     )
     common_version_test(
-        runner, install_deb, remove_deb, "config_main.py", "", "2.5.1", ""
+        runner, install_deb, remove_deb, "agent_main.py", "", "2.5.1", ""
     )
 
 
@@ -189,9 +189,9 @@ def common_version_test(
     else:
         stdout, _ = install_package_fn()
 
-    current_config_script_file_name = _get_current_config_script_name()
+    current_main_script_file_name = _get_current_main_script_name()
 
-    assert current_config_script_file_name == expected_conf_file_name
+    assert current_main_script_file_name == expected_conf_file_name
 
     _mock_binaries("", "", "")
 
@@ -242,7 +242,7 @@ def common_test_only_python_mapped_to_python2(
     assert "Switching the Python interpreter used by the Scalyr Agent" not in stdout
 
     # 'scalyr-agent-2-config' command must be a symlink to config_main.py
-    assert _get_current_config_script_name() == "config_main.py"
+    assert _get_current_main_script_name() == "agent_main.py"
 
     runner = AgentRunner(PACKAGE_INSTALL)
     runner.start()
@@ -254,8 +254,8 @@ def common_test_only_python_mapped_to_python2(
     # install next version of the package
     install_next_version_fn()
 
-    # the source file should be "config_main.py"
-    assert _get_current_config_script_name() == "config_main.py"
+    # the source file should be "agent_main.py"
+    assert _get_current_main_script_name() == "agent_main.py"
 
 
 def common_test_only_python_mapped_to_python3(
@@ -277,8 +277,8 @@ def common_test_only_python_mapped_to_python3(
     # this is signaled by the install script not trying to switch the interpreter
     assert "Switching the Python interpreter used by the Scalyr Agent" not in stdout
 
-    # 'scalyr-agent-2-config' command must be a symlink to config_main.py
-    assert _get_current_config_script_name() == "config_main.py"
+    # 'scalyr-agent-2-config' command must be a symlink to agent_main.py
+    assert _get_current_main_script_name() == "agent_main.py"
 
     runner = AgentRunner(PACKAGE_INSTALL)
     runner.start()
@@ -290,8 +290,8 @@ def common_test_only_python_mapped_to_python3(
     # install next version of the package
     install_next_version_fn()
 
-    # the source file should be "config_main.py"
-    assert _get_current_config_script_name() == "config_main.py"
+    # the source file should be "agent_main.py"
+    assert _get_current_main_script_name() == "agent_main.py"
 
 
 def common_test_python2(install_package_fn, install_next_version_fn):
@@ -318,8 +318,8 @@ def common_test_python2(install_package_fn, install_next_version_fn):
     # make sure that installer has found 'python2'.
     assert "The default 'python' command not found, will use python2 binary" in stdout
 
-    # 'scalyr-agent-2-config' command must be a symlink to config_main_py2.py
-    assert _get_current_config_script_name() == "config_main_py2.py"
+    # 'scalyr-agent-2-config' command must be a symlink to agent_main_py2.py
+    assert _get_current_main_script_name() == "agent_main_py2.py"
 
     runner = AgentRunner(PACKAGE_INSTALL)
     runner.start()
@@ -331,8 +331,8 @@ def common_test_python2(install_package_fn, install_next_version_fn):
 
     # install next version of the package
     stdout, _ = install_next_version_fn()
-    # the source file should be "config_main_py2.py"
-    assert _get_current_config_script_name() == "config_main_py2.py"
+    # the source file should be "agent_main_py2.py"
+    assert _get_current_main_script_name() == "agent_main_py2.py"
 
 
 def common_test_python3(install_package_fn, install_next_version_fn):
@@ -358,8 +358,8 @@ def common_test_python3(install_package_fn, install_next_version_fn):
     assert "The default 'python' command not found, will use python2 binary" in stdout
     assert "The 'python2' command not found, will use python3 binary" in stdout
 
-    # 'scalyr-agent-2-config' command must be a symlink to config_main_py3.py
-    assert _get_current_config_script_name() == "config_main_py3.py"
+    # 'scalyr-agent-2-config' command must be a symlink to agent_main_py3.py
+    assert _get_current_main_script_name() == "agent_main_py3.py"
 
     runner = AgentRunner(PACKAGE_INSTALL)
 
@@ -371,8 +371,8 @@ def common_test_python3(install_package_fn, install_next_version_fn):
 
     # install next version of the package
     stdout, _ = install_next_version_fn()
-    # the source file should be "config_main_py3.py"
-    assert _get_current_config_script_name() == "config_main_py3.py"
+    # the source file should be "agent_main_py3.py"
+    assert _get_current_main_script_name() == "agent_main_py3.py"
 
 
 def common_test_switch_default_to_python2(install_package_fn, install_next_version_fn):
@@ -392,7 +392,7 @@ def common_test_switch_default_to_python2(install_package_fn, install_next_versi
     # this is signaled by the install script not trying to switch the interpreter
     assert "Switching the Python interpreter used by the Scalyr Agent" not in stdout
 
-    assert _get_current_config_script_name() == "config_main.py"
+    assert _get_current_main_script_name() == "agent_main.py"
 
     runner = AgentRunner(PACKAGE_INSTALL)
     runner.start()
@@ -403,7 +403,7 @@ def common_test_switch_default_to_python2(install_package_fn, install_next_versi
     # switching to python2
     runner.stop()
     runner.switch_version("python2")
-    assert _get_current_config_script_name() == "config_main_py2.py"
+    assert _get_current_main_script_name() == "agent_main_py2.py"
     runner.start()
     time.sleep(1)
     assert _get_python_major_version(runner) == 2
@@ -413,12 +413,12 @@ def common_test_switch_default_to_python2(install_package_fn, install_next_versi
     stdout, _ = install_next_version_fn()
     # Installer must not switch to default python.
     assert "Switching the Python interpreter used by the Scalyr Agent" not in stdout
-    # the source file should be "config_main_py3.py"
-    assert _get_current_config_script_name() == "config_main_py2.py"
+    # the source file should be "agent_main_py3.py"
+    assert _get_current_main_script_name() == "agent_main_py2.py"
 
     # switching back to default python
     runner.switch_version("default")
-    assert _get_current_config_script_name() == "config_main.py"
+    assert _get_current_main_script_name() == "agent_main.py"
     runner.start()
     time.sleep(1)
     assert _get_python_major_version(runner) == 2
@@ -440,7 +440,7 @@ def common_test_switch_default_to_python3(install_package_fn, install_next_versi
     # this is signaled by the install script not trying to switch the interpreter
     assert "Switching the Python interpreter used by the Scalyr Agent" not in stdout
 
-    assert _get_current_config_script_name() == "config_main.py"
+    assert _get_current_main_script_name() == "agent_main.py"
 
     runner = AgentRunner(PACKAGE_INSTALL)
     runner.start()
@@ -451,7 +451,7 @@ def common_test_switch_default_to_python3(install_package_fn, install_next_versi
     # switching to python3
     runner.stop()
     runner.switch_version("python3")
-    assert _get_current_config_script_name() == "config_main_py3.py"
+    assert _get_current_main_script_name() == "agent_main_py3.py"
     runner.start()
     time.sleep(1)
     assert _get_python_major_version(runner) == 3
@@ -461,12 +461,12 @@ def common_test_switch_default_to_python3(install_package_fn, install_next_versi
     stdout, _ = install_next_version_fn()
     # Installer must not switch to default python.
     assert "Switching the Python interpreter used by the Scalyr Agent" not in stdout
-    # the source file should be "config_main_py3.py"
-    assert _get_current_config_script_name() == "config_main_py3.py"
+    # the source file should be "agent_main_py3.py"
+    assert _get_current_main_script_name() == "agent_main_py3.py"
 
     # switching back to default python
     runner.switch_version("default")
-    assert _get_current_config_script_name() == "config_main.py"
+    assert _get_current_main_script_name() == "agent_main.py"
     runner.start()
     time.sleep(1)
     assert _get_python_major_version(runner) == 2
@@ -583,7 +583,7 @@ def common_test_switch_python2_to_python3(install_package_fn, install_next_versi
     _remove_python("python")
 
     install_package_fn()
-    assert _get_current_config_script_name() == "config_main_py2.py"
+    assert _get_current_main_script_name() == "agent_main_py2.py"
 
     runner = AgentRunner(PACKAGE_INSTALL)
     runner.start()
@@ -594,7 +594,7 @@ def common_test_switch_python2_to_python3(install_package_fn, install_next_versi
     # switching to python3
     runner.stop()
     runner.switch_version("python3")
-    assert _get_current_config_script_name() == "config_main_py3.py"
+    assert _get_current_main_script_name() == "agent_main_py3.py"
     runner.start()
     time.sleep(1)
     assert _get_python_major_version(runner) == 3
@@ -604,12 +604,12 @@ def common_test_switch_python2_to_python3(install_package_fn, install_next_versi
     stdout, _ = install_next_version_fn()
     # Installer must not switch to default python.
     assert "Switching the Python interpreter used by the Scalyr Agent" not in stdout
-    # the source file should be "config_main_py3.py"
-    assert _get_current_config_script_name() == "config_main_py3.py"
+    # the source file should be "agent_main_py3.py"
+    assert _get_current_main_script_name() == "agent_main_py3.py"
 
     # switching bach to python2
     runner.switch_version("python2")
-    assert _get_current_config_script_name() == "config_main_py2.py"
+    assert _get_current_main_script_name() == "agent_main_py2.py"
     runner.start()
     time.sleep(1)
     assert _get_python_major_version(runner) == 2

--- a/tests/distribution/python_version_change_tests/ubuntu1404/ubuntu1404_test.py
+++ b/tests/distribution/python_version_change_tests/ubuntu1404/ubuntu1404_test.py
@@ -49,16 +49,16 @@ def test_ubuntu_test_versions(request):
     )
 
     common_version_test(
-        runner, install_deb, remove_deb, "config_main_py2.py", "2.5.1", "", ""
+        runner, install_deb, remove_deb, "agent_main_py2.py", "2.5.1", "", ""
     )
     common_version_test(
-        runner, install_deb, remove_deb, "config_main_py2.py", "2.5.1", "", ""
+        runner, install_deb, remove_deb, "agent_main_py2.py", "2.5.1", "", ""
     )
 
-    common_version_test(runner, install_deb, remove_deb, "config_main.py", "", "", "")
+    common_version_test(runner, install_deb, remove_deb, "agent_main.py", "", "", "")
 
     common_version_test(
-        runner, install_deb, remove_deb, "config_main.py", "", "2.5.1", ""
+        runner, install_deb, remove_deb, "agent_main.py", "", "2.5.1", ""
     )
 
 

--- a/tests/distribution/python_version_change_tests/ubuntu1604/ubuntu1604_test.py
+++ b/tests/distribution/python_version_change_tests/ubuntu1604/ubuntu1604_test.py
@@ -48,16 +48,16 @@ def test_ubuntu_test_versions(request):
     )
 
     common_version_test(
-        runner, install_deb, remove_deb, "config_main_py2.py", "2.5.1", "", ""
+        runner, install_deb, remove_deb, "agent_main_py2.py", "2.5.1", "", ""
     )
     common_version_test(
-        runner, install_deb, remove_deb, "config_main_py2.py", "2.5.1", "", ""
+        runner, install_deb, remove_deb, "agent_main_py2.py", "2.5.1", "", ""
     )
 
-    common_version_test(runner, install_deb, remove_deb, "config_main.py", "", "", "")
+    common_version_test(runner, install_deb, remove_deb, "agent_main.py", "", "", "")
 
     common_version_test(
-        runner, install_deb, remove_deb, "config_main.py", "", "2.5.1", ""
+        runner, install_deb, remove_deb, "agent_main.py", "", "2.5.1", ""
     )
 
 

--- a/tests/distribution/python_version_change_tests/ubuntu1804/ubuntu1804_test.py
+++ b/tests/distribution/python_version_change_tests/ubuntu1804/ubuntu1804_test.py
@@ -53,16 +53,16 @@ def test_ubuntu_test_versions(request):
     )
 
     common_version_test(
-        runner, install_deb, remove_deb, "config_main_py2.py", "2.5.1", "", ""
+        runner, install_deb, remove_deb, "agent_main_py2.py", "2.5.1", "", ""
     )
     common_version_test(
-        runner, install_deb, remove_deb, "config_main_py2.py", "2.5.1", "", ""
+        runner, install_deb, remove_deb, "agent_main_py2.py", "2.5.1", "", ""
     )
 
-    common_version_test(runner, install_deb, remove_deb, "config_main.py", "", "", "")
+    common_version_test(runner, install_deb, remove_deb, "agent_main.py", "", "", "")
 
     common_version_test(
-        runner, install_deb, remove_deb, "config_main.py", "", "2.5.1", ""
+        runner, install_deb, remove_deb, "agent_main.py", "", "2.5.1", ""
     )
 
 

--- a/tests/distribution/python_version_change_tests/ubuntu1804/ubuntu1804_test.py
+++ b/tests/distribution/python_version_change_tests/ubuntu1804/ubuntu1804_test.py
@@ -53,10 +53,10 @@ def test_ubuntu_test_versions(request):
     )
 
     common_version_test(
-        runner, install_deb, remove_deb, "agent_main.py", "2.5.1", "", ""
+        runner, install_deb, remove_deb, "agent_main_py2.py", "2.5.1", "", ""
     )
     common_version_test(
-        runner, install_deb, remove_deb, "agent_main.py", "2.5.1", "", ""
+        runner, install_deb, remove_deb, "agent_main_py2.py", "2.5.1", "", ""
     )
 
     common_version_test(runner, install_deb, remove_deb, "agent_main.py", "", "", "")

--- a/tests/distribution/python_version_change_tests/ubuntu1804/ubuntu1804_test.py
+++ b/tests/distribution/python_version_change_tests/ubuntu1804/ubuntu1804_test.py
@@ -53,10 +53,10 @@ def test_ubuntu_test_versions(request):
     )
 
     common_version_test(
-        runner, install_deb, remove_deb, "agent_main_py2.py", "2.5.1", "", ""
+        runner, install_deb, remove_deb, "agent_main.py", "2.5.1", "", ""
     )
     common_version_test(
-        runner, install_deb, remove_deb, "agent_main_py2.py", "2.5.1", "", ""
+        runner, install_deb, remove_deb, "agent_main.py", "2.5.1", "", ""
     )
 
     common_version_test(runner, install_deb, remove_deb, "agent_main.py", "", "", "")

--- a/tests/utils/image_builder.py
+++ b/tests/utils/image_builder.py
@@ -186,16 +186,18 @@ class AgentImageBuilder(object):
         dockerfile_path.write_text(self.get_dockerfile_content())
         self._copy_to_build_context(build_context_path)
 
-        subprocess.check_call([
-            "docker",
-            "build",
-            "-t",
-            self.image_tag,
-            "-f",
-            six.text_type(dockerfile_path),
-            "--rm",
-            six.text_type(build_context_path)
-        ])
+        subprocess.check_call(
+            [
+                "docker",
+                "build",
+                "-t",
+                self.image_tag,
+                "-f",
+                six.text_type(dockerfile_path),
+                "--rm",
+                six.text_type(build_context_path),
+            ]
+        )
 
         shutil.rmtree(six.text_type(build_context_path), ignore_errors=True)
 

--- a/tests/utils/image_builder.py
+++ b/tests/utils/image_builder.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 import shutil
 import argparse
 import hashlib
+import subprocess
 from abc import ABCMeta
 
 if False:  # NOSONAR
@@ -185,17 +186,18 @@ class AgentImageBuilder(object):
         dockerfile_path.write_text(self.get_dockerfile_content())
         self._copy_to_build_context(build_context_path)
 
-        _, output_gen = self._docker_client.images.build(
-            tag=self.image_tag,
-            path=six.text_type(build_context_path),
-            dockerfile=six.text_type(dockerfile_path),
-            rm=True,
-        )
+        subprocess.check_call([
+            "docker",
+            "build",
+            "-t",
+            self.image_tag,
+            "-f",
+            six.text_type(dockerfile_path),
+            "--rm",
+            six.text_type(build_context_path)
+        ])
 
         shutil.rmtree(six.text_type(build_context_path), ignore_errors=True)
-
-        for chunk in output_gen:
-            print(chunk.get("stream", ""), end="")
 
     def build_with_cache(
         self, dir_path, skip_if_exists=True


### PR DESCRIPTION
This PR adds other small fixes to the package tests to make them work after the `scalyr-agent-2-config` file was replaced with a shell script.

PS. Also disabled AMI test for centos 8 because of the bad vault repo availability.