### PR TITLE
Fix a bug with "import_vars" functionality which would not work correctly when multiple variables used the same common prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Windows:
 * Update Windows Process Metrics monitor to log a message in case process with the specified pid / command line string is not found when retrieving process metrics.
 * Update Windows Process Metrics monitor to throw an error in case invalid monitor configuration is specified (neither "pid" nor "commandline" config option is specified or both config options which are mutually exclusive are specified).
 
+Bug fixes:
+* Fix a bug with ``import_vars`` functionality which didn't work correctly when the same variable name prefix was used (e.g. ``SCALYR_FOO_TEST``, ``SCALYR_FOO``).
+
 Other:
 * Support for Python 2.6 has been dropped.
 

--- a/conftest.py
+++ b/conftest.py
@@ -64,17 +64,6 @@ collect_ignore_glob.extend(GLOBAL_WHITELIST)
 
 collect_ignore = ["setup.py"]
 
-# NOTE: Older version of pytest (<= 3.2.5 )which is used under Python 2.6 doesn't support
-# collect_ignore_glob directive
-if sys.version_info[:2] == (2, 6):
-    import fnmatch
-
-    for directory in GLOBAL_WHITELIST:
-        for root, dirnames, filenames in os.walk(directory.replace("/*", "/")):
-            for filename in fnmatch.filter(filenames, "*.py"):
-                file_path = os.path.join(root, filename)
-                collect_ignore.append(file_path)
-
 
 def get_module_path_for_fqdn(module_fqdn):
     # type: (str) -> str

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -665,15 +665,6 @@ class ScalyrAgent(object):
             log.error("Terminating agent, please fix the error and restart the agent.")
             return 1
 
-        if sys.version_info[:2] < (2, 6):
-            print(
-                "Warning, the Scalyr Agent will not support running on Python 2.4, 2.5 after Oct 2019",
-                file=sys.stderr,
-            )
-            log.error(
-                "Warning, the Scalyr Agent will not support running on Python 2.4, 2.5 after Oct 2019"
-            )
-
         if not self.__no_fork:
             # Do one last check to just cut down on the window of race conditions.
             self.__fail_if_already_running()

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -4650,7 +4650,16 @@ def perform_str_substitution(str_value, substitutions):
     @rtype: str or unicode
     """
     result = str_value
-    for (var_name, value) in six.iteritems(substitutions):
+
+    # NOTE: Right now out substitution code also supports partial substitutions which means we can't
+    # use regular expression directly, but we need to sort substitutions variables by length (desc)
+    # before we perform substitutions to ensure we use the correct substitution variable in case
+    # multiple variables share the same prefix.
+    # For example: $SCALYR_FOO_VAR1, $SCALYR_FOO_VAR2, $SCALYR_FOO
+    substitutions_variable_names = sorted(substitutions.keys(), key=len, reverse=True)
+
+    for var_name in substitutions_variable_names:
+        value = substitutions[var_name]
         result = result.replace("$%s" % var_name, value)
     return result
 

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -1249,6 +1249,40 @@ class TestConfiguration(TestConfigurationBase):
 
         self.assertEquals(config.api_key, "hibye")
 
+    def test_import_vars_substitution_common_prefix(self):
+        self._write_file_with_separator_conversion(
+            """ {
+            import_vars: [ "TEST_FOO", "TEST_FOO_VAR1", "TEST_FOO_VAR", "TEST_FOO_VAR2", "SCALYR_DEVICE", "SCALYR_DEVICE_BAR" ],
+            api_key: "key",
+            server_attributes: {
+                "serverHost": "bar",
+                "var1": "$TEST_FOO_VAR1",
+                "var2": "$TEST_FOO_VAR2",
+                "var3": "$TEST_FOO",
+                "var4": "$TEST_FOO_VAR",
+                "var5": "hi$SCALYR_DEVICE"
+                "var6": "hi$SCALYR_DEVICE_BAR"
+            }
+          }
+        """
+        )
+        os.environ["TEST_FOO_VAR1"] = "foovar1"
+        os.environ["TEST_FOO_VAR2"] = "foovar2"
+        os.environ["TEST_FOO"] = "abc"
+        os.environ["TEST_FOO_VAR"] = "defg"
+        os.environ["SCALYR_DEVICE"] = "device"
+        os.environ["SCALYR_DEVICE_BAR"] = "bar"
+
+        config = self._create_test_configuration_instance()
+        config.parse()
+
+        self.assertEqual(config.server_attributes["var1"], "foovar1")
+        self.assertEqual(config.server_attributes["var2"], "foovar2")
+        self.assertEqual(config.server_attributes["var3"], "abc")
+        self.assertEqual(config.server_attributes["var4"], "defg")
+        self.assertEqual(config.server_attributes["var5"], "hidevice")
+        self.assertEqual(config.server_attributes["var6"], "hibar")
+
     def test_substitution_with_default(self):
         self._write_file_with_separator_conversion(
             """ {

--- a/tests/unit/log_processing_test.py
+++ b/tests/unit/log_processing_test.py
@@ -490,7 +490,6 @@ class TestLogFileIterator(ScalyrTestCase):
 
     # Since it cannot keep file handles open when their permissions are changed, win32 cannot handle this case:
     @skipIf(platform.system() == "Windows", "Skipping tests under Windows")
-    @skipIf(sys.version_info[:2] == (2, 6), "Skipping under Python 2.6")
     def test_losing_read_access(self):
         self.append_file(self.__path, b"L001\n", b"L002\n")
         restore_access = self.remove_read_access()
@@ -2872,16 +2871,15 @@ class TestLogMatcher(ScalyrTestCase):
 
     def test_matches_recursive_glob(self):
         # Recursive "**" glob patterns are only supported on Python 2.6 and above.
-        if sys.version_info >= (2, 6):
-            matcher = LogMatcher(
-                self.__config, self._create_log_config(self.__glob_recursive)
-            )
-            processors = matcher.find_matches(dict(), dict())
-            self.assertEqual(len(processors), 2)
-            self.assertEqual(processors[0].get_log_path(), self.__path_three)
-            self.assertEqual(processors[1].get_log_path(), self.__path_four)
+        matcher = LogMatcher(
+            self.__config, self._create_log_config(self.__glob_recursive)
+        )
+        processors = matcher.find_matches(dict(), dict())
+        self.assertEqual(len(processors), 2)
+        self.assertEqual(processors[0].get_log_path(), self.__path_three)
+        self.assertEqual(processors[1].get_log_path(), self.__path_four)
 
-            self._close_processors(processors)
+        self._close_processors(processors)
 
     def test_ignores_stale_file(self):
         staleness_threshold = 300  # 5 mins

--- a/tests/unit/util/json_util_test.py
+++ b/tests/unit/util/json_util_test.py
@@ -155,7 +155,7 @@ class EncodeDecodeTest(ScalyrTestCase):
             finally:
                 util.set_json_lib(original_lib)
 
-        if sys.version_info[:2] > (2, 4) and sys.version_info[:2] != (2, 6):
+        if sys.version_info[:2] >= (2, 7):
             __runtest(UJSON)
         if sys.version_info[:2] > (2, 5):
             __runtest(JSON)


### PR DESCRIPTION
This pull request fixes bug in the ``import_vars`` functionality which would not work correctly when multiple variables used the same common prefix (e.g. ``SCALYR_FOO, SCALYR_FOO_BAR, SCALYR_FOO_BAZ``).

## Proposed Fix

Proposed fix in this PR includes sorting variable names by length in the descending order (from the longest to the shortest) when applying variable substitutions. This way we make sure that the correct and most "specific" variable is used when common prefix is shared by multiple variables.

It's worth noting that we can't use regular expressions directly since we support partial / inline substitutions, e.g. (``foo$VARIABLE_BARbaz``).