### PR TITLE
Remove optional pyyaml dependency used by tests

### DIFF
--- a/agent_build/requirement-files/testing-requirements.txt
+++ b/agent_build/requirement-files/testing-requirements.txt
@@ -21,9 +21,6 @@ coverage==4.5.4
 codecov==2.1.9
 decorator==4.4.1
 requests-mock==1.9.3
-PyYAML==5.4.1; python_version >= '3.6'
-PyYAML==5.3.1; python_version == '3.5'
-PyYAML==5.3.1; python_version <= '2.7'
 six==1.13.0
 docker==4.4.4
 # the version of 'requests' library that 'docker' uses as a dependency is higher than we use in agent,

--- a/benchmarks/scripts/send_usage_data_to_codespeed.py
+++ b/benchmarks/scripts/send_usage_data_to_codespeed.py
@@ -113,7 +113,7 @@ METRICS_COUNTERS = {
 # Once we drop support for Python 2, we can switch back to numpy
 def calculate_percentile(data, percentile):
     size = len(data)
-    return sorted(data)[math.ceil((size * percentile) / 100) - 1]
+    return sorted(data)[int(math.ceil((size * percentile) / 100)) - 1]
 
 
 def calculate_stddev(data):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,6 @@ import os
 import sys
 
 import pytest
-import yaml
 import six
 
 from scalyr_agent import compat
@@ -81,6 +80,13 @@ def test_config(request, agent_env_settings_fields):
     """
     config_path = request.config.getoption("--test-config")
     if config_path and Path(config_path).exists():
+        try:
+            import yaml
+        except ImportError:
+            raise ImportError(
+                "Missing pyyaml dependency, you can install it using pip:\n\tpip install pyyaml"
+            )
+
         config_path = Path(config_path)
         with config_path.open("r") as f:
             config = yaml.safe_load(f)

--- a/windows-unit-tests-requirements.txt
+++ b/windows-unit-tests-requirements.txt
@@ -11,9 +11,6 @@ pytest-xdist==1.31.0
 coverage==4.5.4
 codecov==2.1.9
 decorator==4.4.1
-PyYAML==5.4.1; python_version >= '3.6'
-PyYAML==5.4; python_version == '3.5'
-PyYAML==5.4; python_version <= '2.7'
 six==1.13.0
 docker==4.1.0
 # the version of 'requests' library that 'docker' uses as a dependency is higher than we use in agent,


### PR DESCRIPTION
This pull request makes ``pyyaml`` dependency optional since it's not used by any code out of the box (it's only used when ``--test-config`` config option is specified and that doesn't seem to be used by any automated tests right now).

This allows us to simplify our requirements files and get rid of vulnerable (test only) dependency under Python < 3.8.