### PR TITLE
Log a warning in case a mandatory metrics exporter is not being scrapped

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -223,6 +223,8 @@ DEFAULT_SCRAPE_SCHEME = "http"
 DEFAULT_SCRAPE_PORT = None
 DEFAULT_SCRAPE_PATH = "/metrics"
 
+CONFIG_DOCS_URL = "https://app.scalyr.com/help/scalyr-agent-k8s-explorer"
+
 define_config_option(
     __monitor__,
     "module",
@@ -380,6 +382,14 @@ define_config_option(
     default=True,
 )
 
+define_config_option(
+    __monitor__,
+    "silence_mandatory_monitors_warnings",
+    "True to silence warnings about mandatory pods not being scraped. This should be set to True when non-default / non-standard resource names are used for node-exporter DaemonSet and kube-state-metrics Deployment.",
+    convert_to=bool,
+    default=False,
+)
+
 KUBERNETES_API_METRICS_URL = Template(
     "${k8s_api_url}/api/v1/nodes/${node_name}/proxy/metrics"
 )
@@ -514,6 +524,9 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
         )
         self.__include_node_name = self._config.get("include_node_name", False)
         self.__include_cluster_name = self._config.get("include_cluster_name", False)
+        self.__silence_mandatory_monitors_warnings = self._config.get(
+            "silence_mandatory_monitors_warnings", False
+        )
 
         self.__k8s_api_url = self._global_config.k8s_api_url
 
@@ -603,6 +616,48 @@ class KubernetesOpenMetricsMonitor(ScalyrMonitor):
 
         self.__schedule_dynamic_open_metrics_monitors()
         self.__log_running_stats()
+
+        if self.__static_monitors_started:
+            self.__check_mandatory_monitors_are_running()
+
+    def __check_mandatory_monitors_are_running(self):
+        """
+        This method checks that the monitors which scrape node-exporter and kube-state-metrics
+        exporter pods are running.
+
+        Those two exporters are needed for the complete Kubernetes Explorer experience.
+
+        NOTE: kube-state-metrics exporter is a Deployment which only runs on a single node and
+        node-exporter is a DaemonSet.
+
+        Keep in mind that this check only covers default / standard setups and doesn't handle
+        scenario where non-standard resource names are used.
+        """
+        if self.__silence_mandatory_monitors_warnings:
+            return
+
+        has_node_exporter_monitor = False
+
+        monitor_names = self.__running_monitors.values()
+        for monitor_name in monitor_names:
+            if "node_exporter" in monitor_name or "node-exporter" in monitor_name:
+                has_node_exporter_monitor = True
+                break
+
+        if not has_node_exporter_monitor:
+            GLOBAL_LOG.warn(
+                'Could not find running OpenMetrics monitor for "node-exporter" '
+                "Deployment. Scraping node-exporter is mandatory for a complete "
+                "Kubernetes Explorer experience. For information on how to configure "
+                "scraping of node-exporter Deployment pod, please visit "
+                f"{CONFIG_DOCS_URL}",
+                limit_once_per_x_secs=(1 * 60 * 60),
+                limit_key="node_exporter_monitor_not_found",
+            )
+
+        # TODO: Also implement kube-state-metrics check - this is harder since it's a Deployment
+        # which doesn't run on every node which means we need to introduce lightweight consensus /
+        # store metadata in k8s and query it here
 
     def __log_running_stats(self):
         # We log a message either if the value from the previous run changes or every X minutes

--- a/scalyr_agent/builtin_monitors/openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/openmetrics_monitor.py
@@ -457,6 +457,8 @@ class OpenMetricsMonitor(ScalyrMonitor):
                 # float
                 metric_value = float(metric_value)  # type: ignore
                 metric_value = int(metric_value)  # type: ignore
+            elif metric_value == "NaN":
+                continue
             elif metric_value == "+Inf":
                 pass
             else:

--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -918,3 +918,78 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
             "k8s_explorer_enable config option is set to true, enabling kubernetes events monitor"
         )
         self.assertEqual(mock_global_log.info.call_count, 1)
+
+    @mock.patch(
+        "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor.GLOBAL_LOG"
+    )
+    def test_warning_logged_on_missing_mandatory_monitor(self, mock_global_log):
+        global_config = mock.Mock()
+        global_config.agent_log_path = MOCK_AGENT_LOG_PATH
+        global_config.k8s_include_namespaces = []
+        global_config.k8s_ignore_namespaces = []
+        mock_logger = mock.Mock()
+
+        KubernetesEventsMonitor._get_log_rotation_configuration = mock.Mock(
+            return_value=(None, None)
+        )
+
+        mock_global_log.reset_mock()
+
+        global_config.k8s_explorer_enable = False
+        monitor_config = {
+            "module": "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor",
+        }
+        self.assertEqual(mock_global_log.info.call_count, 0)
+        monitor = KubernetesOpenMetricsMonitor(
+            monitor_config=monitor_config,
+            logger=mock_logger,
+            global_config=global_config,
+        )
+
+        # 1. has node_exporter
+        monitor._KubernetesOpenMetricsMonitor__running_monitors = {
+            "http://192.168.1.10:9100/metrics": "scalyr_agent.builtin_monitors.openmetrics_monitor-homelab-k8s-pi4b-4g-worker-1_node_exporter-xmsw5",
+        }
+        self.assertEqual(mock_global_log.warn.call_count, 0)
+        monitor._KubernetesOpenMetricsMonitor__check_mandatory_monitors_are_running()
+        self.assertEqual(mock_global_log.warn.call_count, 0)
+
+        # 2. has node-exporter
+        mock_global_log.reset_mock()
+
+        monitor._KubernetesOpenMetricsMonitor__running_monitors = {
+            "http://192.168.1.10:9100/metrics": "scalyr_agent.builtin_monitors.openmetrics_monitor-homelab-k8s-pi4b-4g-worker-1_node-exporter-xmsw5",
+        }
+        self.assertEqual(mock_global_log.warn.call_count, 0)
+        monitor._KubernetesOpenMetricsMonitor__check_mandatory_monitors_are_running()
+        self.assertEqual(mock_global_log.warn.call_count, 0)
+
+        # 3. doesn't have node exporter
+        mock_global_log.reset_mock()
+
+        monitor._KubernetesOpenMetricsMonitor__running_monitors = {
+            "http://192.168.1.10:9100/metrics": "scalyr_agent.builtin_monitors.openmetrics_monitor-homelab-k8s-pi4b-4g-worker-1_foobar-xmsw5",
+        }
+        self.assertEqual(mock_global_log.warn.call_count, 0)
+        monitor._KubernetesOpenMetricsMonitor__check_mandatory_monitors_are_running()
+        self.assertEqual(mock_global_log.warn.call_count, 1)
+
+        # 3. doesn't have node exporter, warnings silenced
+        mock_global_log.reset_mock()
+
+        monitor_config = {
+            "module": "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor",
+            "silence_mandatory_monitors_warnings": True,
+        }
+        self.assertEqual(mock_global_log.info.call_count, 0)
+        monitor = KubernetesOpenMetricsMonitor(
+            monitor_config=monitor_config,
+            logger=mock_logger,
+            global_config=global_config,
+        )
+        monitor._KubernetesOpenMetricsMonitor__running_monitors = {
+            "http://192.168.1.10:9100/metrics": "scalyr_agent.builtin_monitors.openmetrics_monitor-homelab-k8s-pi4b-4g-worker-1_foobar-xmsw5",
+        }
+        self.assertEqual(mock_global_log.warn.call_count, 0)
+        monitor._KubernetesOpenMetricsMonitor__check_mandatory_monitors_are_running()
+        self.assertEqual(mock_global_log.warn.call_count, 0)


### PR DESCRIPTION
This pull request updates Kubernetes OpenMetrics monitor to log a warning in case OpenMetrics monitor for node exporter pod is not found.

Scrapping node-exporter pod is mandatory for a complete Kubernetes Explorer experience.

Same thing goes for kube state metrics exporter pod, but logic for detecting that has not been implemented yet. kube state metrics is a `Deployment` which means only a single pod will run in a cluster at a time.

Agent deployment and work distribution model is heavily based around the DaemonSet model where each agent pod instance is only responsible for work on a specific node the agent is running on.

That means that if we wanted to implement kube state metrics scrapper running detection logic we would need to check across all the running agent pod instances (aka across all the nodes) which would require us to implement basic coordination primitives.

Implementing something like that is definitely possible, but it would result in unnecessary complexity and overhead, especially since we can solve that much easier on the server (dashboard) side - we can have a simple widget which prints helpful error message in case a specific data is missing and points user to the docs on how to configure their Kubernetes cluster for Kubernetes Explorer.