### PR TITLE
Instrumentation logging improvements

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -121,6 +121,8 @@ from scalyr_agent.platform_controller import (
 from scalyr_agent.platform_controller import AgentNotRunning
 from scalyr_agent.build_info import get_build_revision
 from scalyr_agent.metrics.base import clear_internal_cache
+from scalyr_agent.instrumentation.constants import update_instrumentation_log_interval
+
 from scalyr_agent import config_main
 from scalyr_agent import compat
 import scalyr_agent.monitors_manager
@@ -1496,6 +1498,13 @@ class ScalyrAgent(object):
 
                     # Clear metrics functions related cache
                     clear_internal_cache()
+
+                    # Update module level constant (if needed). We need to do this here since we
+                    # don't have access to the global config instance in that module and we also
+                    # don't want to create a cyclic dependency there
+                    update_instrumentation_log_interval(
+                        self.__config.instrumentation_stats_log_interval
+                    )
 
                 # Log the stats one more time before we terminate.
                 self.__log_overall_stats(

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -1159,6 +1159,11 @@ class ScalyrAgent(object):
                 # verify server certificates.
                 verify_server_certificate(self.__config)
 
+                # set initial constant value based on the config option
+                update_instrumentation_log_interval(
+                    self.__config.instrumentation_stats_log_interval
+                )
+
                 def start_worker_thread(config, logs_initial_positions=None):
                     wt = self.__create_worker_thread(config)
                     # attach callbacks before starting monitors

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -121,7 +121,6 @@ from scalyr_agent.platform_controller import (
 from scalyr_agent.platform_controller import AgentNotRunning
 from scalyr_agent.build_info import get_build_revision
 from scalyr_agent.metrics.base import clear_internal_cache
-from scalyr_agent.instrumentation.constants import update_instrumentation_log_interval
 
 from scalyr_agent import config_main
 from scalyr_agent import compat
@@ -1159,11 +1158,6 @@ class ScalyrAgent(object):
                 # verify server certificates.
                 verify_server_certificate(self.__config)
 
-                # set initial constant value based on the config option
-                update_instrumentation_log_interval(
-                    self.__config.instrumentation_stats_log_interval
-                )
-
                 def start_worker_thread(config, logs_initial_positions=None):
                     wt = self.__create_worker_thread(config)
                     # attach callbacks before starting monitors
@@ -1503,13 +1497,6 @@ class ScalyrAgent(object):
 
                     # Clear metrics functions related cache
                     clear_internal_cache()
-
-                    # Update module level constant (if needed). We need to do this here since we
-                    # don't have access to the global config instance in that module and we also
-                    # don't want to create a cyclic dependency there
-                    update_instrumentation_log_interval(
-                        self.__config.instrumentation_stats_log_interval
-                    )
 
                 # Log the stats one more time before we terminate.
                 self.__log_overall_stats(

--- a/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
@@ -390,9 +390,12 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
 
         # NOTE: Right now Kubernetes Explorer functionality also needs data from Kubernetes events
         # monitor so in case explorer functionality is enabled, we also enable events monitor
-        if self._global_config.k8s_explorer_enable:
+        if self.__disable_monitor and self._global_config.k8s_explorer_enable:
+            # NOTE: In case
             global_log.info(
-                "k8s_explorer_enable config option is set to true, enabling kubernetes events monitor"
+                "k8s_explorer_enable config option is set to true, enabling kubernetes events monitor",
+                limit_once_per_x_secs=(12 * 60 * 60),
+                limit_key="k8s-ev-expr-enabled",
             )
             self.__disable_monitor = False
 

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1222,6 +1222,10 @@ class Configuration(object):
         return self.__get_config().get_float("config_change_check_interval")
 
     @property
+    def instrumentation_stats_log_interval(self):
+        return self.__get_config().get_int("instrumentation_stats_log_interval")
+
+    @property
     def overall_stats_log_interval(self):
         return self.__get_config().get_float("overall_stats_log_interval")
 
@@ -3159,6 +3163,20 @@ class Configuration(object):
         )
         self.__verify_or_set_optional_int(
             config, "disable_leak_config_reload", None, description, apply_defaults
+        )
+
+        # How often to long instrumentation related stats using INFO log level to agent.log
+        # (in seconds)
+        # NOTE: To avoid large overhead of logging this stats often, this value should not be
+        # set lower than 10-30 minutes in production environments
+        self.__verify_or_set_optional_int(
+            config,
+            "instrumentation_stats_log_interval",
+            (12 * 60 * 60),
+            description,
+            apply_defaults,
+            min_value=10,
+            env_aware=True,
         )
 
         self.__verify_or_set_optional_float(

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -3179,7 +3179,7 @@ class Configuration(object):
             config, "disable_leak_config_reload", None, description, apply_defaults
         )
 
-        # How often to long instrumentation related stats using INFO log level to agent.log
+        # How often to log instrumentation related stats using INFO log level to agent.log
         # (in seconds)
         # NOTE: To avoid large overhead of logging this stats often, this value should not be
         # set lower than 10-30 minutes in production environments

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -3172,10 +3172,11 @@ class Configuration(object):
         self.__verify_or_set_optional_int(
             config,
             "instrumentation_stats_log_interval",
-            (12 * 60 * 60),
+            # defaults to disabled
+            0,
             description,
             apply_defaults,
-            min_value=10,
+            min_value=0,
             env_aware=True,
         )
 

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -414,6 +414,20 @@ class Configuration(object):
 
             self.__k8s_log_configs = list(self.__config.get_json_array("k8s_logs"))
 
+            if (
+                self.__log_warnings
+                and self.instrumentation_stats_log_interval > 0
+                and self.instrumentation_stats_log_interval < (30 * 60 * 60)
+            ):
+                self.__logger.info(
+                    "Instrumentation logging is enabled (instrumentation_stats_log_interval config "
+                    "option), but logging interval is "
+                    "set lower than 30 minutes. To avoid overhead you are advised to "
+                    "set this interval to 30 minutes or more in production.",
+                    limit_once_per_x_secs=86400,
+                    limit_key="instrumentation-interval-too-low",
+                )
+
             # add in the profile logs if we have enabled profiling
             if self.enable_profiling and self.__log_warnings:
                 self.__logger.info(

--- a/scalyr_agent/instrumentation/constants.py
+++ b/scalyr_agent/instrumentation/constants.py
@@ -1,0 +1,35 @@
+# Copyright 2014-2022 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    "get_instrumentation_log_interval",
+    "update_instrumentation_log_interval",
+]
+
+# How often (in seconds) to log various internal cache related statistics
+INSTRUMENTATION_STATS_LOG_INTERVAL_SECONDS = 12 * 60 * 60
+
+
+def get_instrumentation_log_interval():
+    # type: () -> int
+    return INSTRUMENTATION_STATS_LOG_INTERVAL_SECONDS
+
+
+def update_instrumentation_log_interval(interval):
+    # type: (int) -> None
+    """
+    Update the value of CACHE_STATS_LOG_INTERVAL_SECONDS variable.
+    """
+    global INSTRUMENTATION_STATS_LOG_INTERVAL_SECONDS
+    INSTRUMENTATION_STATS_LOG_INTERVAL_SECONDS = interval

--- a/scalyr_agent/instrumentation/constants.py
+++ b/scalyr_agent/instrumentation/constants.py
@@ -18,7 +18,9 @@ __all__ = [
 ]
 
 # How often (in seconds) to log various internal cache related statistics
-INSTRUMENTATION_STATS_LOG_INTERVAL_SECONDS = 12 * 60 * 60
+# Defaults to 0 aka logging is disabled. In production this value should be set to value > 10
+# minutes to avoid overhead
+INSTRUMENTATION_STATS_LOG_INTERVAL_SECONDS = 0
 
 
 def get_instrumentation_log_interval():

--- a/scalyr_agent/metrics/base.py
+++ b/scalyr_agent/metrics/base.py
@@ -114,21 +114,23 @@ def get_functions_for_metric(monitor, metric_name):
         MONITOR_METRIC_TO_FUNCTIONS_CACHE[cache_key] = result
 
     # Periodically print cache size and function timing information
-    LOG.info(
-        "agent_monitor_metric_to_function_cache_stats cache_entries=%s,cache_size_bytes=%s",
-        LAZY_PRINT_CACHE_SIZE_LENGTH,
-        LAZY_PRINT_CACHE_SIZE_BYTES,
-        limit_key="mon-met-cache-stats",
-        limit_once_per_x_secs=instrumentation_constants.get_instrumentation_log_interval(),
-    )
-    LOG.info(
-        "agent_get_function_for_metric_timing_stats avg=%s,min=%s,max=%s",
-        LAZY_PRINT_TIMING_MIN,
-        LAZY_PRINT_TIMING_MAX,
-        LAZY_PRINT_TIMING_AVG,
-        limit_key="mon-met-timing-stats",
-        limit_once_per_x_secs=instrumentation_constants.get_instrumentation_log_interval(),
-    )
+    log_interval = instrumentation_constants.get_instrumentation_log_interval()
+    if log_interval > 0:
+        LOG.info(
+            "agent_monitor_metric_to_function_cache_stats cache_entries=%s,cache_size_bytes=%s",
+            LAZY_PRINT_CACHE_SIZE_LENGTH,
+            LAZY_PRINT_CACHE_SIZE_BYTES,
+            limit_key="mon-met-cache-stats",
+            limit_once_per_x_secs=instrumentation_constants.get_instrumentation_log_interval(),
+        )
+        LOG.info(
+            "agent_get_function_for_metric_timing_stats avg=%s,min=%s,max=%s",
+            LAZY_PRINT_TIMING_MIN,
+            LAZY_PRINT_TIMING_MAX,
+            LAZY_PRINT_TIMING_AVG,
+            limit_key="mon-met-timing-stats",
+            limit_once_per_x_secs=instrumentation_constants.get_instrumentation_log_interval(),
+        )
 
     return MONITOR_METRIC_TO_FUNCTIONS_CACHE[cache_key]
 

--- a/scalyr_agent/metrics/base.py
+++ b/scalyr_agent/metrics/base.py
@@ -116,7 +116,11 @@ def get_functions_for_metric(monitor, metric_name):
     # NOTE: We don't have direct access to global config here so we access it via monitor. An
     # alternative would be to use a module level variable which is updated during config load and
     # re-load process (as initially implemented in https://github.com/scalyr/scalyr-agent-2/pull/942)
-    log_interval = monitor._global_config.instrumentation_stats_log_interval or 0
+    log_interval = (
+        monitor._global_config
+        and monitor._global_config.instrumentation_stats_log_interval
+        or 0
+    )
     if log_interval > 0:
         LOG.info(
             "agent_instrumentation_stats key=monitor_metric_to_function_cache_stats cache_entries=%s cache_size_bytes=%s",

--- a/scalyr_agent/metrics/base.py
+++ b/scalyr_agent/metrics/base.py
@@ -36,15 +36,13 @@ import six
 from scalyr_agent.util import get_flat_dictionary_memory_usage
 from scalyr_agent.instrumentation.timing import get_empty_stats_dict
 from scalyr_agent.instrumentation.decorators import time_function_call
+from scalyr_agent.instrumentation import constants as instrumentation_constants
 from scalyr_agent.metrics.functions import MetricFunction
 from scalyr_agent.metrics.functions import RateMetricFunction
 from scalyr_agent.scalyr_logging import getLogger
 from scalyr_agent.scalyr_logging import LazyOnPrintEvaluatedFunction
 
 LOG = getLogger(__name__)
-
-# How often (in seconds) to log various internal cache related statistics
-CACHE_STATS_LOG_INTERVAL_SECONDS = 6 * 60 * 60
 
 
 # Stores a list of class instance (singleton) for each available metric function.
@@ -121,7 +119,7 @@ def get_functions_for_metric(monitor, metric_name):
         LAZY_PRINT_CACHE_SIZE_LENGTH,
         LAZY_PRINT_CACHE_SIZE_BYTES,
         limit_key="mon-met-cache-stats",
-        limit_once_per_x_secs=CACHE_STATS_LOG_INTERVAL_SECONDS,
+        limit_once_per_x_secs=instrumentation_constants.get_instrumentation_log_interval(),
     )
     LOG.info(
         "agent_get_function_for_metric_timing_stats avg=%s,min=%s,max=%s",
@@ -129,7 +127,7 @@ def get_functions_for_metric(monitor, metric_name):
         LAZY_PRINT_TIMING_MAX,
         LAZY_PRINT_TIMING_AVG,
         limit_key="mon-met-timing-stats",
-        limit_once_per_x_secs=CACHE_STATS_LOG_INTERVAL_SECONDS,
+        limit_once_per_x_secs=instrumentation_constants.get_instrumentation_log_interval(),
     )
 
     return MONITOR_METRIC_TO_FUNCTIONS_CACHE[cache_key]

--- a/scalyr_agent/metrics/base.py
+++ b/scalyr_agent/metrics/base.py
@@ -117,14 +117,14 @@ def get_functions_for_metric(monitor, metric_name):
     log_interval = instrumentation_constants.get_instrumentation_log_interval()
     if log_interval > 0:
         LOG.info(
-            "agent_monitor_metric_to_function_cache_stats cache_entries=%s,cache_size_bytes=%s",
+            "agent_instrumentation_stats key=monitor_metric_to_function_cache_stats cache_entries=%s cache_size_bytes=%s",
             LAZY_PRINT_CACHE_SIZE_LENGTH,
             LAZY_PRINT_CACHE_SIZE_BYTES,
             limit_key="mon-met-cache-stats",
             limit_once_per_x_secs=instrumentation_constants.get_instrumentation_log_interval(),
         )
         LOG.info(
-            "agent_get_function_for_metric_timing_stats avg=%s,min=%s,max=%s",
+            "agent_instrumentation_stats key=agent_get_function_for_metric_timing_stats avg=%s min=%s max=%s",
             LAZY_PRINT_TIMING_MIN,
             LAZY_PRINT_TIMING_MAX,
             LAZY_PRINT_TIMING_AVG,

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -302,22 +302,24 @@ could add overhead in terms of CPU and memory usage.
         result = [(rate_metric_name, rate_value)]
 
         # Periodically print cache size and function timing information
-        LOG.info(
-            "agent_monitor_rate_metric_calculation_values_cache_stats cache_entries=%s,cache_size_bytes=%s",
-            cls.LAZY_PRINT_CACHE_SIZE_LENGTH,
-            cls.LAZY_PRINT_CACHE_SIZE_BYTES,
-            limit_key="mon-met-rate-cache-stats",
-            limit_once_per_x_secs=instrumentation_constants.get_instrumentation_log_interval(),
-        )
+        log_interval = instrumentation_constants.get_instrumentation_log_interval()
+        if log_interval > 0:
+            LOG.info(
+                "agent_monitor_rate_metric_calculation_values_cache_stats cache_entries=%s,cache_size_bytes=%s",
+                cls.LAZY_PRINT_CACHE_SIZE_LENGTH,
+                cls.LAZY_PRINT_CACHE_SIZE_BYTES,
+                limit_key="mon-met-rate-cache-stats",
+                limit_once_per_x_secs=instrumentation_constants.get_instrumentation_log_interval(),
+            )
 
-        LOG.info(
-            "agent_rate_func_calculate_timing_stats avg=%s,min=%s,max=%s",
-            cls.LAZY_PRINT_TIMING_MIN,
-            cls.LAZY_PRINT_TIMING_MAX,
-            cls.LAZY_PRINT_TIMING_AVG,
-            limit_key="mon-rate-calc-timing-stats",
-            limit_once_per_x_secs=instrumentation_constants.get_instrumentation_log_interval(),
-        )
+            LOG.info(
+                "agent_rate_func_calculate_timing_stats avg=%s,min=%s,max=%s",
+                cls.LAZY_PRINT_TIMING_MIN,
+                cls.LAZY_PRINT_TIMING_MAX,
+                cls.LAZY_PRINT_TIMING_AVG,
+                limit_key="mon-rate-calc-timing-stats",
+                limit_once_per_x_secs=instrumentation_constants.get_instrumentation_log_interval(),
+            )
 
         return result
 

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -305,7 +305,7 @@ could add overhead in terms of CPU and memory usage.
         log_interval = instrumentation_constants.get_instrumentation_log_interval()
         if log_interval > 0:
             LOG.info(
-                "agent_monitor_rate_metric_calculation_values_cache_stats cache_entries=%s,cache_size_bytes=%s",
+                "agent_instrumentation_stats key=monitor_rate_metric_calculation_values_cache_stats cache_entries=%s cache_size_bytes=%s",
                 cls.LAZY_PRINT_CACHE_SIZE_LENGTH,
                 cls.LAZY_PRINT_CACHE_SIZE_BYTES,
                 limit_key="mon-met-rate-cache-stats",
@@ -313,7 +313,7 @@ could add overhead in terms of CPU and memory usage.
             )
 
             LOG.info(
-                "agent_rate_func_calculate_timing_stats avg=%s,min=%s,max=%s",
+                "agent_instrumentation_stats key=agent_rate_func_calculate_timing_stats avg=%s min=%s max=%s",
                 cls.LAZY_PRINT_TIMING_MIN,
                 cls.LAZY_PRINT_TIMING_MAX,
                 cls.LAZY_PRINT_TIMING_AVG,

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -301,7 +301,11 @@ could add overhead in terms of CPU and memory usage.
         result = [(rate_metric_name, rate_value)]
 
         # Periodically print cache size and function timing information
-        log_interval = monitor._global_config.instrumentation_stats_log_interval or 0
+        log_interval = (
+            monitor._global_config
+            and monitor._global_config.instrumentation_stats_log_interval
+            or 0
+        )
         if log_interval > 0:
             LOG.info(
                 "agent_instrumentation_stats key=monitor_rate_metric_calculation_values_cache_stats cache_entries=%s cache_size_bytes=%s",

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -41,7 +41,6 @@ from scalyr_agent.util import get_hash_for_flat_dictionary
 from scalyr_agent.util import get_flat_dictionary_memory_usage
 from scalyr_agent.instrumentation.timing import get_empty_stats_dict
 from scalyr_agent.instrumentation.decorators import time_function_call
-from scalyr_agent.instrumentation import constants as instrumentation_constants
 from scalyr_agent.scalyr_logging import getLogger
 from scalyr_agent.scalyr_logging import LazyOnPrintEvaluatedFunction
 
@@ -302,14 +301,14 @@ could add overhead in terms of CPU and memory usage.
         result = [(rate_metric_name, rate_value)]
 
         # Periodically print cache size and function timing information
-        log_interval = instrumentation_constants.get_instrumentation_log_interval()
+        log_interval = monitor._global_config.instrumentation_stats_log_interval or 0
         if log_interval > 0:
             LOG.info(
                 "agent_instrumentation_stats key=monitor_rate_metric_calculation_values_cache_stats cache_entries=%s cache_size_bytes=%s",
                 cls.LAZY_PRINT_CACHE_SIZE_LENGTH,
                 cls.LAZY_PRINT_CACHE_SIZE_BYTES,
                 limit_key="mon-met-rate-cache-stats",
-                limit_once_per_x_secs=instrumentation_constants.get_instrumentation_log_interval(),
+                limit_once_per_x_secs=log_interval,
             )
 
             LOG.info(
@@ -318,7 +317,7 @@ could add overhead in terms of CPU and memory usage.
                 cls.LAZY_PRINT_TIMING_MAX,
                 cls.LAZY_PRINT_TIMING_AVG,
                 limit_key="mon-rate-calc-timing-stats",
-                limit_once_per_x_secs=instrumentation_constants.get_instrumentation_log_interval(),
+                limit_once_per_x_secs=log_interval,
             )
 
         return result

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -41,13 +41,11 @@ from scalyr_agent.util import get_hash_for_flat_dictionary
 from scalyr_agent.util import get_flat_dictionary_memory_usage
 from scalyr_agent.instrumentation.timing import get_empty_stats_dict
 from scalyr_agent.instrumentation.decorators import time_function_call
+from scalyr_agent.instrumentation import constants as instrumentation_constants
 from scalyr_agent.scalyr_logging import getLogger
 from scalyr_agent.scalyr_logging import LazyOnPrintEvaluatedFunction
 
 LOG = getLogger(__name__)
-
-# How often (in seconds) to log various internal cache and function timing related statistics
-FUNCTION_STATS_LOG_INTERVAL_SECONDS = 6 * 60 * 60
 
 # Dictionary which stores timing / run time information for "RateMetricFunction.calculate()"
 # method
@@ -309,7 +307,7 @@ could add overhead in terms of CPU and memory usage.
             cls.LAZY_PRINT_CACHE_SIZE_LENGTH,
             cls.LAZY_PRINT_CACHE_SIZE_BYTES,
             limit_key="mon-met-rate-cache-stats",
-            limit_once_per_x_secs=FUNCTION_STATS_LOG_INTERVAL_SECONDS,
+            limit_once_per_x_secs=instrumentation_constants.get_instrumentation_log_interval(),
         )
 
         LOG.info(
@@ -318,7 +316,7 @@ could add overhead in terms of CPU and memory usage.
             cls.LAZY_PRINT_TIMING_MAX,
             cls.LAZY_PRINT_TIMING_AVG,
             limit_key="mon-rate-calc-timing-stats",
-            limit_once_per_x_secs=FUNCTION_STATS_LOG_INTERVAL_SECONDS,
+            limit_once_per_x_secs=instrumentation_constants.get_instrumentation_log_interval(),
         )
 
         return result

--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -927,7 +927,9 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
 
         self.assertEqual(mock_global_log.info.call_count, 1)
         mock_global_log.info.assert_called_with(
-            "k8s_explorer_enable config option is set to true, enabling kubernetes events monitor"
+            "k8s_explorer_enable config option is set to true, enabling kubernetes events monitor",
+            limit_key="k8s-ev-expr-enabled",
+            limit_once_per_x_secs=43200,
         )
         self.assertEqual(mock_global_log.info.call_count, 1)
 

--- a/tests/unit/scalyr_logging_test.py
+++ b/tests/unit/scalyr_logging_test.py
@@ -349,12 +349,18 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
     def test_metric_logging_metric_name_blacklist_actual_monitor_class(self):
         from scalyr_agent.scalyr_monitor import ScalyrMonitor
 
+        global_config = mock.Mock()
+        global_config.instrumentation_stats_log_interval = 300
+        global_config.calculate_rate_metric_names = []
+
         monitor_1_config = {"module": "foo1", "metric_name_blacklist": ["a", "b"]}
         monitor_1_logger = scalyr_logging.getLogger(
             "scalyr_agent.builtin_monitors.foo1(1)"
         )
         monitor_1 = ScalyrMonitor(
-            monitor_config=monitor_1_config, logger=monitor_1_logger
+            monitor_config=monitor_1_config,
+            logger=monitor_1_logger,
+            global_config=global_config,
         )
 
         metric_file_fd, monitor_1_metric_file_path = tempfile.mkstemp(".log")
@@ -368,7 +374,9 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
             "scalyr_agent.builtin_monitors.foo2(1)"
         )
         monitor_2 = ScalyrMonitor(
-            monitor_config=monitor_2_config, logger=monitor_1_logger
+            monitor_config=monitor_2_config,
+            logger=monitor_1_logger,
+            global_config=global_config,
         )
 
         metric_file_fd, monitor_2_metric_file_path = tempfile.mkstemp(".log")
@@ -1297,6 +1305,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
             mock_config = mock.Mock()
             mock_config.calculate_rate_metric_names = []
+            mock_config.instrumentation_stats_log_interval = 300
             self._global_config = mock_config
 
         def get_calculate_rate_metric_names(self):

--- a/tests/unit/test_metrics_functions.py
+++ b/tests/unit/test_metrics_functions.py
@@ -101,6 +101,7 @@ class RateMetricFunctionTestCase(ScalyrTestCase):
         monitor.short_hash = "hashhash"
         monitor.get_calculate_rate_metric_names.return_value = []
         monitor._global_config = mock.Mock()
+        monitor._global_config.instrumentation_stats_log_interval = 10
         monitor._global_config.calculate_rate_metric_names = [
             "openmetrics_monitor:metric1",
             "openmetrics_monitor:metric2",
@@ -119,6 +120,7 @@ class RateMetricFunctionTestCase(ScalyrTestCase):
         monitor.short_hash = "hashhash"
         monitor.get_calculate_rate_metric_names.return_value = []
         monitor._global_config = mock.Mock()
+        monitor._global_config.instrumentation_stats_log_interval = 10
         monitor._global_config.calculate_rate_metric_names = [
             "openmetrics_monitor:metric1",
             "openmetrics_monitor:metric2",
@@ -196,6 +198,7 @@ class RateMetricFunctionTestCase(ScalyrTestCase):
         monitor.short_hash = "hashhash"
         monitor.get_calculate_rate_metric_names.return_value = []
         monitor._global_config = mock.Mock()
+        monitor._global_config.instrumentation_stats_log_interval = 10
         monitor._global_config.calculate_rate_metric_names = [
             "openmetrics_monitor:metric1",
             "openmetrics_monitor:metric2",
@@ -363,6 +366,7 @@ class RateMetricFunctionTestCase(ScalyrTestCase):
         monitor.short_hash = "hashhash"
         monitor.get_calculate_rate_metric_names.return_value = []
         monitor._global_config = mock.Mock()
+        monitor._global_config.instrumentation_stats_log_interval = 10
         monitor._global_config.calculate_rate_metric_names = [
             "openmetrics_monitor:metric1",
             "openmetrics_monitor:metric2",
@@ -406,6 +410,7 @@ class RateMetricFunctionTestCase(ScalyrTestCase):
         monitor.short_hash = "hashhash"
         monitor.get_calculate_rate_metric_names.return_value = []
         monitor._global_config = mock.Mock()
+        monitor._global_config.instrumentation_stats_log_interval = 10
         monitor._global_config.calculate_rate_metric_names = [
             "openmetrics_monitor:metric1",
             "openmetrics_monitor:metric2",


### PR DESCRIPTION
This pull request includes two small improvements:

1. Make sure Kubernetes Events monitor only logs message on initialize when monitor is disabled via environment variable or config option. I also added rate limit for that log call to avoid duplicate messages under some scenarios.

2. Allow user to change logging interval which is used to log instrumentation related statistics to agent.log using INFO log level. This can come handy in various troubleshooting scenario, but most users should leave this value as is on production deployments (since low value could add a lot of overhead).

   Since code where those messages are logged doesn't have direct access to global Configuration object instance (technically, I could access it via ``monitor._global_config``, but I'm not 100% sure this is always set and it could also cause cyclic dependency issues), I needed to a different pattern for updating that module level constant - I set / update it as part of the code where the config file is re-read and things are reloaded, etc. in case changes are detected.

   Logging can also be disabled by setting that value to ``0`` (which will be the case for non Kubernetes Explorer deployments where that functionality is not used).