### PR TITLE
fix: handling python > 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Packaged by Arthur Kamalov <arthurk@sentinelone.com> on Apr 25, 2022 23:04 -0800
 Kubernetes:
 * Agent has been updated to periodically try to re-read Kubernetes authentication token value from ``/var/run/secrets/kubernetes.io/serviceaccount/token`` file on disk (every 5 minutes by default). This way agent also supports Kubernetes deployments where token files are periodically automatically refreshed / rotated (e.g. https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection).
 
+Bug fixes:
+ * Fix minimum Python version detection in the deb/rpm package post install script and make sure agent packages also support Python >= 3.10 (e.g. Ubuntu 22.04).
+
 ## 2.1.29 "Auter" - Mar 15, 2022
 
 <!---

--- a/installer/scripts/postinstall.sh
+++ b/installer/scripts/postinstall.sh
@@ -13,24 +13,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Requirements
+MIN_REQ_PYTHON2_VERSION="2.7"
+MIN_REQ_PYTHON3_VERSION="3.5"
+
 # Used below to execute a command to retrieve the Python interpreter version.
 run_and_check_persion_version() {
-  command=$1
-  version=$(${command} 2>&1 | grep -o "[0-9].[0-9]")
+  local command=$1
+  local version=$(${command} 2>&1 | grep -Eo "[0-9](.[0-9]+)+")
   exit_code=$?
 
   # shellcheck disable=SC2072,SC2071
   if [[ -z "${version}" || "${exit_code}" -ne "0" ]]; then
     return 1
-  elif [[ "$version" < "2.6" ]]; then
-    echo "Python ${version} is found but the minimum version for Python 2 is 2.6."
-    return 1
-  elif [[ "$version" > "3" && "$version" < "3.5" ]]; then
-    echo "Python ${version} is found but the minimum version for Python 3 is 3.5."
-    return 1
-  else
-    return 0
   fi
+
+  case ${version::1} in
+    2)
+      if test "$(echo "${version}" "${MIN_REQ_PYTHON2_VERSION}" | xargs -n1 | sort -V | head -n1)" == "$version" ; then
+        echo "- Python ${version} is found but the minimum version for Python 2 is 2.6."
+        return 1
+      fi
+      ;;
+    3)
+      if test "$(echo "${version}" "${MIN_REQ_PYTHON3_VERSION}" | xargs -n1 | sort -V | head -n1)" == "$version" ; then
+        echo "- Python ${version} is found but the minimum version for Python 3 is 3.5."
+        return 1
+      fi
+      ;;
+    *)
+      echo "- command $command found with unsupported major version $version."
+      return 1
+      ;;
+  esac
+
+  echo "+ Found Python $version"
+
+  return 0
 }
 
 # Checks to see if `/usr/bin/env $1` is a valid Python interpreter (2.6, 2.7, or >= 3.5)
@@ -56,26 +75,26 @@ check_python_version() {
   # Verify that a suitable Python version is available and set up the agent symlinks
   if is_python_valid python; then
     # 'python' command exists
-    echo "The Scalyr Agent will use the default system python binary (/usr/bin/env python)."
-    /usr/share/scalyr-agent-2/bin/scalyr-switch-python default
+    echo "+ The Scalyr Agent will use the default system python binary (/usr/bin/env python)."
+  #  /usr/share/scalyr-agent-2/bin/scalyr-switch-python default
     return 0
   fi
 
-  echo "The default 'python' command not found, will use python2 binary (/usr/bin/env python2) for running the agent."
+  echo "- The default 'python' command not found, will try to use python2 binary (/usr/bin/env python2) for running the agent."
   if is_python_valid python2; then
-    /usr/share/scalyr-agent-2/bin/scalyr-switch-python python2
-    echo "The Scalyr Agent will use the python2 binary (/usr/bin/env python2)."
+    echo "+ The Scalyr Agent will use the python2 binary (/usr/bin/env python2)."
+     /usr/share/scalyr-agent-2/bin/scalyr-switch-python python2
     return 0
   fi
 
-  echo "The 'python2' command not found, will use python3 binary (/usr/bin/env python3) for running the agent."
+  echo "- The 'python2' command not found, will try to use python2 binary (/usr/bin/env python3) for running the agent."
   if is_python_valid python3; then
-    echo "The Scalyr Agent will use the python3 binary (/usr/bin/env python3)."
+    echo "+ The Scalyr Agent will use the python3 binary (/usr/bin/env python3)."
     /usr/share/scalyr-agent-2/bin/scalyr-switch-python python3
     return 0
   fi
 
-  echo "Warning, no valid Python interpreter found."
+  echo "! Warning, no valid Python interpreter found."
 }
 
 # Function which ensures that the provided file path permissions for "group" match the

--- a/installer/scripts/preinstall.sh
+++ b/installer/scripts/preinstall.sh
@@ -18,26 +18,43 @@
 # In this cases script have to exit with an error.
 # This is important because all agent scripts rely on '/usr/bin/env python' command.
 
+# Requirements
+MIN_REQ_PYTHON2_VERSION="2.7"
+MIN_REQ_PYTHON3_VERSION="3.5"
 
 echo "Checking Python version."
 
 is_python_valid() {
-  command=$1
-  version=$(/usr/bin/env "${command}" --version 2>&1 | grep -o "[0-9].[0-9]")
+  local command=$1
+  local version=$(/usr/bin/env "${command}" --version 2>&1 | grep -Eo "[0-9](.[0-9]+)+")
   exit_code=$?
 
   # shellcheck disable=SC2072,SC2071
   if [[ -z "${version}" || "${exit_code}" -ne "0" ]]; then
     return 1
-  elif [[ "$version" < "2.6" ]]; then
-    echo "Python ${version} is found but the minimum version for Python 2 is 2.6."
-    return 1
-  elif [[ "$version" > "3" && "$version" < "3.5" ]]; then
-    echo "Python ${version} is found but the minimum version for Python 3 is 3.5."
-    return 1
-  else
-    return 0
   fi
+
+  case ${version::1} in
+    2)
+      if test "$(echo "${version}" "${MIN_REQ_PYTHON2_VERSION}" | xargs -n1 | sort -V | head -n1)" == "$version" ; then
+        echo "- Python ${version} is found but the minimum version for Python 2 is 2.7."
+        return 1
+      fi
+      ;;
+    3)
+      if test "$(echo "${version}" "${MIN_REQ_PYTHON3_VERSION}" | xargs -n1 | sort -V | head -n1)" == "$version" ; then
+        echo "- Python ${version} is found but the minimum version for Python 3 is 3.5."
+        return 1
+      fi
+      ;;
+    *)
+      echo "- command $command found with unsupported major version $version."
+      return 1
+      ;;
+  esac
+
+  echo "+ Found Python $version [$command]"
+  return 0
 }
 
 if ! is_python_valid python && ! is_python_valid python2 && ! is_python_valid python3; then


### PR DESCRIPTION
Set minimum Python2 to 2.7.

Follow up on https://github.com/scalyr/scalyr-agent-2/pull/868#discussion_r866809725