### PR TITLE
Fix bug in build_package.py

### DIFF
--- a/build_package.py
+++ b/build_package.py
@@ -1844,6 +1844,17 @@ def get_install_info(install_type):
     )
 
 
+def get_build_info_json():
+    """
+    Get json serialized string with the build info.
+    """
+    return json.dumps(
+        get_build_info(),
+        indent=4,
+        sort_keys=True,
+    )
+
+
 def set_build_info(build_info_file_path):
     """Sets the file to use as the build_info file to include in the package.
 
@@ -1925,7 +1936,7 @@ if __name__ == "__main__":
     # If we are just suppose to create the build_info, then do it and exit.  We do not bother to check to see
     # if they specified a package.
     if options.build_info_only:
-        write_to_file(get_build_info(), "build_info")
+        write_to_file(get_build_info_json(), "build_info")
         print("Built build_info")
         sys.exit(0)
 


### PR DESCRIPTION
Fixes a small bug in build_package.py which is causing Jenkins CI failure.

```bash
12:12:47  Creating build_info for new build
12:12:47  Traceback (most recent call last):
12:12:47    File "build_package.py", line 1928, in <module>
12:12:47      write_to_file(get_build_info(), "build_info")
12:12:47    File "build_package.py", line 1349, in write_to_file
12:12:47      dest_fp.write(string_value.rstrip())
12:12:47  AttributeError: 'dict' object has no attribute 'rstrip'
12:12:47  Could not create build_info
```