### PR TITLE
Bump orjson version to pull in upstream fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
-## 2.1.31 "Irati" - Jun 27, 2022
+## 2.1.31 "Irati" - Jun 28, 2022
 
 <!---
-Packaged by Dominic LoBue <dominicl@sentinelone.com> on Jun 24, 2022 13:29 -0800
+Packaged by Dominic LoBue <dominicl@sentinelone.com> on Jun 28, 2022 12:29 -0800
 --->
 
 Windows:

--- a/agent_build/requirement-files/main-requirements.txt
+++ b/agent_build/requirement-files/main-requirements.txt
@@ -2,7 +2,7 @@
 # orjson is not available for armv7 + musl yet, but it's available for armv7 +
 # libc. we handle that in dockerfile since python environment markers are not
 # specific enough.
-orjson==3.7.3; python_version >= '3.7' and platform_system != 'Darwin'
+orjson==3.7.5; python_version >= '3.7' and platform_system != 'Darwin'
 orjson==3.6.1; python_version == '3.6' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 orjson==2.0.11; python_version == '3.5' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 


### PR DESCRIPTION
Primarily pulling in a segfault on dealloc fix:
https://github.com/ijl/orjson/commit/4d2011931947d4b5dd355d9fd0d562ee6cc5dff9
https://github.com/ijl/orjson/pull/273

Need to jump to 3.7.5 though since it fixes a bug included in 3.7.4.