### PR TITLE
k8s agent support for windows nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+RUN choco install python git -y
+
+RUN python -m pip install --upgrade pip
+RUN pip install --upgrade --no-cache-dir \
+    orjson==3.6.8 \
+    zstandard==0.17.0  \
+    lz4==4.0.0 \
+    requests==2.20.0 \
+    docker==4.1.0 \
+    psutil
+
+WORKDIR /Scalyr
+ADD . /Scalyr
+ADD ./docker/k8s-config/ /Scalyr/config
+
+RUN Get-Content /Scalyr/certs/*.pem | Set-Content /Scalyr/certs/ca_certs.crt
+RUN "[Environment]::SetEnvironmentVariable('PYTHONUTF8', '1', 'Machine')"
+ENV SCALYR_STDOUT_SEVERITY ERROR
+ENV SCALYR_K8S_KUBELET_CA_CERT /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+ENV SCALYR_K8S_SERVICE_ACCOUNT_CERT /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+CMD ["python", "-X", "utf8", "/Scalyr/scalyr_agent/agent_main.py", "--no-fork", "--no-change-user", "--verbose", "start"]

--- a/k8s-windows/scalyr-windows-agent.yaml
+++ b/k8s-windows/scalyr-windows-agent.yaml
@@ -1,0 +1,107 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: windows-scalyr-agent
+  name: winscaler-config-agent-d
+  namespace: scalyr
+data:
+  "kubernetes.json": |
+    {
+      "monitors":[
+        {
+          "module": "scalyr_agent.builtin_monitors.kubernetes_events_monitor"
+        },
+        {
+          "module": "scalyr_agent.builtin_monitors.kubernetes_monitor",
+          "report_container_metrics": true,
+          "report_k8s_metrics": true
+        }
+      ]
+    }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: windows-scalyr-agent
+  name: windows-scalyr-agent
+  namespace: scalyr
+spec:
+  selector:
+    matchLabels:
+      app: windows-scalyr-agent
+  template:
+    metadata:
+      labels:
+        app: windows-scalyr-agent
+    spec:
+      containers:
+      - name: winscaler
+        image: winscaler:latest
+        env:
+          - name: SCALYR_SERVER
+            value: agent.scalyr.com
+          - name: SCALYR_API_KEY
+            value: <putyourapikeyhere>
+          - name: SCALYR_K8S_CLUSTER_NAME
+            value: winscaler-test
+          - name: SCALYR_K8S_VERIFY_KUBELET_QUERIES
+            value: "true"
+          - name: SCALYR_K8S_API_URL
+            value: https://kubernetes.default.svc.cluster.local
+          - name: "SCALYR_K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: "spec.nodeName"
+                apiVersion: "v1"
+          - name: "SCALYR_K8S_POD_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: "metadata.name"
+                apiVersion: "v1"
+          - name: "SCALYR_K8S_POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: "metadata.namespace"
+                apiVersion: "v1"
+          - name: "SCALYR_K8S_POD_UID"
+            valueFrom:
+              fieldRef:
+                fieldPath: "metadata.uid"
+                apiVersion: "v1"
+          - name: "SCALYR_K8S_KUBELET_HOST_IP"
+            valueFrom:
+              fieldRef:
+                fieldPath: "status.hostIP"
+                apiVersion: "v1"
+        volumeMounts:
+          - name: varlogpods
+            mountPath: "/var/log/pods"
+            readOnly: true
+          - name: varlogcontainers
+            mountPath: "/var/log/containers"
+            readOnly: true
+          - name: "scalyr-config-agent-d"
+            mountPath: "/etc/scalyr-agent-2/agent.d"
+      nodeSelector:
+        kubernetes.io/os: windows
+      tolerations:
+      - key: "kubernetes.azure.com/scalesetpriority"
+        operator: "Equal"
+        value: "spot"
+        effect: "NoSchedule"
+      volumes:
+      - name: "varlogpods"
+        hostPath:
+          path: "/var/log/pods"
+      - name: "varlogcontainers"
+        hostPath:
+          path: "/var/log/containers"
+      - name: "scalyr-config-agent-d"
+        configMap:
+          name: winscaler-config-agent-d
+          defaultMode: 0600
+      dnsPolicy: "ClusterFirst"
+      automountServiceAccountToken: true
+      serviceAccountName: scalyr-scalyr-agent-sa # use service account from default scalyr helm installation

--- a/scalyr_agent/platform_windows.py
+++ b/scalyr_agent/platform_windows.py
@@ -567,7 +567,10 @@ class WindowsPlatformController(PlatformController):
                 win32service.SERVICE_RUNNING,
                 win32service.SERVICE_START_PENDING,
             )
-
+        except:
+            # When running the script without a service on windows, this will fail
+            # If we return false here, we can use it without a service
+            return False
         finally:
             if hs is not None:
                 win32service.CloseServiceHandle(hs)


### PR DESCRIPTION
Since we run a mix OS cluster on AKS (linux and windows nodes) We need the Scalyr agent to collect logs from all nodes.
Installing the scalyr agent for k8s via helm, only provides support for linux nodes, and fails trying to run on windows nodes. Adding the `nodeSelector.kubernetes\\.io/os: linux` option restricts it to linux nodes only.

For windows nodes, I've essentially just made another DaemonSet restricted to windows nodes only. I've built a docker image, using `servercore:ltsc2019`, installed the latest python for windows, and all other dependencies. I've had to make a small change to the python code, because it is trying to check for a running service on windows, which is not the case here.

This is not meant to be merged, it is simply an example of how to get a windows node with the pod/container logs mounted in, so scalyr agent can upload them.

This is as far as I've got. The agent runs, it can communicate with the kubernetes API, but unfortunately atm it only uploads its own logs. If anyone has any ideas as to what is missing, please do let me know.

If you want to try it out, make sure you first install the scalyr helm chart, as I reuse the serviceaccount. Also, I've named the image "winscaler", make sure to change this to whatever you have built.