### PR TITLE
Change formatting of check-python step in pre/post install script

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -128,7 +128,7 @@ jobs:
           SCALYR_AGENT_POD_NAME: "${{ env.SCALYR_AGENT_POD_NAME }}"
           K8S_NODE_NAME: "${{ env.K8S_NODE_NAME }}"
         run: |
-          export RETRY_ATTEMPTS="8"
+          export RETRY_ATTEMPTS="10"
           export SLEEP_DELAY="10"
 
           # Verify agent is running

--- a/installer/scripts/check-python.sh
+++ b/installer/scripts/check-python.sh
@@ -39,9 +39,7 @@ is_python_valid() {
   local MIN_REQ_PYTHON2_VERSION="2.7"
   local MIN_REQ_PYTHON3_VERSION="3.5"
 
-  echo ""
-  echo ". Searching for ${command} in Path:"
-  echo "$PATH"
+  echo ". Searching for ${command} in PATH \"${PATH}\":"
 
   version=$(/usr/bin/env "${command}" --version 2>&1 | grep -Eo "[0-9](.[0-9]+)+")
   local exit_code=$?


### PR DESCRIPTION
Small change in the pre/post install script to make the output a bit more concise by removing two line breaks.

Before:

```bash
Preparing to unpack .../scalyr-agent-2_2.1.29.pre30.1_all.deb ...

. Searching for python in Path:
/usr/sbin:/usr/bin:/sbin:/bin
- command python not found.

. Searching for python2 in Path:
/usr/sbin:/usr/bin:/sbin:/bin
- command python2 not found.

. Searching for python3 in Path:
/usr/sbin:/usr/bin:/sbin:/bin
+ command python3 [3.8.10] is found and matches the minimum required version - Success!
Unpacking scalyr-agent-2 (2.1.29.pre30.1) over (2.1.29) ...
Setting up scalyr-agent-2 (2.1.29.pre30.1) ...

. Searching for python3 in Path:
/usr/sbin:/usr/bin:/sbin:/bin
+ command python3 [3.8.10] is found and matches the minimum required version - Success!
```

After:

```bash
Preparing to unpack .../scalyr-agent-2_2.1.29.pre30.1_all.deb ...
. Searching for python in PATH "/usr/sbin:/usr/bin:/sbin:/bin":
- command python not found.
. Searching for python in PATH "/usr/sbin:/usr/bin:/sbin:/bin":
- command python2 not found.
. Searching for python in PATH "/usr/sbin:/usr/bin:/sbin:/bin":
+ command python3 [3.8.10] is found and matches the minimum required version - Success!
Unpacking scalyr-agent-2 (2.1.29.pre30.1) over (2.1.29) ...
Setting up scalyr-agent-2 (2.1.29.pre30.1) ...
. Searching for python3 in Path: /usr/sbin:/usr/bin:/sbin:/bin
+ command python3 [3.8.10] is found and matches the minimum required version - Success!
```