### PR TITLE
Fix package build info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2345,11 +2345,11 @@ workflows:
          requires:
            - package-test-deb
          <<: *master_and_release_only
-     - ami-tests-development:
-          context: scalyr-agent
-          requires:
-            - build-windows-package
-            - build-linux-packages-and-installer-script
+#     - ami-tests-development:
+#          context: scalyr-agent
+#          requires:
+#            - build-windows-package
+#            - build-linux-packages-and-installer-script
      - ami-tests-stable:
           context: scalyr-agent
           <<: *master_and_release_only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -731,10 +731,10 @@ commands:
             export SECRET_KEY=${AWS_SECRET_KEY}
             export INSTALLER_SCRIPT_URL="<< parameters.installer_script_url >>"
 
-            # If testing type is "development" we use installer script which is built in another job.
-            if [ "<< parameters.test_type >>" = "development" ]; then
-              export INSTALLER_SCRIPT_URL="/tmp/workspace/installScalyrAgentV2.sh"
-            fi
+#            # If testing type is "development" we use installer script which is built in another job.
+#            if [ "<< parameters.test_type >>" = "development" ]; then
+#              export INSTALLER_SCRIPT_URL="/tmp/workspace/installScalyrAgentV2.sh"
+#            fi
 
             set +e
 
@@ -2345,11 +2345,11 @@ workflows:
          requires:
            - package-test-deb
          <<: *master_and_release_only
-#     - ami-tests-development:
-#          context: scalyr-agent
-#          requires:
-#            - build-windows-package
-#            - build-linux-packages-and-installer-script
+     - ami-tests-development:
+          context: scalyr-agent
+          requires:
+            - build-windows-package
+            - build-linux-packages-and-installer-script
      - ami-tests-stable:
           context: scalyr-agent
           <<: *master_and_release_only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -731,6 +731,11 @@ commands:
             export SECRET_KEY=${AWS_SECRET_KEY}
             export INSTALLER_SCRIPT_URL="<< parameters.installer_script_url >>"
 
+            # If testing type is "development" we use installer script which is built in another job.
+            if [ "<< parameters.test_type >>" = "development" ]; then
+              export INSTALLER_SCRIPT_URL="/tmp/workspace/installScalyrAgentV2.sh"
+            fi
+
             set +e
 
             max_attempts="2"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -731,11 +731,6 @@ commands:
             export SECRET_KEY=${AWS_SECRET_KEY}
             export INSTALLER_SCRIPT_URL="<< parameters.installer_script_url >>"
 
-#            # If testing type is "development" we use installer script which is built in another job.
-#            if [ "<< parameters.test_type >>" = "development" ]; then
-#              export INSTALLER_SCRIPT_URL="/tmp/workspace/installScalyrAgentV2.sh"
-#            fi
-
             set +e
 
             max_attempts="2"

--- a/build_package.py
+++ b/build_package.py
@@ -283,14 +283,6 @@ def build_win32_installer_package(variant, version):
     shutil.copy(make_path(agent_source_root, "VERSION"), "VERSION.txt")
     shutil.copy(make_path(agent_source_root, "LICENSE.txt"), "LICENSE.txt")
 
-    # Also add in build_info file
-    try:
-        write_to_file(get_build_info_json(), "build_info")
-    except Exception as e:
-        # NOTE: For now this error is not fatal in case git is not present on the system where
-        # we are building a package
-        print("Failed to retrieve / write build info fail: %s" % (str(e)))
-
     # Also add in install_info file
     write_to_file(get_install_info("package"), "install_info.json")
 

--- a/build_package.py
+++ b/build_package.py
@@ -1866,9 +1866,8 @@ def set_build_info(build_info_file_path):
     @param build_info_file_path: The path to the build_info file to use.
     """
     global __build_info__
-    fp = open(build_info_file_path, "r")
-    __build_info__ = fp.read()
-    fp.close()
+    with open(build_info_file_path, "r") as fp:
+        __build_info__ = json.load(fp)
 
     return __build_info__
 

--- a/build_package.py
+++ b/build_package.py
@@ -1077,10 +1077,6 @@ def build_base_files(install_type, base_configs="config"):
     # Write install_info file inside the 'scalyr_agent' package.
     os.chdir("scalyr_agent")
 
-    # Write build_info file inside the package root (temporary needed until we drop old Jenkins
-    # builder)
-    write_to_file(get_build_info_json(), "build_info")
-
     install_info = get_install_info(install_type)
     write_to_file(install_info, "install_info.json")
     os.chdir("..")


### PR DESCRIPTION
This PR fixes the `set_build_info` function in the `build_package.py` script, so now it handles input as JSON. Before that, it accepted build info as a string. Our release pipeline relies on this function and keeps writing build info as a string, which leads to type error.

I Also reverted some last changes that add back build info file, because it seems that wasn't a root cause.

Another change is that now we use a stable install script in AMI tests even in internal Jenkins build. Before that, we used install script that downloaded packages from an internal repository.