### PR TITLE
Add missing GHA token permission

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -11,6 +11,7 @@ on:
     - cron: '0 4 * * *'
 
 permissions:
+  actions: write  # Needed for skip-duplicate-jobs job
   contents: read
 
 jobs:


### PR DESCRIPTION
This pull request adds missing GHA token permission which is needed for skip duplicate actions job to run (https://github.com/fkirc/skip-duplicate-actions).

> 
> For GitHub repositories where [default permissions](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository) for GITHUB_TOKEN has been set to "permissive (read-only)", the following lines must be included in the workflow (see [permissions syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)):
> 
> # Minimum permissions required by skip-duplicate-actions
> permissions:
>   actions: write
>   contents: read
