### PR TITLE
Client side rate calculation for counter metrics

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -120,6 +120,7 @@ from scalyr_agent.platform_controller import (
 )
 from scalyr_agent.platform_controller import AgentNotRunning
 from scalyr_agent.build_info import get_build_revision
+from scalyr_agent.metrics.base import clear_internal_cache
 from scalyr_agent import config_main
 from scalyr_agent import compat
 import scalyr_agent.monitors_manager
@@ -1501,6 +1502,9 @@ class ScalyrAgent(object):
                             current_time,
                         )
                     )
+
+                    # Clear metrics functions related cache
+                    clear_internal_cache()
 
                 # Log the stats one more time before we terminate.
                 self.__log_overall_stats(

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -867,7 +867,7 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
 
             if scrape_config:
                 self._logger.debug(
-                    f'Found scrape url "{scrape_config.scrape_url}" for pod {pod.namespace}/{pod.name} ({pod.uid})',
+                    f'Found scrape url "{scrape_config.scrape_url}" for pod {pod.namespace}/{pod.name} ({pod.uid}) with scrape config "{scrape_config}"',
                 )
                 assert (
                     scrape_config.scrape_url not in scrape_configs

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1635,6 +1635,16 @@ class Configuration(object):
         )
 
     @property
+    def calculate_rate_metric_names(self):
+        """
+        Returns the configuration value for 'calculate_rate_metric_names'.
+
+        This value should include a list of metric name (global across all the monitors for which)
+        rate value should be calculated on the agent side.
+        """
+        return self.__get_config().get_json_array("calculate_rate_metric_names")
+
+    @property
     def minimum_scan_interval(self):
         """Returns the configuration value for 'minimum_scan_interval'."""
         return self.__get_config().get_int(
@@ -2242,7 +2252,15 @@ class Configuration(object):
             separators=[None, ","],
             env_aware=True,
         )
-
+        self.__verify_or_set_optional_array_of_strings(
+            config,
+            "calculate_rate_metric_names",
+            [],
+            description,
+            apply_defaults,
+            separators=[None, ","],
+            env_aware=True,
+        )
         self.__verify_or_set_optional_string(
             config,
             "max_send_rate_enforcement",

--- a/scalyr_agent/metrics/base.py
+++ b/scalyr_agent/metrics/base.py
@@ -1,0 +1,105 @@
+# Copyright 2014-2022 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+
+"""
+Metric functions related base functionality.
+
+NOTE: Right now this code is only used inside a single thread so it's not designed to be thread
+safe.
+"""
+
+__all__ = [
+    "get_functions_for_metric",
+    "clear_internal_cache",
+]
+
+if False:
+    from typing import List
+    from typing import Dict
+
+    from scalyr_agent.scalyr_monitor import ScalyrMonitor  # NOQA
+
+import six
+
+from scalyr_agent.metrics.functions import MetricFunction
+from scalyr_agent.metrics.functions import RateMetricFunction
+from scalyr_agent.scalyr_logging import getLogger
+
+LOG = getLogger(__name__)
+
+
+# Stores a list of class instance (singleton) for each available metric function.
+# TODO: Once we only support Python 3 use registry / adapter pattern
+FUNCTIONS_REGISTRY = {
+    "rate": RateMetricFunction(),
+}
+
+# Stores cached list of MetricFunction class instances for the provided monitor and metric name
+# This cache needs to be invalidated each time config is reloaded and a chance is found.
+MONITOR_METRIC_TO_FUNCTIONS_CACHE = (
+    {}
+)  # type: Dict[six.text_type, List[MetricFunction]]
+
+
+def get_functions_for_metric(monitor, metric_name):
+    # type: (ScalyrMonitor, six.text_type) -> List[MetricFunction]
+    """
+    Return a list of class instances for functions which should be applied to this metric.
+
+    TODO:
+
+      - [ ] To speed things up, we should cache this result per metric name or similar (this does
+           increase the complexity though since we would need to invalidate the cache on each
+           config reload and similar).
+      - [ ] To speed up the common case then there are no functions defined, we should short circuit
+           in such scenario.
+    """
+    cache_key = "%s.%s" % (monitor.short_hash, metric_name)
+
+    if cache_key not in MONITOR_METRIC_TO_FUNCTIONS_CACHE:
+        result = []
+
+        for function_instance in FUNCTIONS_REGISTRY.values():
+            if function_instance.should_calculate(
+                monitor=monitor, metric_name=metric_name
+            ):
+                result.append(function_instance)
+
+        MONITOR_METRIC_TO_FUNCTIONS_CACHE[cache_key] = result
+
+    return MONITOR_METRIC_TO_FUNCTIONS_CACHE[cache_key]
+
+
+def clear_registry_cache():
+    global MONITOR_METRIC_TO_FUNCTIONS_CACHE
+
+    LOG.debug("Clearing registry cache")
+
+    MONITOR_METRIC_TO_FUNCTIONS_CACHE = {}
+
+
+def clear_internal_cache():
+    """
+    Clear internal cache where we store various metadata and metric related values which are needed
+    to calculate derived metrics.
+    """
+    LOG.debug("Clearing internal cache")
+
+    # 1. Clear module level cache (registry)
+    clear_registry_cache()
+
+    # 2. Clear function level cache
+    for function_instance in FUNCTIONS_REGISTRY.values():
+        function_instance.clear_cache()

--- a/scalyr_agent/metrics/base.py
+++ b/scalyr_agent/metrics/base.py
@@ -41,13 +41,13 @@ LOG = getLogger(__name__)
 
 
 # Stores a list of class instance (singleton) for each available metric function.
-# TODO: Once we only support Python 3 use registry / adapter pattern
+# TODO: Once we only support Python 3 use registry / adapter pattern.
 FUNCTIONS_REGISTRY = {
     "rate": RateMetricFunction(),
 }
 
-# Stores cached list of MetricFunction class instances for the provided monitor and metric name
-# This cache needs to be invalidated each time config is reloaded and a chance is found.
+# Stores cached list of MetricFunction class instances for the provided monitor and metric name.
+# This cache needs to be invalidated each time config is reloaded and config change is detected.
 MONITOR_METRIC_TO_FUNCTIONS_CACHE = (
     {}
 )  # type: Dict[six.text_type, List[MetricFunction]]
@@ -59,10 +59,6 @@ def get_functions_for_metric(monitor, metric_name):
     Return a list of class instances for functions which should be applied to this metric.
 
     TODO:
-
-      - [ ] To speed things up, we should cache this result per metric name or similar (this does
-           increase the complexity though since we would need to invalidate the cache on each
-           config reload and similar).
       - [ ] To speed up the common case then there are no functions defined, we should short circuit
            in such scenario.
     """

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -36,6 +36,10 @@ import six
 
 
 class MetricFunction(six.with_metaclass(ABCMeta)):
+    # Suffix which get's added to the derived metric name. For example, if metric name is
+    # "cpu.seconds_total", derived rate metric would be named "cpu.seconds_total_rate"
+    METRIC_SUFFIX = ""  # type: str
+
     @classmethod
     @abstractmethod
     def should_calculate(cls, monitor, metric_name):
@@ -70,6 +74,8 @@ class MetricFunction(six.with_metaclass(ABCMeta)):
 
 
 class RateMetricFunction(MetricFunction):
+    METRIC_SUFFIX = "_rate"
+
     # Stores metric values and timestamp for the metrics which we calculate per second rate in the
     # agent.
     # Maps <monitor name + monitor instance id short hash>.<metric name> to a tuple
@@ -221,7 +227,7 @@ could add overhead in terms of CPU and memory usage.
             ),
         )
 
-        rate_metric_name = "%s_rate" % (metric_name)
+        rate_metric_name = "%s%s" % (metric_name, cls.METRIC_SUFFIX)
         # TODO: Use dataclass once we only support Python 3
         result = [(rate_metric_name, rate_value)]
         return result

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -240,14 +240,16 @@ could add overhead in terms of CPU and memory usage.
         if not monitor or not monitor._global_config:
             return False
 
+        config_entry_key = "%s:%s" % (monitor.monitor_module_name, metric_name)
+
         config_calculate_rate_metric_names = (
             monitor._global_config.calculate_rate_metric_names
         )
         monitor_calculate_rate_metric_names = monitor.get_calculate_rate_metric_names()
 
         return (
-            metric_name in config_calculate_rate_metric_names
-            or metric_name in monitor_calculate_rate_metric_names
+            config_entry_key in config_calculate_rate_metric_names
+            or config_entry_key in monitor_calculate_rate_metric_names
         )
 
     @classmethod

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -14,8 +14,8 @@
 # ------------------------------------------------------------------------
 
 """
-This module contains various functions which can be applied to metrics to calculate various derived
-values (e.g. rates, aggregations, etc).
+This module contains various functions which can be applied to metrics to calculate derived values
+such as rates, derivatives, aggregations, etc.
 """
 
 if False:
@@ -51,6 +51,12 @@ class MetricFunction(six.with_metaclass(ABCMeta)):
         # type: (ScalyrMonitor, six.text_type, Union[int, float], Optional[int]) -> Optional[List[Tuple[str, float]]]
         """
         Run function on the provided metric and return any derived metrics which should be emitted.
+
+        :param monitor: ScalyrMonitor instance.
+        :param metric_name: Metric name.
+        :param metric_value: Metric value.
+        :param timestamp: Optional timestamp of metric collection in ms. If not provided, we
+                          default to current time.
         """
         pass
 
@@ -58,7 +64,7 @@ class MetricFunction(six.with_metaclass(ABCMeta)):
     def clear_cache(cls):
         # type: () -> None
         """
-        Clear any internal cache used by the class.
+        Clear any internal cache used by the class (if any).
         """
         pass
 

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -1,0 +1,243 @@
+# Copyright 2014-2022 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+
+"""
+This module contains various functions which can be applied to metrics to calculate various derived
+values (e.g. rates, aggregations, etc).
+"""
+
+if False:
+    from typing import Optional
+    from typing import List
+    from typing import Union
+    from typing import Tuple
+
+    from scalyr_agent.scalyr_monitor import ScalyrMonitor  # NOQA
+
+import time
+
+from abc import ABCMeta
+from abc import abstractmethod
+from collections import defaultdict
+
+import six
+
+
+class MetricFunction(six.with_metaclass(ABCMeta)):
+    @classmethod
+    @abstractmethod
+    def should_calculate(cls, monitor, metric_name):
+        # type: (ScalyrMonitor, six.text_type) -> bool
+        """
+        Return True if this function should be calculated for the provided metric.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def calculate(cls, monitor, metric_name, metric_value, timestamp):
+        # type: (ScalyrMonitor, six.text_type, Union[int, float], Optional[int]) -> Optional[List[Tuple[str, float]]]
+        """
+        Run function on the provided metric and return any derived metrics which should be emitted.
+        """
+        pass
+
+    @classmethod
+    def clear_cache(cls):
+        # type: () -> None
+        """
+        Clear any internal cache used by the class.
+        """
+        pass
+
+
+class RateMetricFunction(MetricFunction):
+    # Stores metric values and timestamp for the metrics which we calculate per second rate in the
+    # agent.
+    # Maps <monitor name + monitor instance id short hash>.<metric name> to a tuple
+    # (<timestamp_of_previous_colection>, <previously_collected_value>).
+    # To avoid collisions across monitors (same metric name can be used by multiple monitors), we prefix
+    # metric name with a short hash of the monitor FQDN (<monitor module>.<monitor class name>) +
+    # monitor instance id. We use a short hash and not fully qualified monitor name to reduce memory
+    # usage a bit.
+    # NOTE: Those values are not large, but we should probably still implement some kind of watch dog
+    # job where we periodically purge out entries for values which are older than MAX_RATE_TIMESTAMP_DELTA_SECONDS
+    # (since those won't be used for calculation anyway).
+    RATE_CALCULATION_METRIC_VALUES = defaultdict(lambda: (None, None))
+
+    # If the time delta between previous metric collection timestamp value and current metric collection
+    # timestamp value is longer than this amount of seconds (11 minutes by default), we will ignore
+    # previous value and not calculate the rate with old / stale metric value.
+    MAX_RATE_TIMESTAMP_DELTA_SECONDS = 11 * 60
+
+    # If we track rate for more than this many metrics, a warning will be emitted.
+    MAX_RATE_METRICS_COUNT_WARN = 5000
+
+    MAX_RATE_METRIC_WARN_MESSAGE = """
+Tracking client side rate for over %s metrics. Tracking and calculating rate for that many metrics
+could add overhead in terms of CPU and memory usage.
+    """.strip() % (
+        MAX_RATE_METRICS_COUNT_WARN
+    )
+
+    @classmethod
+    def calculate(cls, monitor, metric_name, metric_value, timestamp=None):
+        """
+        Calculate per second rate for the provided metric name (if configured to do so).
+
+        The formula used is:
+
+            (<current metric value> - <previous metric value>) / (<current collection timestamp in seconds> - <previous collection timestamp in seconds>)
+
+        This method also takes into account and handles the following scenarios:
+
+            - Metric value is not a number
+            - New metric value is smaller than previous one
+            - New metric collection timestamp is smaller or equal to the previous one
+            - Time delta between current and previous metric collection timestamp is larged than the
+              defined upper bound
+
+        :param monitor: Monitor instance.
+        :param metric_name: Metric name,
+        :param metric_value: Metric value.
+        :param timestamp: Optional metric timestamp in ms.
+        """
+        if timestamp:
+            timestamp_s = timestamp / 1000
+        else:
+            timestamp_s = int(time.time())
+
+        if not isinstance(metric_value, (int, float)):
+            limit_key = "%s-nan" % (metric_name)
+            monitor._logger.warn(
+                'Metric "%s" is not a number. Cannot calculate rate.' % (metric_name),
+                limit_once_per_x_secs=86400,
+                limit_key=limit_key,
+            )
+            return None
+
+        # To avoid collisions across multiple monitors (same metric name being used by multiple
+        # monitors), we prefix data in internal dictionary with the short hash of the fully
+        # qualified monitor name
+        dict_key = monitor.short_hash + "." + metric_name
+
+        (
+            previous_collection_timestamp,
+            previous_metric_value,
+        ) = cls.RATE_CALCULATION_METRIC_VALUES[dict_key]
+
+        if previous_collection_timestamp is None or previous_metric_value is None:
+            # If this is first time we see this metric, we just store the value sine we don't have
+            # previous sample yet to be able to calculate rate
+            monitor._logger.debug(
+                'No previous data yet for metric "%s", unable to calculate rate yet.'
+                % (metric_name)
+            )
+
+            cls.RATE_CALCULATION_METRIC_VALUES[dict_key] = (timestamp_s, metric_value)
+            return None
+
+        if timestamp_s <= previous_collection_timestamp:
+            monitor._logger.debug(
+                'Current timestamp for metric "%s" is smaller or equal to current timestamp, cant '
+                "calculate rate (timestamp_previous=%s,timestamp_current=%s)"
+                % (metric_name, previous_collection_timestamp, timestamp_s)
+            )
+            return None
+
+        # If time delta between previous and current collection timestamp is too large, we ignore
+        # the previous value (but we still store the latest value for future rate calculations)
+        if (
+            timestamp_s - previous_collection_timestamp
+        ) >= cls.MAX_RATE_TIMESTAMP_DELTA_SECONDS:
+            monitor._logger.debug(
+                'Time delta between previous and current metric collection timestamp for metric "%s"'
+                "is larger than %s seconds, ignoring rate calculation (timestamp_previous=%s,timestamp_current=%s)"
+                % (
+                    metric_name,
+                    cls.MAX_RATE_TIMESTAMP_DELTA_SECONDS,
+                    previous_collection_timestamp,
+                    timestamp_s,
+                )
+            )
+
+            cls.RATE_CALCULATION_METRIC_VALUES[dict_key] = (timestamp_s, metric_value)
+            return None
+
+        # NOTE: Metrics for which we calculate rates need to be counters. This means they
+        # should be increasing over time. If new value is < old value, we skip calculation (same
+        # as the current server side implementation)
+        if metric_value < previous_metric_value:
+            monitor._logger.debug(
+                'Current metric value for metric "%s" is smaller than previous value (current_value=%s,previous_value=%s)'
+                % (metric_name, metric_value, previous_metric_value)
+            )
+            return None
+
+        rate_value = round(
+            (metric_value - previous_metric_value)
+            / (timestamp_s - previous_collection_timestamp),
+            5,
+        )
+
+        cls.RATE_CALCULATION_METRIC_VALUES[dict_key] = (timestamp_s, metric_value)
+
+        if len(cls.RATE_CALCULATION_METRIC_VALUES) > cls.MAX_RATE_METRICS_COUNT_WARN:
+            # Warn if we are tracking rate for a large number of metrics which could cause
+            # performance issues / overhead
+            monitor._logger.warn(
+                cls.MAX_RATE_METRIC_WARN_MESSAGE,
+                limit_once_per_x_secs=86400,
+                limit_key="rate-max-count-reached",
+            )
+
+        monitor._logger.debug(
+            'Calculated rate "%s" for metric "%s" (previous_collection_timestamp=%s,previous_metric_value=%s,current_timestamp=%s,current_value=%s)'
+            % (
+                rate_value,
+                metric_name,
+                previous_collection_timestamp,
+                previous_metric_value,
+                timestamp_s,
+                metric_value,
+            ),
+        )
+
+        rate_metric_name = "%s_rate" % (metric_name)
+        # TODO: Use dataclass once we only support Python 3
+        result = [(rate_metric_name, rate_value)]
+        return result
+
+    @classmethod
+    def should_calculate(cls, monitor, metric_name):
+        """
+        Return True if client side rate should be calculated for the provided metric.
+        """
+        if not monitor or not monitor._global_config:
+            return False
+
+        config_calculate_rate_metric_names = (
+            monitor._global_config.calculate_rate_metric_names
+        )
+        monitor_calculate_rate_metric_names = monitor.get_calculate_rate_metric_names()
+
+        return (
+            metric_name in config_calculate_rate_metric_names
+            or metric_name in monitor_calculate_rate_metric_names
+        )
+
+    @classmethod
+    def clear_cache(cls):
+        cls.RATE_CALCULATION_METRIC_VALUES = defaultdict(lambda: (None, None))

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -75,11 +75,14 @@ DEBUG_LEVEL_5 = 4
 
 # Stores metric values and timestamp for the metrics which we calculate per second rate on the
 # agent.
-# Maps <monitor name short hash>.<metric name> to a tuple (<timestamp_of_previous_colection>,
-# <previously_collected_value>).
+# Maps <monitor name + monitor instance id short hash>.<metric name> to a tuple
+# (<timestamp_of_previous_colection>, <previously_collected_value>).
 # To avoid collisions across monitors (same metric name can be used by multiple monitors), we prefix
 # metric name with a short hash of the monitor FQDN (<monitor module>.<monitor class> name). We
 # use a short hash and not fully qualified monitor name to reduce memory usage a bit.
+# NOTE: Those values are not large but we should probably still implement some kind of watch dog
+# timer where we periodically purge out entries for values which are older than MAX_RATE_TIMESTAMP_DELTA_SECONDS
+# (since those won't be used for calculation anyway).
 RATE_CALCULATION_METRIC_VALUES = defaultdict(lambda: (None, None))
 
 # If the time delta between previous metric value and current metric value is longer than this

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -111,6 +111,15 @@ RESERVED_EVENT_ATTRIBUTE_NAMES = [
 ]
 
 
+def clear_rate_cache():
+    """
+    Clear internal cache where we store metric values we need to calculate per second rates for
+    whitelisted metrics.
+    """
+    global RATE_CALCULATION_METRIC_VALUES
+    RATE_CALCULATION_METRIC_VALUES = defaultdict(lambda: (None, None))
+
+
 # noinspection PyPep8Naming
 def getLogger(name):
     """Returns a logger instance to use for the given name that implements the Scalyr agent's extra logging features.
@@ -480,7 +489,7 @@ class AgentLogger(logging.Logger):
 
         if timestamp_s <= previous_collection_timestamp:
             monitor._logger.debug(
-                'Current timestamp for metric "%s" is smaller or equal to current timestamp, cant'
+                'Current timestamp for metric "%s" is smaller or equal to current timestamp, cant '
                 "calculate rate (timestamp_previous=%s,timestamp_current=%s)"
                 % (metric_name, previous_collection_timestamp, timestamp_s)
             )

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -471,7 +471,7 @@ class AgentLogger(logging.Logger):
         if timestamp:
             timestamp_s = timestamp / 1000
         else:
-            timestamp_s = timestamp or int(time.time())
+            timestamp_s = int(time.time())
 
         if not isinstance(metric_value, (int, float)):
             limit_key = "%s-nan" % (metric_name)
@@ -672,7 +672,6 @@ class AgentLogger(logging.Logger):
             monitor_id_override=monitor_id_override,
             timestamp=timestamp,
         )
-        # string_buffer.close()
 
         # Calculate and emit metric per second rate value (if configured and available for this
         # metric.

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -30,8 +30,6 @@ __author__ = "czerwin@scalyr.com"
 
 if False:  # NOSONAR
     from typing import Dict
-    from typing import Optional
-    from typing import Union
 
     # Workaround for a cyclic import - scalyr_monitor depends on scalyr_logging and vice versa
     from scalyr_agent.scalyr_monitor import ScalyrMonitor
@@ -45,7 +43,6 @@ import time
 import threading
 import io
 import inspect
-from collections import defaultdict
 
 import six
 
@@ -73,33 +70,6 @@ DEBUG_LEVEL_3 = 6
 DEBUG_LEVEL_4 = 5
 DEBUG_LEVEL_5 = 4
 
-# Stores metric values and timestamp for the metrics which we calculate per second rate in the
-# agent.
-# Maps <monitor name + monitor instance id short hash>.<metric name> to a tuple
-# (<timestamp_of_previous_colection>, <previously_collected_value>).
-# To avoid collisions across monitors (same metric name can be used by multiple monitors), we prefix
-# metric name with a short hash of the monitor FQDN (<monitor module>.<monitor class name>) +
-# monitor instance id. We use a short hash and not fully qualified monitor name to reduce memory
-# usage a bit.
-# NOTE: Those values are not large, but we should probably still implement some kind of watch dog
-# job where we periodically purge out entries for values which are older than MAX_RATE_TIMESTAMP_DELTA_SECONDS
-# (since those won't be used for calculation anyway).
-RATE_CALCULATION_METRIC_VALUES = defaultdict(lambda: (None, None))
-
-# If the time delta between previous metric collection timestamp value and current metric collection
-# timestamp value is longer than this amount of seconds (11 minutes by default), we will ignore
-# previous value and not calculate the rate with old / stale metric value.
-MAX_RATE_TIMESTAMP_DELTA_SECONDS = 11 * 60
-
-# If we track rate for more than this many metrics, a warning will be emitted.
-MAX_RATE_METRICS_COUNT_WARN = 5000
-
-MAX_RATE_METRIC_WARN_MESSAGE = """
-Tracking client side rate for over %s metrics. Tracking and calculating rate for that many metrics
-could add overhead in terms of CPU and memory usage.
-""".strip() % (
-    MAX_RATE_METRICS_COUNT_WARN
-)
 
 # Stores a list of "reserved" event level attribute names. If we detect metric extra field with this
 # name we sanitize / escape it by adding "_" suffix to the field name. This way we avoid possible
@@ -113,15 +83,6 @@ RESERVED_EVENT_ATTRIBUTE_NAMES = [
     "instance",
     "severity",
 ]
-
-
-def clear_rate_cache():
-    """
-    Clear internal cache where we store metric values we need to calculate per second rates for
-    whitelisted metrics.
-    """
-    global RATE_CALCULATION_METRIC_VALUES
-    RATE_CALCULATION_METRIC_VALUES = defaultdict(lambda: (None, None))
 
 
 # noinspection PyPep8Naming
@@ -421,155 +382,6 @@ class AgentLogger(logging.Logger):
         # right level.
         __log_manager__.add_logger_instance(self)
 
-    def _should_calculate_metric_rate(self, monitor, metric_name):
-        # type: (ScalyrMonitor, str) -> bool
-        """
-        Return True if client side rate should be calculated for the provided metric.
-        """
-        if not monitor or not monitor._global_config:
-            return False
-
-        config_calculate_rate_metric_names = (
-            monitor._global_config.calculate_rate_metric_names
-        )
-        monitor_calculate_rate_metric_names = monitor.get_calculate_rate_metric_names()
-
-        return (
-            metric_name in config_calculate_rate_metric_names
-            or metric_name in monitor_calculate_rate_metric_names
-        )
-
-    def _calculate_metric_rate(
-        self, monitor, metric_name, metric_value, timestamp=None
-    ):
-        # type: (ScalyrMonitor, str, Union[int, float], Optional[int]) -> Optional[float]
-        """
-        Calculate per second rate for the provided metric name (if configured to do so).
-
-        The formula used is:
-
-            (<current metric value> - <previous metric value>) / (<current collection timestamp in s> - <previous collection timestamp in s>)
-
-        This method also takes into account and handles the following scenarios:
-
-            - Metric value is not a number
-            - New metric value is smaller than previous one
-            - New metric collection timestamp is smaller or equal to the previous one
-            - Time delta between current and previous metric collection timestamp is larged than the
-              defined upper bound
-
-        :param monitor: Monitor instance.
-        :param metric_name: Metric name,
-        :param metric_value: Metric value.
-        :param timestamp: Optional metric timestamp in ms.
-        """
-        if not self._should_calculate_metric_rate(
-            monitor=monitor, metric_name=metric_name
-        ):
-            return None
-
-        if timestamp:
-            timestamp_s = timestamp / 1000
-        else:
-            timestamp_s = int(time.time())
-
-        if not isinstance(metric_value, (int, float)):
-            limit_key = "%s-nan" % (metric_name)
-            monitor._logger.warn(
-                'Metric "%s" is not a number. Cannot calculate rate.' % (metric_name),
-                limit_once_per_x_secs=86400,
-                limit_key=limit_key,
-            )
-            return None
-
-        # To avoid collisions across multiple monitors (same metric name being used by multiple
-        # monitors), we prefix data in internal dictionary with the short hash of the fully
-        # qualified monitor name
-        dict_key = monitor.short_hash + "." + metric_name
-
-        (
-            previous_collection_timestamp,
-            previous_metric_value,
-        ) = RATE_CALCULATION_METRIC_VALUES[dict_key]
-
-        if previous_collection_timestamp is None or previous_metric_value is None:
-            # If this is first time we see this metric, we just store the value sine we don't have
-            # previous sample yet to be able to calculate rate
-            monitor._logger.debug(
-                'No previous data yet for metric "%s", unable to calculate rate yet.'
-                % (metric_name)
-            )
-
-            RATE_CALCULATION_METRIC_VALUES[dict_key] = (timestamp_s, metric_value)
-            return None
-
-        if timestamp_s <= previous_collection_timestamp:
-            monitor._logger.debug(
-                'Current timestamp for metric "%s" is smaller or equal to current timestamp, cant '
-                "calculate rate (timestamp_previous=%s,timestamp_current=%s)"
-                % (metric_name, previous_collection_timestamp, timestamp_s)
-            )
-            return None
-
-        # If time delta between previous and current collection timestamp is too large, we ignore
-        # the previous value (but we still store the latest value for future rate calculations)
-        if (
-            timestamp_s - previous_collection_timestamp
-        ) >= MAX_RATE_TIMESTAMP_DELTA_SECONDS:
-            monitor._logger.debug(
-                'Time delta between previous and current metric collection timestamp for metric "%s"'
-                "is larger than %s seconds, ignoring rate calculation (timestamp_previous=%s,timestamp_current=%s)"
-                % (
-                    metric_name,
-                    MAX_RATE_TIMESTAMP_DELTA_SECONDS,
-                    previous_collection_timestamp,
-                    timestamp_s,
-                )
-            )
-
-            RATE_CALCULATION_METRIC_VALUES[dict_key] = (timestamp_s, metric_value)
-            return None
-
-        # NOTE: Metrics for which we calculate rates need to be counters. This means they
-        # should be increasing over time. If new value is < old value, we skip calculation (same
-        # as the current server side implementation)
-        if metric_value < previous_metric_value:
-            monitor._logger.debug(
-                'Current metric value for metric "%s" is smaller than previous value (current_value=%s,previous_value=%s)'
-                % (metric_name, metric_value, previous_metric_value)
-            )
-            return None
-
-        rate_value = round(
-            (metric_value - previous_metric_value)
-            / (timestamp_s - previous_collection_timestamp),
-            5,
-        )
-
-        RATE_CALCULATION_METRIC_VALUES[dict_key] = (timestamp_s, metric_value)
-
-        if len(RATE_CALCULATION_METRIC_VALUES) > MAX_RATE_METRICS_COUNT_WARN:
-            # Warn if we are tracking rate for a large number of metrics which could cause
-            # performance issues / overhead
-            monitor._logger.warn(
-                MAX_RATE_METRIC_WARN_MESSAGE,
-                limit_once_per_x_secs=86400,
-                limit_key="rate-max-count-reached",
-            )
-
-        monitor._logger.debug(
-            'Calculated rate "%s" for metric "%s" (previous_collection_timestamp=%s,previous_metric_value=%s,current_timestamp=%s,current_value=%s)'
-            % (
-                rate_value,
-                metric_name,
-                previous_collection_timestamp,
-                previous_metric_value,
-                timestamp_s,
-                metric_value,
-            ),
-        )
-        return rate_value
-
     def emit_value(
         self,
         metric_name,
@@ -673,19 +485,27 @@ class AgentLogger(logging.Logger):
             timestamp=timestamp,
         )
 
-        # Calculate and emit metric per second rate value (if configured and available for this
-        # metric.
-        # For consistency with server side, we add "_rate" suffix to the calculated rates.
-        # For example: calculate_rate_metric_names -> calculate_rate_metric_names_rate
-        metric_rate_value = self._calculate_metric_rate(
-            monitor, metric_name, metric_value, timestamp
+        # Run and calculate any functions which should be applied (as configured) to this metric
+        from scalyr_agent.metrics.base import get_functions_for_metric
+
+        function_instances = get_functions_for_metric(
+            monitor=monitor, metric_name=metric_name
         )
 
-        if metric_rate_value:
-            # NOTE: We include extra_fields from the original metric, but that may not be needed
-            metric_name_rate = "%s_rate" % (metric_name)
+        derived_metrics_to_emit = []
+        for function_instance in function_instances:
+            metric_tuples = function_instance.calculate(
+                monitor=monitor,
+                metric_name=metric_name,
+                metric_value=metric_value,
+                timestamp=timestamp,
+            )
+            derived_metrics_to_emit.extend(metric_tuples or [])
+
+        # NOTE: We always include original extra_fields (if any) for any derived metrics
+        for derived_metric_name, derived_metric_value in derived_metrics_to_emit:
             self.info(
-                "%s %s" % (metric_name_rate, util.json_encode(metric_rate_value))
+                "%s %s" % (derived_metric_name, util.json_encode(derived_metric_value))
                 + extra_fields_string_buffer.getvalue(),
                 metric_log_for_monitor=monitor,
                 monitor_id_override=monitor_id_override,

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -121,6 +121,10 @@ class ScalyrMonitor(StoppableThread):
         # The logger instance that this monitor should use to report all information and metric values.
         self._logger = logger
         self.monitor_name = monitor_config["module"]
+        # Includes just the monitor module name. For example, if the full module name is
+        # "scalyr_agent.builtin_monitors.symlink_file_monitor", module name would be
+        # "symlink_file_monitor"
+        self.monitor_module_name = self.monitor_name.split(".")[-1]
         # NOTE: In case there is only one monitor configured without "id" attribute defined, the
         # value will be set to empty string. In case there are multiple monitor configs defined, but
         # the user doesn't explicitly set "id" attribute for those, config index (number) will be

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -121,9 +121,15 @@ class ScalyrMonitor(StoppableThread):
         # The logger instance that this monitor should use to report all information and metric values.
         self._logger = logger
         self.monitor_name = monitor_config["module"]
-        self.short_hash = hashlib.sha256(self.monitor_name.encode("utf-8")).hexdigest()[
-            :10
-        ]
+        # NOTE: In case there is only one monitor configured without "id" attribute defined, the
+        # value will be set to empty string. In case there are multiple monitor configs defined, but
+        # the user doesn't explicitly set "id" attribute for those, config index (number) will be
+        # used.
+        self.monitor_id = str(monitor_config.get("id", "") or "default")
+        # Short hash of this monitor instance which is unique across all the monitors
+        self.short_hash = hashlib.sha256(
+            self.monitor_name.encode("utf-8") + b":" + self.monitor_id.encode("utf-8")
+        ).hexdigest()[:10]
 
         # Holds raw monitor name without the part which are specific to monitor instances
         if "." in monitor_config["module"]:

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -34,6 +34,7 @@ import os
 import sys
 import time
 import random
+import hashlib
 from threading import Lock
 
 import six
@@ -120,6 +121,9 @@ class ScalyrMonitor(StoppableThread):
         # The logger instance that this monitor should use to report all information and metric values.
         self._logger = logger
         self.monitor_name = monitor_config["module"]
+        self.short_hash = hashlib.sha256(self.monitor_name.encode("utf-8")).hexdigest()[
+            :10
+        ]
 
         # Holds raw monitor name without the part which are specific to monitor instances
         if "." in monitor_config["module"]:
@@ -468,6 +472,17 @@ class ScalyrMonitor(StoppableThread):
         if self.__metric_log_open:
             self._logger.closeMetricLog()
             self.__metric_log_open = False
+
+    def get_calculate_rate_metric_names(self):
+        """
+        Return a list of metric names for this monitor for which rate should be calculated on the
+        agent side.
+
+        This method can either return value which is read from the monitor config or it can obtain
+        a list of those metric names dynamically (e.g. from the OpenMetrics metric schema / type or
+        similar).
+        """
+        return []
 
     # 2->TODO '_is_stopped' name is reserved in python3
     def _is_thread_stopped(self):

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -196,6 +196,11 @@ class ScalyrMonitor(StoppableThread):
             "metric_name_blacklist", convert_to=ArrayOfStrings, default=[]
         )
 
+        # List of metric names for which per second rates should be calculated in the agent
+        self._calculate_rate_metric_name = self._config.get(
+            "calculate_rate_metric_names", convert_to=ArrayOfStrings, default=[]
+        )
+
         # If true, will adjust the sleep time between gather_sample calls by the time spent in gather_sample, rather
         # than sleeping the full sample_interval_secs time.
         self._adjust_sleep_by_gather_time = False
@@ -488,7 +493,7 @@ class ScalyrMonitor(StoppableThread):
         a list of those metric names dynamically (e.g. from the OpenMetrics metric schema / type or
         similar).
         """
-        return []
+        return self._calculate_rate_metric_name
 
     # 2->TODO '_is_stopped' name is reserved in python3
     def _is_thread_stopped(self):

--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -797,7 +797,7 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
             mock_monitors_manager.add_monitor.call_args_list[0][1]["monitor_config"][
                 "calculate_rate_metric_names"
             ],
-            ["metric5", "metric6"],
+            ["openmetrics_monitor:metric5", "openmetrics_monitor:metric6"],
         )
 
         # 4. And now API returns no pods which means all the monitors should be removed

--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -27,6 +27,7 @@ from scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor import (
     PROMETHEUS_ANNOTATION_SCRAPE_PORT,
     SCALYR_AGENT_ANNOTATION_SCRAPE_ENABLE,
     SCALYR_AGENT_ANNOTATION_ATTRIBUTES,
+    SCALYR_AGENT_ANNOTATION_CALCULATE_RATE_METRIC_NAMES,
     KubernetesOpenMetricsMonitor,
     K8sPod,
     TemplateWithSpecialCharacters,
@@ -73,6 +74,9 @@ for index, pod in enumerate(
         pod["metadata"]["annotations"][
             PROMETHEUS_ANNOTATION_SCRAPE_PATH
         ] = "/test/new/path"
+        pod["metadata"]["annotations"][
+            SCALYR_AGENT_ANNOTATION_CALCULATE_RATE_METRIC_NAMES
+        ] = "metric5,metric6"
 
 
 class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
@@ -285,6 +289,7 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
             "headers": None,
             "include_node_name": True,
             "include_cluster_name": True,
+            "calculate_rate_metric_names": ["metric1", "metric2"],
         }
         (
             monitor_config,
@@ -308,6 +313,7 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
             "metric_component_value_include_list": JsonObject({}),
             "metric_name_exclude_list": [],
             "metric_name_include_list": ["*"],
+            "calculate_rate_metric_names": ["metric1", "metric2"],
             "module": "scalyr_agent.builtin_monitors.openmetrics_monitor",
             "sample_interval": 10,
             "timeout": 10,
@@ -786,6 +792,12 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
                 "url"
             ],
             "http://10.5.5.5.141:9243/test/new/path",
+        )
+        self.assertEqual(
+            mock_monitors_manager.add_monitor.call_args_list[0][1]["monitor_config"][
+                "calculate_rate_metric_names"
+            ],
+            ["metric5", "metric6"],
         )
 
         # 4. And now API returns no pods which means all the monitors should be removed

--- a/tests/unit/scalyr_logging_test.py
+++ b/tests/unit/scalyr_logging_test.py
@@ -779,7 +779,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
         for index in range(0, RateMetricFunction.MAX_RATE_METRICS_COUNT_WARN + 1):
             monitor_instance._global_config.calculate_rate_metric_names.append(
-                "test_name_%s" % (index)
+                "fake_monitor_module:test_name_%s" % (index)
             )
 
         # NOTE: We close the fd here because we open it again below. This way file deletion at
@@ -829,7 +829,9 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
     @skipIf(sys.version_info < (2, 8, 0), "Skipping tests under Python <= 2.7")
     def test_emit_value_metric_rate_calculation_metric_metric_value_not_a_number(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
-        monitor_instance._global_config.calculate_rate_metric_names = ["test_name_2"]
+        monitor_instance._global_config.calculate_rate_metric_names = [
+            "fake_monitor_module:test_name_2"
+        ]
         metric_file_fd, metric_file_path = tempfile.mkstemp(".log")
 
         # NOTE: We close the fd here because we open it again below. This way file deletion at
@@ -869,7 +871,9 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
     @skipIf(sys.version_info < (2, 8, 0), "Skipping tests under Python <= 2.7")
     def test_emit_value_metric_rate_calculation_metric_invalid_timestamp(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
-        monitor_instance._global_config.calculate_rate_metric_names = ["test_name_2"]
+        monitor_instance._global_config.calculate_rate_metric_names = [
+            "fake_monitor_module:test_name_2"
+        ]
         metric_file_fd, metric_file_path = tempfile.mkstemp(".log")
 
         # NOTE: We close the fd here because we open it again below. This way file deletion at
@@ -904,7 +908,9 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
     @skipIf(sys.version_info < (2, 8, 0), "Skipping tests under Python <= 2.7")
     def test_emit_value_metric_rate_calculation_new_metric_smaller_than_previous(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
-        monitor_instance._global_config.calculate_rate_metric_names = ["test_name_2"]
+        monitor_instance._global_config.calculate_rate_metric_names = [
+            "fake_monitor_module:test_name_2"
+        ]
         metric_file_fd, metric_file_path = tempfile.mkstemp(".log")
 
         # NOTE: We close the fd here because we open it again below. This way file deletion at
@@ -930,7 +936,9 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
     @skipIf(sys.version_info < (2, 8, 0), "Skipping tests under Python <= 2.7")
     def test_emit_value_metric_rate_calculation_metric_not_whitelisted(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
-        monitor_instance._global_config.calculate_rate_metric_names = ["test_name_2"]
+        monitor_instance._global_config.calculate_rate_metric_names = [
+            "fake_monitor_module:test_name_2"
+        ]
         metric_file_fd, metric_file_path = tempfile.mkstemp(".log")
 
         # NOTE: We close the fd here because we open it again below. This way file deletion at
@@ -957,7 +965,9 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
     @skipIf(sys.version_info < (2, 8, 0), "Skipping tests under Python <= 2.7")
     def test_emit_value_metric_rate_calculation_metric_success(self):
         monitor_instance = ScalyrLoggingTest.FakeMonitor("testing")
-        monitor_instance._global_config.calculate_rate_metric_names = ["test_name_2"]
+        monitor_instance._global_config.calculate_rate_metric_names = [
+            "fake_monitor_module:test_name_2"
+        ]
         metric_file_fd, metric_file_path = tempfile.mkstemp(".log")
 
         # NOTE: We close the fd here because we open it again below. This way file deletion at
@@ -1022,14 +1032,20 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
     ):
         # Ensure there are no collisions in case two monitors use the same metric name
         monitor_instance_1 = ScalyrLoggingTest.FakeMonitor("testing-one")
-        monitor_instance_1._global_config.calculate_rate_metric_names = ["test_name_2"]
+        monitor_instance_1._global_config.calculate_rate_metric_names = [
+            "fake_monitor_module:test_name_2"
+        ]
 
         # Same monitor name, but a different instance id
         monitor_instance_2 = ScalyrLoggingTest.FakeMonitor("testing-one", "two")
-        monitor_instance_2._global_config.calculate_rate_metric_names = ["test_name_2"]
+        monitor_instance_2._global_config.calculate_rate_metric_names = [
+            "fake_monitor_module:test_name_2"
+        ]
 
         monitor_instance_3 = ScalyrLoggingTest.FakeMonitor("testing-two")
-        monitor_instance_3._global_config.calculate_rate_metric_names = ["test_name_2"]
+        monitor_instance_3._global_config.calculate_rate_metric_names = [
+            "fake_monitor_module:test_name_2"
+        ]
 
         metric_file_fd_1, metric_file_path_1 = tempfile.mkstemp(".log")
         metric_file_fd_2, metric_file_path_2 = tempfile.mkstemp(".log")
@@ -1127,6 +1143,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
         def __init__(self, name, monitor_id=None):
             self.__name = name
             self.monitor_id = str(monitor_id or "default")
+            self.monitor_module_name = "fake_monitor_module"
             self.short_hash = hashlib.sha256(
                 self.__name.encode("utf-8") + b":" + self.monitor_id.encode("utf-8")
             ).hexdigest()[:10]

--- a/win32/dynamic_modules.py
+++ b/win32/dynamic_modules.py
@@ -38,4 +38,5 @@ WINDOWS_MONITOR_MODULES_TO_EXCLUDE = [
     "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor",
     "scalyr_agent.builtin_monitors.openmetrics_monitor",
     "scalyr_agent.builtin_monitors.symlink_file_monitor",
+    "tests.unit.scalyr_logging_test",
 ]


### PR DESCRIPTION
## Description

This pull request implements client (agent) side per second rate calculation for "counter" metric types (metric types which values increase over time).

Having this functionality done on the client and not on the server will give us more flexibility and also works better with the new future "stateless" ingestion API.

## Proposed Implementation

I went with an implementation where per second rate is calculated inside the ``emit_value()`` method where metric values are emitted. This implementation is the simplest and doesn't require any large refactoring.

---

If in the future we will want to perform more client side aggregations and transformations we may want to change and refactor the code then - perhaps also do that in another background thread so we don't "block" writing metrics to monitor log file on disk in case a lot of calculations need to be done (but this could also be problematic and we would need to decide how and when to handle writing rate metrics to a file on disk - ideally we want them written to the disk in the same monitor log file and ingested as close as possible to the original metric value from which the derivatives are calculated).

### Notes on Edge Cases

Here is a list of the edge cases which are currently handled.

#### 1. We don't have previous value yet

This happens on initial monitor start up and / or restart where we don't have a previous value yet. In such case, we can't perform a rate calculation yet so we simply skip calculating rate.

#### 2. Current timestamp <= previous timestamp

If current collection timestamp is smaller or equal than previous one, we don't perform any calculation since this would result in an invalid value and division by zero.

Keep in mind that such scenario likely indicates bug / developer error (invalid timestamp being passed to the ``emit_value()`` method or similar).

#### 3. New metric value is < previous value

Rate is calculated for counter metrics which values should be increasing over time. If a new value is smaller than the previous one, we don't calculate the rate for that value. We only calculate the rate once a new value which is larger than the previous one is available.

#### 4. Time delta between the current and previous collection timestamp is too large

If time delta between previous metric collection value timestamp and current collection value timestamp is too large, we ignore the previous collection value and don't calculate the rate for it.

I used the same threshold value which is currently used on the server side - 11 minutes.

---

Most of those edge cases are handled in the similar manner as they are currently handled in the backend / server side code, but now we also have the opportunity to change and improve any of that behavior if we think that is justified and it makes sense.

## Configuration

Right now we only calculate per second rates for metrics which are specified in the ``calculate_rate_metric_names`` config option.

To begin with, we will likely define default value for this config option ourselves (which may be deployment dependent - thing Docker / Kubernetes vs non Docker deployment).

## Open Questions / To Decide

- [x] Should we persist "metadata" which is needed to calculate the rates (previous metric value, previous timestamp) on disk? This would allow us to pick up where we left up on agent / monitor restart or similar, but it does increase the complexity a bit and may not be needed since we already have an upper bound on previous metric value (11 minutes) before we consider it stale and don't use it for future metric calculations. In most cases, sample collection interval is 60 seconds so losing a rate value for one or two samples is probably not a problem (?).

## TODO

- [x] Allow user to define for which Kubernetes Open Metrics monitor metrics rates should be calculated using pod annotations.
- [x] Include monitor name in the internal value cache to avoid conflicts where the are the same metric names used by multiple monitors.

## TODO (future)

- [ ] Detect "counter" metric types and automatically "enroll" those metrics into client / agent side rate calculation. This can be done for monitors such as Open Metrics one where we know metric schema / type. For now, we probably don't want to do that for every single Open Metrics monitor counter metric type since there are many of those and this could include non-trivial amount of overhead. For the time being, it will be an opt-in functionality (we will likely define default values as part of the standard agent config).