### PR TITLE
[WIP] Periodically re-read authentication token from token volume mount file on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
+## 2.1.30 "TBD" - April 28, 2022
+
+<!---
+Packaged by Arthur Kamalov <arthurk@sentinelone.com> on Apr 25, 2022 23:04 -0800
+--->
+
+Kubernetes:
+* Agent has been updated to periodically try to re-read Kubernetes authentication token value from ``/var/run/secrets/kubernetes.io/serviceaccount/token`` file on disk (every 5 minutes by default). This way agent also supports Kubernetes deployments where token files are periodically automatically refreshed / rotated (e.g. https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection).
+
 ## 2.1.29 "Auter" - Mar 15, 2022
 
 <!---

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -985,6 +985,10 @@ class Configuration(object):
         return self.__get_config().get_string("k8s_service_account_namespace")
 
     @property
+    def k8s_token_re_read_interval(self):
+        return self.__get_config().get_int("k8s_token_re_read_interval")
+
+    @property
     def k8s_log_api_responses(self):
         # UNDOCUMENTED_CONFIG
         return self.__get_config().get_bool("k8s_log_api_responses")
@@ -2767,6 +2771,15 @@ class Configuration(object):
             config,
             "k8s_service_account_namespace",
             "/var/run/secrets/kubernetes.io/serviceaccount/namespace",
+            description,
+            apply_defaults,
+            env_aware=True,
+        )
+        # In seconds, defaults to every 5 minutes
+        self.__verify_or_set_optional_int(
+            config,
+            "k8s_token_re_read_interval",
+            5 * 60,
             description,
             apply_defaults,
             env_aware=True,

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -1737,6 +1737,7 @@ class KubernetesApi(object):
                     ),
                     "token_file": global_config.k8s_service_account_token,
                     "namespace_file": global_config.k8s_service_account_namespace,
+                    "token_re_read_interval": global_config.k8s_token_re_read_interval,
                 }
             )
         return KubernetesApi(**kwargs)
@@ -1756,6 +1757,7 @@ class KubernetesApi(object):
         rate_limiter=None,
         token_file="/var/run/secrets/kubernetes.io/serviceaccount/token",
         namespace_file="/var/run/secrets/kubernetes.io/serviceaccount/namespace",
+        token_re_read_interval=300,
     ):
         """Init the kubernetes object"""
         self.log_api_responses = log_api_responses
@@ -1773,6 +1775,8 @@ class KubernetesApi(object):
         self._session = None
 
         self._ca_file = ca_file
+        self._token_file = token_file
+        self._token_re_read_interval = int(token_re_read_interval)
 
         # We create a few headers ahead of time so that we don't have to recreate them each time we need them.
         self._standard_headers = {
@@ -1780,20 +1784,13 @@ class KubernetesApi(object):
             "Accept": "application/json",
         }
 
-        # The k8s API requires us to pass in an authentication token
-        # which we can obtain from a token file in a 'well known' location
-        self.token = ""
+        # Stores unix timestamp of when we last read the token value from file on disk (so we can
+        # periodically re-reading this file to support tokens which get periodically refreshed /
+        # rotated)
+        self._token_read_time_ts = 0
 
-        try:
-            # using with is ok here, because we need to be running
-            # a recent version of python for various 3rd party libs
-            f = open(token_file, "r")
-            try:
-                self.token = f.read().strip()
-            finally:
-                f.close()
-        except IOError:
-            pass
+        # Stores cached value of the authentication token read from a volume mount on disk.
+        self._token = None
 
         # get the namespace this pod is running on
         self.namespace = "default"
@@ -1808,8 +1805,6 @@ class KubernetesApi(object):
         except IOError:
             pass
 
-        self._standard_headers["Authorization"] = "Bearer %s" % (self.token)
-
         # A rate limiter should normally be passed unless no rate limiting is desired.
         self._query_options_max_retries = query_options_max_retries
         self._rate_limiter = rate_limiter
@@ -1821,6 +1816,53 @@ class KubernetesApi(object):
             ca_file,
             bool(self._verify_connection()),
         )
+
+    @property
+    def token(self):
+        """
+        Retrieve currently cached authentication token value.
+
+        This method will read token from the mounted volume on disk. It also supports re-reading
+        the token from disk (by default every 5 minutes) to ensure we have the latest version of
+        the token in case it has been rotated.
+        """
+        token_re_read_interval = self._token_re_read_interval
+
+        now_ts = int(time.time())
+        should_re_read_token = (now_ts - token_re_read_interval) >= self._token_read_time_ts
+
+        # TODO: We should probably consider token file not existing fatal and throw so we don't end
+        # up in a constant re-read token loop?
+        # But previous version of the code didn't treat token file not existing as fatal so I left
+        # that behavior the same, for now.
+
+        if should_re_read_token:
+            # We periodically try to re-read the token from disk to support scenarios where the
+            # token has been refreshed or rotated.
+            # See https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection
+            # for details.
+            self._token_read_time_ts = int(time.time())
+            previous_token_value = self._token
+
+            if not self._token:
+                global_log.debug("Locally cached token not available, reading it from %s file on "
+                                 "disk." % (self._token_file))
+            elif should_re_read_token:
+                global_log.debug("%s seconds have passed since reading the token from file %s on "
+                                 "disk, re-reading it in case the token has been refreshed or "
+                                 "rotated." % (token_re_read_interval, self._token_file))
+
+            try:
+                with open(self._token_file, "r") as fp:
+                    self._token = fp.read().strip()
+            except IOError:
+                global_log.warning("Unable to read auth token from file %s: %s" % (self._token_file, str(e)))
+
+            if previous_token_value != self._token:
+                global_log.debug("Read token value from file %s is different than the one which "
+                                 "we had cached which indicates token has been rotated.")
+
+        return self._token
 
     @property
     def default_query_options(self):
@@ -1840,7 +1882,19 @@ class KubernetesApi(object):
         """Create the session if it doesn't exist, otherwise do nothing"""
         if not self._session:
             self._session = requests.Session()
-            self._session.headers.update(self._standard_headers)
+
+        self._add_auth_header()
+
+    def _add_auth_header(self):
+        """
+        Add authentication header to the current session.
+
+        This method also takes care of periodically re-reading token value from disk.
+        """
+        headers = {
+            "Authorization": "Bearer %s" % (self.token)
+        }
+        self._session.headers.update(headers)
 
     def get_pod_name(self):
         """Gets the pod name of the pod running the scalyr-agent"""
@@ -2336,7 +2390,6 @@ class KubeletApi(object):
         self._session = requests.Session()
         headers = {
             "Accept": "application/json",
-            "Authorization": "Bearer %s" % k8s.token,
         }
         self._session.headers.update(headers)
 
@@ -2381,7 +2434,19 @@ class KubeletApi(object):
             return self._ca_file
         return False
 
+    def _add_auth_header(self):
+        """
+        Add authentication header to the current session.
+
+        This method also takes care of periodically re-reading token value from disk.
+        """
+        headers = {
+            "Authorization": "Bearer %s" % (self._k8s.token)
+        }
+        self._session.headers.update(headers)
+
     def _get(self, url, verify):
+        self._add_auth_header()
         return self._session.get(url, timeout=self._timeout, verify=verify)
 
     def query_api(self, path):


### PR DESCRIPTION
This pull request updates Kubernetes code (KubernetesApi, KubeletApi) to periodically re-read token which is used to authenticate from `/var/run/secrets/kubernetes.io/serviceaccount/token` volume mount file on disk.

## Background, Context

In recent versions, Kubernetes supports authentication tokens which are periodically refreshed (https://thenewstack.io/no-more-forever-tokens-changes-in-identity-management-for-kubernetes/).

In our agent code base, we used the same token value for the whole duration of the life time of the agent process (Kubernetes monitor, https://docs.kubermatic.com/kubermatic/v2.20/architecture/concept/kkp-concepts/service_account/service_account_token_projection/) which doesn't play along nicely with the refresh functionality.

## Proposed Implementation

There are two ways to support tokens which are periodically refreshed / rotated.

1. Rely on "Service Account Token Volume Projection" functionality and periodically re-read token value from the file on disk (service account token volume projection will take care of updating that volume mount file content)
2. Directly talk to the Kubernetes API and handle refreshing the token ourselves

In this PR, I went with the approach 1) since it simpler and it should be drop in for the current approach - new code will now periodically re-read token file from disk and in case the value has changed, new value will be used for subsequent requests.

Per recommendation in the Kubernetes docs, we re-read the value from the file every 5 minutes - https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/.

> The application is responsible for reloading the token when it rotates. Periodic reloading (e.g. once every 5 minutes) is sufficient for most use cases.

If this ever becomes a problem, we can lower that value (the interval can also be changed using ``k8s_re_read_token_interval`` config option). An option also is to try to re-read the token in case we get 401 back, but I decided to go with the simpler approach, especially since official documentation says that re-reading the token every X minutes should be sufficient for most cases.

It's also worth noting that with the this approach, there doesn't appear to be any easy way to retrieve token TTL directly so we could use a smarter logic to determine when to re-read the token.