### PR TITLE
Fix config export config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Windows:
 Bug fixes:
 * Fix a bug with ``import_vars`` functionality which didn't work correctly when the same variable name prefix was used (e.g. ``SCALYR_FOO_TEST``, ``SCALYR_FOO``).
 * Fix a bug with handling the log file of the Kubernetes Event Monitor twice, which led to duplication in the agent's status. 
+* Fix a bug in scalyr-agent-2-config ``--export-config``, ``import-config`` options caused by Python 2 and 3 code incompatibility.
 
 Docker images:
 * Upgrade various dependencies: orjson, requests, zstandard, lz4, docker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Bug fixes:
 * Fix a bug with ``import_vars`` functionality which didn't work correctly when the same variable name prefix was used (e.g. ``SCALYR_FOO_TEST``, ``SCALYR_FOO``).
 * Fix a bug with handling the log file of the Kubernetes Event Monitor twice, which led to duplication in the agent's status. 
 * Fix a bug in scalyr-agent-2-config ``--export-config``, ``import-config`` options caused by Python 2 and 3 code incompatibility.
+* Fix a bug with the wrong executable ``scalyr-agent-2-config`` in Docker and Kubernetes, due to which it could not be used.
 
 Docker images:
 * Upgrade various dependencies: orjson, requests, zstandard, lz4, docker.

--- a/agent_build/package_builders.py
+++ b/agent_build/package_builders.py
@@ -599,9 +599,10 @@ class PackageBuilder(abc.ABC):
                 pl.Path("..", "py", "scalyr_agent", "agent_main.py")
             )
 
-            agent_config_executable_path = bin_path / "scalyr-agent-2-config"
-            agent_config_executable_path.symlink_to(
-                pl.Path("..", "py", "scalyr_agent", "config_main.py")
+            # Copy the backward compatibility "scalyr-agent-2-config" script.
+            shutil.copy2(
+                constants.SOURCE_ROOT / "agent_build/linux/scalyr-agent-2-config",
+                bin_path,
             )
 
             # Write install_info file inside the "scalyr_agent" package.

--- a/build_package.py
+++ b/build_package.py
@@ -1153,7 +1153,7 @@ def build_base_files(install_type, base_configs="config"):
     )
     os.chdir("..")
 
-    # Create symlinks for the two commands
+    # Create symlinks for the agent_main
     os.chdir("bin")
 
     make_soft_link("../py/scalyr_agent/agent_main.py", "scalyr-agent-2")

--- a/scalyr_agent/config_main.py
+++ b/scalyr_agent/config_main.py
@@ -1068,7 +1068,12 @@ def export_config(config_dest, config_file_path, configuration):
         if config_dest != "-":
             out_tar = tarfile.open(config_dest, mode="w:gz")
         else:
-            out_tar = tarfile.open(fileobj=sys.stdout, mode="w|gz")
+            if sys.version_info < (3,):
+                file_obj = sys.stdout
+            else:
+                file_obj = sys.stdout.buffer
+
+            out_tar = tarfile.open(fileobj=file_obj, mode="w|gz")
         out_tar.add(os.path.basename(config_file_path))
 
         for x in glob.glob(os.path.join(fragment_dir, "*.json")):
@@ -1184,7 +1189,11 @@ def create_custom_dockerfile(
     if tarball_path != "-":
         out_tar = tarfile.open(tarball_path, mode="w:gz")
     else:
-        out_tar = tarfile.open(fileobj=sys.stdout, mode="w|gz")
+        if sys.version_info < (3,):
+            file_obj = sys.stdout
+        else:
+            file_obj = sys.stdout.buffer
+        out_tar = tarfile.open(fileobj=file_obj, mode="w|gz")
 
     # Read the Dockerfile.custom_agent_config out of the misc directory and replace :latest with the version used
     # by this current agent install.  We want the version of this install in order to make sure the new docker image

--- a/scalyr_agent/config_main.py
+++ b/scalyr_agent/config_main.py
@@ -1141,7 +1141,12 @@ def import_config(config_src, config_file_path, configuration):
         if config_src != "-":
             in_tar = tarfile.open(config_src, "r:gz")
         else:
-            in_tar = tarfile.open(fileobj=sys.stdin, mode="r|gz")
+            if sys.version_info < (3,):
+                file_obj = sys.stdin
+            else:
+                file_obj = sys.stdin.buffer
+
+            in_tar = tarfile.open(fileobj=file_obj, mode="r|gz")
 
         # Track which files were in the tarball so that we can delete unused ones later.
         used_files = dict()
@@ -1153,7 +1158,10 @@ def import_config(config_src, config_file_path, configuration):
         # current config.
         for x in in_tar.getmembers():
             used_files[get_canonical_name(x.name)] = True
-            in_tar.chown(existing_config_tarinfo, x.name)
+            if sys.version_info < (3, 0):
+                in_tar.chown(existing_config_tarinfo, x.name)
+            else:
+                in_tar.chown(existing_config_tarinfo, x.name, False)
 
         in_tar.close()
 

--- a/tests/package_tests/internals/docker_test.py
+++ b/tests/package_tests/internals/docker_test.py
@@ -89,12 +89,9 @@ def _test(
     )
 
     # Quick check for the `scalyr-agent-2-config script.
-    export_config_output = subprocess.check_output([
-        *docker_exec_command,
-        "scalyr-agent-2-config",
-        "--export-config",
-        "-"
-    ])
+    export_config_output = subprocess.check_output(
+        [*docker_exec_command, "scalyr-agent-2-config", "--export-config", "-"]
+    )
 
     assert len(export_config_output) > 0
 

--- a/tests/package_tests/internals/docker_test.py
+++ b/tests/package_tests/internals/docker_test.py
@@ -88,6 +88,16 @@ def _test(
         stdout=subprocess.PIPE,
     )
 
+    # Quick check for the `scalyr-agent-2-config script.
+    export_config_output = subprocess.check_output([
+        *docker_exec_command,
+        "scalyr-agent-2-config",
+        "--export-config",
+        "-"
+    ])
+
+    assert len(export_config_output) > 0
+
     # Read lines from agent.log. Create pipe reader to read lines from the previously created tail process.
 
     # Also set the mode for the process' std descriptor as non-blocking.

--- a/tests/unit/agent_main_test.py
+++ b/tests/unit/agent_main_test.py
@@ -16,7 +16,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import io
 import os
 import shutil
 import sys
@@ -715,6 +714,7 @@ class TestConfigArgumentParsing:
 
         subprocess.check_call(
             [
+                sys.executable,
                 _AGENT_MAIN_PATH,
                 "config",
                 "--export-config",
@@ -741,6 +741,7 @@ class TestConfigArgumentParsing:
 
         subprocess.check_call(
             [
+                sys.executable,
                 _AGENT_MAIN_PATH,
                 "config",
                 "--import-config",
@@ -765,6 +766,7 @@ class TestConfigArgumentParsing:
 
         output = subprocess.check_output(
             [
+                sys.executable,
                 _AGENT_MAIN_PATH,
                 "config",
                 "--export-config",
@@ -795,6 +797,7 @@ class TestConfigArgumentParsing:
         with open(self.output_file, "rb") as f:
             subprocess.check_call(
                 [
+                    sys.executable,
                     _AGENT_MAIN_PATH,
                     "config",
                     "--import-config",


### PR DESCRIPTION
Fix `--import-config`, `--export-config` options of the `scalyr-agent-2-config` comand which is caused by Python2,3 incompatibility.

I also noticed, that docker images don't have `scalyr-agent-2-config` compatibility script, which caused errors on docker images when running config commands.