### PR TITLE
Fix dynamic pod metadata updates in the Kubernetes monitor, additional debug level logging, new GHA based Kubernetes end to end tests

### DIFF
--- a/.github/actions/install-k8s-agent-daemonset/action.yml
+++ b/.github/actions/install-k8s-agent-daemonset/action.yml
@@ -69,7 +69,7 @@ runs:
         kubectl apply -f "${{ inputs.daemonset_yaml_path }}"
 
         # Give it some time to start up
-        sleep 40
+        sleep 60
         kubectl -n scalyr get event
         kubectl -n scalyr get serviceaccount
         kubectl -n scalyr get pods

--- a/.github/actions/install-k8s-agent-daemonset/action.yml
+++ b/.github/actions/install-k8s-agent-daemonset/action.yml
@@ -50,7 +50,8 @@ runs:
           --from-literal=SCALYR_K8S_CLUSTER_NAME="${{ inputs.scalyr_cluster_name }}" \
           --from-literal=SCALYR_K8S_EVENTS_DISABLE="true" \
           --from-literal=SCALYR_K8S_VERIFY_KUBELET_QUERIES="false" \
-          --from-literal=SCALYR_SERVER="${{ inputs.scalyr_server }}"
+          --from-literal=SCALYR_SERVER="${{ inputs.scalyr_server }}" \
+          --from-literal=SCALYR_K8S_CACHE_EXPIRY_SECS="5"
 
         # Apply any additional custom resources
         if [ ! -z "${{ inputs.extra_yaml_paths }}" ]; then
@@ -68,7 +69,7 @@ runs:
         kubectl apply -f "${{ inputs.daemonset_yaml_path }}"
 
         # Give it some time to start up
-        sleep 60
+        sleep 40
         kubectl -n scalyr get event
         kubectl -n scalyr get serviceaccount
         kubectl -n scalyr get pods

--- a/.github/actions/install-k8s-agent-daemonset/action.yml
+++ b/.github/actions/install-k8s-agent-daemonset/action.yml
@@ -1,0 +1,81 @@
+name: "Install Scalyr Agent"
+description: "Install Scalyr agent on K8s cluster as DaemonSet"
+
+inputs:
+  scalyr_server:
+    description: "Scalyr agent endpoint to use."
+    required: false
+    default: "agent.scalyr.com"
+  scalyr_api_key:
+    description: "Write API key to be used by the agent."
+    required: true
+  scalyr_cluster_name:
+    description: "Cluster name to use."
+    required: true
+  daemonset_yaml_path:
+    description: "Which Kubernetes resource YAML file with scalyr agent daemonset definition to use."
+    required: true
+    default: "k8s/no-kustomize/scalyr-agent-2.yaml"
+  extra_yaml_paths:
+    description: "Comma delimited list of any additional Kubernetes resource YAML files which should be applied before applying DaemonSet YAML."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create scalyr-agent-2 daemonset
+      id: create-daemonset
+      shell: bash
+      run: |
+        export NODE_NAME=$(kubectl get nodes -o jsonpath="{.items[0].metadata.name}")
+        echo "NODE_NAME=${NODE_NAME}" >> ${GITHUB_ENV}
+        echo "Using node name: ${NODE_NAME}"
+
+        export K8S_CLUSTER_NAME="ci-agent-e2e-k8s-om-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+        echo "K8S_CLUSTER_NAME=${K8S_CLUSTER_NAME}" >> ${GITHUB_ENV}
+        echo "Using cluster name: ${K8S_CLUSTER_NAME}"
+
+        # Create namespace
+        kubectl create namespace scalyr
+
+        # Create service account
+        kubectl apply -f k8s/no-kustomize/scalyr-service-account.yaml
+
+        # Define api key
+        kubectl create secret generic scalyr-api-key --namespace scalyr --from-literal=scalyr-api-key="${{ inputs.scalyr_api_key }}"
+
+        # Create configmap
+        kubectl create configmap --namespace scalyr scalyr-config \
+          --from-literal=SCALYR_K8S_CLUSTER_NAME="${{ inputs.scalyr_cluster_name }}" \
+          --from-literal=SCALYR_K8S_EVENTS_DISABLE="true" \
+          --from-literal=SCALYR_K8S_VERIFY_KUBELET_QUERIES="false" \
+          --from-literal=SCALYR_SERVER="${{ inputs.scalyr_server }}"
+
+        # Apply any additional custom resources
+        if [ ! -z "${{ inputs.extra_yaml_paths }}" ]; then
+          echo "Applying additional custom YAML resources"
+
+          IFS=', ' read -r -a EXTRA_YAML_FILE_PATHS <<< "${{ inputs.extra_yaml_paths }}"
+
+          for yaml_path in "${EXTRA_YAML_FILE_PATHS[@]}"; do
+            echo "Applying: ${yaml_path}"
+            kubectl apply -f "${yaml_path}"
+          done
+        fi
+
+        # Create daemonset
+        kubectl apply -f "${{ inputs.daemonset_yaml_path }}"
+
+        # Give it some time to start up
+        sleep 60
+        kubectl -n scalyr get event
+        kubectl -n scalyr get serviceaccount
+        kubectl -n scalyr get pods
+
+        export SCALYR_AGENT_POD_NAME=$(kubectl get pod --namespace=scalyr --selector=app=scalyr-agent-2 -o jsonpath="{.items[0].metadata.name}")
+        echo "SCALYR_AGENT_POD_NAME=${SCALYR_AGENT_POD_NAME}" >> ${GITHUB_ENV}
+        echo "Using scalyr agent pod name: ${SCALYR_AGENT_POD_NAME}"
+
+        echo "Agent pod logs (${SCALYR_AGENT_POD_NAME})"
+        kubectl logs -n scalyr "${SCALYR_AGENT_POD_NAME}"

--- a/.github/actions/install-k8s-agent-daemonset/action.yml
+++ b/.github/actions/install-k8s-agent-daemonset/action.yml
@@ -12,6 +12,18 @@ inputs:
   scalyr_cluster_name:
     description: "Cluster name to use."
     required: true
+  scalyr_verify_api_queries:
+    description: "Set to true to verify HTTP requests to Kubernetes API."
+    required: false
+    default: "false"
+  scalyr_verify_k8s_queries:
+    description: "Set to true to verify HTTP requests to Kubelet API."
+    required: false
+    default: "false"
+  scalyr_k8s_events_disable:
+    description: "Set to true to disable Kubernetes events monitor."
+    required: false
+    default: "true"
   daemonset_yaml_path:
     description: "Which Kubernetes resource YAML file with scalyr agent daemonset definition to use."
     required: true
@@ -48,9 +60,12 @@ runs:
         # Create configmap
         kubectl create configmap --namespace scalyr scalyr-config \
           --from-literal=SCALYR_K8S_CLUSTER_NAME="${{ inputs.scalyr_cluster_name }}" \
-          --from-literal=SCALYR_K8S_EVENTS_DISABLE="true" \
-          --from-literal=SCALYR_K8S_VERIFY_KUBELET_QUERIES="false" \
+          --from-literal=SCALYR_K8S_EVENTS_DISABLE="${{ inputs.scalyr_k8s_events_disable }}" \
+          --from-literal=SCALYR_K8S_VERIFY_API_QUERIES="${{ inputs.scalyr_verify_api_queries }}" \
+          --from-literal=SCALYR_K8S_VERIFY_KUBELET_QUERIES="${{ inputs.scalyr_verify_k8s_queries }}" \
           --from-literal=SCALYR_SERVER="${{ inputs.scalyr_server }}" \
+          --from-literal=SCALYR_K8S_LEADER_CHECK_INTERVAL="5" \
+          --from-literal=SCALYR_K8S_IGNORE_MASTER="false" \
           --from-literal=SCALYR_K8S_CACHE_EXPIRY_SECS="5"
 
         # Apply any additional custom resources

--- a/.github/actions/setup-minikube-cluster/action.yml
+++ b/.github/actions/setup-minikube-cluster/action.yml
@@ -10,6 +10,14 @@ inputs:
     description: "Kubernetes version to be installed by minikube (if any)"
     required: false
     default: ""
+  minikube_driver:
+    description: "Minikube driver to use"
+    required: false
+    default: ""
+  container_runtime:
+    description: "Container runtime to use"
+    required: false
+    default: "docker"
   github_token:
     description: "Github token to use for communication with Github API to avoid rate limits"
     required: true
@@ -25,11 +33,13 @@ runs:
       with:
         if: ${{ inputs.k8s_version != '' }}
         step: |
-          uses: manusa/actions-setup-minikube@3cce81c968cabc530141d5620b7d9942a2907df5 # v2.4.2
+          uses: manusa/actions-setup-minikube@f6ceea1a32df47f602b1345bd8ad7da7c5824cbf # v2.4.3
           with:
             minikube version: '${{ inputs.minikube_version }}'
             kubernetes version: '${{ inputs.k8s_version }}'
             github token: '${{ inputs.github_token }}'
+            driver: '${{ inputs.minikube_driver }}'
+            start args: '--container-runtime=${{ inputs.container_runtime }}'
 
     - name: Print minikube environment info
       id: print-k8s-cluster-info
@@ -39,11 +49,29 @@ runs:
         step: |
           shell: bash
           run: |
-            # Workaround for occasional DNS issues
-            # kubectl -n kube-system rollout restart deployment coredns
+            echo "kubectl version"
             kubectl version
+            echo ""
+            echo "minikube addions"
+            echo ""
             minikube addons list
+            echo ""
+            echo "kubectl get nodes"
+            echo ""
             kubectl get nodes
+            echo ""
+            echo "kubectl cluster-info"
+            echo ""
             kubectl cluster-info
+            echo ""
+            echo "kubectl get pods -A"
+            echo ""
             kubectl get pods -A
-            sleep 5
+
+            export NODE_NAME=$(kubectl get nodes -o jsonpath="{.items[0].metadata.name}")
+            echo ""
+            echo "kubectl describe node"
+            echo ""
+            kubectl describe node ${NODE_NAME}
+
+            sleep 2

--- a/.github/actions/setup-minikube-cluster/action.yml
+++ b/.github/actions/setup-minikube-cluster/action.yml
@@ -73,5 +73,3 @@ runs:
             echo "kubectl describe node"
             echo ""
             kubectl describe node ${NODE_NAME}
-
-            sleep 2

--- a/.github/actions/setup-minikube-cluster/action.yml
+++ b/.github/actions/setup-minikube-cluster/action.yml
@@ -5,7 +5,7 @@ inputs:
   minikube_version:
     description: "Minikube version to use"
     required: false
-    default: "v1.23.2"
+    default: "v1.25.1"
   k8s_version:
     description: "Kubernetes version to be installed by minikube (if any)"
     required: false

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -53,9 +53,9 @@ jobs:
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1.2.0
         with:
-          image: tonistiigi/binfmt:qemu-v6.1.0
+          image: tonistiigi/binfmt:qemu-v6.2.0
           platforms: all
 
       - name: Perform the build of the base docker image in the deployment.
@@ -64,7 +64,7 @@ jobs:
           deployment-name: ${{ matrix.image-type }}-${{ matrix.image-distro-name }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # v1.6.0
         with:
           driver-opts: network=host
 

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -19,7 +19,6 @@ on: [push]
 # For example: https://github.com/scalyr/scalyr-agent-2/pull/804/commits/0eccf278623552b51d9289d75a47794e88f02862
 jobs:
   test-images:
-    if: ${{ github.ref == 'refs/heads/false' }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -19,6 +19,7 @@ on: [push]
 # For example: https://github.com/scalyr/scalyr-agent-2/pull/804/commits/0eccf278623552b51d9289d75a47794e88f02862
 jobs:
   test-images:
+    if: ${{ github.ref == 'refs/heads/false' }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -97,13 +97,13 @@ jobs:
           channel: '#cloud-tech'
 
   publish-images:
-    if: ${{ github.ref == 'refs/heads/master' || github.ref_type == 'tag' || github.ref == 'refs/heads/k8s_additional_logging' }}
+    if: ${{ github.ref == 'refs/heads/master' || github.ref_type == 'tag' }}
     needs:
       - test-images
 
-    uses: scalyr/scalyr-agent-2/.github/workflows/publish-docker-images.yml@k8s_additional_logging
+    uses: scalyr/scalyr-agent-2/.github/workflows/publish-docker-images.yml@master
     secrets:
       SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_TEST_ACCOUNT }}
-      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_TEST_ACCOUNT }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_PROD_ACCOUNT }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_PROD_ACCOUNT }}

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -97,13 +97,13 @@ jobs:
           channel: '#cloud-tech'
 
   publish-images:
-    if: ${{ github.ref == 'refs/heads/master' || github.ref_type == 'tag' }}
+    if: ${{ github.ref == 'refs/heads/master' || github.ref_type == 'tag' || github.ref == 'refs/heads/k8s_additional_logging' }}
     needs:
       - test-images
 
-    uses: scalyr/scalyr-agent-2/.github/workflows/publish-docker-images.yml@master
+    uses: scalyr/scalyr-agent-2/.github/workflows/publish-docker-images.yml@k8s_additional_logging
     secrets:
       SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN: ${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}
       SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY: ${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_PROD_ACCOUNT }}
-      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_PROD_ACCOUNT }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_TEST_ACCOUNT }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_TEST_ACCOUNT }}

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Build Agent k8s Docker Image
         run: |
-          # python3 build_package_new.py k8s-debian --tag "local_k8s_image" --platforms linux/amd64
+          python3 build_package_new.py k8s-debian --tag "local_k8s_image" --platforms linux/amd64
           docker image ls
 
       # Here we build the dummy Java app image which exposes JMX metrics via exporter
@@ -99,50 +99,15 @@ jobs:
           kubectl get pods -A
 
       - name: Create scalyr-agent-2 daemonset
-        run: |
-          export NODE_NAME=$(kubectl get nodes -o jsonpath="{.items[0].metadata.name}")
-          echo "NODE_NAME=${NODE_NAME}" >> ${GITHUB_ENV}
-          echo "Using node name: ${NODE_NAME}"
-
-          export K8S_CLUSTER_NAME="ci-agent-e2e-k8s-om-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          echo "K8S_CLUSTER_NAME=${K8S_CLUSTER_NAME}" >> ${GITHUB_ENV}
-          echo "Using cluster name: ${K8S_CLUSTER_NAME}"
-
-          # Create namespace
-          kubectl create namespace scalyr
-
-          # Create service account
-          kubectl apply -f k8s/no-kustomize/scalyr-service-account.yaml
-
-          # Define api key
-          kubectl create secret generic scalyr-api-key --namespace scalyr --from-literal=scalyr-api-key="${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}"
-
-          # Create configmap
-          kubectl create configmap --namespace scalyr scalyr-config \
-            --from-literal=SCALYR_K8S_CLUSTER_NAME="${K8S_CLUSTER_NAME}" \
-            --from-literal=SCALYR_K8S_EVENTS_DISABLE="true" \
-            --from-literal=SCALYR_K8S_VERIFY_KUBELET_QUERIES="false" \
-            --from-literal=SCALYR_SERVER="agent.scalyr.com"
-
-          # Create extra-d configmap
+        uses: ./.github/actions/install-k8s-agent-daemonset/
+        with:
+          scalyr_server: "agent.scalyr.com"
+          scalyr_api_key: "${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}"
+          scalyr_cluster_name: "${K8S_CLUSTER_NAME}"
+          daemonset_yaml_path: "tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml"
           # Monitor is not enabled by default yet since it's still in preview and testing phase so
           # we expliticly enable it here
-          kubectl apply -f tests/e2e/k8s_om_monitor/scalyr-agent-extra-config-configmap.yaml
-
-          # Create daemonset
-          kubectl apply -f tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml
-
-          sleep 60
-          kubectl -n scalyr get event
-          kubectl -n scalyr get serviceaccount
-          kubectl -n scalyr get pods
-
-          export SCALYR_AGENT_POD_NAME=$(kubectl get pod --namespace=scalyr --selector=app=scalyr-agent-2 -o jsonpath="{.items[0].metadata.name}")
-          echo "SCALYR_AGENT_POD_NAME=${SCALYR_AGENT_POD_NAME}" >> ${GITHUB_ENV}
-          echo "Using scalyr agent pod name: ${SCALYR_AGENT_POD_NAME}"
-
-          echo "Agent pod logs (${SCALYR_AGENT_POD_NAME})"
-          kubectl logs -n scalyr "${SCALYR_AGENT_POD_NAME}"
+          extra_yaml_paths: "tests/e2e/k8s_om_monitor/scalyr-agent-extra-config-configmap.yaml"
 
       - name: Verify data has been ingested
         timeout-minutes: 8
@@ -179,8 +144,8 @@ jobs:
           echo "Node exporter metrics monitor checks"
           ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-node-exporter-" "process_max_fds "'
           ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-node-exporter-" "process_open_fds "'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-node-exporter-" "node_vmstat_pswpin 0 node=\"'${NODE_NAME}'\""'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-node-exporter-" "node_vmstat_pswpout 0 node=\"'${NODE_NAME}'\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-node-exporter-" "node_vmstat_pswpin "'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-node-exporter-" "node_vmstat_pswpout "'
 
           # 3. Verify kube state event metrics
           echo "Kube state events metrics monitor checks"

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - k8s_om_monitor_e2e_tests
   pull_request:
     branches:
       - master
@@ -26,8 +25,9 @@ jobs:
           cancel_others: 'true'
           github_token: ${{ github.token }}
 
+  # Jobs which performs basic sanity checks for the Kubernetes Monitor and Kubernetes Events Monitor
   k8s_kubernetes_monitor_tests:
-    name: Kubernetes Monitor - k8s ${{ matrix.k8s_version.version }}-${{ matrix.k8s_version.runtime}}
+    name: Kubernetes Monitors - k8s ${{ matrix.k8s_version.version }}-${{ matrix.k8s_version.runtime}}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -43,6 +43,7 @@ jobs:
           - { "version": "v1.20.15", "driver": "", "runtime": "docker" }
           - { "version": "v1.21.10", "driver": "", "runtime": "docker" }
           - { "version": "v1.22.7", "driver": "", "runtime": "docker" }
+          # NOTE: Using containerd runtime in minikube on  GHA only works with docker driver
           - { "version": "v1.23.4", "driver": "docker", "runtime": "containerd" }
 
     steps:
@@ -71,6 +72,8 @@ jobs:
           container_runtime: "${{ matrix.k8s_version.runtime }}"
           github_token: "${{ secrets.GITHUB_TOKEN }}"
 
+      # TODO: Build image as a first job in the workflow and then re-use that image for other jobs
+      # to speed up the build and reduce number of redundant builds.
       - name: Build Agent k8s Docker Image
         run: |
           python3 build_package_new.py k8s-debian --tag "local_k8s_image" --platforms linux/amd64
@@ -81,7 +84,7 @@ jobs:
             minikube image load scalyr-k8s-agent:local_k8s_image
           fi
 
-      # Here we build the dummy container which continously prints data to stdout
+      # Here we build the dummy container which continously prints data to stdout and stderr
       - name: Build Dummy App Docker Image
         run: |
           docker build -f docker/Dockerfile.docker_monitor_testing_config -t std-printer scripts/
@@ -92,7 +95,7 @@ jobs:
             minikube image load std-printer:latest
           fi
 
-      # Create pod for our mock container which agent will ingest
+      # Create pod for our mock std printer container which logs will be ingested by the agent
       - name: Create mock pod
         run: |
           kubectl apply -f tests/e2e/k8s_k8s_monitor/std_printer_deployment.yaml
@@ -114,6 +117,7 @@ jobs:
           scalyr_server: "agent.scalyr.com"
           scalyr_api_key: "${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}"
           scalyr_cluster_name: "${K8S_CLUSTER_NAME}"
+          scalyr_k8s_events_disable: "false"
           daemonset_yaml_path: "tests/e2e/scalyr-agent-2-daemonset.yaml"
 
       - name: Verify data has been ingested
@@ -132,8 +136,14 @@ jobs:
           ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Starting scalyr agent..."'
 
           # Verify Kubernetes monitor is running
-          echo "Monitoring running checks"
+          echo "Kubernetes Monitor running checks"
           ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "kubernetes_monitor parameters: ignoring namespaces: "'
+          echo ""
+
+          # Verify Kubernetes events monitor is running
+          echo "Kubernetes events monitor running checks"
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Starting monitor kubernetes_events_monitor"'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Acting as Kubernetes event leader"'
           echo ""
 
           # Verify initial std-printer pod data has been ingested
@@ -163,6 +173,25 @@ jobs:
           ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="changed" stream="stderr" "stderr: line"'
           echo ""
 
+          # Verify Kubernetes Events Monitor events are ingested
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/kubernetes_events.log" "\"kind\":\"Event\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/kubernetes_events.log" "\"kind\":\"Pod\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/kubernetes_events.log" "involvedObject"'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/kubernetes_events.log" "NodeReady"'
+
+      - name: Notify Slack on Failure
+        # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull
+        # requests and that's why we need this special conditional and check for github.head_ref in
+        # case of PRs
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || github.head_ref == 'master') }}
+        uses: act10ns/slack@e4e71685b9b239384b0f676a63c32367f59c2522 # v1.2.2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#cloud-tech'
+
   k8s_open_metrics_monitor_tests:
     name: OpenMetrics Monitor - k8s ${{ matrix.k8s_version.version }}-${{ matrix.k8s_version.runtime}}
     runs-on: ubuntu-latest
@@ -170,7 +199,7 @@ jobs:
 
     needs: pre_job
     # NOTE: We always want to run job on master branch
-    #if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
 
     strategy:
       fail-fast: false
@@ -180,6 +209,7 @@ jobs:
           - { "version": "v1.20.15", "driver": "", "runtime": "docker" }
           - { "version": "v1.21.10", "driver": "", "runtime": "docker" }
           - { "version": "v1.22.7", "driver": "", "runtime": "docker" }
+          # NOTE: Using containerd runtime in minikube on  GHA only works with docker driver
           - { "version": "v1.23.4", "driver": "docker", "runtime": "containerd" }
 
     steps:
@@ -235,7 +265,7 @@ jobs:
       # Create mock pods and exporters which will be scrapped by the monitor
       - name: Create mock pods and exporters
         run: |
-          kubectl create namespace monitoring
+          kubectl create namespace 
 
           # 1. node exporter pod
           kubectl apply -f tests/e2e/k8s_om_monitor/node_exporter.yaml
@@ -276,7 +306,7 @@ jobs:
           ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Starting scalyr agent..."'
 
           # Verify monitor is running
-          echo "Monitoring running checks"
+          echo "Monitor running checks"
           ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Found 3 URL(s) to scrape for node"'
           ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "There are currently 3 dynamic and 2 static open metrics monitors running"'
           echo ""

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -26,6 +26,142 @@ jobs:
           cancel_others: 'true'
           github_token: ${{ github.token }}
 
+  k8s_kubernetes_monitor_tests:
+    name: Kubernetes Monitor - k8s ${{ matrix.k8s_version.version }}-${{ matrix.k8s_version.runtime}}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    needs: pre_job
+    # NOTE: We always want to run job on master branch
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version:
+          - { "version": "v1.17.2", "driver": "", "runtime": "docker" }
+          - { "version": "v1.20.15", "driver": "", "runtime": "docker" }
+          - { "version": "v1.22.2", "driver": "", "runtime": "docker" }
+          - { "version": "v1.23.4", "driver": "docker", "runtime": "containerd" }
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v2
+        id: setup-python
+        with:
+          python-version: 3.8
+
+      - name: Install Scalyr tool
+        run: |
+          curl https://raw.githubusercontent.com/scalyr/scalyr-tool/master/scalyr > scalyr
+          chmod +x scalyr
+          sudo mv scalyr /usr/local/bin
+
+      - name: Setup minikube k8s cluster
+        uses: ./.github/actions/setup-minikube-cluster/
+        with:
+          k8s_version: "${{ matrix.k8s_version.version }}"
+          minikube_driver: "${{ matrix.k8s_version.driver }}"
+          container_runtime: "${{ matrix.k8s_version.runtime }}"
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Build Agent k8s Docker Image
+        run: |
+          python3 build_package_new.py k8s-debian --tag "local_k8s_image" --platforms linux/amd64
+          docker image ls
+
+          # Needed for containerd runtime
+          if [ "${{ matrix.k8s_version.runtime }}" = "containerd" ]; then
+            minikube image load scalyr-k8s-agent:local_k8s_image
+          fi
+
+      # Here we build the dummy container which continously prints data to stdout
+      - name: Build Dummy App Docker Image
+        run: |
+          docker build -f docker/Dockerfile.docker_monitor_testing_config -t std-printer scripts/
+          docker image ls
+
+          # Needed for containerd runtime
+          if [ "${{ matrix.k8s_version.runtime }}" = "containerd" ]; then
+            minikube image load std-printer:latest
+          fi
+
+      # Create pod for our mock container which agent will ingest
+      - name: Create mock pod
+        run: |
+          kubectl apply -f tests/e2e/k8s_k8s_monitor/std_printer_deployment.yaml
+
+          sleep 10
+          kubectl get pods -A
+
+          export APP_POD_NAME=$(kubectl get pod --namespace=default --selector=app=std-printer -o jsonpath="{.items[0].metadata.name}")
+          echo "APP_POD_NAME=${APP_POD_NAME}" >> ${GITHUB_ENV}
+          echo "APP_POD_NAME=${APP_POD_NAME}"
+
+          echo ""
+          kubectl logs "${APP_POD_NAME}"
+          echo ""
+
+      - name: Create scalyr-agent-2 daemonset
+        uses: ./.github/actions/install-k8s-agent-daemonset/
+        with:
+          scalyr_server: "agent.scalyr.com"
+          scalyr_api_key: "${{ secrets.SCALYR_PROD_CLOUDTECH_TESTING_WRITE_TOKEN }}"
+          scalyr_cluster_name: "${K8S_CLUSTER_NAME}"
+          daemonset_yaml_path: "tests/e2e/scalyr-agent-2-daemonset.yaml"
+
+      - name: Verify data has been ingested
+        timeout-minutes: 5
+        env:
+          # Needed for scalyr-tool
+          scalyr_readlog_token: "${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}"
+          SCALYR_AGENT_POD_NAME: "${{ env.SCALYR_AGENT_POD_NAME }}"
+          NODE_NAME: "${{ env.NODE_NAME }}"
+        run: |
+          export RETRY_ATTEMPTS="5"
+          export SLEEP_DELAY="10"
+
+          # Verify agent is running
+          echo "Agent running checks"
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Starting scalyr agent..."'
+
+          # Verify Kubernetes monitor is running
+          echo "Monitoring running checks"
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "kubernetes_monitor parameters: ignoring namespaces: "'
+          echo ""
+
+          # Verify initial std-printer pod data has been ingested
+
+          # 1. First we want for some data to be ingested using "log.config.scalyr.com/attributes.parser"
+          # annotation set as part of the deployment YAML.
+          # After a while, we change that dynamically using kubectl and verify that this change has
+          # been correctly picked up by the agent.
+          sleep 20
+
+          echo "Initial pod ingested data checks"
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stdout" "stdout: line 2"'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stderr" "stderr: line 2"'
+          echo ""
+
+          kubectl describe pod ${APP_POD_NAME}
+          kubectl annotate --overwrite pods ${APP_POD_NAME} log.config.scalyr.com/attributes.parser="changed"
+          kubectl describe pod ${APP_POD_NAME}
+
+          # Give agent some time to pick up the annotation change (by default we poll every 30 seconds
+          # for pod metadata changes, but we use lower value for the tests)
+          sleep 15
+
+          echo ""
+          echo "Post annotation change data checks"
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="changed" stream="stdout" "stdout: line"'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="changed" stream="stderr" "stderr: line"'
+          echo ""
+
   k8s_open_metrics_monitor_tests:
     name: OpenMetrics Monitor - k8s ${{ matrix.k8s_version }}
     runs-on: ubuntu-latest
@@ -33,7 +169,7 @@ jobs:
 
     needs: pre_job
     # NOTE: We always want to run job on master branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
+    #if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -39,9 +39,9 @@ jobs:
       fail-fast: false
       matrix:
         k8s_version:
-          - { "version": "v1.17.2", "driver": "", "runtime": "docker" }
+          - { "version": "v1.17.17", "driver": "", "runtime": "docker" }
           - { "version": "v1.20.15", "driver": "", "runtime": "docker" }
-          - { "version": "v1.22.2", "driver": "", "runtime": "docker" }
+          - { "version": "v1.22.7", "driver": "", "runtime": "docker" }
           - { "version": "v1.23.4", "driver": "docker", "runtime": "containerd" }
 
     steps:
@@ -123,7 +123,7 @@ jobs:
           SCALYR_AGENT_POD_NAME: "${{ env.SCALYR_AGENT_POD_NAME }}"
           NODE_NAME: "${{ env.NODE_NAME }}"
         run: |
-          export RETRY_ATTEMPTS="5"
+          export RETRY_ATTEMPTS="8"
           export SLEEP_DELAY="10"
 
           # Verify agent is running
@@ -163,7 +163,7 @@ jobs:
           echo ""
 
   k8s_open_metrics_monitor_tests:
-    name: OpenMetrics Monitor - k8s ${{ matrix.k8s_version }}
+    name: OpenMetrics Monitor - k8s ${{ matrix.k8s_version.version }}-${{ matrix.k8s_version.runtime}}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -175,9 +175,10 @@ jobs:
       fail-fast: false
       matrix:
         k8s_version:
-          - 'v1.17.2'
-          - 'v1.20.15'
-          - 'v1.22.2'
+          - { "version": "v1.17.17", "driver": "", "runtime": "docker" }
+          - { "version": "v1.20.15", "driver": "", "runtime": "docker" }
+          - { "version": "v1.22.7", "driver": "", "runtime": "docker" }
+          - { "version": "v1.23.4", "driver": "docker", "runtime": "containerd" }
 
     steps:
       - name: Checkout Repository
@@ -200,13 +201,20 @@ jobs:
       - name: Setup minikube k8s cluster
         uses: ./.github/actions/setup-minikube-cluster/
         with:
-          k8s_version: "${{ matrix.k8s_version }}"
+          k8s_version: "${{ matrix.k8s_version.version }}"
+          minikube_driver: "${{ matrix.k8s_version.driver }}"
+          container_runtime: "${{ matrix.k8s_version.runtime }}"
           github_token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Build Agent k8s Docker Image
         run: |
           python3 build_package_new.py k8s-debian --tag "local_k8s_image" --platforms linux/amd64
           docker image ls
+
+          # Needed for containerd runtime
+          if [ "${{ matrix.k8s_version.runtime }}" = "containerd" ]; then
+            minikube image load scalyr-k8s-agent:local_k8s_image
+          fi
 
       # Here we build the dummy Java app image which exposes JMX metrics via exporter
       - name: Build Test Java App Docker Image
@@ -216,6 +224,11 @@ jobs:
           popd
 
           docker image ls
+
+          # Needed for containerd runtime
+          if [ "${{ matrix.k8s_version.runtime }}" = "containerd" ]; then
+            minikube image load java-hello-world:latest
+          fi
 
       # Create mock pods and exporters which will be scrapped by the monitor
       - name: Create mock pods and exporters
@@ -253,7 +266,7 @@ jobs:
           SCALYR_AGENT_POD_NAME: "${{ env.SCALYR_AGENT_POD_NAME }}"
           NODE_NAME: "${{ env.NODE_NAME }}"
         run: |
-          export RETRY_ATTEMPTS="5"
+          export RETRY_ATTEMPTS="8"
           export SLEEP_DELAY="10"
 
           # Verify agent is running

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -41,6 +41,7 @@ jobs:
         k8s_version:
           - { "version": "v1.17.17", "driver": "", "runtime": "docker" }
           - { "version": "v1.20.15", "driver": "", "runtime": "docker" }
+          - { "version": "v1.21.10", "driver": "", "runtime": "docker" }
           - { "version": "v1.22.7", "driver": "", "runtime": "docker" }
           - { "version": "v1.23.4", "driver": "docker", "runtime": "containerd" }
 
@@ -177,6 +178,7 @@ jobs:
         k8s_version:
           - { "version": "v1.17.17", "driver": "", "runtime": "docker" }
           - { "version": "v1.20.15", "driver": "", "runtime": "docker" }
+          - { "version": "v1.21.10", "driver": "", "runtime": "docker" }
           - { "version": "v1.22.7", "driver": "", "runtime": "docker" }
           - { "version": "v1.23.4", "driver": "docker", "runtime": "containerd" }
 

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -265,7 +265,7 @@ jobs:
       # Create mock pods and exporters which will be scrapped by the monitor
       - name: Create mock pods and exporters
         run: |
-          kubectl create namespace 
+          kubectl create namespace monitoring
 
           # 1. node exporter pod
           kubectl apply -f tests/e2e/k8s_om_monitor/node_exporter.yaml

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -41,13 +41,13 @@ jobs:
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1.2.0
         with:
-          image: tonistiigi/binfmt:qemu-v6.1.0
+          image: tonistiigi/binfmt:qemu-v6.2.0
           platforms: all
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # v1.6.0
         with:
           driver-opts: network=host
 

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -107,7 +107,8 @@ jobs:
             --git-ref-name ${{ github.ref_name }} \
             --git-ref-type ${{ github.ref_type }} \
             --git-commit-sha ${{ github.sha }} \
-            --user ${{ secrets.DOCKER_HUB_USERNAME }}
+            --user ${{ secrets.DOCKER_HUB_USERNAME }} \
+            --ignore-errors
 
       - name: Notify Slack on Failure
         # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -27,14 +27,15 @@ concurrency: publish-release
 
 jobs:
   publish-temp-release:
-    name: Publish Docker Image to a temporary tag.
+    name: Publish Docker Image to a temporary tag - ${{ matrix.image-type }}-${{ matrix.image-distro-name }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         image-type: [ "k8s" ]
         #image-type: [ "docker-json", "docker-syslog", "k8s" ]
-        image-distro-name: [ "debian", "alpine" ]
+        image-distro-name: [ "debian" ]
+        #image-distro-name: [ "debian", "alpine" ]
 
     steps:
       - name: Checkout repository
@@ -88,7 +89,7 @@ jobs:
 
   publish-release:
     needs: [ publish-temp-release ]
-    name: Publish Docker Image
+    name: Publish Docker Image - ${{ matrix.image-type }}-${{ matrix.image-distro-name }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -32,10 +32,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image-type: [ "k8s" ]
-        #image-type: [ "docker-json", "docker-syslog", "k8s" ]
-        image-distro-name: [ "debian" ]
-        #image-distro-name: [ "debian", "alpine" ]
+        image-type: [ "docker-json", "docker-syslog", "k8s" ]
+        image-distro-name: [ "debian", "alpine" ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,4 +1,4 @@
-name: Publish Agent Images
+name: Publish Docker Images
 
 on:
   workflow_call:
@@ -27,7 +27,7 @@ concurrency: publish-release
 
 jobs:
   publish-temp-release:
-    name: Publish Docker Image to a temporary tag - ${{ matrix.image-type }}-${{ matrix.image-distro-name }}
+    name: Publish temporary tag (${{ matrix.image-type }}, ${{ matrix.image-distro-name }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -64,7 +64,7 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
-      - name: Push image using the a temporary tag.
+      - name: Push image using the a temporary tag
         run: |
           # Push result docker image with a special tag "_temp_release".
           # The next job will "re-tag" that image to an appropriate one.
@@ -89,7 +89,7 @@ jobs:
 
   publish-release:
     needs: [ publish-temp-release ]
-    name: Publish Docker Image - ${{ matrix.image-type }}-${{ matrix.image-distro-name }}
+    name: Publish Docker Image (${{ matrix.image-type }}, ${{ matrix.image-distro-name }})
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -101,7 +101,7 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
-      - name: Publish real image tags.
+      - name: Publish real image tags
         run: |
           python3 scripts/cicd/publish-docker-images-tags.py \
             --git-ref-name ${{ github.ref_name }} \

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -32,7 +32,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image-type: [ "docker-json", "docker-syslog", "k8s" ]
+        image-type: [ "k8s" ]
+        #image-type: [ "docker-json", "docker-syslog", "k8s" ]
         image-distro-name: [ "debian", "alpine" ]
 
     steps:

--- a/BUILD.md
+++ b/BUILD.md
@@ -39,7 +39,7 @@ It is also possible to set other registries, for example, to spin up a container
 and to push an image there. That is also a possible workaround for a local build's architecture limitation.
 
 ```bash
-docker run --it --rm --name registry -p 5000:5000 registry:2
+docker run -it --rm --name registry -p 5005:5000 registry:2
 
 python3 build_package_new.py <build_name> --push --registry localhost:5000
 ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -3,7 +3,7 @@
 To build agent docker image run command:
 
 ```
-python3 build_package_new.py <build_name>
+python3 build_package_new.py <build_name>-{debian,alpine}
 ```
 
 Available builds:

--- a/BUILD.md
+++ b/BUILD.md
@@ -3,7 +3,7 @@
 To build agent docker image run command:
 
 ```
-python3 build_package_new.py <build_name>-{debian,alpine}
+python3 build_package_new.py <build_name>-{debian,alpine} [--tag <tag name>] [--push]
 ```
 
 Available builds:
@@ -57,8 +57,8 @@ local Docker image into minikube using ``minikube image load`` command as shown 
 below:
 
 ```bash
-python build_package_new.py k8s-debian --platforms linux/amd64
-minikube image load scalyr-k8s-agent:latest
+python build_package_new.py k8s-debian --tag local-image --platforms linux/amd64
+minikube image load scalyr-k8s-agent:local-image
 ```
 
 In addition to that, you also need to update ``k8s/no-kustomize/scalyr-agent-2.yaml``  image
@@ -66,7 +66,7 @@ section to look something like this:
 
 ```yaml
 ...
-        image: scalyr-k8s-agent:latest
+        image: scalyr-k8s-agent:local-image
         imagePullPolicy: Never
 ...
 ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -50,6 +50,16 @@ Pushing image with username:
 python3 build_package_new.py <build_name> --push --user my-dockerhub-user
 ```
 
+## Using Locally built images with minikube
+
+If you want to use locally built images with minikube, the easiest way to do that is to load
+local Docker image into minikube using ``minikube image load`` command as shown in the example
+below:
+
+```bash
+minikube image load scalyr-k8s-agent:latest
+python build_package_new.py k8s-debian --platforms linux/amd64
+```
 
 ## Supported Images and Architectures
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -57,8 +57,18 @@ local Docker image into minikube using ``minikube image load`` command as shown 
 below:
 
 ```bash
-minikube image load scalyr-k8s-agent:latest
 python build_package_new.py k8s-debian --platforms linux/amd64
+minikube image load scalyr-k8s-agent:latest
+```
+
+In addition to that, you also need to update ``k8s/no-kustomize/scalyr-agent-2.yaml``  image
+section to look something like this:
+
+```yaml
+...
+        image: scalyr-k8s-agent:latest
+        imagePullPolicy: Never
+...
 ```
 
 ## Supported Images and Architectures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
+## 2.1.29 "Dryria" - Mar 10, 2022
+
+<!---
+Packaged by Arthur Kamalov <arthurk@sentinelone.com> on Mar 10, 2022 23:04 -0800
+--->
+
+Bug fixes:
+* Kubernetes monitor now correctly dynamically detects pod metadata changes (e.g. annotations) when using containerd runtime. Previously metadata updates were not detected dynamically which meant agent needed to be restarted to pick up any metadata changes (such as Scalyr related annotations).
+
 ## 2.1.28 "Dryria" - Feb 23, 2022
 
 <!---

--- a/agent_build/package_builders.py
+++ b/agent_build/package_builders.py
@@ -967,7 +967,7 @@ class ContainerPackageBuilder(LinuxFhsBasedPackageBuilder):
             "--build-arg",
             f"BUILDER_NAME={self.name}",
             "--build-arg",
-            f"BASE_IMAGE=localhost:5000/{base_image_name}",
+            f"BASE_IMAGE=localhost:5005/{base_image_name}",
             "--build-arg",
             f"BASE_IMAGE_SUFFIX={base_image_tag_suffix}",
         ]
@@ -1012,7 +1012,7 @@ class ContainerPackageBuilder(LinuxFhsBasedPackageBuilder):
         # Create container with local image registry. And mount existing registry root with base images.
         registry_container = build_in_docker.LocalRegistryContainer(
             name="agent_image_output_registry",
-            registry_port=5000,
+            registry_port=5005,
             registry_data_path=registry_data_path,
         )
 

--- a/agent_build/tools/environment_deployments/steps/build_base_docker_image/build_base_images_common_lib.sh
+++ b/agent_build/tools/environment_deployments/steps/build_base_docker_image/build_base_images_common_lib.sh
@@ -79,7 +79,7 @@ trap kill_registry_container EXIT
 kill_registry_container
 
 log "Spin up local registry  in container"
-sh_cs docker run -d --rm -p 5000:5000 -v "$tmp_registry_output_path:/var/lib/registry" --name "$container_name" registry:2
+sh_cs docker run -d --rm -p 5005:5000 -v "$tmp_registry_output_path:/var/lib/registry" --name "$container_name" registry:2
 
 
 buildx_builder_name="agent_image_buildx_builder"
@@ -121,7 +121,7 @@ build_all_base_images() {
     # shellcheck disable=SC2086 # Intended splitting of coverage_arg
     sh_cs docker \
       buildx build \
-      -t "localhost:5000/agent_base_image:$base_image_tag_suffix$tag_suffix" \
+      -t "localhost:5005/agent_base_image:$base_image_tag_suffix$tag_suffix" \
       -f "$SOURCE_ROOT/agent_build/docker/Dockerfile.base" \
       --push \
       --build-arg "BASE_IMAGE_SUFFIX=$base_image_tag_suffix" \

--- a/build_package_new.py
+++ b/build_package_new.py
@@ -112,17 +112,6 @@ if __name__ == "__main__":
             )
 
             package_parser.add_argument(
-                "--remove-image-name-prefix",
-                action="store_true",
-                help=(
-                    "True to remove user / org name prefix from the image name when using a custom registry. This "
-                    "is usually a desired behavior when using a custom registry url where the user or "
-                    "the organization name doesn't match one specified in the Docker image name. E.g. "
-                    "scalyr/scalyr-k8s-agent -> scalyr-k8s-agent."
-                ),
-            )
-
-            package_parser.add_argument(
                 "--push", action="store_true", help="Push the result docker image."
             )
 

--- a/docker/Dockerfile.docker_monitor_testing_config
+++ b/docker/Dockerfile.docker_monitor_testing_config
@@ -31,7 +31,7 @@
 #
 # Log files should then be available at ~/scalyr-agent-dev/log/docker-std-printer-stdout.log.
 
-FROM python:3.7-slim as build-image
+FROM python:3.8-slim as build-image
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 ADD print-to-stdout-stderr.sh /app/print-to-stdout-stderr.sh

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -2198,7 +2198,7 @@ class CRIEnumerator(ContainerEnumerator):
                     k8s_namespaces_to_include
                 )
             else:
-                global_lob.log(
+                global_log.log(
                     scalyr_logging.DEBUG_LEVEL_2, "Retrieving containers from Kubelet"
                 )
                 container_info = self._get_containers_from_kubelet(

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -2207,7 +2207,7 @@ class CRIEnumerator(ContainerEnumerator):
 
             global_log.log(
                 scalyr_logging.DEBUG_LEVEL_2,
-                "Found %s containers" % (len(container_info)),
+                "Found %s non-excluded containers" % (len(container_info)),
             )
 
             # process the container info
@@ -2674,6 +2674,11 @@ class ContainerChecker(object):
             # self.__verify_service_account()
 
             if self.__controlled_warmer is not None:
+                self._logger.log(
+                    scalyr_logging.DEBUG_LEVEL_2,
+                    "Using ControlledCacheWarmer instance: %s"
+                    % (self.__controlled_warmer),
+                )
                 self.__controlled_warmer.set_k8s_cache(self.k8s_cache)
                 self.__controlled_warmer.start()
 

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -2259,10 +2259,14 @@ class CRIEnumerator(ContainerEnumerator):
 
                 # get pod and deployment/controller information for the container
                 if k8s_cache:
+                    # NOTE: CRIEnumerator doesn't utilize ControlledCacheWarmer so it's important
+                    # we use allow_expired=False here otherwise we will always read cached entry
+                    # even if it's stale
                     pod = k8s_cache.pod(
                         pod_namespace,
                         pod_name,
                         current_time,
+                        allow_expired=False,
                         ignore_k8s_api_exception=True,
                     )
                     if pod:

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -2336,12 +2336,6 @@ class KubeletApi(object):
         }
         self._session.headers.update(headers)
 
-        # TODO: Allow monitor to pass it's own logger instance to it to make cross tracking logs
-        # easier
-        global_log.info(
-            "KubeletApi host ip = %s, verify_https = %s, ca_file = %s, node_name = %s"
-            % (self._host_ip, self._verify_https, self._ca_file, node_name)
-        )
         self._kubelet_url = self._build_kubelet_url(
             kubelet_url_template, host_ip, node_name
         )
@@ -2349,6 +2343,20 @@ class KubeletApi(object):
             FALLBACK_KUBELET_URL_TEMPLATE, host_ip, node_name
         )
         self._timeout = 20.0
+
+        # TODO: Allow monitor to pass it's own logger instance to it to make cross tracking logs
+        # easier
+        global_log.info(
+            "KubeletApi host ip = %s, verify_https = %s, ca_file = %s, node_name = %s, kubelet_url = %s, fallback_kubelet_url = %s"
+            % (
+                self._host_ip,
+                self._verify_https,
+                self._ca_file,
+                node_name,
+                self._kubelet_url,
+                self._fallback_kubelet_url,
+            )
+        )
 
     @staticmethod
     def _build_kubelet_url(kubelet_url, host_ip, node_name):

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -482,6 +482,9 @@ class PodInfo(object):
 
         return result
 
+    def __repr__(self):
+        return str(self.__dict__)
+
 
 class Controller(object):
     """
@@ -910,7 +913,6 @@ class PodProcessor(_K8sProcessor):
 
         @return A PodInfo object
         """
-
         result = {}
 
         metadata = obj.get("metadata", {})
@@ -924,6 +926,11 @@ class PodProcessor(_K8sProcessor):
 
         controller = self._get_controller_from_owners(
             k8s, owners, namespace, query_options=query_options
+        )
+
+        global_log.log(
+            scalyr_logging.DEBUG_LEVEL_2,
+            "Pod %s/%s metadata: %s" % (namespace, pod_name, six.text_type(metadata)),
         )
 
         container_names = []
@@ -944,7 +951,7 @@ class PodProcessor(_K8sProcessor):
 
         global_log.log(
             scalyr_logging.DEBUG_LEVEL_2,
-            "Annotations: %s" % (six.text_type(annotations)),
+            "Processed annotations: %s" % (six.text_type(annotations)),
         )
 
         # create the PodInfo

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -1768,10 +1768,6 @@ class KubernetesApi(object):
 
         self._http_host = k8s_api_url
 
-        global_log.log(
-            scalyr_logging.DEBUG_LEVEL_1, "Kubernetes API host: %s", self._http_host
-        )
-
         self.query_timeout = query_timeout
 
         self._session = None
@@ -1817,6 +1813,14 @@ class KubernetesApi(object):
         # A rate limiter should normally be passed unless no rate limiting is desired.
         self._query_options_max_retries = query_options_max_retries
         self._rate_limiter = rate_limiter
+
+        global_log.info(
+            "Kubernetes API host = %s, url = %s, ca_file = %s, verify_https = %s",
+            self._http_host,
+            k8s_api_url,
+            ca_file,
+            bool(self._verify_connection()),
+        )
 
     @property
     def default_query_options(self):

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -393,9 +393,9 @@ class PodInfo(object):
         namespace="",
         uid="",
         node_name="",
-        labels={},
-        container_names=[],
-        annotations={},
+        labels=None,
+        container_names=None,
+        annotations=None,
         controller=None,
     ):
 
@@ -403,9 +403,9 @@ class PodInfo(object):
         self.namespace = namespace
         self.uid = uid
         self.node_name = node_name
-        self.labels = labels
-        self.container_names = container_names
-        self.annotations = annotations
+        self.labels = labels or {}
+        self.container_names = container_names or []
+        self.annotations = annotations or {}
 
         self.controller = controller  # controller can't change for the life of the object so we don't include it in hash
 

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -763,7 +763,13 @@ class _K8sCache(object):
         if result:
             global_log.log(
                 scalyr_logging.DEBUG_LEVEL_2,
-                "cache hit for %s %s/%s" % (kind, namespace, name),
+                "cache hit for %s %s/%s (allow_expired=%s)"
+                % (kind, namespace, name, allow_expired),
+            )
+            global_log.log(
+                scalyr_logging.DEBUG_LEVEL_2,
+                "cache value for %s %s/%s: %s (allow_expired=%s)"
+                % (kind, namespace, name, result, allow_expired),
             )
             return result
 

--- a/scripts/cicd/publish-docker-images-tags.py
+++ b/scripts/cicd/publish-docker-images-tags.py
@@ -92,7 +92,7 @@ def main(
         tags = [git_commit_sha]
 
     for builder in BUILDERS_TO_USE:
-        for image_name in builder.RESULT_IMAGE_NAMES:
+        for image_name in builder.RESULT_IMAGE_NAMES:  # pylint: disable=no-member
             full_image_name = image_name
 
             if registry_user:
@@ -126,14 +126,16 @@ def main(
                 temp_release_tag = f"{temp_release_tag}-debian"
 
             try:
-                subprocess.check_call([
-                    "docker",
-                    "buildx",
-                    "imagetools",
-                    "create",
-                    f"{full_image_name}:{temp_release_tag}",
-                    *tag_options
-                ])
+                subprocess.check_call(
+                    [
+                        "docker",
+                        "buildx",
+                        "imagetools",
+                        "create",
+                        f"{full_image_name}:{temp_release_tag}",
+                        *tag_options,
+                    ]
+                )
             except Exception as e:
                 if ignore_errors:
                     print("Ignoring error: %s" % (str(e)))
@@ -141,7 +143,7 @@ def main(
                     raise e
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument("--git-ref-name", required=False)
@@ -151,7 +153,9 @@ if __name__ == '__main__':
     parser.add_argument("--user", required=False)
     # Can be useful to set that when we just want to publish subset of images and ignore errors
     # if some image doesn't exist
-    parser.add_argument("--ignore-errors", action="store_true", required=False, default=False)
+    parser.add_argument(
+        "--ignore-errors", action="store_true", required=False, default=False
+    )
 
     args = parser.parse_args()
     main(

--- a/tests/e2e/k8s_k8s_monitor/std_printer_deployment.yaml
+++ b/tests/e2e/k8s_k8s_monitor/std_printer_deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: std-printer
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: std-printer
+  template:
+    metadata:
+      labels:
+        app: std-printer
+      annotations:
+        log.config.scalyr.com/attributes.parser: "test-parser-1"
+    spec:
+      containers:
+      - name: std-printer
+        image: std-printer:latest
+        imagePullPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml
+++ b/tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml
@@ -54,7 +54,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: scalyr-config
-          #image: scalyr/scalyr-k8s-agent:2.1.27
           image: scalyr-k8s-agent:local_k8s_image
           imagePullPolicy: Never
           name: scalyr-agent

--- a/tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml
+++ b/tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml
@@ -54,10 +54,9 @@ spec:
           envFrom:
             - configMapRef:
                 name: scalyr-config
-          image: scalyr/scalyr-k8s-agent:2.1.27
-          #image: scalyr-k8s-agent:local_k8s_image
-          #imagePullPolicy: Never
-          imagePullPolicy: Always
+          #image: scalyr/scalyr-k8s-agent:2.1.27
+          image: scalyr-k8s-agent:local_k8s_image
+          imagePullPolicy: Never
           name: scalyr-agent
           resources:
             limits:

--- a/tests/e2e/scalyr-agent-2-daemonset.yaml
+++ b/tests/e2e/scalyr-agent-2-daemonset.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: scalyr-agent-2
+  name: scalyr-agent-2
+  namespace: scalyr
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: scalyr-agent-2
+  template:
+    metadata:
+      labels:
+        app: scalyr-agent-2
+    spec:
+      containers:
+      - env:
+        - name: SCALYR_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: scalyr-api-key
+              name: scalyr-api-key
+        - name: SCALYR_K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: SCALYR_K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: SCALYR_K8S_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: SCALYR_K8S_POD_UID
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.uid
+        - name: SCALYR_K8S_KUBELET_HOST_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        envFrom:
+        - configMapRef:
+            name: scalyr-config
+        image: scalyr-k8s-agent:local_k8s_image
+        imagePullPolicy: Never
+        name: scalyr-agent
+        resources:
+          limits:
+            memory: 500Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/docker/containers
+          name: varlibdockercontainers
+          readOnly: true
+        - mountPath: /var/log/pods
+          name: varlogpods
+          readOnly: true
+        - mountPath: /var/log/containers
+          name: varlogcontainers
+          readOnly: true
+        - mountPath: /var/scalyr/docker.sock
+          name: dockersock
+        - mountPath: /var/lib/scalyr-agent-2
+          name: checkpoints
+        livenessProbe:
+          exec:
+            command:
+            - scalyr-agent-2
+            - status
+            - -H
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 10
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: scalyr-service-account
+      serviceAccountName: scalyr-service-account
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - hostPath:
+          path: /var/lib/docker/containers
+          type: ""
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/log/pods
+          type: ""
+        name: varlogpods
+      - hostPath:
+          path: /var/log/containers
+          type: ""
+        name: varlogcontainers
+      - hostPath:
+          path: /var/run/docker.sock
+          type: ""
+        name: dockersock
+      - hostPath:
+          path: /tmp/scalyr-agent-2
+          type: DirectoryOrCreate
+        name: checkpoints
+      # comment this section if you do not want to run on the master
+      tolerations:
+      - operator: Exists

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ basepython =
 # NOTE: We pass the TERM env to preserve colors
 passenv = TERM XDG_CACHE_HOME PYTEST_BENCH_FORCE_UNIT
 setenv =
-  LINT_FILES_TO_CHECK={env:LINT_FILES_TO_CHECK:*.py scripts/*.py scripts/circleci/*.py benchmarks/scripts/*.py tests/ pylint_plugins/*.py .circleci/*.py .circleci/modernize/ scalyr_agent/ scalyr_agent/third_party/tcollector/ agent_build/}
+  LINT_FILES_TO_CHECK={env:LINT_FILES_TO_CHECK:*.py scripts/*.py scripts/circleci/*.py scripts/cicd/*.py benchmarks/scripts/*.py tests/ pylint_plugins/*.py .circleci/*.py .circleci/modernize/ scalyr_agent/ scalyr_agent/third_party/tcollector/ agent_build/}
   # Which Python binary to use for various lint targets
   LINT_PYTHON_BINARY={env:LINT_PYTHON_BINARY:python3.6}
   PYTHONPATH={toxinidir}


### PR DESCRIPTION
## Description

This pull request fixes Kubernetes monitor to correctly handle dynamic pod metadata updates when Kubernetes cluster is using containerd container run time.

## Background, Context

When using containerd runtime, scalyr agent would not automatically pick up any pod metadata changes (e.g. adding or changing Scalyr related annotation) without the agent pod restart.

This issue only affected containerd runtime. When using Docker runtime, `ControlledCacheWarmed` abstraction which dynamically populates the cache in background is used.

## Proposed Implementation / Fix

This fix involves making sure we don't always use locally cached value - now when retrieving pod information from the ``KubernetesCache`` object, we will query Kubernetes API in case the cached entry is stale / expired.

An alternative would be utilize ``ControlledCacheWarmer`` abstraction to continuously update (warm) cache in the background for active pods, but that approach would be more involved so I decided to go with a simpler approach first.

In case it turns out that this approach has too big of a performance overhead (on the Kubernetes API or similar), we may need to consider ``ControlledCacheWarmer`` approach.

It's worth noting though that in aggregate, CPU used by both approaches should be the same - only difference is, that in theory, CCW approach should result in those Kubernetes API requests potentially being spread over longer time frame instead of happening "on demand" when inspecting pods inside the monitor main loop.

## Other (related) Changes

In addition to that, it includes the following changes:

1. Add additional debug level logging to the Kubernetes monitor. 

While troubleshooting the issue with original set of debug logs it was impossible to pin point down the root cause because the logs didn't contain enough information. This change should improve that.

2. Fix docker image build script on OS X.

On Monterey, port 5000 is already used by a system service meaning script would fail. This pull request fixes it by using a different port. If this becomes a bigger issue in the future, we may want to update the code to pick a random unused port.

3. Some docker image build docker fixes and info on how to use locally built images with local minikube cluster

4. Fixed usage of mutable default values for method argument in one places. I don't think there was an issue related to that because of they way that code has been used, but it's a bad practice and can cause issues.

5. New initial set of Kubernetes end to end tests running on Github actions (including regression test for bug fix in this PR)