### PR TITLE
Turn container metrics request error to warning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docker images:
 Other:
 * Monitor ``emit_value()`` method now correctly sanitizes / escapes metric field names which are "reserved" (logfile, metric, value, serverHost, instance, severity). This is done to prevent possible collisions with special / reserved metric event attribute names which could cause issues with some queries. Metric field names which are escaped get added ``_`` suffix (e.g. ``metric`` becomes ``metric_``).
 * Upgrade dependency ``requests`` library to 2.25.1.
+* Failed docker container metric status requests from the docker client now logged as warnings instead of errors.
 
 ## 2.1.30 "Heturn" - May 17, 2022
 

--- a/scalyr_agent/builtin_monitors/docker_monitor.py
+++ b/scalyr_agent/builtin_monitors/docker_monitor.py
@@ -2449,7 +2449,7 @@ TODO:  Back fill the instructions here.
             if result is not None:
                 self.__log_json_metrics(container, result)
         except Exception as e:
-            self._logger.error(
+            self._logger.warning(
                 "Error readings stats for '%s': %s\n%s"
                 % (container, six.text_type(e), traceback.format_exc()),
                 limit_once_per_x_secs=300,

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -2867,7 +2867,7 @@ class DockerMetricFetcher(object):
                     container=container_id, stream=False
                 )
             except Exception as e:
-                global_log.error(
+                global_log.warning(
                     "Error readings stats for '%s': %s\n%s"
                     % (container_id, six.text_type(e), traceback.format_exc()),
                     limit_once_per_x_secs=300,


### PR DESCRIPTION
log warning error instead of error on non-critical docker container metric stat request. Our tests  parse agent log for errors and this error may happen often due to some race condition, but it is recoverable so it shouldn't be considered as ERROR/