### PR TITLE
fix: No support for python greater than 3.9

### DIFF
--- a/installer/scripts/check-python.sh
+++ b/installer/scripts/check-python.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Copyright 2014-2020 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Requirements
+MIN_REQ_PYTHON2_VERSION="2.7"
+MIN_REQ_PYTHON3_VERSION="3.5"
+
+INPUT_PYTHON_BIN_NAME=${1}
+
+echo -e "\n. Searching for ${INPUT_PYTHON_BIN_NAME} in Path:\n$PATH"
+
+test_python_version() {
+  local command=$1
+  local version=$2
+  local min_version=$3
+
+  if [ "$version" == "$min_version" ] ; then return 0; fi
+
+  if test "$(echo "$version" "$min_version" | xargs -n1 | sort -V | head -n1)" == "$version" ; then
+    echo "- command $command [$version] is found but the minimum required version is '${min_version}'."
+    return 1
+  fi
+
+  return 0
+}
+
+is_python_valid() {
+  local command=$1
+  local version
+
+  version=$(/usr/bin/env "${command}" --version 2>&1 | grep -Eo "[0-9](.[0-9]+)+")
+  local exit_code=$?
+
+  if [[ -z "${version}" || "${exit_code}" -ne "0" ]]; then
+    echo "- command $command not found."
+    return 1
+  fi
+
+  case ${version::1} in
+    2)
+      if ! test_python_version "$command" "$version" "$MIN_REQ_PYTHON2_VERSION" ; then return 1; fi
+      ;;
+    3)
+      if ! test_python_version "$command" "$version" "$MIN_REQ_PYTHON3_VERSION" ; then return 1; fi
+      ;;
+    *)
+      echo "- command $command found with unsupported major version $version."
+      return 1
+      ;;
+  esac
+
+  echo "+ command $command [$version] is found and matches the minimum required version - Success!"
+  return 0
+}
+
+is_python_valid ${INPUT_PYTHON_BIN_NAME}
+exit $?

--- a/installer/scripts/postinstall.sh
+++ b/installer/scripts/postinstall.sh
@@ -13,35 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Used below to execute a command to retrieve the Python interpreter version.
-run_and_check_persion_version() {
-  command=$1
-  version=$(${command} 2>&1 | grep -o "[0-9].[0-9]")
-  exit_code=$?
-
-  # shellcheck disable=SC2072,SC2071
-  if [[ -z "${version}" || "${exit_code}" -ne "0" ]]; then
-    return 1
-  elif [[ "$version" < "2.6" ]]; then
-    echo "Python ${version} is found but the minimum version for Python 2 is 2.6."
-    return 1
-  elif [[ "$version" > "3" && "$version" < "3.5" ]]; then
-    echo "Python ${version} is found but the minimum version for Python 3 is 3.5."
-    return 1
-  else
-    return 0
-  fi
-}
-
-# Checks to see if `/usr/bin/env $1` is a valid Python interpreter (2.6, 2.7, or >= 3.5)
-is_python_valid() {
-  command=$1
-  run_and_check_persion_version "/usr/bin/env ${command} --version"
-}
-
 # Return success if the current symlinks point to a valid Python interpreter (2.6, 2.7, or >= 3.5)
 is_current_python_valid() {
   run_and_check_persion_version "/usr/share/scalyr-agent-2/bin/scalyr-agent-2-config --report-python-version" > /dev/null 2>&1;
+}
+
+switch_python() {
+  local python_bin_name=$1
+
+  # Verify that a suitable Python version is available and set up the agent symlinks
+  if /usr/share/scalyr-agent-2/bin/check-python.sh "$python_bin_name" ; then
+    echo "+ The Scalyr Agent will use the default system $python_bin_name binary (/usr/bin/env $python_bin_name)."
+    /usr/share/scalyr-agent-2/bin/scalyr-switch-python "$python_bin_name"
+    return 0
+  fi
+
+  return 1
 }
 
 check_python_version() {
@@ -52,26 +39,10 @@ check_python_version() {
     return 0
   fi
 
-  echo "Switching the Python interpreter used by the Scalyr Agent."
+  echo ". Trying to switch the Python interpreter for the Scalyr Agent."
+
   # Verify that a suitable Python version is available and set up the agent symlinks
-  if is_python_valid python; then
-    # 'python' command exists
-    echo "The Scalyr Agent will use the default system python binary (/usr/bin/env python)."
-    /usr/share/scalyr-agent-2/bin/scalyr-switch-python default
-    return 0
-  fi
-
-  echo "The default 'python' command not found, will use python2 binary (/usr/bin/env python2) for running the agent."
-  if is_python_valid python2; then
-    /usr/share/scalyr-agent-2/bin/scalyr-switch-python python2
-    echo "The Scalyr Agent will use the python2 binary (/usr/bin/env python2)."
-    return 0
-  fi
-
-  echo "The 'python2' command not found, will use python3 binary (/usr/bin/env python3) for running the agent."
-  if is_python_valid python3; then
-    echo "The Scalyr Agent will use the python3 binary (/usr/bin/env python3)."
-    /usr/share/scalyr-agent-2/bin/scalyr-switch-python python3
+  if switch_python "python" || switch_python "python3" || switch_python "python2" ; then
     return 0
   fi
 

--- a/installer/scripts/preinstall.sh
+++ b/installer/scripts/preinstall.sh
@@ -18,57 +18,9 @@
 # In this cases script have to exit with an error.
 # This is important because all agent scripts rely on '/usr/bin/env python' command.
 
-# Requirements
-MIN_REQ_PYTHON2_VERSION="2.7"
-MIN_REQ_PYTHON3_VERSION="3.5"
+CHECK_PYTHON=/usr/share/scalyr-agent-2/bin/check-python.sh
 
-echo "Searching for Python in Path: $PATH"
-
-test_python_version() {
-  local command=$1
-  local version=$2
-  local min_version=$3
-
-  if [ "$version" == "$min_version" ] ; then return 0; fi
-
-  if test "$(echo "$version" "$min_version" | xargs -n1 | sort -V | head -n1)" == "$version" ; then
-    echo "- command $command [$version] is found but the minimum required version is '${min_version}'."
-    return 1
-  fi
-
-  return 0
-}
-
-is_python_valid() {
-  local command=$1
-  local version
-
-  version=$(/usr/bin/env "${command}" --version 2>&1 | grep -Eo "[0-9](.[0-9]+)+")
-  local exit_code=$?
-
-  if [[ -z "${version}" || "${exit_code}" -ne "0" ]]; then
-    echo "- command $command not found."
-    return 1
-  fi
-
-  case ${version::1} in
-    2)
-      if ! test_python_version "$command" "$version" "$MIN_REQ_PYTHON2_VERSION" ; then return 1; fi
-      ;;
-    3)
-      if ! test_python_version "$command" "$version" "$MIN_REQ_PYTHON3_VERSION" ; then return 1; fi
-      ;;
-    *)
-      echo "- command $command found with unsupported major version $version."
-      return 1
-      ;;
-  esac
-
-  echo "+ command $command [$version] is found and matches the minimum required version - Success!"
-  return 0
-}
-
-if ! is_python_valid python && ! is_python_valid python3 && ! is_python_valid python2; then
+if ! $CHECK_PYTHON "python" && ! $CHECK_PYTHON "python3" && ! $CHECK_PYTHON "python2" ; then
   echo "! Suitable Python interpreter not found."
   # get 'ID_LIKE' and 'ID' fields from '/etc/os-release' file and then search for distributions key words.
   if [[ -f "/etc/os-release" ]]; then

--- a/installer/scripts/preinstall.sh
+++ b/installer/scripts/preinstall.sh
@@ -19,7 +19,7 @@
 # This is important because all agent scripts rely on '/usr/bin/env python' command.
 
 # Requirements
-MIN_REQ_PYTHON2_VERSION="2.6"
+MIN_REQ_PYTHON2_VERSION="2.7"
 MIN_REQ_PYTHON3_VERSION="3.5"
 
 echo "Searching for Python in Path: $PATH"

--- a/installer/scripts/preinstall.sh
+++ b/installer/scripts/preinstall.sh
@@ -18,44 +18,68 @@
 # In this cases script have to exit with an error.
 # This is important because all agent scripts rely on '/usr/bin/env python' command.
 
+# Requirements
+MIN_REQ_PYTHON2_VERSION="2.6"
+MIN_REQ_PYTHON3_VERSION="3.5"
 
-echo "Checking Python version."
+echo "Searching for Python in Path: $PATH"
 
-is_python_valid() {
-  command=$1
-  version=$(/usr/bin/env "${command}" --version 2>&1 | grep -o "[0-9].[0-9]")
-  exit_code=$?
+test_python_version() {
+  local command=$1
+  local version=$2
+  local min_version=$3
 
-  # shellcheck disable=SC2072,SC2071
-  if [[ -z "${version}" || "${exit_code}" -ne "0" ]]; then
+  if [ "$version" == "$min_version" ] ; then return 0; fi
+
+  if test "$(echo "$version" "$min_version" | xargs -n1 | sort -V | head -n1)" == "$version" ; then
+    echo "- command $command [$version] is found but the minimum required version is '${min_version}'."
     return 1
-  elif [[ "$version" < "2.6" ]]; then
-    echo "Python ${version} is found but the minimum version for Python 2 is 2.6."
-    return 1
-  elif [[ "$version" > "3" && "$version" < "3.5" ]]; then
-    echo "Python ${version} is found but the minimum version for Python 3 is 3.5."
-    return 1
-  else
-    return 0
   fi
+
+  return 0
 }
 
-if ! is_python_valid python && ! is_python_valid python2 && ! is_python_valid python3; then
-  echo -e "\e[31mSuitable Python interpreter not found.\e[0m"
-  echo "You can install it by running command:"
+is_python_valid() {
+  local command=$1
+  local version
+
+  version=$(/usr/bin/env "${command}" --version 2>&1 | grep -Eo "[0-9](.[0-9]+)+")
+  local exit_code=$?
+
+  if [[ -z "${version}" || "${exit_code}" -ne "0" ]]; then
+    echo "- command $command not found."
+    return 1
+  fi
+
+  case ${version::1} in
+    2)
+      if ! test_python_version "$command" "$version" "$MIN_REQ_PYTHON2_VERSION" ; then return 1; fi
+      ;;
+    3)
+      if ! test_python_version "$command" "$version" "$MIN_REQ_PYTHON3_VERSION" ; then return 1; fi
+      ;;
+    *)
+      echo "- command $command found with unsupported major version $version."
+      return 1
+      ;;
+  esac
+
+  echo "+ command $command [$version] is found and matches the minimum required version - Success!"
+  return 0
+}
+
+if ! is_python_valid python && ! is_python_valid python3 && ! is_python_valid python2; then
+  echo "! Suitable Python interpreter not found."
   # get 'ID_LIKE' and 'ID' fields from '/etc/os-release' file and then search for distributions key words.
   if [[ -f "/etc/os-release" ]]; then
+    echo "You can install it by running command:"
     found_distros=$(grep -E "^ID_LIKE=|^ID=" /etc/os-release)
     # debian and etc.
     if echo "${found_distros}" | grep -qE "debian|ubuntu"; then
-      echo "'apt install python'"
-      echo "or"
-      echo "apt install python3"
+      echo -e "'apt install python'\nor\n'apt install python3"
     # RHEL and etc.
     elif echo "${found_distros}" | grep -qE "rhel|centos|fedora"; then
-      echo "'yum install python2'"
-      echo "or"
-      echo "'yum install python3'"
+      echo -e "'yum install python2'\nor\n'yum install python3'"
     fi
   fi
   exit 1


### PR DESCRIPTION
Introduce proper version check for python 3.10+

Sample output:
```
---
Searching for Python in Path: /Users/skalski/.sdkman/candidates/java/current/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/skalski/Library/Python/3.8/bin
- command python not found.
- command python3 [3.4.1] is found but the minimum required version is '3.5'.
- command python2 [2.2] is found but the minimum required version is '2.6'.
! Suitable Python interpreter not found.
---
Searching for Python in Path: ...
- command python not found.
- command python3 [3.4.1] is found but the minimum required version is '3.5'.
+ command python2 [2.6] is found and matches the minimum required version - Success!
---
Searching for Python in Path:...
- command python not found.
+ command python3 [3.10.1] is found and matches the minimum required version - Success!
```