### PR TITLE
Client side rate calculation improvements

### DIFF
--- a/scalyr_agent/metrics/base.py
+++ b/scalyr_agent/metrics/base.py
@@ -72,13 +72,13 @@ LAZY_PRINT_CACHE_SIZE_BYTES = LazyOnPrintEvaluatedFunction(
 )
 
 LAZY_PRINT_TIMING_MIN = LazyOnPrintEvaluatedFunction(
-    lambda: GET_FUNCTIONS_FOR_METRICS_RUNTIME_STATS["min"]
+    lambda: round(GET_FUNCTIONS_FOR_METRICS_RUNTIME_STATS["min"], 4)
 )
 LAZY_PRINT_TIMING_MAX = LazyOnPrintEvaluatedFunction(
-    lambda: GET_FUNCTIONS_FOR_METRICS_RUNTIME_STATS["max"]
+    lambda: round(GET_FUNCTIONS_FOR_METRICS_RUNTIME_STATS["max"], 4)
 )
 LAZY_PRINT_TIMING_AVG = LazyOnPrintEvaluatedFunction(
-    lambda: GET_FUNCTIONS_FOR_METRICS_RUNTIME_STATS["avg"]
+    lambda: round(GET_FUNCTIONS_FOR_METRICS_RUNTIME_STATS["avg"], 4)
 )
 
 

--- a/scalyr_agent/metrics/base.py
+++ b/scalyr_agent/metrics/base.py
@@ -92,7 +92,7 @@ def get_functions_for_metric(monitor, metric_name):
       - [ ] To speed up the common case then there are no functions defined, we should short circuit
            in such scenario.
     """
-    cache_key = "%s.%s" % (monitor.short_hash, metric_name)
+    cache_key = "%s:%s" % (monitor.short_hash, metric_name)
 
     # NOTE: Since there can be tons of different unique extra_fields values for a specific metric
     # and as such permutations, we have first level cache for monitor and metric name here. Having

--- a/scalyr_agent/metrics/base.py
+++ b/scalyr_agent/metrics/base.py
@@ -94,6 +94,8 @@ def get_functions_for_metric(monitor, metric_name):
     """
     cache_key = "%s:%s" % (monitor.short_hash, metric_name)
 
+    # TODO: Use LRU cache with limited max size
+
     # NOTE: Since there can be tons of different unique extra_fields values for a specific metric
     # and as such permutations, we have first level cache for monitor and metric name here. Having
     # cache entry for each possible monitor name, metric name, extra_fields values would result in

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -476,9 +476,9 @@ could add overhead in terms of CPU and memory usage.
         duration_ms = (end_ts - start_ts) * 1000
 
         monitor._logger.info(
-            "RateMetricFunction clean up routine finished (removed_entries=%s,"
-            "entries_pre_cleanup=%s,entries_post_cleanup=%s,bytes_pre_cleanup=%s,"
-            "bytes_post_cleanup=%s,duration_ms=%s)"
+            "RateMetricFunction clean up routine finished (removed_entries=%s "
+            "entries_pre_cleanup=%s entries_post_cleanup=%s bytes_pre_cleanup=%s "
+            "bytes_post_cleanup=%s duration_ms=%s)"
             % (
                 (entries_pre_cleanup - entries_post_cleanup),
                 entries_pre_cleanup,

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -133,7 +133,9 @@ class RateMetricFunction(MetricFunction):
     LAST_CLEANUP_RUNTIME_TS = 0
 
     # If we track rate for more than this many metrics, a warning will be emitted.
-    MAX_RATE_METRICS_COUNT_WARN = 15000
+    # With average metric name and value (timestamp, value) taking around 240 bytes, that means
+    # around 5 MB of memory usage (240 bytes * 20_000 entries = 4800000 bytes)
+    MAX_RATE_METRICS_COUNT_WARN = 20000
 
     MAX_RATE_METRIC_WARN_MESSAGE = """
 Tracking client side rate for over %s metrics. Tracking and calculating rate for that many metrics

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -40,6 +40,7 @@ import six
 
 from scalyr_agent.util import get_hash_for_flat_dictionary
 from scalyr_agent.util import get_flat_dictionary_memory_usage
+from scalyr_agent.util import get_flat_dictionary_memory_usage
 from scalyr_agent.instrumentation.timing import get_empty_stats_dict
 from scalyr_agent.instrumentation.decorators import time_function_call
 from scalyr_agent.scalyr_logging import getLogger
@@ -453,6 +454,9 @@ could add overhead in terms of CPU and memory usage.
         start_ts = timer()
 
         entries_pre_cleanup = len(cls.RATE_CALCULATION_METRIC_VALUES)
+        bytes_pre_cleanup = get_flat_dictionary_memory_usage(
+            cls.RATE_CALCULATION_METRIC_VALUES
+        )
 
         delete_threshold_ts = now_s - cls.DELETE_OLD_VALUES_THRESHOLD_SECONDS
 
@@ -462,17 +466,23 @@ could add overhead in terms of CPU and memory usage.
                 cls.RATE_CALCULATION_METRIC_VALUES.pop(dict_key, None)
 
         entries_post_cleanup = len(cls.RATE_CALCULATION_METRIC_VALUES)
+        bytes_post_cleanup = get_flat_dictionary_memory_usage(
+            cls.RATE_CALCULATION_METRIC_VALUES
+        )
 
         end_ts = timer()
         duration_ms = (end_ts - start_ts) * 1000
 
         monitor._logger.info(
             "RateMetricFunction clean up routine finished (removed_entries=%s,"
-            "entries_pre_cleanup=%s,entries_post_cleanup=%s,duration_ms=%s)"
+            "entries_pre_cleanup=%s,entries_post_cleanup=%s,bytes_pre_cleanup=%s,"
+            "bytes_post_cleanup=%s,duration_ms=%s)"
             % (
                 (entries_pre_cleanup - entries_post_cleanup),
                 entries_pre_cleanup,
                 entries_post_cleanup,
+                bytes_pre_cleanup,
+                bytes_post_cleanup,
                 duration_ms,
             )
         )

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -485,7 +485,7 @@ could add overhead in terms of CPU and memory usage.
                 entries_post_cleanup,
                 bytes_pre_cleanup,
                 bytes_post_cleanup,
-                duration_ms,
+                round(duration_ms, 4),
             )
         )
 

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -34,6 +34,7 @@ from abc import ABCMeta
 from abc import abstractmethod
 from collections import defaultdict
 from itertools import chain
+from timeit import default_timer as timer
 
 import six
 
@@ -449,6 +450,8 @@ could add overhead in terms of CPU and memory usage.
             "Running periodic clean up routine for RateMetricFunction"
         )
 
+        start_ts = timer()
+
         entries_pre_cleanup = len(cls.RATE_CALCULATION_METRIC_VALUES)
 
         delete_threshold_ts = now_s - cls.DELETE_OLD_VALUES_THRESHOLD_SECONDS
@@ -459,13 +462,18 @@ could add overhead in terms of CPU and memory usage.
                 cls.RATE_CALCULATION_METRIC_VALUES.pop(dict_key, None)
 
         entries_post_cleanup = len(cls.RATE_CALCULATION_METRIC_VALUES)
+
+        end_ts = timer()
+        duration_ms = (end_ts - start_ts) * 1000
+
         monitor._logger.info(
             "RateMetricFunction clean up routine finished (removed_entries=%s,"
-            "entries_pre_cleanup=%s,entries_post_cleanup=%s)"
+            "entries_pre_cleanup=%s,entries_post_cleanup=%s,duration_ms=%s)"
             % (
                 (entries_pre_cleanup - entries_post_cleanup),
                 entries_pre_cleanup,
                 entries_post_cleanup,
+                duration_ms,
             )
         )
 

--- a/scalyr_agent/third_party/tcollector/tcollector.py
+++ b/scalyr_agent/third_party/tcollector/tcollector.py
@@ -145,7 +145,7 @@ class Collector(object):
             if out:
                 LOG.debug("reading %s got %d bytes on stderr", self.name, len(out))
                 for line in out.splitlines():
-                    LOG.warning("%s: %s", self.name, line)
+                    LOG.warning("%s: %s", self.name, six.ensure_text(line))
         except IOError as error:
             (err, msg) = error.args
             if err != errno.EAGAIN:

--- a/tests/ami/requirements.txt
+++ b/tests/ami/requirements.txt
@@ -1,5 +1,5 @@
 # Includes paramiko >= 2.9.0 workaround
 git+https://github.com/scalyr/libcloud.git@paramiko_2_9_compatibility_requests_2200#egg=apache-libcloud
 #apache-libcloud==3.4.1
-paramiko==2.10.4
+paramiko==2.11.0
 Jinja2==3.0.3

--- a/tests/unit/scalyr_logging_test.py
+++ b/tests/unit/scalyr_logging_test.py
@@ -831,7 +831,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
             (RateMetricFunction.MAX_RATE_METRICS_COUNT_WARN * 3) + 2,
         )
         monitor_instance._logger.warn.assert_called_with(
-            "Tracking client side rate for over 15000 metrics. Tracking and calculating rate for that many metrics\ncould add overhead in terms of CPU and memory usage.",
+            "Tracking client side rate for over 20000 metrics. Tracking and calculating rate for that many metrics\ncould add overhead in terms of CPU and memory usage.",
             limit_key="rate-max-count-reached",
             limit_once_per_x_secs=86400,
         )


### PR DESCRIPTION
This PR includes various small improvements / polish for the client side rate calculation:

* Update clean up routine to also log clean up duration in ms and include approximate dictionary byte size pre and post cleanup
* Bump internal dictionary warning threshold to 20k (this should result to around 5 MB additional memory usage, we may want to bump this further in the future)
* Round duration values in the timing log messages to 4 decimal places (that's plenty since the unit is milliseconds)

Other changes:

* Upgrade paramiko used by AMI tests
* Fix small issue with logging with tcollectors on exit