### PR TITLE
Revert "Unblock release by removing openmetrics monitor from workflow"

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image-type: [ "docker-json", "docker-syslog", "k8s" ]
+        image-type: [ "docker-json", "docker-syslog", "k8s", "k8s-with-openmetrics-monitor" ]
         image-distro-name: [ "debian", "alpine" ]
 
     steps:


### PR DESCRIPTION
Reverts scalyr/scalyr-agent-2#923

The release workflow completed successfully. This can be added back.