### PR TITLE
Upgrade orjson dependency used by Docker images to 3.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
-## 2.1.31 "Irati" - Jun 8, 2022
+## 2.1.31 "Irati" - Jun 25, 2022
 
 <!---
-Packaged by Dominic LoBue <dominicl@sentinelone.com> on Jun 8, 2022 23:04 -0800
+Packaged by Dominic LoBue <dominicl@sentinelone.com> on Jun 25, 2022 23:04 -0800
 --->
 
 Windows:
@@ -20,12 +20,11 @@ Bug fixes:
 * Fix a bug in the Agent's custom JSON parser, which did not raise error on unexpected ending of the JSON document which might be caused by a JSON syntax error.
 
 Docker images:
-* Temporarily disable ``orjson`` JSON library for the arm64 platform of the Agent's alpine docker image due to upstream build errors.
+* Upgrade orjson dependency
 
 Other:
 * Monitor ``emit_value()`` method now correctly sanitizes / escapes metric field names which are "reserved" (logfile, metric, value, serverHost, instance, severity). This is done to prevent possible collisions with special / reserved metric event attribute names which could cause issues with some queries. Metric field names which are escaped get added ``_`` suffix (e.g. ``metric`` becomes ``metric_``).
 * Upgrade dependency ``requests`` library to 2.25.1.
-
 
 ## 2.1.30 "Heturn" - May 17, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
-## 2.1.31 "Irati" - Jun 25, 2022
+## 2.1.31 "Irati" - Jun 24, 2022
 
 <!---
-Packaged by Dominic LoBue <dominicl@sentinelone.com> on Jun 25, 2022 23:04 -0800
+Packaged by Dominic LoBue <dominicl@sentinelone.com> on Jun 24, 2022 23:04 -0800
 --->
 
 Windows:

--- a/agent_build/docker/Dockerfile.base
+++ b/agent_build/docker/Dockerfile.base
@@ -67,7 +67,7 @@ ADD agent_build/requirement-files/main-requirements.txt agent_build/requirement-
 # with pip environment markers since they are not specific enough.
 # We also remove installation of the orjson for alpine/arm64, since its build is not possible for now due to upstream error.
 # TODO add it back when issue is fixed or orjson bindings for musl/arm64 are available on pypi.
-RUN if ([ "$TARGETVARIANT" = "v7" ] || [ "$TARGETARCH" = "arm64" ])  && [ "$BASE_IMAGE_SUFFIX" = "alpine" ]; then sed -i '/^orjson/d' agent_build/requirement-files/main-requirements.txt; fi
+RUN if [ "$TARGETVARIANT" = "v7" ] && [ "$BASE_IMAGE_SUFFIX" = "alpine" ]; then sed -i '/^orjson/d' agent_build/requirement-files/main-requirements.txt; fi
 
 # Right now we don't support lz4 on server side yet so we don't include this dependency since it doesn't offer pre built
 # wheel and it substantially slows down base image build

--- a/agent_build/docker/Dockerfile.base
+++ b/agent_build/docker/Dockerfile.base
@@ -65,8 +65,6 @@ ADD agent_build/requirement-files/main-requirements.txt agent_build/requirement-
 
 # orjson is wheel is not available for armv7 + musl yet so we exclude it here. We can't exclude it
 # with pip environment markers since they are not specific enough.
-# We also remove installation of the orjson for alpine/arm64, since its build is not possible for now due to upstream error.
-# TODO add it back when issue is fixed or orjson bindings for musl/arm64 are available on pypi.
 RUN if [ "$TARGETVARIANT" = "v7" ] && [ "$BASE_IMAGE_SUFFIX" = "alpine" ]; then sed -i '/^orjson/d' agent_build/requirement-files/main-requirements.txt; fi
 
 # Right now we don't support lz4 on server side yet so we don't include this dependency since it doesn't offer pre built

--- a/agent_build/requirement-files/main-requirements.txt
+++ b/agent_build/requirement-files/main-requirements.txt
@@ -2,7 +2,7 @@
 # orjson is not available for armv7 + musl yet, but it's available for armv7 +
 # libc. we handle that in dockerfile since python environment markers are not
 # specific enough.
-orjson==3.7.2; python_version >= '3.7' and platform_system != 'Darwin'
+orjson==3.7.3; python_version >= '3.7' and platform_system != 'Darwin'
 orjson==3.6.1; python_version == '3.6' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 orjson==2.0.11; python_version == '3.5' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 

--- a/agent_build/requirement-files/main-requirements.txt
+++ b/agent_build/requirement-files/main-requirements.txt
@@ -2,7 +2,7 @@
 # orjson is not available for armv7 + musl yet, but it's available for armv7 +
 # libc. we handle that in dockerfile since python environment markers are not
 # specific enough.
-orjson==3.6.8; python_version >= '3.7' and platform_system != 'Darwin'
+orjson==3.7.2; python_version >= '3.7' and platform_system != 'Darwin'
 orjson==3.6.1; python_version == '3.6' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 orjson==2.0.11; python_version == '3.5' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 


### PR DESCRIPTION
This pull request upgrades orjson dependency used by Docker images to 3.7.3 (https://github.com/ijl/orjson/blob/master/CHANGELOG.md#373---2022-06-23).