### PR TITLE
Introduce clean up routine for RateMetricFunction, fix log function argument order

### DIFF
--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -3202,7 +3202,7 @@ class Configuration(object):
         self.__verify_or_set_optional_int(
             config,
             "metric_functions_cleanup_interval",
-            (30 * 60 * 60),
+            (30 * 60),
             description,
             apply_defaults,
             min_value=0,

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1240,6 +1240,10 @@ class Configuration(object):
         return self.__get_config().get_int("instrumentation_stats_log_interval")
 
     @property
+    def metric_functions_cleanup_interval(self):
+        return self.__get_config().get_int("metric_functions_cleanup_interval")
+
+    @property
     def overall_stats_log_interval(self):
         return self.__get_config().get_float("overall_stats_log_interval")
 
@@ -3188,6 +3192,17 @@ class Configuration(object):
             "instrumentation_stats_log_interval",
             # defaults to disabled
             0,
+            description,
+            apply_defaults,
+            min_value=0,
+            env_aware=True,
+        )
+
+        # How often (in seconds) clean up routine should run for metric functions functionality
+        self.__verify_or_set_optional_int(
+            config,
+            "metric_functions_cleanup_interval",
+            (30 * 60 * 60),
             description,
             apply_defaults,
             min_value=0,

--- a/scalyr_agent/metrics/base.py
+++ b/scalyr_agent/metrics/base.py
@@ -131,9 +131,9 @@ def get_functions_for_metric(monitor, metric_name):
         )
         LOG.info(
             "agent_instrumentation_stats key=agent_get_function_for_metric_timing_stats avg=%s min=%s max=%s",
+            LAZY_PRINT_TIMING_AVG,
             LAZY_PRINT_TIMING_MIN,
             LAZY_PRINT_TIMING_MAX,
-            LAZY_PRINT_TIMING_AVG,
             limit_key="mon-met-timing-stats",
             limit_once_per_x_secs=log_interval,
         )

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -443,7 +443,7 @@ could add overhead in terms of CPU and memory usage.
         TODO: Thread safety?
         """
         now_s = int(time.time())
-        LAST_CLEANUP_RUNTIME_TS = now_s
+        cls.LAST_CLEANUP_RUNTIME_TS = now_s
 
         monitor._logger.debug(
             "Running periodic clean up routine for RateMetricFunction"

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -317,9 +317,9 @@ could add overhead in terms of CPU and memory usage.
 
             LOG.info(
                 "agent_instrumentation_stats key=agent_rate_func_calculate_timing_stats avg=%s min=%s max=%s",
+                cls.LAZY_PRINT_TIMING_AVG,
                 cls.LAZY_PRINT_TIMING_MIN,
                 cls.LAZY_PRINT_TIMING_MAX,
-                cls.LAZY_PRINT_TIMING_AVG,
                 limit_key="mon-rate-calc-timing-stats",
                 limit_once_per_x_secs=log_interval,
             )

--- a/tests/unit/scalyr_logging_test.py
+++ b/tests/unit/scalyr_logging_test.py
@@ -350,6 +350,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
         from scalyr_agent.scalyr_monitor import ScalyrMonitor
 
         global_config = mock.Mock()
+        global_config.metric_functions_cleanup_interval = 0
         global_config.instrumentation_stats_log_interval = 300
         global_config.calculate_rate_metric_names = []
 
@@ -1305,6 +1306,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
 
             mock_config = mock.Mock()
             mock_config.calculate_rate_metric_names = []
+            mock_config.metric_functions_cleanup_interval = 0
             mock_config.instrumentation_stats_log_interval = 300
             self._global_config = mock_config
 

--- a/tests/unit/test_metrics_functions.py
+++ b/tests/unit/test_metrics_functions.py
@@ -554,6 +554,7 @@ class RateMetricFunctionTestCase(ScalyrTestCase):
         }
 
         func._remove_old_entries(monitor=monitor)
+        self.assertEqual(RateMetricFunction.LAST_CLEANUP_RUNTIME_TS, now_ts)
         self.assertEqual(len(func.RATE_CALCULATION_METRIC_VALUES), 3)
         self.assertTrue("one" in func.RATE_CALCULATION_METRIC_VALUES)
         self.assertTrue("two" in func.RATE_CALCULATION_METRIC_VALUES)

--- a/tests/unit/test_metrics_functions.py
+++ b/tests/unit/test_metrics_functions.py
@@ -553,6 +553,7 @@ class RateMetricFunctionTestCase(ScalyrTestCase):
             "six": (now_ts - 90, 1),
         }
 
+        self.assertEqual(len(func.RATE_CALCULATION_METRIC_VALUES), 6)
         func._remove_old_entries(monitor=monitor)
         self.assertEqual(RateMetricFunction.LAST_CLEANUP_RUNTIME_TS, now_ts)
         self.assertEqual(len(func.RATE_CALCULATION_METRIC_VALUES), 3)

--- a/tests/unit/test_metrics_functions.py
+++ b/tests/unit/test_metrics_functions.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 from collections import OrderedDict
 
 import mock
@@ -101,6 +103,7 @@ class RateMetricFunctionTestCase(ScalyrTestCase):
         monitor.short_hash = "hashhash"
         monitor.get_calculate_rate_metric_names.return_value = []
         monitor._global_config = mock.Mock()
+        monitor._global_config.metric_functions_cleanup_interval = 0
         monitor._global_config.instrumentation_stats_log_interval = 10
         monitor._global_config.calculate_rate_metric_names = [
             "openmetrics_monitor:metric1",
@@ -120,6 +123,7 @@ class RateMetricFunctionTestCase(ScalyrTestCase):
         monitor.short_hash = "hashhash"
         monitor.get_calculate_rate_metric_names.return_value = []
         monitor._global_config = mock.Mock()
+        monitor._global_config.metric_functions_cleanup_interval = 0
         monitor._global_config.instrumentation_stats_log_interval = 10
         monitor._global_config.calculate_rate_metric_names = [
             "openmetrics_monitor:metric1",
@@ -198,6 +202,7 @@ class RateMetricFunctionTestCase(ScalyrTestCase):
         monitor.short_hash = "hashhash"
         monitor.get_calculate_rate_metric_names.return_value = []
         monitor._global_config = mock.Mock()
+        monitor._global_config.metric_functions_cleanup_interval = 0
         monitor._global_config.instrumentation_stats_log_interval = 10
         monitor._global_config.calculate_rate_metric_names = [
             "openmetrics_monitor:metric1",
@@ -366,6 +371,7 @@ class RateMetricFunctionTestCase(ScalyrTestCase):
         monitor.short_hash = "hashhash"
         monitor.get_calculate_rate_metric_names.return_value = []
         monitor._global_config = mock.Mock()
+        monitor._global_config.metric_functions_cleanup_interval = 0
         monitor._global_config.instrumentation_stats_log_interval = 10
         monitor._global_config.calculate_rate_metric_names = [
             "openmetrics_monitor:metric1",
@@ -410,6 +416,7 @@ class RateMetricFunctionTestCase(ScalyrTestCase):
         monitor.short_hash = "hashhash"
         monitor.get_calculate_rate_metric_names.return_value = []
         monitor._global_config = mock.Mock()
+        monitor._global_config.metric_functions_cleanup_interval = 0
         monitor._global_config.instrumentation_stats_log_interval = 10
         monitor._global_config.calculate_rate_metric_names = [
             "openmetrics_monitor:metric1",
@@ -523,3 +530,31 @@ class RateMetricFunctionTestCase(ScalyrTestCase):
             monitor=monitor, metric_name=metric_name, extra_fields=extra_fields
         )
         self.assertTrue(result)
+
+    def test_old_entries_cleanup(self):
+        now_ts = int(time.time())
+
+        monitor = mock.Mock()
+        monitor.monitor_module_name = "openmetrics_monitor"
+        monitor.short_hash = "hashhash"
+        monitor.get_calculate_rate_metric_names.return_value = []
+        monitor._global_config = mock.Mock()
+        monitor._global_config.metric_functions_cleanup_interval = 60
+        monitor._global_config.instrumentation_stats_log_interval = 10
+
+        func = RateMetricFunction()
+        RateMetricFunction.DELETE_OLD_VALUES_THRESHOLD_SECONDS = 60
+        RateMetricFunction.RATE_CALCULATION_METRIC_VALUES = {
+            "one": (now_ts, 1),
+            "two": (now_ts - 10, 1),
+            "three": (now_ts - 50, 1),
+            "four": (now_ts - 70, 1),
+            "five": (now_ts - 80, 1),
+            "six": (now_ts - 90, 1),
+        }
+
+        func._remove_old_entries(monitor=monitor)
+        self.assertEqual(len(func.RATE_CALCULATION_METRIC_VALUES), 3)
+        self.assertTrue("one" in func.RATE_CALCULATION_METRIC_VALUES)
+        self.assertTrue("two" in func.RATE_CALCULATION_METRIC_VALUES)
+        self.assertTrue("three" in func.RATE_CALCULATION_METRIC_VALUES)


### PR DESCRIPTION
This pull request includes two changes:

1. Fix invalid ``log.info()`` function call arguments order
2. Introduce clean up routine for the ``RateMetricFunction`` function which periodically cleans up old / stale values.

We need periodic clean up routine to ensure internal data structure which stores metric values doesn't grow too large and that stale / unused values are correctly removed (a lot of stored metrics will become stale and unused over time since they will refer to resources which are now gone - imagine metric which refer to old containers, old nodes, etc.)

NOTE: In the future I may refactor some of that functionality and instead of having a global singleton instance of ``RateMetricFunction`` move it to an approach where we have an instance per ``ScalyrMonitor`` (I think this should work well, reduce some overhead / spread it across monitor threads and simplify some of the thread safety issues. A lot of that functionality is already scoped to a monitor and should work well as long as we never need cross monitor metrics calculations in the future).