### PR TITLE
Reduce permissions for GHA token used by GHA workflows to the minimum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1016,6 +1016,7 @@ jobs:
             python.exe -m pip install --user --upgrade "pip==<< pipeline.parameters.default_pip_version >>"
       - run:
           name: Run Unit Tests under Python 3.10
+          no_output_timeout: 8m
           command: |
             # NOTE: If we don't redirect the output, Windows this step doesn't correctly exit even
             # after the tox commands finishes. That's why we use the redirect workaround. Sadly
@@ -1034,7 +1035,6 @@ jobs:
             cat output
 
             exit ${EXIT_CODE}
-          no_output_timeout: 4m
       - save_cache:
           name: Save Python Dependencies Cache
           key: deps-v3-<< pipeline.parameters.cache_version_py_dependencies >>-tox-{{ .Branch }}-<< parameters.python_version >>-windows-{{ checksum "dev-requirements.txt" }}-{{ checksum "agent_build/requirement-files/compression-requirements.txt" }}-{{ checksum "agent_build/requirement-files/testing-requirements.txt" }}

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -3,6 +3,9 @@ name: Docker Images Build
 
 on: [push]
 
+permissions:
+  contents: read
+
 # Agent Docker image tests
 #
 # To test this workflow with your branch, make the following changes:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,10 +6,17 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
 
     strategy:
       fail-fast: false

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Special job which automatically cancels old runs for the same branch, prevents runs for the
   # same file set which has already passed, etc.

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -18,6 +18,9 @@ on:
       DOCKER_HUB_PASSWORD:
         required: true
 
+permissions:
+  contents: read
+
 env:
   DOCKER_BUILDKIT: 1
   # Set this variable to tell the agent build code that it runs in CI/CD and it needs to use caching.


### PR DESCRIPTION
This pull request is an attempt at reducing the permissions for Github token used by the GHA workflows to the minimum.

By default, token gets assigned broad set of permissions and for security reasons, we want to reduce those to the bare minimum which is needed for the workflows to run.

Default permissions (from https://github.com/scalyr/scalyr-agent-2/runs/6904005239?check_suite_focus=true job)

```bash
GITHUB_TOKEN Permissions
  Actions: write
  Checks: write
  Contents: write
  Deployments: write
  Discussions: write
  Issues: write
  Metadata: read
  Packages: write
  Pages: write
  PullRequests: write
  RepositoryProjects: write
  SecurityEvents: write
  Statuses: write
```

NOTE: The permissions YAML syntax is a bit weird and in case only a single permission is specified, rest of the permissions will default to ``none``. Perhaps we may still want to be explicit and explicitly set rest of the permissions to ``none`` although most of the other repos I checked don't use this notation.

> You can use the permissions key in your workflow file to modify permissions for the GITHUB_TOKEN for an entire workflow or for individual jobs. This allows you to configure the minimum required permissions for a workflow or job. When the permissions key is used, all unspecified permissions are set to no access, with the exception of the metadata scope, which always gets read access.

References:

* https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
* https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
* https://docs.github.com/en/actions/security-guides/automatic-token-authentication