### PR TITLE
Add logging on startup for the monitor 'stop_agent_on_failure' option.

### DIFF
--- a/scalyr_agent/agent_status.py
+++ b/scalyr_agent/agent_status.py
@@ -590,6 +590,8 @@ class MonitorStatus(BaseAgentStatus):
         self.monitor_id = None
         # monitors unique short_hash
         self.monitor_short_hash = None
+        # bool flag that indicates that the 'stop_agent_on_failure' config option is enabled.
+        self.stop_agent_on_failure = None
         # The total number of metric lines reported by the monitor.
         self.reported_lines = 0
         # The total number of errors produced by the monitor.
@@ -1079,16 +1081,15 @@ def __report_monitor_manager(output, manager_status, read_time):
 
     for entry in manager_status.monitors_status:
         if entry.is_alive:
-            print(
-                "%s%s: %d lines emitted, %d errors"
-                % (
-                    padding,
-                    entry.monitor_name,
-                    entry.reported_lines,
-                    entry.errors,
-                ),
-                file=output,
+            running_monitors_message = "%s%s: %d lines emitted, %d errors" % (
+                padding,
+                entry.monitor_name,
+                entry.reported_lines,
+                entry.errors,
             )
+            if entry.stop_agent_on_failure:
+                running_monitors_message = "{}, stop_agent_on_failure=true".format(running_monitors_message)
+            print(running_monitors_message, file=output)
 
     dead_monitors = (
         len(manager_status.monitors_status) - manager_status.total_alive_monitors

--- a/scalyr_agent/agent_status.py
+++ b/scalyr_agent/agent_status.py
@@ -1088,7 +1088,9 @@ def __report_monitor_manager(output, manager_status, read_time):
                 entry.errors,
             )
             if entry.stop_agent_on_failure:
-                running_monitors_message = "{}, stop_agent_on_failure=true".format(running_monitors_message)
+                running_monitors_message = "{}, stop_agent_on_failure=true".format(
+                    running_monitors_message
+                )
             print(running_monitors_message, file=output)
 
     dead_monitors = (

--- a/scalyr_agent/monitors_manager.py
+++ b/scalyr_agent/monitors_manager.py
@@ -370,13 +370,13 @@ class MonitorsManager(StoppableThread):
         # Check to see if we can open the metric log.  Maybe we should not silently fail here but instead fail.
         if monitor.open_metric_log():
             monitor.config_from_monitors(self)
-            starting_minitor_message = "Starting monitor %s." % monitor.monitor_name
+            starting_monitor_message = "Starting monitor %s." % monitor.monitor_name
             if monitor.get_stop_agent_on_failure():
-                starting_minitor_message += (
+                starting_monitor_message += (
                     " Config option 'stop_agent_on_failure' is enabled."
                 )
 
-            log.info(starting_minitor_message)
+            log.info(starting_monitor_message)
 
             # NOTE: Workaround for a not so great behavior with out code where we create
             # thread instances before forking. This causes issues because "_is_stopped"

--- a/scalyr_agent/monitors_manager.py
+++ b/scalyr_agent/monitors_manager.py
@@ -372,10 +372,11 @@ class MonitorsManager(StoppableThread):
             monitor.config_from_monitors(self)
             starting_minitor_message = "Starting monitor %s." % monitor.monitor_name
             if monitor.get_stop_agent_on_failure():
-                starting_minitor_message += " Config option 'stop_agent_on_failure' is enabled."
+                starting_minitor_message += (
+                    " Config option 'stop_agent_on_failure' is enabled."
+                )
 
             log.info(starting_minitor_message)
-
 
             # NOTE: Workaround for a not so great behavior with out code where we create
             # thread instances before forking. This causes issues because "_is_stopped"

--- a/scalyr_agent/monitors_manager.py
+++ b/scalyr_agent/monitors_manager.py
@@ -143,6 +143,7 @@ class MonitorsManager(StoppableThread):
             status.monitor_name = monitor.monitor_name
             status.monitor_id = monitor.monitor_id
             status.monitor_short_hash = monitor.short_hash
+            status.stop_agent_on_failure = monitor.get_stop_agent_on_failure()
             status.reported_lines = monitor.reported_lines()
             status.errors = monitor.errors()
             status.is_alive = monitor.isAlive()
@@ -369,7 +370,12 @@ class MonitorsManager(StoppableThread):
         # Check to see if we can open the metric log.  Maybe we should not silently fail here but instead fail.
         if monitor.open_metric_log():
             monitor.config_from_monitors(self)
-            log.info("Starting monitor %s", monitor.monitor_name)
+            starting_minitor_message = "Starting monitor %s." % monitor.monitor_name
+            if monitor.get_stop_agent_on_failure():
+                starting_minitor_message += " Config option 'stop_agent_on_failure' is enabled."
+
+            log.info(starting_minitor_message)
+
 
             # NOTE: Workaround for a not so great behavior with out code where we create
             # thread instances before forking. This causes issues because "_is_stopped"

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -148,10 +148,6 @@ class ScalyrMonitor(StoppableThread):
 
         # The MonitorConfig object created from the config for this monitor instance.
         self._config = MonitorConfig(monitor_config, monitor_module=self.monitor_name)
-
-        # Flag that indicates that agent can not keep working if that monitor fails.
-        self._stop_agent_on_failure = monitor_config.get("stop_agent_on_failure", False)
-
         log_path = self.monitor_name.split(".")[-1] + ".log"
         self.disabled = False
         # TODO: For now, just leverage the logic in the loggers for naming this monitor.  However,
@@ -222,7 +218,7 @@ class ScalyrMonitor(StoppableThread):
         Returns boolean value which indicates that the agent can not run without this monitor and
         has to fail if monitor fails.
         """
-        return self._stop_agent_on_failure
+        return self._config.get("stop_agent_on_failure", False)
 
     @property
     def uid(self):

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -148,6 +148,10 @@ class ScalyrMonitor(StoppableThread):
 
         # The MonitorConfig object created from the config for this monitor instance.
         self._config = MonitorConfig(monitor_config, monitor_module=self.monitor_name)
+
+        # Flag that indicates that agent can not keep working if that monitor fails.
+        self._stop_agent_on_failure = monitor_config.get("stop_agent_on_failure", False)
+
         log_path = self.monitor_name.split(".")[-1] + ".log"
         self.disabled = False
         # TODO: For now, just leverage the logic in the loggers for naming this monitor.  However,
@@ -218,7 +222,7 @@ class ScalyrMonitor(StoppableThread):
         Returns boolean value which indicates that the agent can not run without this monitor and
         has to fail if monitor fails.
         """
-        return self._config.get("stop_agent_on_failure", False)
+        return self._stop_agent_on_failure
 
     @property
     def uid(self):

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -218,7 +218,10 @@ class ScalyrMonitor(StoppableThread):
         Returns boolean value which indicates that the agent can not run without this monitor and
         has to fail if monitor fails.
         """
-        return self._config.get("stop_agent_on_failure", False)
+        try:
+            return self._config["stop_agent_on_failure"]
+        except KeyError:
+            return False
 
     @property
     def uid(self):

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -218,7 +218,7 @@ class ScalyrMonitor(StoppableThread):
         Returns boolean value which indicates that the agent can not run without this monitor and
         has to fail if monitor fails.
         """
-        return self._config["stop_agent_on_failure"]
+        return self._config.get("stop_agent_on_failure", False)
 
     @property
     def uid(self):

--- a/tests/unit/agent_status_test.py
+++ b/tests/unit/agent_status_test.py
@@ -346,6 +346,14 @@ class TestReportStatus(ScalyrTestCase):
         monitor_status.reported_lines = 20
         monitor_status.errors = 40
 
+        monitor_status = MonitorStatus()
+        monitor_manager.monitors_status.append(monitor_status)
+        monitor_status.stop_agent_on_failure = True
+        monitor_status.is_alive = True
+        monitor_status.monitor_name = "essential_monitor()"
+        monitor_status.reported_lines = 20
+        monitor_status.errors = 40
+
     def make_default(self):
         """
         Keep only one worker and one session to reproduce the default config case.
@@ -449,6 +457,7 @@ Monitors:
 Running monitors:
   linux_process_metrics(agent): 50 lines emitted, 2 errors
   linux_system_metrics(): 20 lines emitted, 0 errors
+  essential_monitor(): 20 lines emitted, 40 errors, stop_agent_on_failure=true
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
@@ -535,6 +544,7 @@ Monitors:
 Running monitors:
   linux_process_metrics(agent): 50 lines emitted, 2 errors
   linux_system_metrics(): 20 lines emitted, 0 errors
+  essential_monitor(): 20 lines emitted, 40 errors, stop_agent_on_failure=true
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
@@ -625,6 +635,7 @@ Monitors:
 Running monitors:
   linux_process_metrics(agent): 50 lines emitted, 2 errors
   linux_system_metrics(): 20 lines emitted, 0 errors
+  essential_monitor(): 20 lines emitted, 40 errors, stop_agent_on_failure=true
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
@@ -728,6 +739,7 @@ Monitors:
 Running monitors:
   linux_process_metrics(agent): 50 lines emitted, 2 errors
   linux_system_metrics(): 20 lines emitted, 0 errors
+  essential_monitor(): 20 lines emitted, 40 errors, stop_agent_on_failure=true
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
@@ -816,6 +828,7 @@ Monitors:
 Running monitors:
   linux_process_metrics(agent): 50 lines emitted, 2 errors
   linux_system_metrics(): 20 lines emitted, 0 errors
+  essential_monitor(): 20 lines emitted, 40 errors, stop_agent_on_failure=true
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
@@ -1015,6 +1028,7 @@ Monitors:
 Running monitors:
   linux_process_metrics(agent): 50 lines emitted, 2 errors
   linux_system_metrics(): 20 lines emitted, 0 errors
+  essential_monitor(): 20 lines emitted, 40 errors, stop_agent_on_failure=true
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
@@ -1125,6 +1139,7 @@ Monitors:
 Running monitors:
   linux_process_metrics(agent): 50 lines emitted, 2 errors
   linux_system_metrics(): 20 lines emitted, 0 errors
+  essential_monitor(): 20 lines emitted, 40 errors, stop_agent_on_failure=true
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
@@ -1247,6 +1262,7 @@ Monitors:
 Running monitors:
   linux_process_metrics(agent): 50 lines emitted, 2 errors
   linux_system_metrics(): 20 lines emitted, 0 errors
+  essential_monitor(): 20 lines emitted, 40 errors, stop_agent_on_failure=true
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors
@@ -1382,6 +1398,7 @@ Monitors:
 Running monitors:
   linux_process_metrics(agent): 50 lines emitted, 2 errors
   linux_system_metrics(): 20 lines emitted, 0 errors
+  essential_monitor(): 20 lines emitted, 40 errors, stop_agent_on_failure=true
 
 Failed monitors:
   bad_monitor() 20 lines emitted, 40 errors


### PR DESCRIPTION
This PR adds logging on startup for the monitor 'stop_agent_on_failure' option and adds 'stop_agent_on_failure' info for the monitor in agent status output.

Here's how monitor startup log line has to look like if monitor has 'stop_agent_on_failure' enabled:

```
2022-08-08 12:25:48.333Z INFO [core] [scalyr_agent.monitors_manager:379] Starting monitor test_monitor(essential). Config option 'stop_agent_on_failure' is enabled.
2022-08-08 12:25:48.333Z INFO [core] [scalyr_agent.monitors_manager:379] Starting monitor test_monitor(not_essential).
2022-08-08 12:25:48.333Z INFO [core] [scalyr_agent.monitors_manager:379] Starting monitor test_monitor(not_essential_default).
2022-08-08 12:25:48.334Z INFO [core] [scalyr_agent.monitors_manager:186] Starting Scalyr Monitors manager thread
```

Agent status output on the same config option.


```
...

Monitors:
=========

(these statistics cover the period from Mon Aug  8 12:25:48 2022 UTC)

test_monitor(essential): 8 lines emitted, 0 errors, stop_agent_on_failure=true
test_monitor(not_essential): 8 lines emitted, 0 errors
test_monitor(not_essential_default): 6 lines emitted, 0 errors

```