### PR TITLE
Fix sample interval overriding in the Windows System and Windows Process monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Packaged by Dominic LoBue <dominicl@sentinelone.com> on Jun 28, 2022 12:29 -0800
 
 Windows:
 * Fix bug in Windows System Metrics and Windows Process Metrics monitor where user wasn't able to override / change default sampling rating of 30 seconds (``sample_interval`` monitor config option).
+* Update Windows Process metrics monitor to log a message in case process with the specified pid / command line string is not found when retrieving process metrics.
 
 Other:
 * Support for Python 2.6 has been dropped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Packaged by Dominic LoBue <dominicl@sentinelone.com> on Jun 28, 2022 12:29 -0800
 
 Windows:
 * Fix bug in Windows System Metrics and Windows Process Metrics monitor where user wasn't able to override / change default sampling rating of 30 seconds (``sample_interval`` monitor config option).
-* Update Windows Process metrics monitor to log a message in case process with the specified pid / command line string is not found when retrieving process metrics.
+* Update Windows Process Metrics monitor to log a message in case process with the specified pid / command line string is not found when retrieving process metrics.
+* Update Windows Process Metrics monitor to throw an error in case invalid monitor configuration is specified (neither "pid" nor "commandline" config option is specified or both config options which are mutually exclusive are specified).
 
 Other:
 * Support for Python 2.6 has been dropped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Packaged by Dominic LoBue <dominicl@sentinelone.com> on Jun 28, 2022 12:29 -0800
 Windows:
 * Fix bug in Windows System Metrics and Windows Process Metrics monitor where user wasn't able to override / change default sampling rating of 30 seconds (``sample_interval`` monitor config option).
 
+Other:
+* Support for Python 2.6 has been dropped.
+
 ## 2.1.31 "Irati" - Jun 28, 2022
 
 <!---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
+## 2.1.33 "TBD" - Aug 28, 2022
+
+<!---
+Packaged by Dominic LoBue <dominicl@sentinelone.com> on Jun 28, 2022 12:29 -0800
+--->
+
+Windows:
+* Fix bug in Windows System Metrics and Windows Process Metrics monitor where user wasn't able to override / change default sampling rating of 30 seconds (``sample_interval`` monitor config option).
+
 ## 2.1.31 "Irati" - Jun 28, 2022
 
 <!---

--- a/scalyr_agent/builtin_monitors/windows_process_metrics.py
+++ b/scalyr_agent/builtin_monitors/windows_process_metrics.py
@@ -88,6 +88,9 @@ import six
 
 from scalyr_agent import ScalyrMonitor, UnsupportedSystem
 from scalyr_agent import define_config_option, define_metric, define_log_field
+from scalyr_agent import scalyr_logging
+
+global_log = scalyr_logging.getLogger(__name__)
 
 
 #
@@ -552,7 +555,6 @@ class ProcessMonitor(ScalyrMonitor):
         self.__process = process
 
     def gather_sample(self):
-        """TODO: Function documentation"""
         try:
             self._select_target_process()
             for idx, metric in enumerate(METRICS):
@@ -572,3 +574,14 @@ class ProcessMonitor(ScalyrMonitor):
                 )
         except psutil.NoSuchProcess:
             self.__process = None
+
+            commandline = self._config.get("commandline", None)
+            pid = self._config.get("pid", None)
+
+            # commandline has precedence over pid
+            if commandline:
+                global_log.warn(
+                    'Unable to find process with commandline "%s"' % (commandline)
+                )
+            elif pid:
+                global_log.warn('Unable to find process with pid "%s"' % (pid))

--- a/scalyr_agent/builtin_monitors/windows_process_metrics.py
+++ b/scalyr_agent/builtin_monitors/windows_process_metrics.py
@@ -86,7 +86,7 @@ except ImportError:
 
 import six
 
-from scalyr_agent import ScalyrMonitor, UnsupportedSystem
+from scalyr_agent import ScalyrMonitor, UnsupportedSystem, BadMonitorConfiguration
 from scalyr_agent import define_config_option, define_metric, define_log_field
 from scalyr_agent import scalyr_logging
 
@@ -538,6 +538,18 @@ class ProcessMonitor(ScalyrMonitor):
         self.__id = self._config.get(
             "id", required_field=True, convert_to=six.text_type
         )
+
+        if not self._config.get("commandline") and not self._config.get("pid"):
+            raise BadMonitorConfiguration(
+                'Either "pid" or "commandline" monitor config option needs to be specified (but not both)',
+                "commandline",
+            )
+
+        if self._config.get("commandline") and self._config.get("pid"):
+            raise BadMonitorConfiguration(
+                'Either "pid" or "commandline" monitor config option needs to be specified (but not both)',
+                "commandline",
+            )
 
     def _select_target_process(self):
         """TODO: Function documentation"""

--- a/scalyr_agent/builtin_monitors/windows_process_metrics.py
+++ b/scalyr_agent/builtin_monitors/windows_process_metrics.py
@@ -511,7 +511,9 @@ class ProcessMonitor(ScalyrMonitor):
     """
     # fmt: on
 
-    def __init__(self, monitor_config, logger, **kw):
+    def __init__(
+        self, monitor_config, logger, sample_interval_secs=None, global_config=None
+    ):
         """TODO: Function documentation"""
         if psutil is None:
             raise UnsupportedSystem(
@@ -521,10 +523,11 @@ class ProcessMonitor(ScalyrMonitor):
                 "  pip install psutil",
             )
 
-        sampling_rate = kw.get("sampling_interval_secs", 30)
-        global_config = kw.get("global_config")
         super(ProcessMonitor, self).__init__(
-            monitor_config, logger, sampling_rate, global_config=global_config
+            monitor_config=monitor_config,
+            logger=logger,
+            sample_interval_secs=sample_interval_secs,
+            global_config=global_config,
         )
         self.__process = None
 

--- a/scalyr_agent/builtin_monitors/windows_system_metrics.py
+++ b/scalyr_agent/builtin_monitors/windows_system_metrics.py
@@ -61,10 +61,9 @@ global_log = scalyr_logging.getLogger(__name__)
 CONFIG_OPTIONS = [
     dict(
         option_name="module",
-        option_description="A ScalyrAgent plugin monitor module",
+        option_description="Always ``scalyr_agent.builtin_monitors.windows_system_metrics``",
         convert_to=six.text_type,
         required_option=True,
-        default="windows_system_metrics",
     )
 ]
 

--- a/scalyr_agent/builtin_monitors/windows_system_metrics.py
+++ b/scalyr_agent/builtin_monitors/windows_system_metrics.py
@@ -34,8 +34,6 @@ limitations under the License.
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
-from __future__ import print_function
-
 __author__ = "Scott Sullivan '<guy.hoozdis@gmail.com>'"
 __version__ = "0.0.1"
 __monitor__ = __name__
@@ -602,7 +600,9 @@ class SystemMonitor(ScalyrMonitor):
     """
     # fmt: on
 
-    def __init__(self, config, logger, **kwargs):
+    def __init__(
+        self, monitor_config, logger, sample_interval_secs=None, global_config=None
+    ):
         """TODO: Fucntion documentation"""
         if psutil is None:
             raise UnsupportedSystem(
@@ -611,10 +611,11 @@ class SystemMonitor(ScalyrMonitor):
                 "can be done with the following command:"
                 "  pip install psutil",
             )
-        sampling_rate = kwargs.get("sampling_interval_secs", 30)
-        global_config = kwargs.get("global_config")
         super(SystemMonitor, self).__init__(
-            config, logger, sampling_rate, global_config=global_config
+            monitor_config=monitor_config,
+            logger=logger,
+            sample_interval_secs=sample_interval_secs,
+            global_config=global_config,
         )
 
     def gather_sample(self):

--- a/tests/unit/builtin_monitors/test_windows_process_metrics.py
+++ b/tests/unit/builtin_monitors/test_windows_process_metrics.py
@@ -78,7 +78,7 @@ class WindowsProcessMetricsMonitorTestCase(ScalyrTestCase):
         }
 
         expected_msg = r'Either "pid" or "commandline" monitor config option needs to be specified \(but not both\)'
-        self.assertRaisesRegex(
+        self.assertRaisesRegexp(
             BadMonitorConfiguration,
             expected_msg,
             ProcessMonitor,
@@ -97,7 +97,7 @@ class WindowsProcessMetricsMonitorTestCase(ScalyrTestCase):
         }
 
         expected_msg = r'Either "pid" or "commandline" monitor config option needs to be specified \(but not both\)'
-        self.assertRaisesRegex(
+        self.assertRaisesRegexp(
             BadMonitorConfiguration,
             expected_msg,
             ProcessMonitor,

--- a/tests/unit/builtin_monitors/test_windows_process_metrics.py
+++ b/tests/unit/builtin_monitors/test_windows_process_metrics.py
@@ -1,0 +1,60 @@
+# Copyright 2014-2022 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import mock
+
+from scalyr_agent.test_base import ScalyrTestCase
+
+from scalyr_agent.builtin_monitors.windows_process_metrics import ProcessMonitor
+
+__all__ = ["WindowsProcessMetricsMonitorTestCase"]
+
+
+class WindowsProcessMetricsMonitorTestCase(ScalyrTestCase):
+    @mock.patch(
+        "scalyr_agent.builtin_monitors.windows_process_metrics.psutil", mock.Mock()
+    )
+    def test_custom_sample_interval(self):
+        mock_logger = mock.Mock()
+
+        # 1. Default interval
+        monitor_config = {
+            "module": "scalyr_agent.builtin_monitors.windows_process_metrics",
+            "id": "id1",
+        }
+        monitor = ProcessMonitor(monitor_config, logger=mock_logger)
+        self.assertEqual(monitor._sample_interval_secs, 30)
+
+        # 2. Custom interval overriden via monitor config option
+        monitor_config = {
+            "module": "scalyr_agent.builtin_monitors.windows_process_metrics",
+            "id": "id1",
+            "sample_interval": 90,
+        }
+        monitor = ProcessMonitor(monitor_config, logger=mock_logger)
+        self.assertEqual(monitor._sample_interval_secs, 90)
+
+        # 3. Overriden via constructor argument (only when used programtically)
+        monitor_config = {
+            "module": "scalyr_agent.builtin_monitors.windows_process_metrics",
+            "id": "id1",
+            "sample_interval": 90,
+        }
+        monitor = ProcessMonitor(
+            monitor_config, logger=mock_logger, sample_interval_secs=66
+        )
+        self.assertEqual(monitor._sample_interval_secs, 66)

--- a/tests/unit/builtin_monitors/test_windows_system_metrics.py
+++ b/tests/unit/builtin_monitors/test_windows_system_metrics.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import mock
 

--- a/tests/unit/builtin_monitors/test_windows_system_metrics.py
+++ b/tests/unit/builtin_monitors/test_windows_system_metrics.py
@@ -18,8 +18,9 @@ import mock
 
 from scalyr_agent.test_base import ScalyrTestCase
 
-from scalyr_agent.builtin_monitors.windows_system_metrics import _gather_metric
 from scalyr_agent.builtin_monitors.windows_system_metrics import __NO_DISK_PERF__
+from scalyr_agent.builtin_monitors.windows_system_metrics import _gather_metric
+from scalyr_agent.builtin_monitors.windows_system_metrics import SystemMonitor
 
 __all__ = ["WindowsSystemMetricsMonitorTestCase"]
 
@@ -55,3 +56,34 @@ class WindowsSystemMetricsMonitorTestCase(ScalyrTestCase):
         result = list(_gather_metric(method="disk_io_counters")())
 
         self.assertEqual(result[0][0], __NO_DISK_PERF__)
+
+    @mock.patch(
+        "scalyr_agent.builtin_monitors.windows_system_metrics.psutil", mock.Mock()
+    )
+    def test_custom_sample_interval(self):
+        mock_logger = mock.Mock()
+
+        # 1. Default interval
+        monitor_config = {
+            "module": "scalyr_agent.builtin_monitors.windows_system_metrics"
+        }
+        monitor = SystemMonitor(monitor_config, logger=mock_logger)
+        self.assertEqual(monitor._sample_interval_secs, 30)
+
+        # 2. Custom interval overriden via monitor config option
+        monitor_config = {
+            "module": "scalyr_agent.builtin_monitors.windows_system_metrics",
+            "sample_interval": 90,
+        }
+        monitor = SystemMonitor(monitor_config, logger=mock_logger)
+        self.assertEqual(monitor._sample_interval_secs, 90)
+
+        # 3. Overriden via constructor argument (only when used programtically)
+        monitor_config = {
+            "module": "scalyr_agent.builtin_monitors.windows_system_metrics",
+            "sample_interval": 90,
+        }
+        monitor = SystemMonitor(
+            monitor_config, logger=mock_logger, sample_interval_secs=66
+        )
+        self.assertEqual(monitor._sample_interval_secs, 66)


### PR DESCRIPTION
This pull request fixes a bug in Windows System and Windows Process monitor which didn't allow user to override / change the default sample interval of 30 seconds using ``sample_interval`` monitor config option.