### PR TITLE
Improvements for the client (agent) side rate calculation

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -85,6 +85,9 @@ for the exporter pod:
             k8s.monitor.config.scalyr.com/scrape_timeout:              '5'
             k8s.monitor.config.scalyr.com/attributes:                  '{"app": "${pod_labels_app}", "instance": "{pod_labels_app.kubernetes.io/instance}", "region": "eu"}'
             k8s.monitor.config.scalyr.com/calculate_rate_metric_names: 'docker.cpu_usage_total_seconds,docker.memory_usage_total'
+            # Or for metrics which have the same metric name, but multiple different extra field values.
+            k8s.monitor.config.scalyr.com/calculate_rate_metric_names: 'node_cpu_seconds_total:mode=user,node_cpu_seconds_total:mode=system'
+
         spec:
         containers:
         - args:

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1645,6 +1645,17 @@ class Configuration(object):
 
         This value should include a list of metric name (global across all the monitors for which)
         rate value should be calculated on the agent side.
+
+        Example values:
+
+        1) Metric name without extra fields:
+          - openmetrics_monitor:metric1
+          - openmetrics_monitor:metric2
+
+        2) Metric name with extra fields (in this case, rate will only be calculated for metric)
+           where extra field "mode" value matches "user" and "kernel":
+          - openmetrics_monitor:docker.cpu_usage_seconds_total:mode=user
+          - openmetrics_monitor:docker.cpu_usage_seconds_total:mode=kernel
         """
         return self.__get_config().get_json_array("calculate_rate_metric_names")
 

--- a/scalyr_agent/instrumentation/decorators.py
+++ b/scalyr_agent/instrumentation/decorators.py
@@ -39,7 +39,7 @@ def should_sample(sample_rate):
 # TODO: Eventually add dependency on numpy or similar and utilize running / moving mean + percentiles
 def time_function_call(stats_dict, sample_rate):
     """
-    Utility decorator which records records function timing related information (how long the function
+    Utility decorator which records function timing related information (how long the function
     took to complete in milliseconds) into the provided stats dictionary.
 
     The following values are tracked / record:

--- a/scalyr_agent/instrumentation/decorators.py
+++ b/scalyr_agent/instrumentation/decorators.py
@@ -12,25 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-This module contains various utility code and functions for recording various code run time and
-timing based information.
-"""
-
-if False:
-    from typing import Dict
-
 import random
 
 from functools import wraps
 from timeit import default_timer as timer
 
+from scalyr_agent.instrumentation.timing import reset_stats_dict
 from scalyr_agent.scalyr_logging import getLogger
 
 __all__ = [
-    "get_empty_stats_dict",
-    "reset_stats_dict",
-    "record_timing_stats_for_function_call",
+    "time_function_call",
 ]
 
 LOG = getLogger(__name__)
@@ -45,31 +36,8 @@ def should_sample(sample_rate):
     return random.random() < sample_rate
 
 
-def get_empty_stats_dict():
-    # type: () -> Dict[str, float]
-    """
-    Return empty dictionary used for holding function timing stats information.
-
-    TODO: Once we move to Python 3 only, use a dataclass instead.
-    """
-    return reset_stats_dict({})
-
-
-def reset_stats_dict(stats_dict):
-    # type: Dict[str, float] -> None
-    """
-    Reset values for the provided function run time stats dictionary.
-    """
-    stats_dict["min"] = float("inf")
-    stats_dict["max"] = float("-inf")
-    stats_dict["avg"] = 0.0
-    stats_dict["sum"] = 0.0
-    stats_dict["count"] = 0
-    return stats_dict
-
-
 # TODO: Eventually add dependency on numpy or similar and utilize running / moving mean + percentiles
-def record_timing_stats_for_function_call(stats_dict, sample_rate):
+def time_function_call(stats_dict, sample_rate):
     """
     Utility decorator which records records function timing related information (how long the function
     took to complete in milliseconds) into the provided stats dictionary.
@@ -113,7 +81,7 @@ def record_timing_stats_for_function_call(stats_dict, sample_rate):
 
             if stats_dict["count"] >= STATS_DICT_SAMPLE_COUNT_RESET_INTERVAL:
                 LOG.debug(
-                    "Reseting stats dict %s after %s samples",
+                    "Resetting stats dict %s after %s samples",
                     stats_dict,
                     STATS_DICT_SAMPLE_COUNT_RESET_INTERVAL,
                 )

--- a/scalyr_agent/instrumentation/timing.py
+++ b/scalyr_agent/instrumentation/timing.py
@@ -32,7 +32,7 @@ def get_empty_stats_dict():
 
 
 def reset_stats_dict(stats_dict):
-    # type: Dict[str, float] -> None
+    # type: (Dict[str, float]) -> None
     """
     Reset values for the provided function run time stats dictionary.
     """

--- a/scalyr_agent/instrumentation/timing.py
+++ b/scalyr_agent/instrumentation/timing.py
@@ -1,0 +1,44 @@
+# Copyright 2014-2022 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if False:
+    from typing import Dict
+
+__all__ = [
+    "get_empty_stats_dict",
+    "reset_stats_dict",
+]
+
+
+def get_empty_stats_dict():
+    # type: () -> Dict[str, float]
+    """
+    Return empty dictionary used for holding function timing stats information.
+
+    TODO: Once we move to Python 3 only, use a dataclass instead.
+    """
+    return reset_stats_dict({})
+
+
+def reset_stats_dict(stats_dict):
+    # type: Dict[str, float] -> None
+    """
+    Reset values for the provided function run time stats dictionary.
+    """
+    stats_dict["min"] = float("inf")
+    stats_dict["max"] = float("-inf")
+    stats_dict["avg"] = 0.0
+    stats_dict["sum"] = 0.0
+    stats_dict["count"] = 0
+    return stats_dict

--- a/scalyr_agent/metrics/base.py
+++ b/scalyr_agent/metrics/base.py
@@ -34,8 +34,8 @@ if False:
 import six
 
 from scalyr_agent.util import get_flat_dictionary_memory_usage
-from scalyr_agent.timing import get_empty_stats_dict
-from scalyr_agent.timing import record_timing_stats_for_function_call
+from scalyr_agent.instrumentation.timing import get_empty_stats_dict
+from scalyr_agent.instrumentation.decorators import time_function_call
 from scalyr_agent.metrics.functions import MetricFunction
 from scalyr_agent.metrics.functions import RateMetricFunction
 from scalyr_agent.scalyr_logging import getLogger
@@ -85,7 +85,7 @@ LAZY_PRINT_TIMING_AVG = LazyOnPrintEvaluatedFunction(
 )
 
 
-@record_timing_stats_for_function_call(GET_FUNCTIONS_FOR_METRICS_RUNTIME_STATS, 0.001)
+@time_function_call(GET_FUNCTIONS_FOR_METRICS_RUNTIME_STATS, 0.001)
 def get_functions_for_metric(monitor, metric_name):
     # type: (ScalyrMonitor, six.text_type) -> List[MetricFunction]
     """

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -39,8 +39,8 @@ import six
 
 from scalyr_agent.util import get_hash_for_flat_dictionary
 from scalyr_agent.util import get_flat_dictionary_memory_usage
-from scalyr_agent.timing import get_empty_stats_dict
-from scalyr_agent.timing import record_timing_stats_for_function_call
+from scalyr_agent.instrumentation.timing import get_empty_stats_dict
+from scalyr_agent.instrumentation.decorators import time_function_call
 from scalyr_agent.scalyr_logging import getLogger
 from scalyr_agent.scalyr_logging import LazyOnPrintEvaluatedFunction
 
@@ -158,7 +158,7 @@ could add overhead in terms of CPU and memory usage.
     )
 
     @classmethod
-    @record_timing_stats_for_function_call(RATE_METRIC_CALCULATE_RUNTIME_STATS, 0.001)
+    @time_function_call(RATE_METRIC_CALCULATE_RUNTIME_STATS, 0.001)
     def calculate(
         cls, monitor, metric_name, metric_value, extra_fields=None, timestamp=None
     ):

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -21,8 +21,10 @@ such as rates, derivatives, aggregations, etc.
 if False:
     from typing import Optional
     from typing import List
-    from typing import Union
     from typing import Tuple
+    from typing import Dict
+    from typing import Any
+    from typing import Union
 
     from scalyr_agent.scalyr_monitor import ScalyrMonitor  # NOQA
 
@@ -31,8 +33,11 @@ import time
 from abc import ABCMeta
 from abc import abstractmethod
 from collections import defaultdict
+from itertools import chain
 
 import six
+
+from scalyr_agent.util import get_hash_for_flat_dictionary
 
 
 class MetricFunction(six.with_metaclass(ABCMeta)):
@@ -42,8 +47,20 @@ class MetricFunction(six.with_metaclass(ABCMeta)):
 
     @classmethod
     @abstractmethod
-    def should_calculate(cls, monitor, metric_name):
+    def should_calculate_for_monitor_and_metric(cls, monitor, metric_name):
         # type: (ScalyrMonitor, six.text_type) -> bool
+        """
+        Return True if rate should be calculated for the provided monitor and metric name.
+
+        This function is used for internal (monitor_name, metric_name) cache and additional filtering
+        which takes extra_field values into account is performed when "calculate()" method is called.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def should_calculate(cls, monitor, metric_name, extra_fields=None):
+        # type: (ScalyrMonitor, six.text_type, Optional[Dict[str, Any]]) -> bool
         """
         Return True if this function should be calculated for the provided metric.
         """
@@ -51,14 +68,17 @@ class MetricFunction(six.with_metaclass(ABCMeta)):
 
     @classmethod
     @abstractmethod
-    def calculate(cls, monitor, metric_name, metric_value, timestamp):
-        # type: (ScalyrMonitor, six.text_type, Union[int, float], Optional[int]) -> Optional[List[Tuple[str, float]]]
+    def calculate(
+        cls, monitor, metric_name, metric_value, extra_fields=None, timestamp=None
+    ):
+        # type: (ScalyrMonitor, six.text_type, Union[int, float], Optional[Dict[str,Any]], Optional[int]) -> Optional[List[Tuple[str, float]]]
         """
         Run function on the provided metric and return any derived metrics which should be emitted.
 
         :param monitor: ScalyrMonitor instance.
         :param metric_name: Metric name.
         :param metric_value: Metric value.
+        :param extra_fields: Optional dictionary with metric extra fields.
         :param timestamp: Optional timestamp of metric collection in ms. If not provided, we
                           default to current time.
         """
@@ -78,7 +98,7 @@ class RateMetricFunction(MetricFunction):
 
     # Stores metric values and timestamp for the metrics which we calculate per second rate in the
     # agent.
-    # Maps <monitor name + monitor instance id short hash>.<metric name> to a tuple
+    # Maps <monitor name + monitor instance id short hash>.<metric name>.<extra fields hash> to a tuple
     # (<timestamp_of_previous_colection>, <previously_collected_value>).
     # To avoid collisions across monitors (same metric name can be used by multiple monitors), we prefix
     # metric name with a short hash of the monitor FQDN (<monitor module>.<monitor class name>) +
@@ -95,7 +115,7 @@ class RateMetricFunction(MetricFunction):
     MAX_RATE_TIMESTAMP_DELTA_SECONDS = 11 * 60
 
     # If we track rate for more than this many metrics, a warning will be emitted.
-    MAX_RATE_METRICS_COUNT_WARN = 5000
+    MAX_RATE_METRICS_COUNT_WARN = 15000
 
     MAX_RATE_METRIC_WARN_MESSAGE = """
 Tracking client side rate for over %s metrics. Tracking and calculating rate for that many metrics
@@ -105,7 +125,9 @@ could add overhead in terms of CPU and memory usage.
     )
 
     @classmethod
-    def calculate(cls, monitor, metric_name, metric_value, timestamp=None):
+    def calculate(
+        cls, monitor, metric_name, metric_value, extra_fields=None, timestamp=None
+    ):
         """
         Calculate per second rate for the provided metric name (if configured to do so).
 
@@ -124,8 +146,14 @@ could add overhead in terms of CPU and memory usage.
         :param monitor: Monitor instance.
         :param metric_name: Metric name,
         :param metric_value: Metric value.
+        :param extra_fields: Optional metric extra fields.
         :param timestamp: Optional metric timestamp in ms.
         """
+        if not cls.should_calculate(
+            monitor=monitor, metric_name=metric_name, extra_fields=extra_fields
+        ):
+            return None
+
         if timestamp:
             timestamp_s = timestamp / 1000
         else:
@@ -142,8 +170,11 @@ could add overhead in terms of CPU and memory usage.
 
         # To avoid collisions across multiple monitors (same metric name being used by multiple
         # monitors), we prefix data in internal dictionary with the short hash of the fully
-        # qualified monitor name
-        dict_key = monitor.short_hash + "." + metric_name
+        # qualified monitor name.
+        # Since same metric name can be used by values with different extra fields, we also include
+        # extra fields as part of the dictionary key.
+        extra_fields_hash = get_hash_for_flat_dictionary(extra_fields)
+        dict_key = monitor.short_hash + "." + metric_name + "." + extra_fields_hash
 
         (
             previous_collection_timestamp,
@@ -154,8 +185,8 @@ could add overhead in terms of CPU and memory usage.
             # If this is first time we see this metric, we just store the value sine we don't have
             # previous sample yet to be able to calculate rate
             monitor._logger.debug(
-                'No previous data yet for metric "%s", unable to calculate rate yet.'
-                % (metric_name)
+                'No previous data yet for metric "%s", unable to calculate rate yet (extra_fields=%s).'
+                % (metric_name, extra_fields)
             )
 
             cls.RATE_CALCULATION_METRIC_VALUES[dict_key] = (timestamp_s, metric_value)
@@ -164,8 +195,13 @@ could add overhead in terms of CPU and memory usage.
         if timestamp_s <= previous_collection_timestamp:
             monitor._logger.debug(
                 'Current timestamp for metric "%s" is smaller or equal to current timestamp, cant '
-                "calculate rate (timestamp_previous=%s,timestamp_current=%s)"
-                % (metric_name, previous_collection_timestamp, timestamp_s)
+                "calculate rate (timestamp_previous=%s,timestamp_current=%s,extra_fields=%s)"
+                % (
+                    metric_name,
+                    previous_collection_timestamp,
+                    timestamp_s,
+                    str(extra_fields),
+                )
             )
             return None
 
@@ -176,12 +212,13 @@ could add overhead in terms of CPU and memory usage.
         ) >= cls.MAX_RATE_TIMESTAMP_DELTA_SECONDS:
             monitor._logger.debug(
                 'Time delta between previous and current metric collection timestamp for metric "%s"'
-                "is larger than %s seconds, ignoring rate calculation (timestamp_previous=%s,timestamp_current=%s)"
+                "is larger than %s seconds, ignoring rate calculation (timestamp_previous=%s,timestamp_current=%s,extra_fields=%s)"
                 % (
                     metric_name,
                     cls.MAX_RATE_TIMESTAMP_DELTA_SECONDS,
                     previous_collection_timestamp,
                     timestamp_s,
+                    str(extra_fields),
                 )
             )
 
@@ -193,13 +230,13 @@ could add overhead in terms of CPU and memory usage.
         # as the current server side implementation)
         if metric_value < previous_metric_value:
             monitor._logger.debug(
-                'Current metric value for metric "%s" is smaller than previous value (current_value=%s,previous_value=%s)'
-                % (metric_name, metric_value, previous_metric_value)
+                'Current metric value for metric "%s" is smaller than previous value (current_value=%s,previous_value=%s,extra_fields=%s)'
+                % (metric_name, metric_value, previous_metric_value, str(extra_fields))
             )
             return None
 
         rate_value = round(
-            (metric_value - previous_metric_value)
+            (float(metric_value) - previous_metric_value)
             / (timestamp_s - previous_collection_timestamp),
             5,
         )
@@ -216,7 +253,7 @@ could add overhead in terms of CPU and memory usage.
             )
 
         monitor._logger.debug(
-            'Calculated rate "%s" for metric "%s" (previous_collection_timestamp=%s,previous_metric_value=%s,current_timestamp=%s,current_value=%s)'
+            'Calculated rate "%s" for metric "%s" (previous_collection_timestamp=%s,previous_metric_value=%s,current_timestamp=%s,current_value=%s,extra_fields=%s)'
             % (
                 rate_value,
                 metric_name,
@@ -224,6 +261,7 @@ could add overhead in terms of CPU and memory usage.
                 previous_metric_value,
                 timestamp_s,
                 metric_value,
+                str(extra_fields),
             ),
         )
 
@@ -233,24 +271,85 @@ could add overhead in terms of CPU and memory usage.
         return result
 
     @classmethod
-    def should_calculate(cls, monitor, metric_name):
+    def should_calculate_for_monitor_and_metric(cls, monitor, metric_name):
         """
-        Return True if client side rate should be calculated for the provided metric.
+        Return True if rate should be calculated for the provided monitor and metric name.
+
+        This function is used for internal (monitor_name, metric_name) cache and additional filtering
+        which takes extra_field values into account is performed when "calculate()" method is called.
         """
         if not monitor or not monitor._global_config:
             return False
-
-        config_entry_key = "%s:%s" % (monitor.monitor_module_name, metric_name)
 
         config_calculate_rate_metric_names = (
             monitor._global_config.calculate_rate_metric_names
         )
         monitor_calculate_rate_metric_names = monitor.get_calculate_rate_metric_names()
 
-        return (
-            config_entry_key in config_calculate_rate_metric_names
-            or config_entry_key in monitor_calculate_rate_metric_names
+        # Partial entry key without extra fields suffix
+        config_entry_key = "%s:%s" % (monitor.monitor_module_name, metric_name)
+
+        for config_value in chain(
+            config_calculate_rate_metric_names, monitor_calculate_rate_metric_names
+        ):
+            has_extra_fields_filter = config_value.count(":") == 2
+
+            if has_extra_fields_filter:
+                config_value_without_extra_fields_filter = config_value.rsplit(":", 1)[
+                    0
+                ]
+            else:
+                config_value_without_extra_fields_filter = config_value
+
+            # Direct simple metric name only match with no additional extra fields filters
+            if config_value_without_extra_fields_filter == config_entry_key:
+                return True
+
+        return False
+
+    @classmethod
+    def should_calculate(cls, monitor, metric_name, extra_fields=None):
+        """
+        Return True if client side rate should be calculated for the provided metric name and
+        extra_fields values.
+        """
+        extra_fields = extra_fields or {}
+
+        if not monitor or not monitor._global_config:
+            return False
+
+        config_calculate_rate_metric_names = (
+            monitor._global_config.calculate_rate_metric_names
         )
+        monitor_calculate_rate_metric_names = monitor.get_calculate_rate_metric_names()
+
+        # Config values follow this notation: <monitor module name>:<metric name>:<optional extra field value>
+        # For example: openmetrics_monitor:docker.cpu_usage_seconds_total:mode=kernel
+
+        # Partial entry key without extra fields suffix
+        config_entry_key = "%s:%s" % (monitor.monitor_module_name, metric_name)
+
+        for config_value in chain(
+            config_calculate_rate_metric_names, monitor_calculate_rate_metric_names
+        ):
+            # Direct simple metric name only match
+            if config_value == config_entry_key:
+                return True
+            elif (
+                extra_fields
+                and config_value.count(":") == 2
+                and config_value.count("=") == 1
+            ):
+                config_extra_field_name, config_extra_field_value = config_value.split(
+                    ":"
+                )[-1].split("=")
+                if (
+                    extra_fields.get(config_extra_field_name, None)
+                    == config_extra_field_value
+                ):
+                    return True
+
+        return False
 
     @classmethod
     def clear_cache(cls):

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -489,7 +489,8 @@ class AgentLogger(logging.Logger):
         from scalyr_agent.metrics.base import get_functions_for_metric
 
         function_instances = get_functions_for_metric(
-            monitor=monitor, metric_name=metric_name
+            monitor=monitor,
+            metric_name=metric_name,
         )
 
         derived_metrics_to_emit = []
@@ -498,6 +499,7 @@ class AgentLogger(logging.Logger):
                 monitor=monitor,
                 metric_name=metric_name,
                 metric_value=metric_value,
+                extra_fields=extra_fields,
                 timestamp=timestamp,
             )
             derived_metrics_to_emit.extend(metric_tuples or [])

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -30,6 +30,8 @@ __author__ = "czerwin@scalyr.com"
 
 if False:  # NOSONAR
     from typing import Dict
+    from typing import Optional
+    from typing import Callable
 
     # Workaround for a cyclic import - scalyr_monitor depends on scalyr_logging and vice versa
     from scalyr_agent.scalyr_monitor import ScalyrMonitor
@@ -1987,3 +1989,21 @@ class UnsupportedValueType(Exception):
                 )
             )
         Exception.__init__(self, message)
+
+
+class LazyOnPrintEvaluatedFunction(object):
+    """
+    Wrapper for function which is evaluated lazily once __str__ called on this object.
+
+    This is primarily meant to be used with scalyr_logging.log function when using limit_once_per_x_secs
+    and we only want function to be evaluated when limit has not been reached (aka so we don't incur
+    overhead on each log.log function call when no logging is to be performed due to rate limit being
+    reached).
+    """
+
+    def __init__(self, func):
+        # type: (Callable, Optional[bool]) -> None
+        self.__func = func
+
+    def __str__(self):
+        return six.text_type(self.__func())

--- a/scalyr_agent/timing.py
+++ b/scalyr_agent/timing.py
@@ -1,0 +1,107 @@
+# Copyright 2014-2022 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains various utility code and functions for recording various code run time and
+timing based information.
+"""
+
+if False:
+    from typing import Dict
+
+import random
+
+from functools import wraps
+from timeit import default_timer as timer
+
+__all__ = [
+    "get_empty_stats_dict",
+    "reset_stats_dict",
+    "record_timing_stats_for_function_call",
+]
+
+
+def should_sample(sample_rate):
+    return random.random() < sample_rate
+
+
+def get_empty_stats_dict():
+    # type: () -> Dict[str, float]
+    return reset_stats_dict({})
+
+
+def reset_stats_dict(stats_dict):
+    # type: Dict[str, float] -> None
+    """
+    Reset values for the provided function run time stats dictionary.
+    """
+    stats_dict["min"] = float("inf")
+    stats_dict["max"] = float("-inf")
+    stats_dict["avg"] = 0.0
+    stats_dict["sum"] = 0.0
+    stats_dict["count"] = 0.0
+    return stats_dict
+
+
+# TODO: Eventually add dependency on numpy or similar and utilize running / moving mean + percentiles
+def record_timing_stats_for_function_call(stats_obj, sample_rate):
+    """
+    Utility decorator which records records function timing related information (how long the function
+    took to complete in milliseconds) into the provided stats dictionary.
+
+    The following values are tracked / record:
+
+        - min run time
+        - max run time
+        - average run time
+
+    To avoid overhead of timing every single function call, it uses random sampling with the provided
+    sample rate. To avoid overhead, sampling rate of 1 in 1000 or higher is recommended (0.001) for
+    functions which are called relatively frequently.
+    """
+
+    def decorate(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if not should_sample(sample_rate):
+                # No stats recording should be done
+                return func(*args, **kwargs)
+
+            start_ts = timer()
+            result = func(*args, **kwargs)
+            end_ts = timer()
+
+            duration_ms = (end_ts - start_ts) * 1000
+
+            # To avoid values from growing very large and potentially overflowing (for very slow
+            # functions), we periodically reset the stats. Keep in mind that this is not ideal and
+            # using moving / running values with a particular window size would be better, but that
+            # would require us to add a dependency on numpy or a similar library.
+            stats_obj["count"] += 1
+            stats_obj["sum"] += duration_ms
+            stats_obj["avg"] = stats_obj["sum"] / stats_obj["count"]
+
+            if duration_ms < stats_obj["min"]:
+                stats_obj["min"] = duration_ms
+            if duration_ms > stats_obj["max"]:
+                stats_obj["max"] = duration_ms
+
+            if stats_obj["count"] >= 10000:
+                reset_stats_dict(stats_obj)
+
+            return result
+
+        return wrapper
+
+    return decorate

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -25,6 +25,7 @@ import socket
 
 if False:  # NOSONAR
     from typing import Union
+    from typing import Dict
     from typing import Tuple
     from typing import Callable
     from typing import Optional
@@ -2724,3 +2725,27 @@ class ParentProcessAwareSyncManager(multiprocessing.managers.SyncManager):
             return self._process.pid  # type: ignore  # pylint: disable=no-member
         except:
             return None
+
+
+def get_hash_for_flat_dictionary(data):
+    # type: (Dict[str, Union[int, bool, six.text_type]]) -> six.text_type
+    """
+    Calculate hash for the provided dictionary which needs to be flat (aka no nested values).
+
+    NOTE: Result of this function is not stable across Python interpreters since it results on
+    hash() function.
+
+    In case we ever require stable results across runs, we should change hash() function to sha256
+    hash or similar.
+
+    NOTE: Dictionary must not be nested and can only contain simple values (numbers, strings,
+    booleans).
+    """
+    data = data or {}
+
+    # NOTE: We use hash over hashlib since it's faster. Keep in mind that result of hash is Python
+    # interpreter instance specific and is not stable acros the run. This is fine in our case where
+    # we only store this hash in memory of a single process (and we never serialize / write it out
+    # to disk or similar). With hash() function, there is also a larger chance of a collision, but
+    # that's fine here.
+    return six.text_type(hash(frozenset(data.items())))

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -2749,3 +2749,19 @@ def get_hash_for_flat_dictionary(data):
     # to disk or similar). With hash() function, there is also a larger chance of a collision, but
     # that's fine here.
     return six.text_type(hash(frozenset(data.items())))
+
+
+def get_flat_dictionary_memory_usage(data):
+    # type: (dict) -> int
+    """
+    Return approximate memory usage (bytes) for the provided dictionary.
+
+    This function only supports flat dictionaries aka dictionaries with simple types.
+    """
+    # Raw dictionary size
+    size = sys.getsizeof(data)
+    # Size for the actual keys and values
+    size += sum(map(sys.getsizeof, data.values())) + sum(
+        map(sys.getsizeof, data.keys())
+    )
+    return size

--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -79,7 +79,7 @@ for index, pod in enumerate(
         ] = "/test/new/path"
         pod["metadata"]["annotations"][
             SCALYR_AGENT_ANNOTATION_CALCULATE_RATE_METRIC_NAMES
-        ] = "metric5,metric6"
+        ] = "metric5,metric6,metric7:label=value"
 
 
 class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
@@ -292,7 +292,11 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
             "headers": None,
             "include_node_name": True,
             "include_cluster_name": True,
-            "calculate_rate_metric_names": ["metric1", "metric2"],
+            "calculate_rate_metric_names": [
+                "metric1",
+                "metric2",
+                "metric3:label=value",
+            ],
         }
         (
             monitor_config,
@@ -316,7 +320,11 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
             "metric_component_value_include_list": JsonObject({}),
             "metric_name_exclude_list": [],
             "metric_name_include_list": ["*"],
-            "calculate_rate_metric_names": ["metric1", "metric2"],
+            "calculate_rate_metric_names": [
+                "metric1",
+                "metric2",
+                "metric3:label=value",
+            ],
             "module": "scalyr_agent.builtin_monitors.openmetrics_monitor",
             "sample_interval": 10,
             "timeout": 10,
@@ -800,7 +808,11 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
             mock_monitors_manager.add_monitor.call_args_list[0][1]["monitor_config"][
                 "calculate_rate_metric_names"
             ],
-            ["openmetrics_monitor:metric5", "openmetrics_monitor:metric6"],
+            [
+                "openmetrics_monitor:metric5",
+                "openmetrics_monitor:metric6",
+                "openmetrics_monitor:metric7:label=value",
+            ],
         )
 
         # 4. And now API returns no pods which means all the monitors should be removed

--- a/tests/unit/test_metrics_functions.py
+++ b/tests/unit/test_metrics_functions.py
@@ -1,0 +1,520 @@
+# Copyright 2014-2022 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import OrderedDict
+
+import mock
+
+from scalyr_agent.util import get_hash_for_flat_dictionary
+from scalyr_agent.metrics.base import get_functions_for_metric
+from scalyr_agent.metrics.base import clear_internal_cache
+from scalyr_agent.metrics.functions import RateMetricFunction
+from scalyr_agent.test_base import ScalyrTestCase
+
+__all__ = [
+    "RateMetricFunctionTestCase",
+]
+
+
+class RateMetricFunctionTestCase(ScalyrTestCase):
+    def setUp(self):
+        super(RateMetricFunctionTestCase, self).setUp()
+        clear_internal_cache()
+
+    def tearDown(self):
+        super(RateMetricFunctionTestCase, self).tearDown()
+        clear_internal_cache()
+
+    def test_get_hash_for_flat_dictionary(self):
+        dict1 = {
+            "foo": "bar",
+            "bar": 1,
+            "baz": "none",
+            "none": None,
+            "a": True,
+            "0": 0,
+        }
+        dict2 = OrderedDict(
+            [
+                ("0", 0),
+                ("bar", 1),
+                ("foo", "bar"),
+                ("a", True),
+                ("baz", "none"),
+                ("none", None),
+            ]
+        )
+        dict3 = OrderedDict(
+            [
+                ("foo", "bar"),
+                ("a", True),
+                ("bar", 1),
+                ("0", 0),
+                ("baz", "none"),
+                ("none", None),
+            ]
+        )
+        dict4 = OrderedDict(
+            [
+                ("foo", "bar"),
+                ("a", True),
+                ("bar", 0),
+                ("0", 0),
+                ("baz", "none"),
+                ("none", None),
+            ]
+        )
+
+        dict5 = {}
+        dict6 = OrderedDict({})
+        dict7 = None
+
+        result1 = get_hash_for_flat_dictionary(dict1)
+        result2 = get_hash_for_flat_dictionary(dict2)
+        result3 = get_hash_for_flat_dictionary(dict3)
+        result4 = get_hash_for_flat_dictionary(dict4)
+        self.assertEqual(result1, result2)
+        self.assertEqual(result3, result3)
+        self.assertNotEqual(result3, result4)
+        self.assertNotEqual(result1, result4)
+
+        result5 = get_hash_for_flat_dictionary(dict5)
+        result6 = get_hash_for_flat_dictionary(dict6)
+        result7 = get_hash_for_flat_dictionary(dict7)
+        self.assertEqual(result5, result6)
+        self.assertEqual(result5, result7)
+
+    def test_rate_metric_function_metric_name_not_in_allowlist(self):
+        monitor = mock.Mock()
+        monitor.monitor_module_name = "openmetrics_monitor"
+        monitor.short_hash = "hashhash"
+        monitor.get_calculate_rate_metric_names.return_value = []
+        monitor._global_config = mock.Mock()
+        monitor._global_config.calculate_rate_metric_names = [
+            "openmetrics_monitor:metric1",
+            "openmetrics_monitor:metric2",
+            "openmetrics_monitor:docker.cpu_usage_seconds_total:mode=user",
+            "openmetrics_monitor:docker.cpu_usage_seconds_total:mode=kernel",
+        ]
+
+        # Invalid metric name (metric name not in allowlist)
+        metric_name = "metric_invalid"
+        funcs = get_functions_for_metric(monitor=monitor, metric_name=metric_name)
+        self.assertEqual(funcs, [])
+
+    def test_rate_metric_function_metric_name_without_extra_fields(self):
+        monitor = mock.Mock()
+        monitor.monitor_module_name = "openmetrics_monitor"
+        monitor.short_hash = "hashhash"
+        monitor.get_calculate_rate_metric_names.return_value = []
+        monitor._global_config = mock.Mock()
+        monitor._global_config.calculate_rate_metric_names = [
+            "openmetrics_monitor:metric1",
+            "openmetrics_monitor:metric2",
+            "openmetrics_monitor:docker.cpu_usage_seconds_total:mode=user",
+            "openmetrics_monitor:docker.cpu_usage_seconds_total:mode=kernel",
+        ]
+
+        ts1 = 10
+        ts2 = 70
+        ts3 = 130
+        ts4 = 190
+
+        val1 = 20
+        val2 = 30
+        val3 = 40
+        val4 = 100
+
+        # Valid metric name, no extra_fields
+        metric_name = "metric1"
+        extra_fields = {}
+
+        funcs = get_functions_for_metric(monitor=monitor, metric_name=metric_name)
+        self.assertEqual(len(funcs), 1)
+        self.assertTrue(isinstance(funcs[0], RateMetricFunction))
+
+        func = funcs[0]
+        func.clear_cache()
+
+        # Initial call, no previous data available yet
+        result = func.calculate(
+            monitor=monitor,
+            metric_name=metric_name,
+            extra_fields=extra_fields,
+            timestamp=ts1 * 1000,
+            metric_value=val1,
+        )
+        self.assertIsNone(result)
+
+        # (30 - 20) / (70 - 10)
+        result = func.calculate(
+            monitor=monitor,
+            metric_name=metric_name,
+            extra_fields=extra_fields,
+            timestamp=ts2 * 1000,
+            metric_value=val2,
+        )
+        self.assertEqual(result, [("metric1_rate", 0.16667)])
+
+        # (40 - 30) / (130 - 70)
+        result = func.calculate(
+            monitor=monitor,
+            metric_name=metric_name,
+            extra_fields=extra_fields,
+            timestamp=ts3 * 1000,
+            metric_value=val3,
+        )
+        self.assertEqual(result, [("metric1_rate", 0.16667)])
+
+        # (100 - 40) / (190 - 130)
+        result = func.calculate(
+            monitor=monitor,
+            metric_name=metric_name,
+            extra_fields=extra_fields,
+            timestamp=ts4 * 1000,
+            metric_value=val4,
+        )
+        self.assertEqual(result, [("metric1_rate", 1.0)])
+
+        # There should be one internal cache entry
+        self.assertEqual(len(func.RATE_CALCULATION_METRIC_VALUES), 1)
+
+    def test_rate_metric_function_metric_name_with_extra_fields(self):
+        monitor = mock.Mock()
+        monitor.monitor_module_name = "openmetrics_monitor"
+        monitor.short_hash = "hashhash"
+        monitor.get_calculate_rate_metric_names.return_value = []
+        monitor._global_config = mock.Mock()
+        monitor._global_config.calculate_rate_metric_names = [
+            "openmetrics_monitor:metric1",
+            "openmetrics_monitor:metric2",
+            "openmetrics_monitor:docker.cpu_usage_seconds_total:mode=user",
+            "openmetrics_monitor:docker.cpu_usage_seconds_total:mode=kernel",
+        ]
+
+        ts1 = 10
+        ts2 = 70
+
+        val1 = 20
+
+        # Valid metric name, different extra fields, ensure rates are scoped to particular extra
+        # fields
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"mode": "user", "pod": "pod1", "node": "node2"}
+
+        funcs = get_functions_for_metric(monitor=monitor, metric_name=metric_name)
+        self.assertEqual(len(funcs), 1)
+        self.assertTrue(isinstance(funcs[0], RateMetricFunction))
+
+        func = funcs[0]
+
+        # Initial call, no previous data available yet
+        # pod=pod1, mode=user, node=node1
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"pod": "pod1", "node": "node1", "mode": "user"}
+
+        result = func.calculate(
+            monitor=monitor,
+            metric_name=metric_name,
+            extra_fields=extra_fields,
+            timestamp=ts1 * 1000,
+            metric_value=val1,
+        )
+        self.assertIsNone(result)
+
+        # pod=pod1, mode=user, node=node2
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"pod": "pod1", "node": "node2", "mode": "user"}
+
+        result = func.calculate(
+            monitor=monitor,
+            metric_name=metric_name,
+            extra_fields=extra_fields,
+            timestamp=ts1 * 1000,
+            metric_value=15,
+        )
+        self.assertIsNone(result)
+
+        # pod=pod1, mode=kernel, node=node1
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"pod": "pod1", "node": "node1", "mode": "kernel"}
+
+        result = func.calculate(
+            monitor=monitor,
+            metric_name=metric_name,
+            extra_fields=extra_fields,
+            timestamp=ts1 * 1000,
+            metric_value=99,
+        )
+        self.assertIsNone(result)
+
+        # pod=pod2, mode=user, node=node1
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"pod": "pod2", "node": "node1", "mode": "user"}
+
+        result = func.calculate(
+            monitor=monitor,
+            metric_name=metric_name,
+            extra_fields=extra_fields,
+            timestamp=ts1 * 1000,
+            metric_value=val1,
+        )
+        self.assertIsNone(result)
+
+        # pod=pod2, mode=kernel, node=node1
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"pod": "pod2", "node": "node1", "mode": "kernel"}
+
+        result = func.calculate(
+            monitor=monitor,
+            metric_name=metric_name,
+            extra_fields=extra_fields,
+            timestamp=ts1 * 1000,
+            metric_value=88,
+        )
+        self.assertIsNone(result)
+
+        # pod=pod1, mode=user, node=node1
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"pod": "pod1", "node": "node1", "mode": "user"}
+
+        result = func.calculate(
+            monitor=monitor,
+            metric_name=metric_name,
+            extra_fields=extra_fields,
+            timestamp=ts2 * 1000,
+            metric_value=300,
+        )
+        self.assertEqual(result, [("docker.cpu_usage_seconds_total_rate", 4.66667)])
+
+        # pod=pod1, mode=kernel, node=node1
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"pod": "pod1", "node": "node1", "mode": "kernel"}
+
+        result = func.calculate(
+            monitor=monitor,
+            metric_name=metric_name,
+            extra_fields=extra_fields,
+            timestamp=ts2 * 1000,
+            metric_value=100,
+        )
+        self.assertEqual(result, [("docker.cpu_usage_seconds_total_rate", 0.01667)])
+
+        # pod=pod1, mode=user, node=node2
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"pod": "pod1", "node": "node2", "mode": "user"}
+
+        result = func.calculate(
+            monitor=monitor,
+            metric_name=metric_name,
+            extra_fields=extra_fields,
+            timestamp=ts2 * 1000,
+            metric_value=20,
+        )
+        self.assertEqual(result, [("docker.cpu_usage_seconds_total_rate", 0.08333)])
+
+        # pod=pod2, mode=user, node=node1
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"pod": "pod2", "node": "node1", "mode": "user"}
+
+        result = func.calculate(
+            monitor=monitor,
+            metric_name=metric_name,
+            extra_fields=extra_fields,
+            timestamp=ts2 * 1000,
+            metric_value=100,
+        )
+        self.assertEqual(result, [("docker.cpu_usage_seconds_total_rate", 1.33333)])
+
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"pod": "pod2", "node": "node1", "mode": "kernel"}
+
+        result = func.calculate(
+            monitor=monitor,
+            metric_name=metric_name,
+            extra_fields=extra_fields,
+            timestamp=ts2 * 1000,
+            metric_value=92,
+        )
+        self.assertEqual(result, [("docker.cpu_usage_seconds_total_rate", 0.06667)])
+
+        # There should be 5 entries in the internal value cache:
+        # - pod=pod1, node=node1, mode=user
+        # - pod=pod1, node=node1, mode=kernel
+        # - pod=pod1, node=node2, mode=user
+        # - pod=pod2, node=node1, mode=user
+        # - pod=pod2, node=node1, mode=kernel
+        self.assertEqual(len(func.RATE_CALCULATION_METRIC_VALUES), 5)
+
+    def test_should_calculate_for_monitor_and_metric_function(self):
+        monitor = mock.Mock()
+        monitor.monitor_module_name = "openmetrics_monitor"
+        monitor.short_hash = "hashhash"
+        monitor.get_calculate_rate_metric_names.return_value = []
+        monitor._global_config = mock.Mock()
+        monitor._global_config.calculate_rate_metric_names = [
+            "openmetrics_monitor:metric1",
+            "openmetrics_monitor:metric2",
+            "openmetrics_monitor:docker.cpu_usage_seconds_total:mode=user",
+            "openmetrics_monitor:docker.cpu_usage_seconds_total:mode=kernel",
+        ]
+
+        func = RateMetricFunction()
+
+        metric_name = "metric"
+
+        result = func.should_calculate_for_monitor_and_metric(
+            monitor=monitor, metric_name=metric_name
+        )
+        self.assertFalse(result)
+
+        metric_name = "metric0"
+
+        result = func.should_calculate_for_monitor_and_metric(
+            monitor=monitor, metric_name=metric_name
+        )
+        self.assertFalse(result)
+
+        metric_name = "metric1"
+
+        result = func.should_calculate_for_monitor_and_metric(
+            monitor=monitor, metric_name=metric_name
+        )
+        self.assertTrue(result)
+
+        metric_name = "docker.cpu_usage_seconds_total"
+
+        result = func.should_calculate_for_monitor_and_metric(
+            monitor=monitor, metric_name=metric_name
+        )
+        self.assertTrue(result)
+
+    def test_should_calculate_function(self):
+        monitor = mock.Mock()
+        monitor.monitor_module_name = "openmetrics_monitor"
+        monitor.short_hash = "hashhash"
+        monitor.get_calculate_rate_metric_names.return_value = []
+        monitor._global_config = mock.Mock()
+        monitor._global_config.calculate_rate_metric_names = [
+            "openmetrics_monitor:metric1",
+            "openmetrics_monitor:metric2",
+            "openmetrics_monitor:docker.cpu_usage_seconds_total:mode=user",
+            "openmetrics_monitor:docker.cpu_usage_seconds_total:mode=kernel",
+        ]
+
+        func = RateMetricFunction()
+
+        metric_name = "metric"
+        extra_fields = {}
+
+        result = func.should_calculate(
+            monitor=monitor, metric_name=metric_name, extra_fields=extra_fields
+        )
+        self.assertFalse(result)
+
+        metric_name = "metric0"
+        extra_fields = {}
+
+        result = func.should_calculate(
+            monitor=monitor, metric_name=metric_name, extra_fields=extra_fields
+        )
+        self.assertFalse(result)
+
+        metric_name = "metric1"
+        extra_fields = {}
+
+        result = func.should_calculate(
+            monitor=monitor, metric_name=metric_name, extra_fields=extra_fields
+        )
+        self.assertTrue(result)
+
+        metric_name = "metric1"
+        extra_fields = {"foo": "bar"}
+
+        result = func.should_calculate(
+            monitor=monitor, metric_name=metric_name, extra_fields=extra_fields
+        )
+        self.assertTrue(result)
+
+        metric_name = "metric1"
+        extra_fields = {"bar": "baz"}
+
+        result = func.should_calculate(
+            monitor=monitor, metric_name=metric_name, extra_fields=extra_fields
+        )
+        self.assertTrue(result)
+
+        metric_name = "metric2"
+        extra_fields = {}
+
+        result = func.should_calculate(
+            monitor=monitor, metric_name=metric_name, extra_fields=extra_fields
+        )
+        self.assertTrue(result)
+
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {}
+
+        result = func.should_calculate(
+            monitor=monitor, metric_name=metric_name, extra_fields=extra_fields
+        )
+        self.assertFalse(result)
+
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"foo": "bar"}
+
+        result = func.should_calculate(
+            monitor=monitor, metric_name=metric_name, extra_fields=extra_fields
+        )
+        self.assertFalse(result)
+
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"mode": "total"}
+
+        result = func.should_calculate(
+            monitor=monitor, metric_name=metric_name, extra_fields=extra_fields
+        )
+        self.assertFalse(result)
+
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"mode": "user"}
+
+        result = func.should_calculate(
+            monitor=monitor, metric_name=metric_name, extra_fields=extra_fields
+        )
+        self.assertTrue(result)
+
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"mode": "user", "foo": "bar"}
+
+        result = func.should_calculate(
+            monitor=monitor, metric_name=metric_name, extra_fields=extra_fields
+        )
+        self.assertTrue(result)
+
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"mode": "kernel"}
+
+        result = func.should_calculate(
+            monitor=monitor, metric_name=metric_name, extra_fields=extra_fields
+        )
+        self.assertTrue(result)
+
+        metric_name = "docker.cpu_usage_seconds_total"
+        extra_fields = {"mode": "kernel", "bar": "baz"}
+
+        result = func.should_calculate(
+            monitor=monitor, metric_name=metric_name, extra_fields=extra_fields
+        )
+        self.assertTrue(result)

--- a/tests/unit/test_timing_module.py
+++ b/tests/unit/test_timing_module.py
@@ -1,0 +1,90 @@
+# Copyright 2014-2022 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from scalyr_agent.timing import get_empty_stats_dict
+from scalyr_agent.timing import reset_stats_dict
+from scalyr_agent.timing import record_timing_stats_for_function_call
+
+from scalyr_agent.test_base import ScalyrTestCase
+
+
+class TimingModuleTestCase(ScalyrTestCase):
+    def test_get_empty_stats_dict(self):
+        stats_dict = get_empty_stats_dict()
+        self.assertEqual(stats_dict["min"], float("+inf"))
+        self.assertEqual(stats_dict["max"], float("-inf"))
+        self.assertEqual(stats_dict["count"], 0)
+        self.assertEqual(stats_dict["sum"], 0)
+
+    def test_reset_stats_dict(self):
+        stats_dict = get_empty_stats_dict()
+        stats_dict["count"] = 20
+        stats_dict["sum"] = 300
+
+        reset_stats_dict(stats_dict=stats_dict)
+        self.assertEqual(stats_dict["count"], 0)
+        self.assertEqual(stats_dict["sum"], 0)
+
+    def test_record_timing_stats_for_function_sample_interval(self):
+        stats_dict = get_empty_stats_dict()
+
+        @record_timing_stats_for_function_call(stats_dict, 1)
+        def mock_timed_function_1():
+            return True
+
+        self.assertEqual(stats_dict["count"], 0)
+        self.assertTrue(mock_timed_function_1())
+        self.assertEqual(stats_dict["count"], 1)
+
+        stats_dict = get_empty_stats_dict()
+
+        @record_timing_stats_for_function_call(stats_dict, 0.1)
+        def mock_timed_function_2():
+            return True
+
+        self.assertEqual(stats_dict["count"], 0)
+        for _ in range(0, 1000):
+            self.assertTrue(mock_timed_function_2())
+        self.assertTrue(stats_dict["count"] >= 2)
+
+    @mock.patch("scalyr_agent.timing.timer")
+    @mock.patch("scalyr_agent.timing.STATS_DICT_SAMPLE_COUNT_RESET_INTERVAL", 6)
+    def test_record_timing_stats_for_function_timing_stats(self, mock_timer):
+        mock_timer.side_effect = [0, 10, 10, 15, 20, 32, 30, 40, 40, 50, 0, 0]
+        stats_dict = get_empty_stats_dict()
+
+        @record_timing_stats_for_function_call(stats_dict, 1)
+        def mock_timed_function():
+            return True
+
+        self.assertEqual(stats_dict["count"], 0)
+        self.assertTrue(mock_timed_function())
+        self.assertEqual(stats_dict["min"], 10 * 1000)
+        self.assertEqual(stats_dict["max"], 10 * 1000)
+        self.assertEqual(stats_dict["sum"], 10 * 1000)
+        self.assertEqual(stats_dict["count"], 1)
+
+        for index in range(0, 4):
+            self.assertTrue(mock_timed_function())
+
+        self.assertEqual(stats_dict["min"], 5 * 1000)
+        self.assertEqual(stats_dict["max"], 12 * 1000)
+        self.assertEqual(stats_dict["sum"], (10 + 5 + 12 + 10 + 10) * 1000)
+        self.assertEqual(stats_dict["count"], 5)
+
+        # Stats should be reset
+        self.assertTrue(mock_timed_function())
+        self.assertEqual(stats_dict["count"], 0)

--- a/tests/unit/test_util_test.py
+++ b/tests/unit/test_util_test.py
@@ -25,7 +25,6 @@ import ssl
 import sys
 import locale
 import platform
-import io
 
 import mock
 import six
@@ -237,7 +236,7 @@ class MiscUtilsTestCase(ScalyrTestCase):
         lazy_func = LazyOnPrintEvaluatedFunction(func)
         self.assertEqual(func.counter, 0)
 
-        fake_file = io.StringIO()
+        fake_file = six.StringIO()
 
         # Only calling str / %s on func should cause it to be evaluated
         print(lazy_func, file=fake_file)

--- a/tests/unit/test_util_test.py
+++ b/tests/unit/test_util_test.py
@@ -16,6 +16,7 @@
 #
 
 from __future__ import absolute_import
+from __future__ import print_function
 
 from io import open
 
@@ -24,6 +25,7 @@ import ssl
 import sys
 import locale
 import platform
+import io
 
 import mock
 import six
@@ -34,6 +36,7 @@ from scalyr_agent.test_base import BaseScalyrLogCaptureTestCase
 from scalyr_agent.test_base import ScalyrTestCase
 from scalyr_agent.test_base import skipIf
 from scalyr_agent.build_info import get_build_revision
+from scalyr_agent.scalyr_logging import LazyOnPrintEvaluatedFunction
 
 __all__ = ["LogCaptureClassTestCase"]
 
@@ -223,3 +226,24 @@ class MiscUtilsTestCase(ScalyrTestCase):
         self.assertTrue("revision=%s" % (build_revision) in msg)
         self.assertTrue("locale=%s" % (locale) in msg)
         self.assertTrue("LANG env variable=%s" % (lang_env_var) in msg)
+
+
+class MiscUtilsTestCase(ScalyrTestCase):
+    def test_lazy_on_print_evaluated_function(self):
+        def func():
+            func.counter += 1
+            return "test"
+
+        func.counter = 0
+
+        lazy_func = LazyOnPrintEvaluatedFunction(func)
+        self.assertEqual(func.counter, 0)
+
+        fake_file = io.StringIO()
+
+        # Only calling str / %s on func should cause it to be evaluated
+        print(lazy_func, file=fake_file)
+        print(lazy_func, file=fake_file)
+        self.assertEqual(lazy_func.__str__(), "test")
+        self.assertEqual(fake_file.getvalue(), "test\ntest\n")
+        self.assertEqual(func.counter, 3)

--- a/tests/unit/test_util_test.py
+++ b/tests/unit/test_util_test.py
@@ -227,8 +227,6 @@ class MiscUtilsTestCase(ScalyrTestCase):
         self.assertTrue("locale=%s" % (locale) in msg)
         self.assertTrue("LANG env variable=%s" % (lang_env_var) in msg)
 
-
-class MiscUtilsTestCase(ScalyrTestCase):
     def test_lazy_on_print_evaluated_function(self):
         def func():
             func.counter += 1


### PR DESCRIPTION
This pull request includes some improvements and fixes for the client side rate calculation functionality to make sure it works correctly when metric contains additional labels (``extra_fields``).

Monitor can produce metrics which look like this:

```bash
process_cpu_seconds_total app="app-1" node="node-1" 155
process_cpu_seconds_total app="app-2" node="node-1" 155
process_cpu_seconds_total app="app-3" node="node-1" 155
process_cpu_seconds_total app="app-3" node="node-3" 155
```

In this case all the metrics have the same name (``process_cpu_seconds_total``), but they represent different metrics and we need to track rate separately for each of those (for each ``(metric name, unique extra fields / labels)`` pair).

In addition to fixing and making sure we currently handle high cardinality metrics with arbitrary labels, it also introduces new config syntax with which user can configure for which metrics rate should be calculated on the client side.

New config notation is as follows: ``<monitor module name>:<metric name>[:optional extra field name=extra field value]``.

For example:

* ``openmetrics_monitor.metric1``
* ``openmetrics_monitor.docker.cpu_usage_seconds_total:mode=user``
* ``openmetrics_monitor.docker.cpu_usage_seconds_total:mode=kernel``

In the 2nd and 3rd example, we will only calculate rate for  the ``docker.cpu_usage_seconds_total`` metric where the ``mode`` label either matches ``user`` or ``kernel``.

In case the last part was omitted (aka just ``openmetrics_monitor.docker.cpu_usage_seconds_total`` is specified), rate would be calculate for all the metrics with this name, regardless of the label / extra_fields values (but of course internally we still need to track those separately since they represent different metrics).

## Implementation Details and Notes

### Overhead on ``emit_value()`` method calls

Each time when monitor emits a metric, we need to check if rate should be calculated for a specific metric.

Since monitors can emit many different metrics, it can be expensive to perform a complete check on each ``emit_value()`` call.

To reduce some of that computational overhead on each ``emit_value()`` call, we use an internal cache, a dictionary which maps ``(monitor name, metric name)`` tuple to a list of metric function instances which should be applied on a specific metric.

This doesn't reduce overhead completely though - as noted above, multiple metrics can have the same name, but different ``extra_fields`` which all represents different metrics. One approach (the fastest) would be to also incorporate extra_field values into the cache key. The problem with this approach is that it could result in an increased / excessive memory usage since there are many possible ``extra_field`` values.

I went with the middle of the ground approach, where I only cache values on per ``(monitor name, metric name)`` basis and then additional extra fields check is performed on ``emit_value()`` when a metric contains ``extra_fields`` attributes.

Over time we will see how this behaves and in case any additional improvements and optimizations are needed (I will add some instrumentation and logging around that code so we can track performance over time).

It's worth noting that some of that overhead is slightly offset (less of an issue) for Kubernetes Explorer and Kubernetes agent DaemonSet deployments.

With that deployment model, each agent pod is only responsible for metrics for resources which are local to that agent node (which basically means that this cache and overhead is spread across different agent instances / nodes).

### Memory Efficiency and Hashing

We need to store (cache) last value and timestamp for each unique metric in memory. This means that we also need to incorporate ``extra_field`` values into our internal cache key.

When doing that, we should try to be as CPU and space / memory efficient as possible.

There are many ways to achieve that, most commonly used one in situations like this is calculating a hash of the value (in this case, hash of the dictionary contents).

With the hashsing approach, we trade off some CPU cycles (for calculating the hash) for memory efficiency since the cache key will be much shorter.

In this PR I used Python ``hash()`` function instead of md5 / sha512 hash or similar. The reason for that is that ``hash()`` is faster than the alternatives and also more space efficient since it returns 64 bit integer. It does mean it has a higher chance of a collision, but in the (non security sensitive) context where this function is used, this is not a big issue.

It's also worth noting that ``hash()`` has some other limitations / invariants:

* Dictionary can't be nested and can only contain simple values (int, bool, string, ...). This is true for metrics ``extra_fields`` value.
* Value returned by ``hash()`` is not stable across Python processes and different interpreter runs. In our case we only store those values in memory for the agent process lifecycle duration which means this is not a problem. In case we ever wanted to make those values stable across run / processes / interpreters (e.g. we cached them in a file on disk), we would need to change the approach to use some other method (e.g. ``hashlib.sha512``).

## TODO

- [x] Update Kubernetes OpenMetrics monitor tests
- [x] Add instrumentation + logging around ``get_functions_for_metric()`` function call
- [x] Periodically log various internal cache sizes