### PR TITLE
Add support for defining arbitrary attributes which are included with every metric in the Open Metrics monitor

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -336,9 +336,9 @@ jobs:
 
           # 4. Verify java app JMX metrics
           echo "Java JMX metrics events metrics monitor checks"
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_error 0.0 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" k8s-node=\"'${K8S_NODE_NAME}'\""'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_cached_beans 0.0 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" k8s-node=\"'${K8S_NODE_NAME}'\""'
-          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jvm_info 1.0 k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" k8s-node=\"'${K8S_NODE_NAME}'\" runtime="'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_error 0.0 app=\"java-hello-world\" attribute1=\"value1\" k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" k8s-node=\"'${K8S_NODE_NAME}'\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_cached_beans 0.0 app=\"java-hello-world\" attribute1=\"value1\" k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" k8s-node=\"'${K8S_NODE_NAME}'\""'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jvm_info 1.0 app=\"java-hello-world\" attribute1=\"value1\" k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" k8s-node=\"'${K8S_NODE_NAME}'\" runtime="'
 
       - name: Notify Slack on Failure
         # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -151,11 +151,6 @@ API endpoints.
 This monitor will only work correctly if the agent is deployed as a DaemonSet. That's because each
 monitor instance will only discover metrics endpoints which are local to the node the agent is
 running on.
-
-## TODO
-
-- [ ] Should we include node name (+cluster name - scalyr_k8s_cluster_name ?) with each metric? We
-      already do in the monitor name, so we could just define a special parser for it.
 """
 
 from __future__ import absolute_import

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -42,7 +42,8 @@ monitor:
     * ``k8s.monitor.config.scalyr.com/verify_https`` (optional) - Set to false to disable remote SSL
       cert and hostname validation.
     * ``k8s.monitor.config.scalyr.com/attributes`` (optional) - Optional JSON object with the attributes
-      (key/value pairs) which get included with every metric.
+      (key/value pairs) which get included with every metric. Template syntax is supported for attribute
+      values. Right now only pod labels are available in the template context.
       scrape requests. Defaults to 10 seconds.
     * ``k8s.monitor.config.scalyr.com/metric_name_include_list`` (optional) - Comma delimited list
       of metric names to include when scraping.
@@ -80,7 +81,7 @@ for the exporter pod:
             k8s.monitor.config.scalyr.com/scrape:          'true'
             k8s.monitor.config.scalyr.com/scrape_interval: '120'
             k8s.monitor.config.scalyr.com/scrape_timeout:  '5'
-            k8s.monitor.config.scalyr.com/attributes:      '{"app": "node-exporter"}'
+            k8s.monitor.config.scalyr.com/attributes:      '{"app": "${pod_labels_app}", "region": "eu"}'
         spec:
         containers:
         - args:

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -384,9 +384,9 @@ KUBERNETES_OPEN_METRICS_MONITOR_MODULE = (
 )
 
 # Annotation related constants
-PROMETHEUS_ANNOTATION_SCAPE_PORT = "prometheus.io/port"
-PROMETHEUS_ANNOTATION_SCAPE_SCHEME = "prometheus.io/scheme"
-PROMETHEUS_ANNOTATION_SCAPE_PATH = "prometheus.io/path"
+PROMETHEUS_ANNOTATION_SCRAPE_PORT = "prometheus.io/port"
+PROMETHEUS_ANNOTATION_SCRAPE_SCHEME = "prometheus.io/scheme"
+PROMETHEUS_ANNOTATION_SCRAPE_PATH = "prometheus.io/path"
 SCALYR_AGENT_ANNOTATION_SCRAPE_ENABLE = "k8s.monitor.config.scalyr.com/scrape"
 
 SCALYR_AGENT_ANNOTATION_SCRAPE_INTERVAL = (
@@ -1018,13 +1018,13 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
         )
 
         scrape_scheme = pod.annotations.get(
-            PROMETHEUS_ANNOTATION_SCAPE_SCHEME, DEFAULT_SCRAPE_SCHEME
+            PROMETHEUS_ANNOTATION_SCRAPE_SCHEME, DEFAULT_SCRAPE_SCHEME
         )
         scrape_port = pod.annotations.get(
-            PROMETHEUS_ANNOTATION_SCAPE_PORT, DEFAULT_SCRAPE_PORT
+            PROMETHEUS_ANNOTATION_SCRAPE_PORT, DEFAULT_SCRAPE_PORT
         )
         scrape_path = pod.annotations.get(
-            PROMETHEUS_ANNOTATION_SCAPE_PATH, DEFAULT_SCRAPE_PATH
+            PROMETHEUS_ANNOTATION_SCRAPE_PATH, DEFAULT_SCRAPE_PATH
         )
 
         node_ip = pod.ips[0] if pod.ips else None

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -451,10 +451,10 @@ class TemplateWithSpecialCharacters(Template):
     delimiter = "$"
     pattern = r"""
     \$(?:
-      (?P<escaped>\$)                             |   # Escape sequence of two delimiters
-      (?P<named>(?a:[_a-z][_a-z0-9\-\.\/]*))      |   # delimiter and a Python identifier
-      {(?P<braced>(?a:[_a-z][_a-z0-9\-\.\/]*))}   |   # delimiter and a braced identifier
-      (?P<invalid>)                                   # Other ill-formed delimiter exprs
+      (?P<escaped>\$)                        |   # Escape sequence of two delimiters
+      (?P<named>[_a-z][_a-z0-9\-\.\/]*)      |   # delimiter and a Python identifier
+      {(?P<braced>[_a-z][_a-z0-9\-\.\/]*)}   |   # delimiter and a braced identifier
+      (?P<invalid>)                              # Other ill-formed delimiter exprs
     )
     """
 

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -446,13 +446,15 @@ class TemplateWithSpecialCharacters(Template):
     since they are only used on Kubernetes with Docker Image which utilizes Python 3).
     """
 
+    # Based on https://github.com/python/cpython/blob/main/Lib/string.py#L74
+
     delimiter = "$"
     pattern = r"""
     \$(?:
-      (?P<escaped>\$) |   # Escape sequence of two delimiters
-      (?P<named>[_a-z][_a-z0-9\-\.\/]*]*)      |   # delimiter and a Python identifier
-      {(?P<braced>[_a-z][_a-z0-9\-\.\/]*)}   |   # delimiter and a braced identifier
-      (?P<invalid>)              # Other ill-formed delimiter exprs
+      (?P<escaped>\$)                             |   # Escape sequence of two delimiters
+      (?P<named>(?a:[_a-z][_a-z0-9\-\.\/]*))      |   # delimiter and a Python identifier
+      {(?P<braced>(?a:[_a-z][_a-z0-9\-\.\/]*))}   |   # delimiter and a braced identifier
+      (?P<invalid>)                                   # Other ill-formed delimiter exprs
     )
     """
 

--- a/scalyr_agent/builtin_monitors/openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/openmetrics_monitor.py
@@ -302,7 +302,13 @@ class OpenMetricsMonitor(ScalyrMonitor):
         # used for that metric
         timestamp_ms = round(time.time() * 1000)
 
+        start_ts = time.time()
         metrics = self._scrape_metrics(self.__url)
+        end_ts = time.time()
+
+        self._logger.debug(
+            f"Scraping and parsing metrics for url {self.__url} took {(end_ts - start_ts):.3f} seconds."
+        )
 
         for metric_name, extra_fields, metric_value in metrics:
             extra_fields.update(self.__base_extra_fields or {})

--- a/tests/e2e/k8s_om_monitor/java_app_deployment.yaml
+++ b/tests/e2e/k8s_om_monitor/java_app_deployment.yaml
@@ -16,6 +16,7 @@ spec:
         prometheus.io/scrape:             'true'
         prometheus.io/port:               '9404'
         k8s.monitor.config.scalyr.com/scrape: 'true'
+        k8s.monitor.config.scalyr.com/attributes: '{"attribute1": "value1", "app": "${pod_labels_app}"}'
     spec:
       hostNetwork: true
       hostPID: true

--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -25,7 +25,7 @@ import mock
 from scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor import (
     KubernetesOpenMetricsMonitor,
     SCALYR_AGENT_ANNOTATION_SCRAPE_ENABLE,
-    PROMETHEUS_ANNOTATION_SCAPE_PATH,
+    PROMETHEUS_ANNOTATION_SCRAPE_PATH,
 )
 from scalyr_agent.json_lib import JsonObject
 from scalyr_agent.monitors_manager import set_monitors_manager
@@ -67,7 +67,7 @@ for index, pod in enumerate(
 ):
     if pod["metadata"]["name"] == "arm-exporter-sv7rk":
         pod["metadata"]["annotations"][
-            PROMETHEUS_ANNOTATION_SCAPE_PATH
+            PROMETHEUS_ANNOTATION_SCRAPE_PATH
         ] = "/test/new/path"
 
 
@@ -135,6 +135,14 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
             "sample_interval": 10,
             "log_filename": "foo.log",
             "verify_https": False,
+            # NOTE: k8s-cluster and k8s-node are special attributes so user shouldn't be able to
+            # override those
+            "attributes": {
+                "app": "my-app",
+                "key-1": "value 1",
+                "k8s-node": "override",
+                "k8s-cluster": "override",
+            },
             "ca_file": None,
             "headers": None,
             "include_node_name": True,
@@ -149,7 +157,12 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
         expected_monitor_config = {
             "ca_file": None,
             "extra_fields": JsonObject(
-                {"k8s-node": "test-node-name", "k8s-cluster": "test-cluster-name"}
+                {
+                    "k8s-node": "test-node-name",
+                    "k8s-cluster": "test-cluster-name",
+                    "app": "my-app",
+                    "key-1": "value 1",
+                }
             ),
             "headers": JsonObject({}),
             "id": "one",

--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -29,6 +29,7 @@ from scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor import (
     SCALYR_AGENT_ANNOTATION_ATTRIBUTES,
     KubernetesOpenMetricsMonitor,
     K8sPod,
+    TemplateWithSpecialCharacters,
 )
 from scalyr_agent.json_lib import JsonObject
 from scalyr_agent.monitors_manager import set_monitors_manager
@@ -817,3 +818,16 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_monitors_manager.remove_monitor.assert_any_call(
             "scalyr_agent.builtin_monitors.openmetrics_monitor-node1_arm-exporter-sv7rk"
         )
+
+    def test_template_with_special_characters(self):
+        context = {
+            "foo": "bar2",
+            "foo.bar/baz-foo": "test2",
+            "FooA": "bar3",
+            "foo-d": "food",
+        }
+        template = (
+            "test hello $world foo ${foo} bar ${foo.bar/baz-foo} ${FooA} f1 ${foo-d}"
+        )
+        result = TemplateWithSpecialCharacters(template).safe_substitute(context)
+        self.assertEqual(result, "test hello $world foo bar2 bar test2 bar3 f1 food")

--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -225,7 +225,7 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
         annotations = copy.copy(base_annotations)
         annotations[
             SCALYR_AGENT_ANNOTATION_ATTRIBUTES
-        ] = '{"app": "test", "template-app": "${pod_labels_app}", "three": "${pod_labels_test_bar_bar}", "invalid": "${pod_labels_doesnt_exist}", "instance": "${pod_labels_app_kubernetes_io_instance}"}'
+        ] = '{"app": "test", "template-app": "${pod_labels_app}", "three": "${pod_labels_test.bar/bar}", "invalid": "${pod_labels_doesnt_exist}", "instance": "${pod_labels_app.kubernetes.io/instance}"}'
 
         expected_attributes = {
             "app": "test",

--- a/tests/unit/builtin_monitors/openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/openmetrics_monitor_test.py
@@ -98,7 +98,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_logger = mock.Mock()
         monitor = OpenMetricsMonitor(monitor_config=monitor_config, logger=mock_logger)
         monitor.gather_sample()
-        self.assertEqual(mock_logger.debug.call_count, 0)
+        self.assertEqual(mock_logger.debug.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 0)
         self.assertEqual(mock_logger.emit_value.call_count, 5)
 
@@ -150,7 +150,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_logger = mock.Mock()
         monitor = OpenMetricsMonitor(monitor_config=monitor_config, logger=mock_logger)
         monitor.gather_sample()
-        self.assertEqual(mock_logger.debug.call_count, 0)
+        self.assertEqual(mock_logger.debug.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 0)
         self.assertEqual(mock_logger.emit_value.call_count, 5)
 
@@ -226,7 +226,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_logger = mock.Mock()
         monitor = OpenMetricsMonitor(monitor_config=monitor_config, logger=mock_logger)
         monitor.gather_sample()
-        self.assertEqual(mock_logger.debug.call_count, 0)
+        self.assertEqual(mock_logger.debug.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 0)
         self.assertEqual(mock_logger.emit_value.call_count, 6)
 
@@ -262,7 +262,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_logger = mock.Mock()
         monitor = OpenMetricsMonitor(monitor_config=monitor_config, logger=mock_logger)
         monitor.gather_sample()
-        self.assertEqual(mock_logger.debug.call_count, 0)
+        self.assertEqual(mock_logger.debug.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 20)
         self.assertEqual(mock_logger.emit_value.call_count, 4900)
 
@@ -309,7 +309,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_logger = mock.Mock()
         monitor = OpenMetricsMonitor(monitor_config=monitor_config, logger=mock_logger)
         monitor.gather_sample()
-        self.assertEqual(mock_logger.debug.call_count, 0)
+        self.assertEqual(mock_logger.debug.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 20)
         self.assertEqual(mock_logger.emit_value.call_count, 0)
 
@@ -344,7 +344,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_logger = mock.Mock()
         monitor = OpenMetricsMonitor(monitor_config=monitor_config, logger=mock_logger)
         monitor.gather_sample()
-        self.assertEqual(mock_logger.debug.call_count, 0)
+        self.assertEqual(mock_logger.debug.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 19)
         self.assertEqual(mock_logger.emit_value.call_count, 20)
 
@@ -395,7 +395,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_logger = mock.Mock()
         monitor = OpenMetricsMonitor(monitor_config=monitor_config, logger=mock_logger)
         monitor.gather_sample()
-        self.assertEqual(mock_logger.debug.call_count, 0)
+        self.assertEqual(mock_logger.debug.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 19)
         self.assertEqual(mock_logger.emit_value.call_count, 55)
 
@@ -414,7 +414,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_logger = mock.Mock()
         monitor = OpenMetricsMonitor(monitor_config=monitor_config, logger=mock_logger)
         monitor.gather_sample()
-        self.assertEqual(mock_logger.debug.call_count, 0)
+        self.assertEqual(mock_logger.debug.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 0)
         self.assertEqual(mock_logger.emit_value.call_count, 144)
 
@@ -500,7 +500,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_logger.warn.assert_called_with(
             "Failed to fetch metrics from https://my.host:8080/metrics: status_code=404,body=bar"
         )
-        self.assertEqual(mock_logger.debug.call_count, 0)
+        self.assertEqual(mock_logger.debug.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 1)
         self.assertEqual(mock_logger.emit_value.call_count, 0)
 
@@ -519,7 +519,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_logger = mock.Mock()
         monitor = OpenMetricsMonitor(monitor_config=monitor_config, logger=mock_logger)
         monitor.gather_sample()
-        self.assertEqual(mock_logger.debug.call_count, 0)
+        self.assertEqual(mock_logger.debug.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 0)
         self.assertEqual(mock_logger.emit_value.call_count, 3)
 
@@ -562,7 +562,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_logger = mock.Mock()
         monitor = OpenMetricsMonitor(monitor_config=monitor_config, logger=mock_logger)
         monitor.gather_sample()
-        self.assertEqual(mock_logger.debug.call_count, 0)
+        self.assertEqual(mock_logger.debug.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 0)
         self.assertEqual(mock_logger.emit_value.call_count, 2)
 
@@ -599,7 +599,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_logger = mock.Mock()
         monitor = OpenMetricsMonitor(monitor_config=monitor_config, logger=mock_logger)
         monitor.gather_sample()
-        self.assertEqual(mock_logger.debug.call_count, 0)
+        self.assertEqual(mock_logger.debug.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 1)
         self.assertEqual(mock_logger.emit_value.call_count, 0)
 
@@ -619,7 +619,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_logger = mock.Mock()
         monitor = OpenMetricsMonitor(monitor_config=monitor_config, logger=mock_logger)
         monitor.gather_sample()
-        self.assertEqual(mock_logger.debug.call_count, 0)
+        self.assertEqual(mock_logger.debug.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 0)
         self.assertEqual(mock_logger.emit_value.call_count, 2)
 
@@ -647,7 +647,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_logger = mock.Mock()
         monitor = OpenMetricsMonitor(monitor_config=monitor_config, logger=mock_logger)
         monitor.gather_sample()
-        self.assertEqual(mock_logger.debug.call_count, 3)
+        self.assertEqual(mock_logger.debug.call_count, 3 + 1)
         self.assertEqual(mock_logger.warn.call_count, 0)
         self.assertEqual(mock_logger.emit_value.call_count, 2)
 
@@ -675,7 +675,7 @@ class OpenMetricsMonitorTestCase(ScalyrTestCase):
         mock_logger = mock.Mock()
         monitor = OpenMetricsMonitor(monitor_config=monitor_config, logger=mock_logger)
         monitor.gather_sample()
-        self.assertEqual(mock_logger.debug.call_count, 0)
+        self.assertEqual(mock_logger.debug.call_count, 1)
         self.assertEqual(mock_logger.warn.call_count, 1)
         self.assertEqual(mock_logger.emit_value.call_count, 0)
 


### PR DESCRIPTION
This pull request updates Kubernetes Open Metrics monitor and allows user to define arbitrary attributes (key value pairs) which are included with every metric log line as part of labels / extra fields.

Attributes are defined using pod annotations. The actual value needs to be a serialized JSON string where a key is a string and a value is a string (complex / nested objects are not supported).

This comes handy in scenarios where user wants to add additional context (e.g. app name) to the metric to make querying easier.

Example configuration:

```yaml
...
    template:
        metadata:
        labels:
            app.kubernetes.io/component: exporter
            app.kubernetes.io/name: node-exporter
        annotations:
            prometheus.io/scrape:                          'true'
            prometheus.io/port:                            '9100'
            k8s.monitor.config.scalyr.com/scrape:          'true'
            k8s.monitor.config.scalyr.com/scrape_interval: '120'
            k8s.monitor.config.scalyr.com/scrape_timeout:  '5'
            k8s.monitor.config.scalyr.com/attributes:      '{"app": "${pod_labels_app}", "env": "eu"}'
...
```

## TODO (future)

- [x] Ability to use template syntax and reference other values from the pod metadata (e.g. pod name, metadata, labels, etc.).