### PR TITLE
 Escape special metric field names which are considered special / reserved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Bug fixes:
 * Fix a regression introduced in v2.1.29 which would cause the agent to inadvertently skip connectivity check on startup.
 * Default value for ``check_remote_if_no_tty`` config option is ``False``. Previously the changelog entry incorrectly stated it defaults to ``True``. This means that a connectivity check is not performed on startup if tty is not available.
 
+Other:
+* Monitor ``emit_value()`` method now correctly sanitizes / escapes metric field names which are "reserved" (logfile, metric, value, serverHost, instance, severity). This is done to prevent possible collisions with special / reserved metric event attribute names which could cause issues with some queries. Metric field names which are escaped get added ``_`` suffix (e.g. ``metric`` becomes ``metric_``).
+
 ## 2.1.30 "Heturn" - May 17, 2022
 
 <!---

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -70,6 +70,19 @@ DEBUG_LEVEL_3 = 6
 DEBUG_LEVEL_4 = 5
 DEBUG_LEVEL_5 = 4
 
+# Stores a list of "reserved" event level attribute names. If we detect metric extra field with this
+# name we sanitize / escape it by adding "_" suffix to the field name. This way we avoid possible
+# collisions with those special / reserved names which could break some tsdb related queries and
+# functionality.
+RESERVED_EVENT_ATTRIBUTE_NAMES = [
+    "logfile",
+    "monitor",
+    "metric",
+    "value",
+    "instance",
+    "severity",
+]
+
 
 # noinspection PyPep8Naming
 def getLogger(name):
@@ -721,6 +734,17 @@ class AgentLogger(logging.Logger):
             self.__monitor = None
 
     @staticmethod
+    def sanitize_metric_field_name(name):
+        """
+        Method which takes care of sanitizing metric field names which are considered special /
+        reserved.
+        """
+        if not name.endswith("_") and name in RESERVED_EVENT_ATTRIBUTE_NAMES:
+            name = name + "_"
+
+        return name
+
+    @staticmethod
     def force_valid_metric_or_field_name(name, is_metric=True, logger=None):
         """Forces the given metric or field name to be valid.
 
@@ -732,6 +756,9 @@ class AgentLogger(logging.Logger):
 
         If a modification had to be applied, a log warning is emitted, but it is only emitted once per day.
 
+        This method also ensures any "reserved" event level field names (monitor, metric, value, logfile, serverHost) are
+        sanitized by adding "_" suffix (for consistency with server side parsing).
+
         @param name: The metric name
         @type name: six.text_type
         @param is_metric: Whether or not the name is a metric or field name
@@ -740,6 +767,7 @@ class AgentLogger(logging.Logger):
         @rtype: six.text_type
         """
         if AgentLogger.__metric_or_field_name_rule.match(name) is not None:
+            name = AgentLogger.sanitize_metric_field_name(name=name)
             return name
 
         if is_metric and logger is not None:
@@ -765,6 +793,8 @@ class AgentLogger(logging.Logger):
 
         if not re.match(r"^[_a-zA-Z]", name):
             name = "sa_" + name
+
+        name = AgentLogger.sanitize_metric_field_name(name=name)
         return re.sub(r"[^\w\-\.]", "_", name)
 
     def report_values(self, values, monitor=None):

--- a/tests/unit/scalyr_logging_test.py
+++ b/tests/unit/scalyr_logging_test.py
@@ -225,6 +225,46 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
         )
         monitor_logger.closeMetricLog()
 
+    def test_metric_logging_reserved_extra_field_names_are_sanitized(self):
+        monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
+        metric_file_fd, metric_file_path = tempfile.mkstemp(".log")
+
+        # NOTE: We close the fd here because we open it again below. This way file deletion at
+        # the end works correctly on Windows.
+        os.close(metric_file_fd)
+
+        extra_fields = {
+            # Reserved field names
+            "logfile": "logfile",
+            "monitor": "monitor",
+            "metric": "metric",
+            "value": "value",
+            "instance": "instance",
+            "severity": "severity",
+            # Non reserved field names
+            "foo": "bar",
+            "bar": "baz",
+        }
+
+        monitor_logger = scalyr_logging.getLogger(
+            "scalyr_agent.builtin_monitors.foo(1)"
+        )
+        monitor_logger.openMetricLogForMonitor(metric_file_path, monitor_instance)
+        monitor_logger.emit_value("test_name", 5, extra_fields)
+
+        self.assertEquals(monitor_instance.reported_lines, 1)
+
+        # The value should only appear in the metric log file and not the main one.
+        self.assertLogFileContainsLineRegex(
+            file_path=metric_file_path, expression="test_name 5"
+        )
+        self.assertLogFileContainsLineRegex(
+            file_path=metric_file_path,
+            expression='test_name 5 bar="baz" foo="bar" instance_="instance" logfile_="logfile" metric_="metric" monitor_="monitor" severity_="severity" value_="value"',
+        )
+
+        monitor_logger.closeMetricLog()
+
     def test_metric_logging_extra_fields_are_sorted(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
         metric_file_fd, metric_file_path = tempfile.mkstemp(".log")


### PR DESCRIPTION
This pull request updates ``emit_value()`` agent logger code which is used by all the monitors to emit metric values to escape / sanitize metric field names which are considered special / reserved (logfile, monitor, metric, value, instance, severity).

This is needed to avoid collisions with special / reserved event attribute names which are set by the server side agent metrics parser code and are needed for various tsdb queries to work correctly.

Those reserved field names are sanitized by suffixing them with `_` (e.g. ``metric`` becomes ``metric``). This suffix was chosen for consistency with the existing server-side parsing behavior (in some situations server side parsing code adds `_` to original field values, e.g. `timestamp_`, ``message_``, etc.).