### PR TITLE
Allow custom timestamp to be specified for emitted metric log lines

### DIFF
--- a/scalyr_agent/builtin_monitors/openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/openmetrics_monitor.py
@@ -102,6 +102,7 @@ if False:
 
 import re
 import fnmatch
+import time
 
 import six
 import requests
@@ -294,12 +295,20 @@ class OpenMetricsMonitor(ScalyrMonitor):
 
     def gather_sample(self):
         # type: () -> None
+        # We want to use the same timestamp for all the metrics in a batch (aka all the metrics
+        # which are scraped at the same time( to make joins and other server side operations easier.
+        # Keep in mind that in case the parsed metric (aka record) contains a custom timestamp,
+        # that value has precedence over this one aka that record / metric specific value will be
+        # used for that metric
+        timestamp_ms = round(time.time() * 1000)
+
         metrics = self._scrape_metrics(self.__url)
 
         for metric_name, extra_fields, metric_value in metrics:
             extra_fields.update(self.__base_extra_fields or {})
             self._logger.emit_value(
-                metric_name, metric_value, extra_fields=extra_fields
+                metric_name, metric_value, extra_fields=extra_fields,
+                timestamp=timestamp_ms,
             )
 
     def check_connectivity(self) -> requests.Response:

--- a/scalyr_agent/builtin_monitors/openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/openmetrics_monitor.py
@@ -307,7 +307,9 @@ class OpenMetricsMonitor(ScalyrMonitor):
         for metric_name, extra_fields, metric_value in metrics:
             extra_fields.update(self.__base_extra_fields or {})
             self._logger.emit_value(
-                metric_name, metric_value, extra_fields=extra_fields,
+                metric_name,
+                metric_value,
+                extra_fields=extra_fields,
                 timestamp=timestamp_ms,
             )
 

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -561,6 +561,8 @@ class AgentLogger(logging.Logger):
             __thread_local__.last_error_for_monitor = None
 
         extra = extra or {}
+        # TODO / NOTE: Add support for using timestamp from "extra_fields" field for metrics
+        # (if available)
         if timestamp:
             extra["timestamp"] = timestamp
 

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -561,11 +561,11 @@ class AgentLogger(logging.Logger):
             __thread_local__.last_error_for_monitor = None
 
         extra = extra or {}
-        if timestamp and "timestamp" not in extra:
+        if timestamp:
             extra["timestamp"] = timestamp
 
         # pylint: disable=assignment-from-no-return
-        if extra is not None:
+        if extra:
             result = logging.Logger._log(self, level, msg, args, exc_info, extra)
         elif exc_info is not None:
             result = logging.Logger._log(self, level, msg, args, exc_info)

--- a/tests/unit/builtin_monitors/openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/openmetrics_monitor_test.py
@@ -82,8 +82,13 @@ with open(os.path.join(FIXTURES_DIR, "jmx_exporter_zookeeper_1.txt"), "r") as fp
     MOCK_DATA_5 = fp.read()
 
 
+MOCK_TIMESTAMP_S = 123456789
+MOCK_TIMESTAMP_MS = MOCK_TIMESTAMP_S * 1000
+
+
 class OpenMetricsMonitorTestCase(ScalyrTestCase):
     @requests_mock.Mocker()
+    @mock.patch("time.time", mock.MagicMock(return_value=MOCK_TIMESTAMP_S))
     def test_gather_sample_success_mock_data_1(self, m):
         m.get(MOCK_URL, text=MOCK_DATA_1, headers=MOCK_RESPONSE_HEADERS_TEXT)
         monitor_config = {
@@ -101,17 +106,25 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
             "http_requests_total",
             3,
             extra_fields={"method": "post", "code": "400", "timestamp": 1395066363000},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
-            "some.metric.name1", 1555, extra_fields={}
+            "some.metric.name1",
+            1555,
+            extra_fields={},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
-            "some.metric.name2", 1556, extra_fields={"timestamp": 123456789}
+            "some.metric.name2",
+            1556,
+            extra_fields={"timestamp": 123456789},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "http_requests_total",
             4,
             extra_fields={"method": "post", "code": "400", "timestamp": 1395066363001},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "traefik_entrypoint_request_duration_seconds_count",
@@ -122,9 +135,11 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
                 "method": "GET",
                 "protocol": "http",
             },
+            timestamp=MOCK_TIMESTAMP_MS,
         )
 
     @requests_mock.Mocker()
+    @mock.patch("time.time", mock.MagicMock(return_value=MOCK_TIMESTAMP_S))
     def test_gather_sample_success_mock_data_1_extra_fields(self, m):
         m.get(MOCK_URL, text=MOCK_DATA_1, headers=MOCK_RESPONSE_HEADERS_TEXT)
         monitor_config = {
@@ -149,16 +164,19 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
                 "foo1": "bar1",
                 "foo2": "bar2",
             },
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "some.metric.name1",
             1555,
             extra_fields={"foo1": "bar1", "foo2": "bar2"},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "some.metric.name2",
             1556,
             extra_fields={"timestamp": 123456789, "foo1": "bar1", "foo2": "bar2"},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
 
     @requests_mock.Mocker()
@@ -198,6 +216,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         )
 
     @requests_mock.Mocker()
+    @mock.patch("time.time", mock.MagicMock(return_value=MOCK_TIMESTAMP_S))
     def test_gather_sample_success_mock_data_jmx_exporter_kafka_1(self, m):
         m.get(MOCK_URL, text=MOCK_DATA_3, headers=MOCK_RESPONSE_HEADERS_TEXT)
         monitor_config = {
@@ -215,19 +234,23 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
             "kafka_server_replicafetchermanager_minfetchrate",
             0.0,
             extra_fields={"clientId": "Replica"},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "kafka_network_requestmetrics_totaltimems",
             1.0,
             extra_fields={"request": "JoinGroup"},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "kafka_network_requestmetrics_totaltimems",
             0.1,
             extra_fields={"request": "GroupCoordinator"},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
 
     @requests_mock.Mocker()
+    @mock.patch("time.time", mock.MagicMock(return_value=MOCK_TIMESTAMP_S))
     def test_gather_sample_success_mock_data_jmx_exporter_kafka_2(self, m):
         m.get(MOCK_URL, text=MOCK_DATA_4, headers=MOCK_RESPONSE_HEADERS_TEXT)
 
@@ -259,11 +282,13 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
                 "network_processor": "3",
                 "timestamp": 123456789,
             },
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "kafka_network_socketserver_memorypoolavailable",
             9.223372036854776e18,
             extra_fields={},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "kafka_log_log_logstartoffset",
@@ -272,6 +297,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
                 "topic": "sample-streams-KSTREAM-AGGREGATE-STATE-STORE-0000000002-repartition",
                 "partition": "0",
             },
+            timestamp=MOCK_TIMESTAMP_MS,
         )
 
         # 2. Metric extra_field filters
@@ -310,6 +336,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
                 "topic": "connect-status",
                 "partition": "0",
             },
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "kafka_server_fetcherlagmetrics_consumerlag",
@@ -319,17 +346,20 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
                 "partition": "0",
                 "topic": "connect-status",
             },
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "kafka_log_log_numlogsegments",
             1.0,
             extra_fields={"topic": "connect-status", "partition": "0"},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
 
         mock_logger.emit_value.assert_any_call(
             "kafka_log_log_logstartoffset",
             0.0,
             extra_fields={"topic": "connect-status", "partition": "3"},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
 
         # 2. Metric extra_field filters (matches any metric name)
@@ -355,6 +385,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
             self.assertEqual(call_kwargs["extra_fields"]["topic"], "connect-status")
 
     @requests_mock.Mocker()
+    @mock.patch("time.time", mock.MagicMock(return_value=MOCK_TIMESTAMP_S))
     def test_gather_sample_success_mock_data_jmx_exporter_zookeeper_1(self, m):
         m.get(MOCK_URL, text=MOCK_DATA_5, headers=MOCK_RESPONSE_HEADERS_TEXT)
         monitor_config = {
@@ -374,6 +405,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
             extra_fields={
                 "replicaid": "2",
             },
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "zookeeper_leader",
@@ -381,6 +413,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
             extra_fields={
                 "replicaid": "3",
             },
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "zookeeper_leader",
@@ -388,11 +421,13 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
             extra_fields={
                 "replicaid": "2",
             },
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "zookeeper_requeststalelatencycheck",
             0.0,
             extra_fields={"membertype": "Follower", "replicaid": "2"},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "jvm_info",
@@ -402,6 +437,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
                 "vendor": "Azul Systems, Inc.",
                 "runtime": "OpenJDK Runtime Environment",
             },
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "jvm_memory_pool_bytes_used",
@@ -409,6 +445,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
             extra_fields={
                 "pool": "CodeHeap 'profiled nmethods'",
             },
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "jvm_memory_pool_bytes_used",
@@ -416,16 +453,19 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
             extra_fields={
                 "pool": "Compressed Class Space",
             },
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "jvm_bar_1",
             1.8446744073709552e19,
             extra_fields={},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "jvm_bar_2",
             6e08,
             extra_fields={},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
 
     @requests_mock.Mocker()
@@ -446,6 +486,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         self.assertEqual(mock_logger.emit_value.call_count, 0)
 
     @requests_mock.Mocker()
+    @mock.patch("time.time", mock.MagicMock(return_value=MOCK_TIMESTAMP_S))
     def test_gather_sample_metric_name_include_list(self, m):
         m.get(MOCK_URL, text=MOCK_DATA_1, headers=MOCK_RESPONSE_HEADERS_TEXT)
         monitor_config = {
@@ -464,10 +505,16 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         self.assertEqual(mock_logger.emit_value.call_count, 3)
 
         mock_logger.emit_value.assert_any_call(
-            "some.metric.name1", 1555, extra_fields={}
+            "some.metric.name1",
+            1555,
+            extra_fields={},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
-            "some.metric.name2", 1556, extra_fields={"timestamp": 123456789}
+            "some.metric.name2",
+            1556,
+            extra_fields={"timestamp": 123456789},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "traefik_entrypoint_request_duration_seconds_count",
@@ -478,9 +525,11 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
                 "method": "GET",
                 "protocol": "http",
             },
+            timestamp=MOCK_TIMESTAMP_MS,
         )
 
     @requests_mock.Mocker()
+    @mock.patch("time.time", mock.MagicMock(return_value=MOCK_TIMESTAMP_S))
     def test_gather_sample_metric_name_exclude_list(self, m):
         m.get(MOCK_URL, text=MOCK_DATA_1, headers=MOCK_RESPONSE_HEADERS_TEXT)
         monitor_config = {
@@ -502,14 +551,17 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
             "http_requests_total",
             3,
             extra_fields={"method": "post", "code": "400", "timestamp": 1395066363000},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "http_requests_total",
             4,
             extra_fields={"method": "post", "code": "400", "timestamp": 1395066363001},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
 
     @requests_mock.Mocker()
+    @mock.patch("time.time", mock.MagicMock(return_value=MOCK_TIMESTAMP_S))
     def test_gather_sample_metric_name_include_list_and_exclude_list(self, m):
         # Both exclude_list and include_list options are specified, but exclude_list has higher priority
         m.get(MOCK_URL, text=MOCK_DATA_1, headers=MOCK_RESPONSE_HEADERS_TEXT)
@@ -556,14 +608,17 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
             "http_requests_total",
             3,
             extra_fields={"method": "post", "code": "400", "timestamp": 1395066363000},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
             "http_requests_total",
             4,
             extra_fields={"method": "post", "code": "400", "timestamp": 1395066363001},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
 
     @requests_mock.Mocker()
+    @mock.patch("time.time", mock.MagicMock(return_value=MOCK_TIMESTAMP_S))
     def test_gather_sample_non_supported_metric_types(self, m):
         m.get(MOCK_URL, text=MOCK_DATA_2, headers=MOCK_RESPONSE_HEADERS_TEXT)
         monitor_config = {
@@ -578,13 +633,20 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         self.assertEqual(mock_logger.emit_value.call_count, 2)
 
         mock_logger.emit_value.assert_any_call(
-            "some.metric.name1", 1555, extra_fields={}
+            "some.metric.name1",
+            1555,
+            extra_fields={},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
         mock_logger.emit_value.assert_any_call(
-            "some.metric.name2", 1556, extra_fields={"timestamp": 123456789}
+            "some.metric.name2",
+            1556,
+            extra_fields={"timestamp": 123456789},
+            timestamp=MOCK_TIMESTAMP_MS,
         )
 
     @requests_mock.Mocker()
+    @mock.patch("time.time", mock.MagicMock(return_value=MOCK_TIMESTAMP_S))
     def test_gather_sample_non_supported_protobuf_format(self, m):
         m.get(MOCK_URL, text=MOCK_DATA_1, headers=MOCK_RESPONSE_HEADERS_PROTOBUF)
         monitor_config = {

--- a/tests/unit/scalyr_logging_test.py
+++ b/tests/unit/scalyr_logging_test.py
@@ -175,7 +175,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
         monitor_logger.closeMetricLog()
 
-    @skipIf(sys.version_info <= (2, 7, 0), "Skipping tests under Python 2.7")
+    @skipIf(sys.version_info < (2, 8, 0), "Skipping tests under Python <= 2.7")
     def test_metric_logging_custom_timestamp(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
         metric_file_fd, metric_file_path = tempfile.mkstemp(".log")

--- a/tests/unit/scalyr_logging_test.py
+++ b/tests/unit/scalyr_logging_test.py
@@ -32,6 +32,7 @@ import mock
 import scalyr_agent.scalyr_logging as scalyr_logging
 
 from scalyr_agent.test_base import BaseScalyrLogCaptureTestCase
+from scalyr_agent.test_base import skipIf
 
 
 class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
@@ -174,6 +175,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
         monitor_logger.closeMetricLog()
 
+    @skipIf(sys.version_info <= (2, 7, 0), "Skipping tests under Python 2.7")
     def test_metric_logging_custom_timestamp(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
         metric_file_fd, metric_file_path = tempfile.mkstemp(".log")

--- a/tests/unit/scalyr_logging_test.py
+++ b/tests/unit/scalyr_logging_test.py
@@ -185,7 +185,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
         timestamp_ms1 = 1650021068015
         timestamp_ms2 = 1650021068016
 
-        expected_line_prefix = "2022-04-15 11:11:08.015Z \[foo\(1\)\] test_name "
+        expected_line_prefix = r"2022-04-15 11:11:08.015Z \[foo\(1\)\] test_name "
 
         monitor_logger = scalyr_logging.getLogger(
             "scalyr_agent.builtin_monitors.foo(1)"

--- a/tests/unit/scalyr_logging_test.py
+++ b/tests/unit/scalyr_logging_test.py
@@ -174,6 +174,55 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
         monitor_logger.closeMetricLog()
 
+    def test_metric_logging_custom_timestamp(self):
+        monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
+        metric_file_fd, metric_file_path = tempfile.mkstemp(".log")
+
+        # NOTE: We close the fd here because we open it again below. This way file deletion at
+        # the end works correctly on Windows.
+        os.close(metric_file_fd)
+
+        timestamp_ms1 = 1650021068015
+        timestamp_ms2 = 1650021068016
+
+        expected_line_prefix = "2022-04-15 11:11:08.015Z \[foo\(1\)\] test_name "
+
+        monitor_logger = scalyr_logging.getLogger(
+            "scalyr_agent.builtin_monitors.foo(1)"
+        )
+        monitor_logger.openMetricLogForMonitor(metric_file_path, monitor_instance)
+        monitor_logger.emit_value("test_name", 1, {"foo": 5}, timestamp=timestamp_ms1)
+        monitor_logger.emit_value("test_name", 2, {"foo": 5}, timestamp=timestamp_ms1)
+        monitor_logger.emit_value("test_name", 3, {"foo": 5}, timestamp=timestamp_ms1)
+        monitor_logger.emit_value("test_name", 4, {"foo": 5}, timestamp=timestamp_ms1)
+        monitor_logger.emit_value(
+            "test_name",
+            5,
+            {"foo": 5, "timestamp": timestamp_ms2},
+            timestamp=timestamp_ms1,
+        )
+
+        self.assertEquals(monitor_instance.reported_lines, 5)
+
+        # The value should only appear in the metric log file and not the main one.
+        self.assertLogFileContainsLineRegex(
+            file_path=metric_file_path, expression=expected_line_prefix + "1 foo=5"
+        )
+        self.assertLogFileContainsLineRegex(
+            file_path=metric_file_path, expression=expected_line_prefix + "2 foo=5"
+        )
+        self.assertLogFileContainsLineRegex(
+            file_path=metric_file_path, expression=expected_line_prefix + "3 foo=5"
+        )
+        self.assertLogFileContainsLineRegex(
+            file_path=metric_file_path, expression=expected_line_prefix + "4 foo=5"
+        )
+        self.assertLogFileContainsLineRegex(
+            file_path=metric_file_path,
+            expression=expected_line_prefix + "5 foo=5 timestamp=1650021068016",
+        )
+        monitor_logger.closeMetricLog()
+
     def test_metric_logging_extra_fields_are_sorted(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
         metric_file_fd, metric_file_path = tempfile.mkstemp(".log")


### PR DESCRIPTION
## Description

This pull request allows monitor developer to specify a custom timestamp which is used for the emitted metric log line when using `logger.emit_value()`.

By default, if that value is not specified, timestamp of the time when a ``Record`` object is created is used (same as before).

## Background, Context

Right now we use a timestamp when a log ``Record`` object is created when writing a metric log line into a file. 

In most cases that works fine, but in some cases we want to use exactly the same value for multiple metrics to make some server side processing easier.

An example of that is Open Metrics monitor - here we want to use the same timestamp for all the metrics which are scraped and parsed as part of the same scrape / gather sample cycle. T

his makes some server side operations such as joins as easier - it's worth noting that this doesn't affect server side operations such as time bucketing since for those we use much longer time bucket periods so small changes in the millisecond range don't matter.