### PR TITLE
Fix copying manager checkpoints selecting logic 

### DIFF
--- a/scalyr_agent/copying_manager/copying_manager.py
+++ b/scalyr_agent/copying_manager/copying_manager.py
@@ -1497,9 +1497,9 @@ class CopyingManager(StoppableThread, LogWatcher):
         :return: Checkpoint state stored in dict.
         """
 
-        found_checkpoints = []
-
         current_time = time.time()
+
+        checkpoints_files_paths = []
 
         # search for all worker session checkpoint files.
         worker_checkpoints_glob = os.path.join(
@@ -1507,16 +1507,44 @@ class CopyingManager(StoppableThread, LogWatcher):
             WORKER_SESSION_CHECKPOINT_FILENAME_GLOB,
         )
 
-        checkpoints_paths = scalyr_util.match_glob(worker_checkpoints_glob)
+        all_workers_checkpoints_paths = set(
+            scalyr_util.match_glob(worker_checkpoints_glob)
+        )
+
+        # Search for all existing worker active checkpoints
+        active_worker_checkpoints_glob = os.path.join(
+            self.__config.agent_data_path,
+            "active-{}".format(WORKER_SESSION_CHECKPOINT_FILENAME_GLOB),
+        )
+
+        all_active_workers_checkpoints_paths = scalyr_util.match_glob(
+            active_worker_checkpoints_glob
+        )
+
+        # Fetch workers main checkpoint file paths from active checkpoint path
+        # in order to handle exotic ede case where an active checkpoint exists but main checkpoint doesn't
+        for active_workers_checkpoints_path in all_active_workers_checkpoints_paths:
+            active_workers_checkpoints_file_name = os.path.basename(
+                active_workers_checkpoints_path
+            )
+            worker_checkpoint_path = os.path.join(
+                os.path.dirname(active_workers_checkpoints_path),
+                active_workers_checkpoints_file_name[7:],
+            )
+            all_workers_checkpoints_paths.add(worker_checkpoint_path)
 
         # also get the previously consolidated file.
         consolidated_checkpoint_path = os.path.join(
             self.__config.agent_data_path, "checkpoints.json"
         )
 
-        checkpoints_paths.append(consolidated_checkpoint_path)
+        checkpoints_files_paths.extend(all_workers_checkpoints_paths)
+        checkpoints_files_paths.append(consolidated_checkpoint_path)
 
-        for checkpoints_path in checkpoints_paths:
+        # Read all found checkpoint files.
+        found_checkpoints_collections = []
+
+        for checkpoints_path in checkpoints_files_paths:
 
             checkpoints = self.__read_checkpoint_state(checkpoints_path)
 
@@ -1542,17 +1570,35 @@ class CopyingManager(StoppableThread, LogWatcher):
                     )
                 continue
 
-            found_checkpoints.append(checkpoints)
+            found_checkpoints_collections.append(checkpoints)
 
         result = {}  # type: ignore
         # merge checkpoints from  all worker sessions to one checkpoint.
 
         # checkpoints from different worker sessions may contain checkpoint for the same file,
-        # so we sort checkpoints by time and update resulting collection with the same order.
-        found_checkpoints.sort(key=operator.itemgetter("time"))
+        # so we sort checkpoints by time.
 
-        for wc in found_checkpoints:
-            result.update(wc["checkpoints"])
+        # First, sort whole collections from files by their write time.
+        found_checkpoints_collections.sort(key=operator.itemgetter("time"))
+
+        # Then iterate through all checkpoints in all found collections and pick the most recent for each log file.
+        for checkpoints_collection in found_checkpoints_collections:
+
+            for file_path, file_checkpoint in checkpoints_collection[
+                "checkpoints"
+            ].items():
+
+                result_checkpoint = result.get(file_path)
+
+                if result_checkpoint is None:
+                    result[file_path] = file_checkpoint
+                    continue
+
+                result_checkpoint = max(
+                    result_checkpoint, file_checkpoint, key=operator.itemgetter("time")
+                )
+
+                result[file_path] = result_checkpoint
 
         return result
 


### PR DESCRIPTION
This PR has a potential fix for issues that potentially happened to some of our customers and on our staging servers as well.

The general problem is that in some circumstances, on start, the agent reuploads old logs causing a spike in log volume. I wasn't able to reproduce the customer's issue, but I found several places in our code, which may lead to similar behavior. 

The proposed changes fix:
*  Bug with not picking `active` checkpoint when `full` checkpoints are not presented.
*  Now, the "freshest" checkpoint for a log file that is presented in multiple checkpoint files is selected according to its own timestamp, not by the write timestamp of the whole checkpoint file. That should avoid the situation where a checkpoint file with the most recent checkpoint has been written earlier than another checkpoint file, so the second file is selected instead of the first.