### PR TITLE
Add end to end tests for Kubernetes Open Metrics monitor client side rate calculation

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -340,6 +340,11 @@ jobs:
           ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jmx_scrape_cached_beans 0.0 app=\"java-hello-world\" attribute1=\"value1\" k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" k8s-node=\"'${K8S_NODE_NAME}'\""'
           ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jvm_info 1.0 app=\"java-hello-world\" attribute1=\"value1\" k8s-cluster=\"'${K8S_CLUSTER_NAME}'\" k8s-node=\"'${K8S_NODE_NAME}'\" runtime="'
 
+          # Client side calculated per second rate metrics
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jvm_threads_started_total "'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "jvm_memory_pool_allocated_bytes_total "'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'" $logfile contains "java-hello-world" "process_cpu_seconds_total_rate "'
+
       - name: Notify Slack on Failure
         # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull
         # requests and that's why we need this special conditional and check for github.head_ref in

--- a/tests/e2e/k8s_om_monitor/java_app_deployment.yaml
+++ b/tests/e2e/k8s_om_monitor/java_app_deployment.yaml
@@ -16,7 +16,9 @@ spec:
         prometheus.io/scrape:             'true'
         prometheus.io/port:               '9404'
         k8s.monitor.config.scalyr.com/scrape: 'true'
+        k8s.monitor.config.scalyr.com/scrape_interval: '30'
         k8s.monitor.config.scalyr.com/attributes: '{"attribute1": "value1", "app": "${pod_labels_app}"}'
+        k8s.monitor.config.scalyr.com/calculate_rate_metric_names: 'jvm_threads_started_total,jvm_memory_pool_allocated_bytes_total,process_cpu_seconds_total'
     spec:
       hostNetwork: true
       hostPID: true


### PR DESCRIPTION
This pull request adds end to end tests for Kubernetes Open Metrics monitor functionality implemented in #891.