### PR TITLE
Fix Docker image name - make sure we push correct docker image to Docker Hub

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image-type: [ "docker-json", "docker-syslog", "k8s", "k8s-with-openmetrics-monitor" ]
+        image-type: [ "docker-json", "docker-syslog", "k8s", "k8s-restart-agent-on-monitor-death" ]
         image-distro-name: [ "debian", "alpine" ]
 
     steps:


### PR DESCRIPTION
This pull request fixes small typo in #985 to make sure we push correct image name to Docker Hub.