### PR TITLE
Include full module name in the agent log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
-## 2.1.32 "Occao" - July 20, 2022
+## 2.1.32 "Occao" - July 20, 2022 - In development
 
 <!---
 Packaged by Dominic LoBue <dominicl@sentinelone.com> on Jul 20, 2022 12:29 -0800
@@ -24,6 +24,7 @@ Docker images:
 Other:
 * Support for Python 2.6 has been dropped.
 * Support for ``ujson`` JSON library (``json_library`` configuration option) has been removed in favor of ``orjson``.
+* Update agent log messages to include full name of the module which produced the message.
 
 ## 2.1.31 "Irati" - Jun 28, 2022
 

--- a/scalyr_agent/scalyr_logging.py
+++ b/scalyr_agent/scalyr_logging.py
@@ -1017,12 +1017,17 @@ class AgentLogFormatter(BaseFormatter):
         # differentiate between log messages which share the same module name, but a different
         # package
         if "pathname" in record.__dict__.keys():
-            record.fqname = (
-                record.pathname[record.pathname.rfind("scalyr_agent") :]
-                .replace(os.path.sep, ".")
-                .replace(".pyc", "")
-                .replace(".py", "")
-            )
+            agent_module_loc = record.pathname.rfind("scalyr_agent")
+            if agent_module_loc != -1:
+                record.fqname = (
+                    record.pathname[record.pathname.rfind("scalyr_agent") :]
+                    .replace(os.path.sep, ".")
+                    .replace(".pyc", "")
+                    .replace(".py", "")
+                )
+            else:
+                # Files without scalyr_agent module (e.g. tests - we only include file name)
+                record.fqname = record.filename.replace(".pyc", "").replace(".py", "")
         else:
             record.fqname = record.filename
 

--- a/tests/smoke_tests/monitors_test/postgres_test.py
+++ b/tests/smoke_tests/monitors_test/postgres_test.py
@@ -117,7 +117,7 @@ def _test(request, python_version):
 
     # wait for agent logs about postgres monitor is started.
     agent_log_reader.wait_for_matching_line(
-        pattern=r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+Z INFO \[core\] \[monitors_manager\.py:\d+\] Starting monitor postgres_monitor\(mydb\)"
+        pattern=r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+Z INFO \[core\] \[scalyr_agent.monitors_manager:\d+\] Starting monitor postgres_monitor\(mydb\)"
     )
 
     # just wait more to be sure that there are no errors in the agent.log.

--- a/tests/unit/builtin_monitors/kubernetes_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_monitor_test.py
@@ -700,7 +700,7 @@ class TestKubeletApi(BaseScalyrLogCaptureTestCase):
                 result = api.query_stats()
                 self.assertEqual(result, {})
                 self.assertLogFileContainsLineRegex(
-                    r".*WARNING \[core\] \[k8s.py:\d+\] Accessing Kubelet with an unverified HTTPS request\."
+                    r".*WARNING \[core\] \[scalyr_agent.monitor_utils.k8s:\d+\] Accessing Kubelet with an unverified HTTPS request\."
                 )
                 self.assertFalse(new_err.getvalue())
                 self.assertFalse(new_out.getvalue())

--- a/tests/unit/scalyr_logging_test.py
+++ b/tests/unit/scalyr_logging_test.py
@@ -80,7 +80,7 @@ class ScalyrLoggingTest(BaseScalyrLogCaptureTestCase):
         self.__logger.info("Test line %d", 5)
         expression = (
             r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3}Z INFO \[core\] "
-            r"\[.*\.py:\d+\] Test line 5"
+            r"\[.*\:\d+\] Test line 5"
         )
         self.assertLogFileContainsLineRegex(expression=expression)
 

--- a/tests/utils/log_reader.py
+++ b/tests/utils/log_reader.py
@@ -112,8 +112,8 @@ class LogReader(threading.Thread):
             except StopIteration:
                 if time.time() >= timeout_time:
                     raise LogReaderTimeoutError(
-                        "Timeout of %s seconds reached while waiting for new line."
-                        % timeout
+                        "Timeout of %s seconds reached while waiting for new line. Accumulated lines:\n%s"
+                        % (timeout, "\n".join(self._lines))
                     )
                 time.sleep(0.01)
 


### PR DESCRIPTION
This pull request updates ``AgentLogFormatter`` to include full module name (previously only the file name was included).

This allows us to disthinghuish between different modules which use the same name (but belong to a different package).

Before:

```bash
2022-07-24 13:15:19.697Z WARNING [monitor:linux_system_metrics()] [tcollector.py:148] iostat.py: b'Traceback (most recent call last):'
```

After:

```bash
2022-07-24 13:15:19.697Z WARNING [monitor:linux_system_metrics()] [scalyr_agent.third_party.tcollector.tcollector:148] iostat.py: b'Traceback (most recent call last):'
```