### PR TITLE
Enable additional Kubernetes metrics collection via global config option

### DIFF
--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image-type: [ "docker-json", "docker-syslog", "docker-api", "k8s", "k8s-with-openmetrics-monitor" ]
+        image-type: [ "docker-json", "docker-syslog", "docker-api", "k8s" ]
         image-distro-name: [ "debian", "alpine" ]
         python-version: [ "3.8.13" ]
 

--- a/docker/k8s-config/agent.d/k8s_open_metrics_monitor.json
+++ b/docker/k8s-config/agent.d/k8s_open_metrics_monitor.json
@@ -1,0 +1,20 @@
+{
+  "monitors":
+  [
+    // NOTE: This monitor is defined here, but it's disabled by default
+    {
+      module:  "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor",
+      include_node_name: true,
+      include_cluster_name: true,
+      logger_include_node_name: false,
+      // Switch to true once preview phase is over
+      verify_https: false,
+      scrape_kubernetes_api_metrics: true,
+      kubernetes_api_metrics_scrape_interval: 60,
+      scrape_kubernetes_api_cadvisor_metrics: true,
+      kubernetes_api_cadvisor_metrics_scrape_interval: 60,
+      sample_interval: 60,
+      scrape_interval: 60
+    }
+  ]
+}

--- a/docker/k8s-config/agent.d/k8s_open_metrics_monitor.json
+++ b/docker/k8s-config/agent.d/k8s_open_metrics_monitor.json
@@ -9,7 +9,7 @@
       logger_include_node_name: false,
       // Switch to true once preview phase is over
       verify_https: false,
-      scrape_kubernetes_api_metrics: true,
+      scrape_kubernetes_api_metrics: false,
       kubernetes_api_metrics_scrape_interval: 60,
       scrape_kubernetes_api_cadvisor_metrics: true,
       kubernetes_api_cadvisor_metrics_scrape_interval: 60,

--- a/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
@@ -391,7 +391,9 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
         # NOTE: Right now Kubernetes Explorer functionality also needs data from Kubernetes events
         # monitor so in case explorer functionality is enabled, we also enable events monitor
         if self._global_config.k8s_explorer_enable:
-            global_log.info("k8s_explorer_enable config option is set to true, enabling kubernetes events monitor")
+            global_log.info(
+                "k8s_explorer_enable config option is set to true, enabling kubernetes events monitor"
+            )
             self.__disable_monitor = False
 
     def open_metric_log(self):

--- a/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
@@ -382,11 +382,17 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
             legacy_disable = "false"
 
         # Note, accepting just a single `t` here due to K8s ConfigMap issues with having a value of `true`
-        self.__disable_monitor = (
+        self.__disable_monitor = bool(
             legacy_disable == "true"
             or legacy_disable == "t"
             or self._global_config.k8s_events_disable
         )
+
+        # NOTE: Right now Kubernetes Explorer functionality also needs data from Kubernetes events
+        # monitor so in case explorer functionality is enabled, we also enable events monitor
+        if self._global_config.k8s_explorer_enable:
+            global_log.info("k8s_explorer_enable config option is set to true, enabling kubernetes events monitor")
+            self.__disable_monitor = False
 
     def open_metric_log(self):
         """Override open_metric_log to prevent a metric log from being created for the Kubernetes Events Monitor

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -38,9 +38,9 @@ monitor:
       building scrapper URL.
     * ``k8s.monitor.config.scalyr.com/scrape_interval`` (optional) - How often to scrape this endpoint.
       Defaults to 60 seconds.
-    * ``k8s.monitor.config.scalyr.com/scrape_timeout`` (optional) - How long to wait before timing out.
+    * ``k8s.monitor.config.scalyr.com/scrape_timeout`` (optional) - How long to wait before timing out. This should be at least 5-10 seconds shorter than scrape interval.
     * ``k8s.monitor.config.scalyr.com/verify_https`` (optional) - Set to false to disable remote SSL
-      cert and hostname validation.
+      cert and hostname validation for this endpoint.
     * ``k8s.monitor.config.scalyr.com/attributes`` (optional) - Optional JSON object with the attributes
       (key/value pairs) which get included with every metric. Template syntax is supported for attribute
       values. Right now only pod labels are available in the template context.
@@ -271,7 +271,7 @@ define_config_option(
 define_config_option(
     __monitor__,
     "scrape_timeout",
-    "Timeout for scrape HTTP requests. Defaults to 10 seconds.",
+    "Timeout for scrape HTTP requests. Defaults to 10 seconds. This should be at least 5-10 seconds shorter than scrape interval.",
     convert_to=int,
     default=DEFAULT_SCRAPE_TIMEOUT,
 )

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -289,7 +289,7 @@ define_config_option(
     "scrape_kubernetes_api_cadvisor_metrics",
     "Set to True to enable scraping metrics from /metrics/cadvisor Kubernetes API endpoint.",
     convert_to=bool,
-    default=False,
+    default=True,
 )
 
 define_config_option(

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -543,11 +543,12 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
 
         self.__enable_monitor = self._global_config.k8s_explorer_enable
 
-
     def run(self):
         if not self.__enable_monitor:
-            GLOBAL_LOG.info("kubernetes_openmetrics_monitor exiting because it's not enabled "
-                            "(k8s_explorer_enable config option is not set to true)")
+            GLOBAL_LOG.info(
+                "kubernetes_openmetrics_monitor exiting because it's not enabled "
+                "(k8s_explorer_enable config option is not set to true)"
+            )
             return None
 
         return super(KubernetesOpenMetricsMonitor, self).run()

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -193,6 +193,8 @@ from scalyr_agent import compat
 
 __monitor__ = __name__
 
+GLOBAL_LOG = scalyr_logging.getLogger(__name__)
+
 # Default config option values
 DEFAULT_SCRAPE_INTERVAL = 60.0
 DEFAULT_SCRAPE_TIMEOUT = 10
@@ -538,6 +540,17 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
         self.__static_monitors_started = False
 
         self.__previous_running_monitors_count = 0
+
+        self.__enable_monitor = self._global_config.k8s_explorer_enable
+
+
+    def run(self):
+        if not self.__enable_monitor:
+            GLOBAL_LOG.info("kubernetes_openmetrics_monitor exiting because it's not enabled "
+                            "(k8s_explorer_enable config option is not set to true)")
+            return None
+
+        return super(KubernetesOpenMetricsMonitor, self).run()
 
     @property
     def k8s(self):

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1034,6 +1034,10 @@ class Configuration(object):
         return self.__get_config().get_bool("k8s_events_disable")
 
     @property
+    def k8s_explorer_enable(self):
+        return self.__get_config().get_bool("k8s_explorer_enable")
+
+    @property
     def k8s_ratelimit_cluster_num_agents(self):
         # UNDOCUMENTED_CONFIG
         return self.__get_config().get_int("k8s_ratelimit_cluster_num_agents")
@@ -2887,6 +2891,15 @@ class Configuration(object):
         self.__verify_or_set_optional_bool(
             config,
             "k8s_events_disable",
+            False,
+            description,
+            apply_defaults,
+            env_aware=True,
+        )
+
+        self.__verify_or_set_optional_bool(
+            config,
+            "k8s_explorer_enable",
             False,
             description,
             apply_defaults,

--- a/tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml
+++ b/tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml
@@ -67,6 +67,10 @@ spec:
           volumeMounts:
             - mountPath: /etc/scalyr-agent-2/agent-extra.d
               name: extraconfig
+            # We want to use custom config for the Kubernetes OpenMetrics monitor
+            # and not one bundled with the agent
+            - mountPath: /etc/scalyr-agent-2/agent.d/k8s_open_metrics_monitor.json
+              name: devnull
             - mountPath: /var/lib/docker/containers
               name: varlibdockercontainers
               readOnly: true
@@ -115,6 +119,10 @@ spec:
             path: /var/run/docker.sock
             type: ''
           name: dockersock
+        - hostPath:
+            path: /dev/null
+            type: ''
+          name: devnull
         - hostPath:
             path: /tmp/scalyr-agent-2
             type: DirectoryOrCreate

--- a/tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml
+++ b/tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml
@@ -69,8 +69,6 @@ spec:
               name: extraconfig
             # We want to use custom config for the Kubernetes OpenMetrics monitor
             # and not one bundled with the agent
-            - mountPath: /etc/scalyr-agent-2/agent.d/k8s_open_metrics_monitor.json
-              name: devnull
             - mountPath: /var/lib/docker/containers
               name: varlibdockercontainers
               readOnly: true
@@ -92,6 +90,12 @@ spec:
                 - -H
             initialDelaySeconds: 60
             periodSeconds: 60
+          # We want to use custom config for the Kubernetes OpenMetrics monitor
+          # and not one bundled with the agent.
+          lifecycle:
+            postStart:
+              exec:
+                command: ["rm", "/etc/scalyr-agent-2/agent.d/k8s_open_metrics_monitor.json"]
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -119,10 +123,6 @@ spec:
             path: /var/run/docker.sock
             type: ''
           name: dockersock
-        - hostPath:
-            path: /dev/null
-            type: ''
-          name: devnull
         - hostPath:
             path: /tmp/scalyr-agent-2
             type: DirectoryOrCreate

--- a/tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml
+++ b/tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml
@@ -21,6 +21,8 @@ spec:
               value: "/etc/scalyr-agent-2/agent-extra.d"
             - name: SCALYR_DEBUG_LEVEL_LOGGER_NAMES
               value: "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor()"
+            - name: SCALYR_K8S_EXPLORER_ENABLE
+              value: "true"
             - name: SCALYR_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml
+++ b/tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml
@@ -23,6 +23,10 @@ spec:
               value: "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor()"
             - name: SCALYR_K8S_EXPLORER_ENABLE
               value: "true"
+            - name: SCALYR_K8S_VERIFY_KUBELET_QUERIES
+              value: "false"
+            - name: SCALYR_K8S_VERIFY_API_QUERIES
+              value: "false"
             - name: SCALYR_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -32,7 +32,9 @@ from scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor import (
     K8sPod,
     TemplateWithSpecialCharacters,
 )
-from scalyr_agent.builtin_monitors.kubernetes_events_monitor import KubernetesEventsMonitor
+from scalyr_agent.builtin_monitors.kubernetes_events_monitor import (
+    KubernetesEventsMonitor,
+)
 from scalyr_agent.json_lib import JsonObject
 from scalyr_agent.monitors_manager import set_monitors_manager
 from scalyr_agent.test_base import ScalyrTestCase
@@ -845,7 +847,9 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
         result = TemplateWithSpecialCharacters(template).safe_substitute(context)
         self.assertEqual(result, "test hello $world foo bar2 bar test2 bar3 f1 food")
 
-    @mock.patch("scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor.GLOBAL_LOG")
+    @mock.patch(
+        "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor.GLOBAL_LOG"
+    )
     def test_run_monitor_is_disabled(self, mock_global_log):
         monitor_config = {
             "module": "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor",
@@ -863,7 +867,9 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
         self.assertEqual(mock_global_log.info.call_count, 0)
         self.assertIsNone(monitor.run())
         self.assertEqual(mock_global_log.info.call_count, 1)
-        mock_global_log.info.assert_called_with("kubernetes_openmetrics_monitor exiting because it's not enabled (k8s_explorer_enable config option is not set to true)")
+        mock_global_log.info.assert_called_with(
+            "kubernetes_openmetrics_monitor exiting because it's not enabled (k8s_explorer_enable config option is not set to true)"
+        )
 
     def test_kubernetes_events_enabled_when_explorer_enabled(self):
         global_config = mock.Mock()
@@ -872,7 +878,9 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
         global_config.k8s_ignore_namespaces = []
         mock_logger = mock.Mock()
 
-        KubernetesEventsMonitor._get_log_rotation_configuration = mock.Mock(return_value=(None, None))
+        KubernetesEventsMonitor._get_log_rotation_configuration = mock.Mock(
+            return_value=(None, None)
+        )
 
         global_config.k8s_explorer_enable = False
         monitor_config = {

--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -32,6 +32,7 @@ from scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor import (
     K8sPod,
     TemplateWithSpecialCharacters,
 )
+from scalyr_agent.builtin_monitors.kubernetes_events_monitor import KubernetesEventsMonitor
 from scalyr_agent.json_lib import JsonObject
 from scalyr_agent.monitors_manager import set_monitors_manager
 from scalyr_agent.test_base import ScalyrTestCase
@@ -843,3 +844,58 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
         )
         result = TemplateWithSpecialCharacters(template).safe_substitute(context)
         self.assertEqual(result, "test hello $world foo bar2 bar test2 bar3 f1 food")
+
+    @mock.patch("scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor.GLOBAL_LOG")
+    def test_run_monitor_is_disabled(self, mock_global_log):
+        monitor_config = {
+            "module": "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor",
+        }
+        global_config = mock.Mock()
+        global_config.agent_log_path = MOCK_AGENT_LOG_PATH
+        global_config.k8s_explorer_enable = False
+        mock_logger = mock.Mock()
+
+        monitor = KubernetesOpenMetricsMonitor(
+            monitor_config=monitor_config,
+            logger=mock_logger,
+            global_config=global_config,
+        )
+        self.assertEqual(mock_global_log.info.call_count, 0)
+        self.assertIsNone(monitor.run())
+        self.assertEqual(mock_global_log.info.call_count, 1)
+        mock_global_log.info.assert_called_with("kubernetes_openmetrics_monitor exiting because it's not enabled (k8s_explorer_enable config option is not set to true)")
+
+    def test_kubernetes_events_enabled_when_explorer_enabled(self):
+        global_config = mock.Mock()
+        global_config.agent_log_path = MOCK_AGENT_LOG_PATH
+        global_config.k8s_include_namespaces = []
+        global_config.k8s_ignore_namespaces = []
+        mock_logger = mock.Mock()
+
+        KubernetesEventsMonitor._get_log_rotation_configuration = mock.Mock(return_value=(None, None))
+
+        global_config.k8s_explorer_enable = False
+        monitor_config = {
+            "module": "scalyr_agent.builtin_monitors.kubernetes_events_monitor",
+            "k8s_events_disable": True,
+        }
+        monitor = KubernetesEventsMonitor(
+            monitor_config=monitor_config,
+            logger=mock_logger,
+            global_config=global_config,
+        )
+        monitor._initialize()
+        self.assertTrue(monitor._KubernetesEventsMonitor__disable_monitor)
+
+        global_config.k8s_explorer_enable = True
+        monitor_config = {
+            "module": "scalyr_agent.builtin_monitors.kubernetes_events_monitor",
+            "k8s_events_disable": True,
+        }
+        monitor = KubernetesEventsMonitor(
+            monitor_config=monitor_config,
+            logger=mock_logger,
+            global_config=global_config,
+        )
+        monitor._initialize()
+        self.assertFalse(monitor._KubernetesEventsMonitor__disable_monitor)

--- a/tests/unit/configuration_k8s_test.py
+++ b/tests/unit/configuration_k8s_test.py
@@ -1,3 +1,17 @@
+# Copyright 2014-2022 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import unicode_literals
 from __future__ import absolute_import
 

--- a/tests/unit/configuration_k8s_test.py
+++ b/tests/unit/configuration_k8s_test.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
+
 import os
+import sys
 
 from scalyr_agent import scalyr_monitor
 from scalyr_agent.builtin_monitors.kubernetes_monitor import KubernetesMonitor
@@ -13,6 +15,7 @@ from scalyr_agent.json_lib.objects import ArrayOfStrings
 from scalyr_agent.monitor_utils.k8s import QualifiedName
 from scalyr_agent.test_util import FakeAgentLogger, FakePlatform
 from scalyr_agent.test_base import ScalyrTestCase
+from scalyr_agent.test_base import skipIf
 
 from mock import patch, Mock
 import six
@@ -270,6 +273,7 @@ class TestConfigurationK8s(TestConfigurationBase):
         self.assertEquals(type(event_object_filter), ArrayOfStrings)
         self.assertEquals(elems, list(event_object_filter))
 
+    @skipIf(sys.version_info < (3, 6, 0), "Skipping under Python 2")
     def test_k8s_explorer_enable(self):
         def _assert_environment_variable(env_var_name, env_var_value, expected_value):
             os.environ[env_var_name] = env_var_value


### PR DESCRIPTION
This pull request adds new ``k8s_explorer_enable`` config option which enables additional metrics collection which is needed for Kubernetes Explorer functionality.

Right now Kubernetes Explorer also depends on some metrics from Kubernetes Events Monitor so when ``k8s_exlorer_enable`` is True, kubernetes events monitor is enabled as well.

For now, this PR also disables building ``k8s-with-openmetrics-monitor`` images (with those changes, those are not needed anymore, but I left code in place in case we may need them in the future - e.g. if we want to release new explorer agent version without main agent release).