### PR TITLE
Optionally include cluster name with all the Kubernetes Open Metrics monitor log lines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2142,6 +2142,8 @@ jobs:
       - run:
           name: Build MSI package
           command: |
+              # Make sure step fails on any command failure
+              $ErrorActionPreference = "Stop"
               $Env:WIX = ";C:\wix311;"
               C:\Users\circleci\AppData\Local\Programs\Python\Python38\python.exe -m pip install -r win32\windows-build-requirements.txt
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2142,21 +2142,35 @@ jobs:
       - run:
           name: Build MSI package
           command: |
-              # Make sure step fails on any command failure
-              $ErrorActionPreference = "Stop"
               $Env:WIX = ";C:\wix311;"
+
+              # Make sure step fails on any command failure
+              Set-StrictMode -Version Latest
+              $ErrorActionPreference = "Stop"
+
+              function ThrowOnNativeFailure {
+                if (-not $?)
+                {
+                    throw 'Native Failure'
+                }
+              }
+
+              $PSDefaultParameterValues['*:ErrorAction']='Stop'
+
               C:\Users\circleci\AppData\Local\Programs\Python\Python38\python.exe -m pip install -r win32\windows-build-requirements.txt
 
               # TODO: This step doesn't correctly exit with non zero on failure
               C:\Users\circleci\AppData\Local\Programs\Python\Python38\python.exe build_package.py win32
-              # TODO: Add a check to fail if exe is not produced which would
-              # indicate command failure
+              ThrowOnNativeFailure
 
               mkdir package
               mkdir artifacts
 
               cp .\ScalyrAgentInstaller-*.msi artifacts/
               mv .\ScalyrAgentInstaller-*.msi package\ScalyrAgentInstaller.msi
+
+              $ErrorActionPreference = "Stop"
+              Test-Path -Path package/ScalyrAgentInstaller.msi -PathType Leaf
 
       - run:
           name: Copy Package With Version in Name

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2149,6 +2149,8 @@ jobs:
 
               # TODO: This step doesn't correctly exit with non zero on failure
               C:\Users\circleci\AppData\Local\Programs\Python\Python38\python.exe build_package.py win32
+              # TODO: Add a check to fail if exe is not produced which would
+              # indicate command failure
 
               mkdir package
               mkdir artifacts

--- a/.github/actions/install-k8s-agent-daemonset/action.yml
+++ b/.github/actions/install-k8s-agent-daemonset/action.yml
@@ -40,9 +40,9 @@ runs:
       id: create-daemonset
       shell: bash
       run: |
-        export NODE_NAME=$(kubectl get nodes -o jsonpath="{.items[0].metadata.name}")
-        echo "NODE_NAME=${NODE_NAME}" >> ${GITHUB_ENV}
-        echo "Using node name: ${NODE_NAME}"
+        export K8S_NODE_NAME=$(kubectl get nodes -o jsonpath="{.items[0].metadata.name}")
+        echo "K8S_NODE_NAME=${K8S_NODE_NAME}" >> ${GITHUB_ENV}
+        echo "Using node name: ${K8S_NODE_NAME}"
 
         export K8S_CLUSTER_NAME="ci-agent-e2e-k8s-om-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
         echo "K8S_CLUSTER_NAME=${K8S_CLUSTER_NAME}" >> ${GITHUB_ENV}

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -314,7 +314,7 @@ jobs:
 
           # Kubernetes API metrics (static monitor)
           echo "Kubernetes API metrics monitor checks"
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'-kubernetes-api-metrics.log" "process_max_fds 1000000 k8s-node=\"'${K8S_NODE_NAME}'\" k8s-cluster=\"'${K8S_CLUSTER_NAME}'\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'-kubernetes-api-metrics.log" "process_max_fds 1000000 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" k8s-node=\"'${K8S_NODE_NAME}'\""'
           ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'-kubernetes-api-metrics.log" "process_open_fds "'
 
           # Kubernetes API cAdvisor metrics (static monitor)
@@ -331,14 +331,14 @@ jobs:
 
           # 3. Verify kube state event metrics
           echo "Kube state events metrics monitor checks"
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "kube-state-metrics" "kube_storageclass_labels 1 k8s-node=\"'${K8S_NODE_NAME}'\" storageclass=\"standard\""'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "kube-state-metrics" "kube_secret_type 1 namespace=\"scalyr\" k8s-node=\"'${K8S_NODE_NAME}'\" secret=\"scalyr-api-key\" type=\"Opaque\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "kube-state-metrics" "kube_storageclass_labels 1 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" k8s-node=\"'${K8S_NODE_NAME}'\" storageclass=\"standard\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "kube-state-metrics" "kube_secret_type 1 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" namespace=\"scalyr\" k8s-node=\"'${K8S_NODE_NAME}'\" secret=\"scalyr-api-key\" type=\"Opaque\""'
 
           # 4. Verify java app JMX metrics
           echo "Java JMX metrics events metrics monitor checks"
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_error 0.0 node=\"'${K8S_NODE_NAME}'\""'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_cached_beans 0.0 node=\"'${K8S_NODE_NAME}'\""'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jvm_info 1.0 node=\"'${K8S_NODE_NAME}'\" runtime="'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_error 0.0 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" node=\"'${K8S_NODE_NAME}'\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_cached_beans 0.0 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" node=\"'${K8S_NODE_NAME}'\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jvm_info 1.0 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" node=\"'${K8S_NODE_NAME}'\" runtime="'
 
       - name: Notify Slack on Failure
         # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -332,13 +332,13 @@ jobs:
           # 3. Verify kube state event metrics
           echo "Kube state events metrics monitor checks"
           ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "kube-state-metrics" "kube_storageclass_labels 1 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" k8s-node=\"'${K8S_NODE_NAME}'\" storageclass=\"standard\""'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "kube-state-metrics" "kube_secret_type 1 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" namespace=\"scalyr\" k8s-node=\"'${K8S_NODE_NAME}'\" secret=\"scalyr-api-key\" type=\"Opaque\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "kube-state-metrics" "kube_secret_type 1 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" k8s-node=\"'${K8S_NODE_NAME}'\" namespace=\"scalyr\" secret=\"scalyr-api-key\" type=\"Opaque\""'
 
           # 4. Verify java app JMX metrics
           echo "Java JMX metrics events metrics monitor checks"
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_error 0.0 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" node=\"'${K8S_NODE_NAME}'\""'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_cached_beans 0.0 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" node=\"'${K8S_NODE_NAME}'\""'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jvm_info 1.0 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" node=\"'${K8S_NODE_NAME}'\" runtime="'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_error 0.0 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" k8s-node=\"'${K8S_NODE_NAME}'\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_cached_beans 0.0 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" k8s-node=\"'${K8S_NODE_NAME}'\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jvm_info 1.0 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" k8s-node=\"'${K8S_NODE_NAME}'\" runtime="'
 
       - name: Notify Slack on Failure
         # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -297,6 +297,7 @@ jobs:
           scalyr_readlog_token: "${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}"
           SCALYR_AGENT_POD_NAME: "${{ env.SCALYR_AGENT_POD_NAME }}"
           NODE_NAME: "${{ env.NODE_NAME }}"
+          CLUSTER_NAME: "${{ env.K8S_CLUSTER_NAME }}"
         run: |
           export RETRY_ATTEMPTS="8"
           export SLEEP_DELAY="10"
@@ -313,7 +314,7 @@ jobs:
 
           # Kubernetes API metrics (static monitor)
           echo "Kubernetes API metrics monitor checks"
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-kubernetes-api-metrics.log" "process_max_fds 1000000 node=\"'${NODE_NAME}'\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-kubernetes-api-metrics.log" "process_max_fds 1000000 k8s-node=\"'${NODE_NAME}'\" k8s-cluster=\"'${CLUSTER_NAME}'\""'
           ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-kubernetes-api-metrics.log" "process_open_fds "'
 
           # Kubernetes API cAdvisor metrics (static monitor)
@@ -330,8 +331,8 @@ jobs:
 
           # 3. Verify kube state event metrics
           echo "Kube state events metrics monitor checks"
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'" $logfile contains "kube-state-metrics" "kube_storageclass_labels 1 node=\"'${NODE_NAME}'\" storageclass=\"standard\""'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'" $logfile contains "kube-state-metrics" "kube_secret_type 1 namespace=\"scalyr\" node=\"'${NODE_NAME}'\" secret=\"scalyr-api-key\" type=\"Opaque\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'" $logfile contains "kube-state-metrics" "kube_storageclass_labels 1 k8s-node=\"'${NODE_NAME}'\" storageclass=\"standard\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'" $logfile contains "kube-state-metrics" "kube_secret_type 1 namespace=\"scalyr\" k8s-node=\"'${NODE_NAME}'\" secret=\"scalyr-api-key\" type=\"Opaque\""'
 
           # 4. Verify java app JMX metrics
           echo "Java JMX metrics events metrics monitor checks"

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -126,7 +126,7 @@ jobs:
           # Needed for scalyr-tool
           scalyr_readlog_token: "${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}"
           SCALYR_AGENT_POD_NAME: "${{ env.SCALYR_AGENT_POD_NAME }}"
-          NODE_NAME: "${{ env.NODE_NAME }}"
+          K8S_NODE_NAME: "${{ env.K8S_NODE_NAME }}"
         run: |
           export RETRY_ATTEMPTS="8"
           export SLEEP_DELAY="10"
@@ -296,8 +296,8 @@ jobs:
           # Needed for scalyr-tool
           scalyr_readlog_token: "${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}"
           SCALYR_AGENT_POD_NAME: "${{ env.SCALYR_AGENT_POD_NAME }}"
-          NODE_NAME: "${{ env.NODE_NAME }}"
-          CLUSTER_NAME: "${{ env.K8S_CLUSTER_NAME }}"
+          K8S_NODE_NAME: "${{ env.K8S_NODE_NAME }}"
+          K8S_CLUSTER_NAME: "${{ env.K8S_CLUSTER_NAME }}"
         run: |
           export RETRY_ATTEMPTS="8"
           export SLEEP_DELAY="10"
@@ -314,31 +314,31 @@ jobs:
 
           # Kubernetes API metrics (static monitor)
           echo "Kubernetes API metrics monitor checks"
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-kubernetes-api-metrics.log" "process_max_fds 1000000 k8s-node=\"'${NODE_NAME}'\" k8s-cluster=\"'${CLUSTER_NAME}'\""'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-kubernetes-api-metrics.log" "process_open_fds "'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'-kubernetes-api-metrics.log" "process_max_fds 1000000 k8s-node=\"'${K8S_NODE_NAME}'\" k8s-cluster=\"'${K8S_CLUSTER_NAME}'\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'-kubernetes-api-metrics.log" "process_open_fds "'
 
           # Kubernetes API cAdvisor metrics (static monitor)
           echo "Kubernetes API cAdvisor metrics monitor checks"
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-kubernetes-api-cadvisor-metrics" "machine_cpu_cores 2"'
-          MINIMUM_RESULTS=2 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-kubernetes-api-cadvisor-metrics" "container_cpu_load_average_10s "'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'-kubernetes-api-cadvisor-metrics" "machine_cpu_cores 2"'
+          MINIMUM_RESULTS=2 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'-kubernetes-api-cadvisor-metrics" "container_cpu_load_average_10s "'
 
           # 2. Verify node exporter metrics
           echo "Node exporter metrics monitor checks"
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-node-exporter-" "process_max_fds "'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-node-exporter-" "process_open_fds "'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-node-exporter-" "node_vmstat_pswpin "'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'-node-exporter-" "node_vmstat_pswpout "'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'-node-exporter-" "process_max_fds "'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'-node-exporter-" "process_open_fds "'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'-node-exporter-" "node_vmstat_pswpin "'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'-node-exporter-" "node_vmstat_pswpout "'
 
           # 3. Verify kube state event metrics
           echo "Kube state events metrics monitor checks"
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'" $logfile contains "kube-state-metrics" "kube_storageclass_labels 1 k8s-node=\"'${NODE_NAME}'\" storageclass=\"standard\""'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'" $logfile contains "kube-state-metrics" "kube_secret_type 1 namespace=\"scalyr\" k8s-node=\"'${NODE_NAME}'\" secret=\"scalyr-api-key\" type=\"Opaque\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "kube-state-metrics" "kube_storageclass_labels 1 k8s-node=\"'${K8S_NODE_NAME}'\" storageclass=\"standard\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "kube-state-metrics" "kube_secret_type 1 namespace=\"scalyr\" k8s-node=\"'${K8S_NODE_NAME}'\" secret=\"scalyr-api-key\" type=\"Opaque\""'
 
           # 4. Verify java app JMX metrics
           echo "Java JMX metrics events metrics monitor checks"
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_error 0.0 node=\"'${NODE_NAME}'\""'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_cached_beans 0.0 node=\"'${NODE_NAME}'\""'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${NODE_NAME}'" $logfile contains "java-hello-world" "jvm_info 1.0 node=\"'${NODE_NAME}'\" runtime="'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_error 0.0 node=\"'${K8S_NODE_NAME}'\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_cached_beans 0.0 node=\"'${K8S_NODE_NAME}'\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jvm_info 1.0 node=\"'${K8S_NODE_NAME}'\" runtime="'
 
       - name: Notify Slack on Failure
         # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -580,7 +580,7 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
 
         return node_name
 
-    def __get_node_name(self):
+    def __get_cluster_name(self):
         """
         Gets name of the cluster this agent i srunning on.
         """
@@ -608,7 +608,7 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
         metric_name_exclude_list: List[str] = None,
         metric_component_value_include_list: dict = None,
         include_node_name: bool = False,
-        __include_cluster_name: bool = False,
+        include_cluster_name: bool = False,
     ) -> Tuple[dict, dict]:
         """
         Return monitor config dictionary and log config dictionary for the provided arguments.
@@ -654,7 +654,7 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
             extra_fields["k8s-node"] = self.__get_node_name()
 
         if include_cluster_name:
-            extra_fields["k8s-cluster"] = self.__get_cluter_name()
+            extra_fields["k8s-cluster"] = self.__get_cluster_name()
 
         if extra_fields:
             monitor_config["extra_fields"] = JsonObject(extra_fields)

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -584,6 +584,9 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
         """
         Gets name of the cluster this agent i srunning on.
         """
+        # TODO: Similar to the old monitor, we could fall back to querying Kubelet in case this
+        # environment variable is not available (but it should really be available since it's
+        # documented in the docs and example config as required).
         cluster_name = compat.os_environ_unicode.get("SCALYR_K8S_CLUSTER_NAME")
 
         if not cluster_name:

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -880,6 +880,7 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
             metric_name_include_list=scrape_config.metric_name_include_list,
             metric_name_exclude_list=scrape_config.metric_name_exclude_list,
             include_node_name=self.__include_node_name,
+            include_cluster_name=self.__include_cluster_name,
         )
 
         monitors_manager = get_monitors_manager()

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -351,7 +351,14 @@ define_config_option(
 define_config_option(
     __monitor__,
     "include_node_name",
-    "Set to true to include node name as an additional attribute with each metric log line.",
+    "Set to true to include Kubernetes node name as an additional attribute with each metric log line.",
+    convert_to=bool,
+    default=False,
+)
+define_config_option(
+    __monitor__,
+    "include_cluster_name",
+    "Set to true to include Kubernetes cluster name as an additional attribute with each metric log line.",
     convert_to=bool,
     default=False,
 )
@@ -463,6 +470,7 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
             DEFAULT_KUBERNETES_API_CADVISOR_METRICS_SCRAPE_INTERVAL,
         )
         self.__include_node_name = self._config.get("include_node_name", False)
+        self.__include_cluster_name = self._config.get("include_cluster_name", False)
 
         self.__k8s_api_url = self._global_config.k8s_api_url
 
@@ -560,15 +568,31 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
 
     def __get_node_name(self):
         """
-        Gets the node name of the node running the agent from downward API
+        Gets the node name of the node running the agent from downward API.
         """
-        if not compat.os_environ_unicode.get("SCALYR_K8S_NODE_NAME"):
+        node_name = compat.os_environ_unicode.get("SCALYR_K8S_NODE_NAME", None)
+
+        if not node_name:
             self._logger.warn(
                 "SCALYR_K8S_NODE_NAME environment variable is not set, monitor will "
                 "not work correctly."
             )
 
-        return compat.os_environ_unicode.get("SCALYR_K8S_NODE_NAME")
+        return node_name
+
+    def __get_node_name(self):
+        """
+        Gets name of the cluster this agent i srunning on.
+        """
+        cluster_name = compat.os_environ_unicode.get("SCALYR_K8S_CLUSTER_NAME")
+
+        if not cluster_name:
+            self._logger.warn(
+                "SCALYR_K8S_CLUSTER_NAME environment variable is not set, monitor will "
+                "not work correctly."
+            )
+
+        return cluster_name
 
     def __get_monitor_config_and_log_config(
         self,
@@ -584,6 +608,7 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
         metric_name_exclude_list: List[str] = None,
         metric_component_value_include_list: dict = None,
         include_node_name: bool = False,
+        __include_cluster_name: bool = False,
     ) -> Tuple[dict, dict]:
         """
         Return monitor config dictionary and log config dictionary for the provided arguments.
@@ -623,10 +648,16 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
             ),
         }
 
+        extra_fields = {}
+
         if include_node_name:
-            monitor_config["extra_fields"] = JsonObject(
-                {"node": self.__get_node_name()}
-            )
+            extra_fields["node"] = self.__get_node_name()
+
+        if include_cluster_name:
+            extra_fields["cluster"] = self.__get_cluter_name()
+
+        if extra_fields:
+            monitor_config["extra_fields"] = JsonObject(extra_fields)
 
         # NOTE: This monitor is only supported on Linux platform
         log_path = os.path.join(self._global_config.agent_log_path, log_filename)
@@ -688,6 +719,7 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
                     "kubernetes_api_metric_component_value_include_list"
                 ),
                 include_node_name=self.__include_node_name,
+                include_cluster_name=self.__include_cluster_name,
             )
 
             monitor = monitors_manager.add_monitor(
@@ -730,6 +762,7 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
                     "kubernetes_api_cadvisor_metric_component_value_include_list"
                 ),
                 include_node_name=self.__include_node_name,
+                include_cluster_name=self.__include_cluster_name,
             )
 
             monitor = monitors_manager.add_monitor(

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -651,10 +651,10 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
         extra_fields = {}
 
         if include_node_name:
-            extra_fields["node"] = self.__get_node_name()
+            extra_fields["k8s-node"] = self.__get_node_name()
 
         if include_cluster_name:
-            extra_fields["cluster"] = self.__get_cluter_name()
+            extra_fields["k8s-cluster"] = self.__get_cluter_name()
 
         if extra_fields:
             monitor_config["extra_fields"] = JsonObject(extra_fields)

--- a/tests/e2e/k8s_om_monitor/scalyr-agent-extra-config-configmap.yaml
+++ b/tests/e2e/k8s_om_monitor/scalyr-agent-extra-config-configmap.yaml
@@ -22,6 +22,7 @@ data:
             {
               module:  "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor",
               include_node_name: true,
+              include_cluster_name: true,
               logger_include_node_name: false,
               verify_https: false,
               scrape_kubernetes_api_metrics: true,

--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -75,6 +75,7 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
     @classmethod
     def setUpClass(cls):
         os.environ["SCALYR_K8S_NODE_NAME"] = "test-node-name"
+        os.environ["SCALYR_K8S_CLUSTER_NAME"] = "test-cluster-name"
 
     @classmethod
     def tearDownClass(cls):
@@ -137,6 +138,7 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
             "ca_file": None,
             "headers": None,
             "include_node_name": True,
+            "include_cluster_name": True,
         }
         (
             monitor_config,
@@ -146,7 +148,7 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
         )
         expected_monitor_config = {
             "ca_file": None,
-            "extra_fields": JsonObject({"node": "test-node-name"}),
+            "extra_fields": JsonObject({"k8s-node": "test-node-name", "k8s-cluster": "test-cluster-name"}),
             "headers": JsonObject({}),
             "id": "one",
             "log_path": "scalyr_agent.builtin_monitors.openmetrics_monitor.log",

--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -148,7 +148,9 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
         )
         expected_monitor_config = {
             "ca_file": None,
-            "extra_fields": JsonObject({"k8s-node": "test-node-name", "k8s-cluster": "test-cluster-name"}),
+            "extra_fields": JsonObject(
+                {"k8s-node": "test-node-name", "k8s-cluster": "test-cluster-name"}
+            ),
             "headers": JsonObject({}),
             "id": "one",
             "log_path": "scalyr_agent.builtin_monitors.openmetrics_monitor.log",

--- a/win32/windows-build-requirements.txt
+++ b/win32/windows-build-requirements.txt
@@ -1,5 +1,5 @@
 psutil==5.7.0
-pyinstaller==4.10
+pyinstaller==4.101
 pywin32==301
 orjson==3.5.2
 six==1.13.0

--- a/win32/windows-build-requirements.txt
+++ b/win32/windows-build-requirements.txt
@@ -1,5 +1,5 @@
 psutil==5.7.0
-pyinstaller==4.101
+pyinstaller==4.10
 pywin32==301
 orjson==3.5.2
 six==1.13.0

--- a/win32/windows-build-requirements.txt
+++ b/win32/windows-build-requirements.txt
@@ -1,5 +1,5 @@
 psutil==5.7.0
-pyinstaller==4.2
+pyinstaller==4.10
 pywin32==301
 orjson==3.5.2
 six==1.13.0


### PR DESCRIPTION
This pull request includes a small changes which allows user to configure the new Kubernetes Open Metrics monitor to include Kubernetes cluster name with each of the emitted metrics log lines.

It follows the same approach as we already follow for the node name inclusion.