### PR TITLE
Upgrade dependencies used by the Docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Bug fixes:
 * Fix a bug with ``import_vars`` functionality which didn't work correctly when the same variable name prefix was used (e.g. ``SCALYR_FOO_TEST``, ``SCALYR_FOO``).
 
 Docker images:
-* Upgrade various dependencies: orjson, requests, zstandard, lz4
+* Upgrade various dependencies: orjson, requests, zstandard, lz4.
 
 Other:
 * Support for Python 2.6 has been dropped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Windows:
 Bug fixes:
 * Fix a bug with ``import_vars`` functionality which didn't work correctly when the same variable name prefix was used (e.g. ``SCALYR_FOO_TEST``, ``SCALYR_FOO``).
 
+Docker images:
+* Upgrade various dependencies: orjson, requests, zstandard, lz4
+
 Other:
 * Support for Python 2.6 has been dropped.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Bug fixes:
 * Fix a bug with ``import_vars`` functionality which didn't work correctly when the same variable name prefix was used (e.g. ``SCALYR_FOO_TEST``, ``SCALYR_FOO``).
 
 Docker images:
-* Upgrade various dependencies: orjson, requests, zstandard, lz4.
+* Upgrade various dependencies: orjson, requests, zstandard, lz4, docker.
 
 Other:
 * Support for Python 2.6 has been dropped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
-## 2.1.32 "TBD" - Aug 28, 2022
+## 2.1.32 "Occao" - July 20, 2022
 
 <!---
-Packaged by Dominic LoBue <dominicl@sentinelone.com> on Jun 28, 2022 12:29 -0800
+Packaged by Dominic LoBue <dominicl@sentinelone.com> on Jul 20, 2022 12:29 -0800
 --->
 
 Windows:

--- a/agent_build/requirement-files/compression-requirements.txt
+++ b/agent_build/requirement-files/compression-requirements.txt
@@ -1,7 +1,7 @@
 # Compression libraries
 # NOTE: zstandard don't include pre-built wheels for ARMv7 for glibc and
 # musl.
-zstandard==0.17.0; python_version >= '3.6' and 'armv7' not in platform_machine
+zstandard==0.18.0; python_version >= '3.6' and 'armv7' not in platform_machine
 zstandard==0.15.2; python_version >= '3.5' and python_version < '3.6' and 'armv7' not in platform_machine
 zstandard==0.14.1; python_version < '3.5' and 'armv7' not in platform_machine
 

--- a/agent_build/requirement-files/compression-requirements.txt
+++ b/agent_build/requirement-files/compression-requirements.txt
@@ -5,6 +5,6 @@ zstandard==0.18.0; python_version >= '3.6' and 'armv7' not in platform_machine
 zstandard==0.15.2; python_version >= '3.5' and python_version < '3.6' and 'armv7' not in platform_machine
 zstandard==0.14.1; python_version < '3.5' and 'armv7' not in platform_machine
 
-lz4==4.0.0; python_version >= '3.7'
+lz4==4.0.1; python_version >= '3.7'
 lz4==3.1.1; python_version >= '3.5' and python_version <= '3.6'
 lz4==2.2.1; python_version < '3.5'

--- a/agent_build/requirement-files/docker-image-requirements.txt
+++ b/agent_build/requirement-files/docker-image-requirements.txt
@@ -8,7 +8,7 @@ udatetime==0.0.16; python_version < '3.9'
 # default. We include it in the Docker image to make  troubleshooting (profiling) easier for the
 # end user (no need to rebuild Docker image - user can simply enable the corresponding agent config
 # option)
-yappi==1.3.3
-pympler==0.8
+yappi==1.3.5
+pympler==1.0.1
 
 docker==4.1.0

--- a/agent_build/requirement-files/docker-image-requirements.txt
+++ b/agent_build/requirement-files/docker-image-requirements.txt
@@ -8,7 +8,9 @@ udatetime==0.0.16; python_version < '3.9'
 # default. We include it in the Docker image to make  troubleshooting (profiling) easier for the
 # end user (no need to rebuild Docker image - user can simply enable the corresponding agent config
 # option)
-yappi==1.3.5
-pympler==1.0.1
+yappi==1.3.5; python_version >= '3.7'
+pympler==1.0.1; python_version >= '3.7'
+# used by Python 2.7 tests
+pympler==0.8; python_version < '3.7'
 
 docker==4.1.0

--- a/agent_build/requirement-files/docker-image-requirements.txt
+++ b/agent_build/requirement-files/docker-image-requirements.txt
@@ -13,4 +13,4 @@ pympler==1.0.1; python_version >= '3.7'
 # used by Python 2.7 tests
 pympler==0.8; python_version < '3.7'
 
-docker==4.1.0
+docker==4.4.4

--- a/agent_build/requirement-files/main-requirements.txt
+++ b/agent_build/requirement-files/main-requirements.txt
@@ -6,4 +6,6 @@ orjson==3.7.7; python_version >= '3.7' and platform_system != 'Darwin'
 orjson==3.6.1; python_version == '3.6' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 orjson==2.0.11; python_version == '3.5' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 
-requests==2.28.1
+requests==2.28.1; python_version >= '3.7'
+# used by Python 2.7 tests
+requests==2.25.1; python_version < '3.7'

--- a/agent_build/requirement-files/main-requirements.txt
+++ b/agent_build/requirement-files/main-requirements.txt
@@ -2,8 +2,8 @@
 # orjson is not available for armv7 + musl yet, but it's available for armv7 +
 # libc. we handle that in dockerfile since python environment markers are not
 # specific enough.
-orjson==3.7.5; python_version >= '3.7' and platform_system != 'Darwin'
+orjson==3.7.7; python_version >= '3.7' and platform_system != 'Darwin'
 orjson==3.6.1; python_version == '3.6' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 orjson==2.0.11; python_version == '3.5' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 
-requests==2.25.1
+requests==2.27.1

--- a/agent_build/requirement-files/main-requirements.txt
+++ b/agent_build/requirement-files/main-requirements.txt
@@ -6,4 +6,4 @@ orjson==3.7.7; python_version >= '3.7' and platform_system != 'Darwin'
 orjson==3.6.1; python_version == '3.6' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 orjson==2.0.11; python_version == '3.5' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 
-requests==2.27.1
+requests==2.28.1

--- a/agent_build/requirement-files/testing-requirements.txt
+++ b/agent_build/requirement-files/testing-requirements.txt
@@ -25,7 +25,7 @@ PyYAML==5.4.1; python_version >= '3.6'
 PyYAML==5.3.1; python_version == '3.5'
 PyYAML==5.3.1; python_version <= '2.7'
 six==1.13.0
-docker==4.1.0
+docker==4.4.4
 # the version of 'requests' library that 'docker' uses as a dependency is higher than we use in agent,
 # to prevent versions conflict, install the appropriate version of 'requests', to force 'docker' to reuse it.
 # NOTE: We can't use requests >= 2.22.0 since we still need to support Python 2.6

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,5 +1,5 @@
 # This file contains requirements which are needed by the lint test targets
-black==22.3.0
+black==22.6.0
 modernize==0.7
 flake8==4.0.1
 pylint==2.13.8


### PR DESCRIPTION
This pull request updates the following dependencies used by the Docker images:

* orjson - https://github.com/ijl/orjson/blob/master/CHANGELOG.md#377---2022-07-06
* requests - https://github.com/psf/requests/blob/main/HISTORY.md#2281-2022-06-29
* docker - https://docker-py.readthedocs.io/en/stable/change-log.html#
* zstandard
* lz4 - https://github.com/python-lz4/python-lz4/releases/tag/v4.0.1
* yappi (debug dependency) - https://github.com/sumerc/yappi/blob/master/CHANGELOG#L4
* pympler (debug dependency) - https://github.com/pympler/pympler/blob/master/CHANGELOG.md#101---2021-12-22

NOTE: Right now our dependencies are a bit of a mess and docker dependencies are also installed by different test targets (including Python 2.7 unit tests) which means I needed to use environment markers.