### PR TITLE
Unblock release by removing openmetrics monitor from workflow

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image-type: [ "docker-json", "docker-syslog", "k8s", "k8s-with-openmetrics-monitor" ]
+        image-type: [ "docker-json", "docker-syslog", "k8s" ]
         image-distro-name: [ "debian", "alpine" ]
 
     steps:


### PR DESCRIPTION
Currently the release is blocked by the image publish workflow breaking.
The agent-build.yml workflow calls the version of
publish-docker-images.yml workflow from the master branch, and the
publish-docker-images.yml workflow runs a python script that is present
in the branch the workflow is being run from (which is not necessarily
the master branch). We're running the python script with arguments it
doesn't recognize, and then it crashes.

To unblock the release without having to resort to merging workflow
changes into the release branch (which would be tantamount to creating a
new release), remove the openmetrics monitor target from the matrix
build. Once the images have been published, this change can be reverted.