### PR TITLE
Small docker monitor stop() bug fix / workaround

### DIFF
--- a/scalyr_agent/builtin_monitors/docker_monitor.py
+++ b/scalyr_agent/builtin_monitors/docker_monitor.py
@@ -977,6 +977,9 @@ class ContainerChecker(StoppableThread):
             target=self.check_containers, name="Container Checker"
         )
 
+        self.docker_loggers = []
+        self.raw_logs = []
+
     def start(self):
         self.__load_checkpoints()
         self.containers = _get_containers(


### PR DESCRIPTION
This pull request includes a small change to make sure docker monitor doesn't throw an exception under some conditions (e.g. is ``stop()`` is called before ``start()`` and similar).

## Background, Context

I noticed this exception in the agent logs:

```bash
2022-06-12 09:54:01.876Z INFO [core] [monitors_manager.py:165] Starting Scalyr Monitors manager thread
2022-06-12 09:54:01.880Z INFO [core] [scalyr-agent-2:1719] agent_status launch_time="Sat Jun 11 09:18:00 2022 UTC" version="2.1.30.pre31.1" watched_paths=13 copying_paths=15 total_bytes_copied=152737902 total_bytes_skipped=0 total_bytes_subsampled=38162017 total_redactions=0 total_bytes_failed=0 total_copy_request_errors=0 total_monitor_reported_lines=1166326 running_monitors=25 dead_monitors=0 user_cpu_=2389.514582 system_cpu=542.083124 ram_usage=69156 skipped_new_bytes=0 skipped_preexisting_bytes=0 total_bytes_pending=0
2022-06-12 09:54:01.880Z INFO [core] [monitors_manager.py:195] Stopping monitor linux_system_metrics()
2022-06-12 09:54:01.881Z INFO [core] [monitors_manager.py:195] Stopping monitor docker_monitor()
2022-06-12 09:54:01.881Z ERROR [core] [scalyr_logging.py:703] Failed to stop the metric log without join due to an exception :stack_trace:
  Traceback (most recent call last):
    File "/usr/share/scalyr-agent-2/py/scalyr_agent/monitors_manager.py", line 196, in stop_manager
      monitor.stop(wait_on_join=False)
    File "/usr/share/scalyr-agent-2/py/scalyr_agent/builtin_monitors/docker_monitor.py", line 2538, in stop
      self.__container_checker.stop(wait_on_join, join_timeout)
    File "/usr/share/scalyr-agent-2/py/scalyr_agent/builtin_monitors/docker_monitor.py", line 1026, in stop
      for logger in self.docker_loggers:
  AttributeError: 'ContainerChecker' object has no attribute 'docker_loggers'

```

I'm not sure about the exact root cause, but I think it's something related to the agent start / stop routine and config reload (perhaps some race condition which results in ``stop()`` being called early before ``start()``).

## Proposed Solution

I added a small change which I think should prevent this issue from occurring since those variables are now also defined inside the constructor.

Ideally we could also track down the root cause (in case there is one), but I wasn't able to do that yet.