### PR TITLE
Upgrade paramiko, libcloud dependency used by the AMI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -695,7 +695,7 @@ commands:
           at: /tmp/workspace
       - restore_cache:
           name: "Restore Python Dependencies cache"
-          key: deps-<<pipeline.parameters.cache_version_py_dependencies>>-{{ .Branch }}-ami-tests-{{ checksum "tests/ami/requirements.txt" }}
+          key: deps-<<pipeline.parameters.cache_version_py_dependencies>>-py310-{{ .Branch }}-ami-tests-{{ checksum "tests/ami/requirements.txt" }}
       - run:
           name: Install Python Dependencies
           command: |
@@ -707,7 +707,7 @@ commands:
             python -m pip install --user -r tests/ami/requirements.txt
       - save_cache:
           name: "Save Python Dependencies cache"
-          key: deps-<<pipeline.parameters.cache_version_py_dependencies>>-{{ .Branch }}-ami-tests-{{ checksum "tests/ami/requirements.txt" }}
+          key: deps-<<pipeline.parameters.cache_version_py_dependencies>>-py310-{{ .Branch }}-ami-tests-{{ checksum "tests/ami/requirements.txt" }}
           paths:
             - "~/.cache/pip"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2261,7 +2261,7 @@ jobs:
     description: "Run scalyr agent packages install sanity tests for the stable packages from the Scalyr repository."
     working_directory: ~/scalyr-agent-2
     docker:
-      - image: cimg/python:3.6
+      - image: cimg/python:3.10
     # TODO: Remove resource_class and use default medium one if tests are still
     # failing with large
     resource_class: large
@@ -2274,7 +2274,7 @@ jobs:
     description: "Run scalyr agent packages sanity tests for the new packages which are built on the current revision."
     working_directory: ~/scalyr-agent-2
     docker:
-      - image: cimg/python:3.6
+      - image: cimg/python:3.10
     # TODO: Remove resource_class and use default medium one if tests are still
     # failing with large
     resource_class: large

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -71,6 +71,7 @@ else
 
   # Tests below install latest stable version using an installer script and then upgrade to a
   # version which was built as part of a Circle CI job
+  python tests/ami/packages_sanity_tests.py --distro=ubuntu2204 --type=upgrade --from-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu2204-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=upgrade --from-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1804-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=upgrade --from-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1604-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=upgrade --from-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1404-upgrade.log &

--- a/scripts/circleci/run-ami-tests-in-bg.sh
+++ b/scripts/circleci/run-ami-tests-in-bg.sh
@@ -71,7 +71,7 @@ else
 
   # Tests below install latest stable version using an installer script and then upgrade to a
   # version which was built as part of a Circle CI job
-  python tests/ami/packages_sanity_tests.py --distro=ubuntu2204 --type=upgrade --from-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu2204-upgrade.log &
+  #python tests/ami/packages_sanity_tests.py --distro=ubuntu2204 --type=upgrade --from-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu2204-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1804 --type=upgrade --from-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1804-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1604 --type=upgrade --from-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1604-upgrade.log &
   python tests/ami/packages_sanity_tests.py --distro=ubuntu1404 --type=upgrade --from-version=current --installer-script-url="${INSTALLER_SCRIPT_URL}" --to-version=/tmp/workspace/scalyr-agent-2.deb &> outputs/ubuntu1404-upgrade.log &

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -151,7 +151,7 @@ EC2_DISTRO_DETAILS_MAP = {
         "image_name": "Ubuntu Server 22.04 (HVM), SSD Volume Type",
         "size_id": "m1.small",
         "ssh_username": "ubuntu",
-        "default_python_package_name": "python",
+        "default_python_package_name": "python3",
     },
     "debian1003": {
         "image_id": "ami-0b9a611a02047d3b1",

--- a/tests/ami/packages_sanity_tests.py
+++ b/tests/ami/packages_sanity_tests.py
@@ -146,6 +146,13 @@ EC2_DISTRO_DETAILS_MAP = {
         "ssh_username": "ubuntu",
         "default_python_package_name": "python",
     },
+    "ubuntu2204": {
+        "image_id": "ami-09d56f8956ab235b3",
+        "image_name": "Ubuntu Server 22.04 (HVM), SSD Volume Type",
+        "size_id": "m1.small",
+        "ssh_username": "ubuntu",
+        "default_python_package_name": "python",
+    },
     "debian1003": {
         "image_id": "ami-0b9a611a02047d3b1",
         "image_name": "Debian 10 Buster",

--- a/tests/ami/requirements.txt
+++ b/tests/ami/requirements.txt
@@ -1,3 +1,5 @@
-apache-libcloud==3.4.1
-paramiko==2.8.1
+# Includes paramiko >= 2.9.0 workaround
+git+https://github.com/Kami/libcloud.git@paramiko_2_9_compatibility#egg=apache-libcloud
+#apache-libcloud==3.4.1
+paramiko==2.10.4
 Jinja2==3.0.3

--- a/tests/ami/scripts/test_rpm.sh.j2
+++ b/tests/ami/scripts/test_rpm.sh.j2
@@ -26,7 +26,8 @@ echo_with_date() {
 # Give it some time to finish provisioning process. It's possible that we can SSH in before
 # cloud-init fully finished
 CLOUD_INIT_RESULT_FILE="/run/cloud-init/result.json"
-MAX_WAIT_COUNTER=30 # we wait a maximum of 30 x 2 seconds for provision to finish
+# We use higher value for rpm due to often timeouts on Amazon Linux
+MAX_WAIT_COUNTER=40 # we wait a maximum of 40 x 2 seconds for provision to finish
 
 WAIT_COUNTER=0
 while [ ! -f "${CLOUD_INIT_RESULT_FILE}" ] && [ ${WAIT_COUNTER} -lt ${MAX_WAIT_COUNTER} ]; do


### PR DESCRIPTION
This pull request upgrades paramiko and libcloud dependency used by the AMI tests.

New version of paramiko supports newer public key algorithms (e.g. Ubuntu 22.04) and the WIP version of Libcloud includes a workaround / fix so the deployment code still works correctly with older OpenSSH versions which don't support SHA2 based algorithms (e.g. Ubuntu 14.04).

This is needed due to the breaking change in paramiko >= 2.9.0.