### PR TITLE
Fix for syslog monitor issue on Windows when using TCP protocol

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2091,7 +2091,7 @@ jobs:
       - checkout
       - restore_cache:
           name: Restore Python installer Cache
-          key: windows-python-installer-cache-{{ .Branch }}-<< parameters.python-version >>
+          key: windows-v2-python-installer-cache-{{ .Branch }}-<< parameters.python-version >>
 
       - restore_cache:
           name: Restore Wix cache
@@ -2127,7 +2127,7 @@ jobs:
 
       - save_cache:
           name: Save Python Installer Cache
-          key: windows-python-installer-cache-{{ .Branch }}-<< parameters.python-version >>
+          key: windows--v2-python-installer-cache-{{ .Branch }}-<< parameters.python-version >>
           paths:
             - "python_installer"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Windows:
 Bug fixes:
 * Fix a regression introduced in v2.1.29 which would cause the agent to inadvertently skip connectivity check on startup.
 * Default value for ``check_remote_if_no_tty`` config option is ``False``. Previously the changelog entry incorrectly stated it defaults to ``True``. This means that a connectivity check is not performed on startup if tty is not available.
+* Fix a bug in syslog monitor on Window which would prevent TCP handler from working.
 
 Other:
 * Monitor ``emit_value()`` method now correctly sanitizes / escapes metric field names which are "reserved" (logfile, metric, value, serverHost, instance, severity). This is done to prevent possible collisions with special / reserved metric event attribute names which could cause issues with some queries. Metric field names which are escaped get added ``_`` suffix (e.g. ``metric`` becomes ``metric_``).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Windows:
 Bug fixes:
 * Fix a regression introduced in v2.1.29 which would cause the agent to inadvertently skip connectivity check on startup.
 * Default value for ``check_remote_if_no_tty`` config option is ``False``. Previously the changelog entry incorrectly stated it defaults to ``True``. This means that a connectivity check is not performed on startup if tty is not available.
-* Fix a bug in syslog monitor on Window which would prevent TCP handler from working.
+* Fix a bug in syslog monitor on Windows under Python 3 which would prevent TCP handler from working.
 
 Other:
 * Monitor ``emit_value()`` method now correctly sanitizes / escapes metric field names which are "reserved" (logfile, metric, value, serverHost, instance, severity). This is done to prevent possible collisions with special / reserved metric event attribute names which could cause issues with some queries. Metric field names which are escaped get added ``_`` suffix (e.g. ``metric`` becomes ``metric_``).

--- a/tests/unit/syslog_monitor_test.py
+++ b/tests/unit/syslog_monitor_test.py
@@ -935,9 +935,7 @@ class SyslogTCPRequestParserTestCase(SyslogMonitorTestCase):
             mock_socket_recv.counter += 1
 
             if mock_socket_recv.counter < 3:
-                e = socket.error("EAGAIN", errno.EAGAIN)
-                e.errno = errno.EAGAIN
-                raise e
+                raise socket.error(errno.EAGAIN, "EAGAIN")
 
             return "data1"
 


### PR DESCRIPTION
This pull request fixes a bug in syslog monitor when running in TCP mode on Windows under Python 3.

## Background, Context

When running syslog monitor on Windows under Python 3 in TCP mode, this error would be throw when trying to read data from a socket in non-blocking mode:

```bash
2022-05-31 10:29:12.682Z WARNING [monitor:syslog_monitor] [syslog_monitor.py:873] Error handling request: [WinError 10035] A non-blocking socket operation could not be completed immediately
        Traceback (most recent call last):
  File "scalyr_agent\builtin_monitors\syslog_monitor.py", line 855, in handle
  File "scalyr_agent\builtin_monitors\syslog_monitor.py", line 537, in read
  File "scalyr_agent\builtin_monitors\syslog_monitor.py", line 520, in read
BlockingIOError: [WinError 10035] A non-blocking socket operation could not be completed immediately
```

## Proposed Fix

It turns out that under Python 3 on Windows (perhaps also on Linux, still need to confirm it), ``BlockingIOError`` error is thrown when trying to read from socket in a non-blocking mode when no data is available for reading yet.

This error represents the same situation as ``socker.error`` exception with ``errno`` being set to ``EAGAIN``, but this exception is not a subclass of ``socket.error`` so we need to handle that exception as well for the code to work.