### PR TITLE
disable orjson for alpine arm64, since its build fails with memory leak.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,12 @@ Bug fixes:
 * Fixed agent checkpoint selection bug that could cause old log files to be re-uploaded.
 * Small bug with command line argument parsing for the Agent. Agent raised unhandled exception instead of normal argparse error message when agent main command wasn't specified.
 
+Docker images:
+* Temporarily disable ``orjson`` JSON library for the arm64 platform of the Agent's alpine docker image due to upstream build errors.
+
 Other:
 * Monitor ``emit_value()`` method now correctly sanitizes / escapes metric field names which are "reserved" (logfile, metric, value, serverHost, instance, severity). This is done to prevent possible collisions with special / reserved metric event attribute names which could cause issues with some queries. Metric field names which are escaped get added ``_`` suffix (e.g. ``metric`` becomes ``metric_``).
-* Temporarily disable ``orjson`` JSON library for the arm64 platform of the Agent's alpine docker image due to upstream build errors.
+
 
 ## 2.1.30 "Heturn" - May 17, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Bug fixes:
 
 Other:
 * Monitor ``emit_value()`` method now correctly sanitizes / escapes metric field names which are "reserved" (logfile, metric, value, serverHost, instance, severity). This is done to prevent possible collisions with special / reserved metric event attribute names which could cause issues with some queries. Metric field names which are escaped get added ``_`` suffix (e.g. ``metric`` becomes ``metric_``).
+* Temporarily disable ``orjson`` JSON library for the arm64 platform of the Agent's alpine docker image due to upstream build errors.
 
 ## 2.1.30 "Heturn" - May 17, 2022
 

--- a/agent_build/docker/Dockerfile.base
+++ b/agent_build/docker/Dockerfile.base
@@ -55,6 +55,7 @@ FROM scalyr-dependencies-$BASE_IMAGE_SUFFIX as scalyr-dependencies-rustv7
 FROM scalyr-dependencies-rust$TARGETVARIANT as scalyr-dependencies
 
 ARG TARGETVARIANT
+ARG TARGETARCH
 ARG COVERAGE_VERSION
 ARG BASE_IMAGE_SUFFIX
 
@@ -64,7 +65,7 @@ ADD agent_build/requirement-files/main-requirements.txt agent_build/requirement-
 
 # orjson is wheel is not available for armv7 + musl yet so we exclude it here. We can't exclude it
 # with pip environment markers since they are not specific enough.
-RUN if [ "$TARGETVARIANT" = "v7" ] && [ "$BASE_IMAGE_SUFFIX" = "alpine" ]; then sed -i '/^orjson/d' agent_build/requirement-files/main-requirements.txt; fi
+RUN if ([ "$TARGETVARIANT" = "v7" ] || [ "$TARGETARCH" = "arm64" ])  && [ "$BASE_IMAGE_SUFFIX" = "alpine" ]; then sed -i '/^orjson/d' agent_build/requirement-files/main-requirements.txt; fi
 
 # Right now we don't support lz4 on server side yet so we don't include this dependency since it doesn't offer pre built
 # wheel and it substantially slows down base image build

--- a/agent_build/docker/Dockerfile.base
+++ b/agent_build/docker/Dockerfile.base
@@ -65,6 +65,8 @@ ADD agent_build/requirement-files/main-requirements.txt agent_build/requirement-
 
 # orjson is wheel is not available for armv7 + musl yet so we exclude it here. We can't exclude it
 # with pip environment markers since they are not specific enough.
+# We also remove installation of the orjson for alpine/arm64, since its build is not possible for now due to upstream error.
+# TODO add it back when issue is fixed or orjson bindings for musl/arm64 are available on pypi.
 RUN if ([ "$TARGETVARIANT" = "v7" ] || [ "$TARGETARCH" = "arm64" ])  && [ "$BASE_IMAGE_SUFFIX" = "alpine" ]; then sed -i '/^orjson/d' agent_build/requirement-files/main-requirements.txt; fi
 
 # Right now we don't support lz4 on server side yet so we don't include this dependency since it doesn't offer pre built


### PR DESCRIPTION
Disable orjson library  in arm64 alpine docker image due to upstream issues with its build.