### PR TITLE
Fix invalid end of the json parsing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Bug fixes:
 * Fix a bug in syslog monitor on Windows under Python 3 which would prevent TCP handler from working.
 * Fixed agent checkpoint selection bug that could cause old log files to be re-uploaded.
 * Small bug with command line argument parsing for the Agent. Agent raised unhandled exception instead of normal argparse error message when agent main command wasn't specified.
+* Fix a bug in the Agent's custom JSON parser, which did not raise error on unexpected ending of the JSON document which might be caused by a JSON syntax error.
 
 Other:
 * Monitor ``emit_value()`` method now correctly sanitizes / escapes metric field names which are "reserved" (logfile, metric, value, serverHost, instance, severity). This is done to prevent possible collisions with special / reserved metric event attribute names which could cause issues with some queries. Metric field names which are escaped get added ``_`` suffix (e.g. ``metric`` becomes ``metric_``).

--- a/scalyr_agent/json_lib/parser.py
+++ b/scalyr_agent/json_lib/parser.py
@@ -225,7 +225,7 @@ class JsonParser(object):
         if next_char is not None:
             raise JsonParseException(
                 "Expecting EOF, got '{}'".format(next_char),
-                position=self.__scanner.position
+                position=self.__scanner.position,
             )
 
         return value
@@ -311,7 +311,11 @@ class JsonParser(object):
                 self.__scanner.read_uchar()
                 return result_object
             else:
-                return self.__error("Expected string literal for object attribute name (got '{}')".format(c))
+                return self.__error(
+                    "Expected string literal for object attribute name (got '{}')".format(
+                        c
+                    )
+                )
 
             if key is not None:
                 key = six.ensure_text(key)

--- a/scalyr_agent/json_lib/parser.py
+++ b/scalyr_agent/json_lib/parser.py
@@ -224,11 +224,7 @@ class JsonParser(object):
         next_char = self.__peek_next_non_whitespace()
         if next_char is not None:
             raise JsonParseException(
-                "Parser has processed the input data but has not reached its end. "
-                "Parsing stopped at {}, characters left unread: {}. "
-                "Please check the document for errors and also pay attention to the commented lines".format(
-                    self.__scanner.position, self.__scanner.characters_remaining
-                ),
+                "Expecting EOF, got '{}'".format(next_char),
                 position=self.__scanner.position
             )
 

--- a/scalyr_agent/json_lib/parser.py
+++ b/scalyr_agent/json_lib/parser.py
@@ -226,7 +226,9 @@ class JsonParser(object):
         next_char = self.__peek_next_non_whitespace()
         if next_char is not None:
             raise JsonParseException(
-                "Expecting EOF, got '{}'".format(next_char),
+                "Expecting end of the parsed document at the character '{}', got character '{}' instead".format(
+                    self.__scanner.position, next_char
+                ),
                 position=self.__scanner.position,
             )
 

--- a/scalyr_agent/json_lib/parser.py
+++ b/scalyr_agent/json_lib/parser.py
@@ -226,10 +226,11 @@ class JsonParser(object):
         next_char = self.__peek_next_non_whitespace()
         if next_char is not None:
             raise JsonParseException(
-                "Expecting end of the parsed document at the character '{}', got character '{}' instead".format(
-                    self.__scanner.position, next_char
+                "Expecting end of the parsed document but got character '{}' instead.".format(
+                    next_char
                 ),
                 position=self.__scanner.position,
+                line_number=self.__scanner.line_number,
             )
 
         return value

--- a/scalyr_agent/json_lib/parser.py
+++ b/scalyr_agent/json_lib/parser.py
@@ -219,8 +219,10 @@ class JsonParser(object):
         value = self.__parse_value()
 
         # Check if there's no remaining characters are left in the input data.
-        # That may be the case where the beginning of a nested object is accidentally commented out (parser
-        # supports comments) and all data that goes after the next closing curly brackets '}' is ignored.
+        # That may be the case where:
+        # - Extra closing curly bracket is accidentally added before the actual end of the JSON object.
+        # - The beginning of a nested object is accidentally commented out (parser supports comments) and all data
+        #       that goes after the next closing curly brackets '}' is ignored.
         next_char = self.__peek_next_non_whitespace()
         if next_char is not None:
             raise JsonParseException(

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -1878,9 +1878,9 @@ class TestConfiguration(TestConfigurationBase):
             """{
             api_key: "hi there",
             max_line_size: 5,
-            workers: [{"sessions":2, "api_key": "foo1234", "id": "one"}]}
+            workers: [{"sessions":2, "api_key": "foo1234", "id": "one"}]
             }
-        """
+"""
         )
         mock_logger = Mock()
         config = self._create_test_configuration_instance(logger=mock_logger)
@@ -1899,7 +1899,7 @@ class TestConfiguration(TestConfigurationBase):
             """{
             api_key: "hi there",
             max_line_size: 9900,
-            workers: [{"sessions":10, "api_key": "foo1234", "id": "one"}]},
+            workers: [{"sessions":10, "api_key": "foo1234", "id": "one"}],
             }
         """
         )
@@ -1956,7 +1956,7 @@ class TestConfiguration(TestConfigurationBase):
             """{
             api_key: "hi there",
             max_line_size: 49900,
-            workers: [{"workers":2, "api_key": "foo1234", "id": "one"}]}
+            workers: [{"workers":2, "api_key": "foo1234", "id": "one"}]
             }
         """
         )
@@ -1997,7 +1997,7 @@ class TestConfiguration(TestConfigurationBase):
             api_key: "hi there",
             max_line_size: 49900,
             debug_level: 5,
-            workers: [{"sessions":2, "api_key": "foo1234", "id": "one"}]}
+            workers: [{"sessions":2, "api_key": "foo1234", "id": "one"}]
             }
         """
         )

--- a/tests/unit/json_lib/parser_test.py
+++ b/tests/unit/json_lib/parser_test.py
@@ -292,7 +292,10 @@ class JsonParserTests(ScalyrTestCase):
         with pytest.raises(JsonParseException) as err_info:
             JsonParser.parse(json_data)
 
-        assert "Expecting EOF, got 'f'" in str(err_info.value)
+        assert (
+            "Expecting end of the parsed document at the character '105', got character 'f' instead"
+            in str(err_info.value)
+        )
 
     def test_comma_at_the_end(self):
         json_data = """
@@ -305,7 +308,10 @@ class JsonParserTests(ScalyrTestCase):
         with pytest.raises(JsonParseException) as err_info:
             JsonParser.parse(json_data)
 
-        assert "Expecting EOF, got ','" in str(err_info.value)
+        assert (
+            "Expecting end of the parsed document at the character '114', got character ',' instead"
+            in str(err_info.value)
+        )
 
     def test_commented_start_of_the_object(self):
         """
@@ -330,7 +336,10 @@ class JsonParserTests(ScalyrTestCase):
         with pytest.raises(JsonParseException) as err_info:
             JsonParser.parse(json_data)
 
-        assert "Expecting EOF, got 'm'" in str(err_info.value)
+        assert (
+            "Expecting end of the parsed document at the character '451', got character 'm' instead"
+            in str(err_info.value)
+        )
 
     def test_commented_list_beginning(self):
         json_data = """

--- a/tests/unit/json_lib/parser_test.py
+++ b/tests/unit/json_lib/parser_test.py
@@ -293,8 +293,8 @@ class JsonParserTests(ScalyrTestCase):
             JsonParser.parse(json_data)
 
         assert (
-            "Expecting end of the parsed document at the character '105', got character 'f' instead"
-            in str(err_info.value)
+            "Expecting end of the parsed document but got character 'f' instead. (line 6, byte position 105)"
+            == str(err_info.value)
         )
 
     def test_comma_at_the_end(self):
@@ -309,8 +309,8 @@ class JsonParserTests(ScalyrTestCase):
             JsonParser.parse(json_data)
 
         assert (
-            "Expecting end of the parsed document at the character '114', got character ',' instead"
-            in str(err_info.value)
+            "Expecting end of the parsed document but got character ',' instead. (line 6, byte position 114)"
+            == str(err_info.value)
         )
 
     def test_commented_start_of_the_object(self):
@@ -337,8 +337,8 @@ class JsonParserTests(ScalyrTestCase):
             JsonParser.parse(json_data)
 
         assert (
-            "Expecting end of the parsed document at the character '451', got character 'm' instead"
-            in str(err_info.value)
+            "Expecting end of the parsed document but got character 'm' instead. (line 9, byte position 451)"
+            == str(err_info.value)
         )
 
     def test_commented_list_beginning(self):

--- a/tests/unit/json_lib/parser_test.py
+++ b/tests/unit/json_lib/parser_test.py
@@ -318,7 +318,7 @@ class JsonParserTests(ScalyrTestCase):
               // server_attributes: {       // the beginning of the nested object is commented.
                  serverHost: "HOST",        // the 'serverHost' field is wrongly parsed as a filed of outer object.
               }                             // this brackets are treated as end of the whole JSON document.
-            
+
               // Everything that remains is just ignored, that's bad.
               monitors: [
                 {

--- a/tests/unit/json_lib/parser_test.py
+++ b/tests/unit/json_lib/parser_test.py
@@ -24,7 +24,11 @@ import unittest
 
 import pytest
 
-from scalyr_agent.json_lib.parser import TextScanner, JsonParser, JsonParseException, JsonArray, JsonObject
+from scalyr_agent.json_lib.parser import (
+    TextScanner,
+    JsonParser,
+    JsonParseException,
+)
 
 from scalyr_agent.test_base import ScalyrTestCase
 
@@ -343,7 +347,9 @@ class JsonParserTests(ScalyrTestCase):
         with pytest.raises(JsonParseException) as err_info:
             JsonParser.parse(json_data)
 
-        assert "Expected string literal for object attribute name (got ']')" in str(err_info.value)
+        assert "Expected string literal for object attribute name (got ']')" in str(
+            err_info.value
+        )
 
     def test_trailing_comment(self):
         json_data = """
@@ -362,7 +368,7 @@ class JsonParserTests(ScalyrTestCase):
 
         assert data.to_dict() == {
             "api_key": "<key>",
-            "monitors": [{"module": "my_module"}]
+            "monitors": [{"module": "my_module"}],
         }
 
 


### PR DESCRIPTION
### Issue:
Our custom JSON parser does check for the end of the document after its parsing. For example ,if we put extra closing curly brackets in the middle of the object, it doesn't raise any error and just returns "incomplete" object.

Here the result object will miss the `filed2` filed and won't raise anything.
```
{
    api_key: ",key."
    field1: 1,
}
    filed2: 2
}
```

There's also the case where the customer accidentally commented out the beginning of the nested object:
```
{
  api_key: ",key."
  // server_attributes: {       // the beginning of the nested object is commented.
     serverHost: "HOST",        // the 'serverHost' field is wrongly parsed as a filed of outer object.
  }                             // this brackets are treated as end of the whole JSON document.

  // Everything that remains is just ignored.
  monitors: [
    {
       module:  "my_module",
    },
  ]
}
```
and the `monitors` list was lost.

### Solution:
To do additional check for the end of the document after the "root" JSON value is parsed.


 