### PR TITLE
Add k8s no kustomize configs for agent with openmetrics monitor enabled

### DIFF
--- a/k8s/no-kustomize-om-monitor/scalyr-agent-2-configmap.yaml
+++ b/k8s/no-kustomize-om-monitor/scalyr-agent-2-configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  SCALYR_K8S_CLUSTER_NAME: <your_cluster_name>
+  #
+  # EU customers must uncomment this next line:
+  # SCALYR_SERVER: "https://upload.eu.scalyr.com"
+  #
+  # Define any other environment variables for config variables that are "environment aware".
+  # Most environment variables start with "SCALYR_"
+  # See https://www.scalyr.com/help/scalyr-agent#environmentAware for more details.
+  #
+  # Example:
+  # SCALYR_K8S_EVENTS_DISABLE: "true"
+  #
+metadata:
+  name: scalyr-config
+  namespace: scalyr

--- a/k8s/no-kustomize-om-monitor/scalyr-agent-2.yaml
+++ b/k8s/no-kustomize-om-monitor/scalyr-agent-2.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: scalyr-agent-2
+  name: scalyr-agent-2
+  namespace: scalyr
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: scalyr-agent-2
+  template:
+    metadata:
+      labels:
+        app: scalyr-agent-2
+    spec:
+      containers:
+      - env:
+        - name: SCALYR_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: scalyr-api-key
+              name: scalyr-api-key
+        - name: SCALYR_K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: SCALYR_K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: SCALYR_K8S_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: SCALYR_K8S_POD_UID
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.uid
+        - name: SCALYR_K8S_KUBELET_HOST_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        envFrom:
+        - configMapRef:
+            name: scalyr-config
+          image: scalyr/scalyr-k8s-agent-with-openmetrics-monitor:4139ddb6790616d813dd22c37cc180fc6cbc463a
+        imagePullPolicy: Always
+        name: scalyr-agent
+        resources:
+          limits:
+            memory: 500Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/docker/containers
+          name: varlibdockercontainers
+          readOnly: true
+        - mountPath: /var/log/pods
+          name: varlogpods
+          readOnly: true
+        - mountPath: /var/log/containers
+          name: varlogcontainers
+          readOnly: true
+        - mountPath: /var/scalyr/docker.sock
+          name: dockersock
+        - mountPath: /var/lib/scalyr-agent-2
+          name: checkpoints
+        livenessProbe:
+          exec:
+            command:
+            - scalyr-agent-2
+            - status
+            - -H
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 10
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: scalyr-service-account
+      serviceAccountName: scalyr-service-account
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - hostPath:
+          path: /var/lib/docker/containers
+          type: ""
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/log/pods
+          type: ""
+        name: varlogpods
+      - hostPath:
+          path: /var/log/containers
+          type: ""
+        name: varlogcontainers
+      - hostPath:
+          path: /var/run/docker.sock
+          type: ""
+        name: dockersock
+      - hostPath:
+          path: /tmp/scalyr-agent-2
+          type: DirectoryOrCreate
+        name: checkpoints
+      # comment this section if you do not want to run on the master
+      tolerations:
+      - operator: Exists

--- a/k8s/no-kustomize-om-monitor/scalyr-service-account.yaml
+++ b/k8s/no-kustomize-om-monitor/scalyr-service-account.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scalyr-service-account
+  namespace: scalyr
+secrets:
+- name: scalyr-api-key
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scalyr-clusterrole
+rules:
+- apiGroups: [""]
+  resources: ["namespaces","pods","replicationcontrollers"]
+  verbs: ["get","list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get","list"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets","deployments","replicasets","statefulsets","namespaces"]
+  verbs: ["get","list"]
+- apiGroups: ["batch", "extensions"]
+  resources: ["cronjobs","jobs"]
+  verbs: ["get","list"]
+- apiGroups: ["","events.k8s.io"]
+  resources: ["events"]
+  verbs: ["get","list","watch"]
+# nodes/proxy and /metrics permissions are needed for Kubernetes Open Metrics monitor
+# so local Kubelet API can be queried for metrics in Open Metrics format.
+- apiGroups: [""]
+  resources: ["nodes/stats", "nodes/proxy"]
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scalyr-clusterrole-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scalyr-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: scalyr-service-account
+    namespace: scalyr


### PR DESCRIPTION
This pull request adds Kubernetes no kustomize config for scalyr agent with Kubernetes Open Metrics monitor enabled.

This is to be used during the preview phase. Once we are out of the preview phase, we will likely want to fold everything into a single docker image, to be controlled via global config (environment variable) option.