### PR TITLE
Fix no check remote regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docker images:
 
 Bug fixes:
 * Fix minimum Python version detection in the deb/rpm package pre/post install script and make sure agent packages also support Python >= 3.10 (e.g. Ubuntu 22.04). Contributed by Arkadiusz Skalski (@askalski85).
+* Fix a regression introduced in v2.1.29 which would cause the agent to inadvertently skip connectivity check on startup.
 
 Other:
 * Update the code to log non-fatal connection related errors which are retried under WARNING instead of ERROR log level.

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -370,8 +370,7 @@ class ScalyrAgent(object):
             command_options.no_change_user,
         )
 
-        if command_options.no_check_remote is not None:
-            no_check_remote = True
+        no_check_remote = command_options.no_check_remote
 
         # noinspection PyBroadException
         try:


### PR DESCRIPTION
This pull request fixes a small regression which caused the agent to never perform connectivity check on startup.

I believe this regression was inadvertently introduced in v2.1.29 via 1d1ce997e6ed23bb30e13cc7a2eacc2ca3bef60c.

With the change in the command parser which is used, the default value for that option is now ``False``. This means that the code would always end up in that if branch and set ``no_check_remote`` to ``True``.

## TODO

- [ ] Tests