### PR TITLE
CT-578 Add codespeed workflow for GHA

### DIFF
--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -63,12 +63,12 @@ jobs:
         run: tox -e micro-benchmarks
 
       - name: Process and submit results to CodeSpeed
-        # if: (github.ref == 'refs/heads/master' || github.head_ref == 'master')
+        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master')
         env:
           PYTHONPATH: .
           CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"
           CODESPEED_PROJECT: "scalyr-agent-2-microbenchmarks"
-          CODESPEED_EXECUTABLE: ${{ steps.setup-python.outputs.python-version }}
+          CODESPEED_EXECUTABLE: Python ${{ steps.setup-python.outputs.python-version }}
           CODESPEED_ENVIRONMENT: GitHub Hosted Action Runner
           CODESPEED_AUTH: ${{ secrets.CODESPEED_AUTH }}
         run: python benchmarks/scripts/send_microbenchmarks_data_to_codespeed.py --data-path="benchmark_results/*.json" --debug

--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: '0 4 * * *'
 
 jobs:
   # Special job which automatically cancels old runs for the same branch, prevents runs for the

--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -48,13 +48,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install tox
+      - name: Install Deps
         env:
           TOX_VERSION: 3.20.1
           TOX_GH_ACTIONS_VERSION: 2.9.1
         run: |
           python -m pip install --upgrade pip
-          pip install "tox==$TOX_VERSION" "tox-gh-actions==$TOX_GH_ACTIONS_VERSION"
+          pip install "tox==$TOX_VERSION" "tox-gh-actions==$TOX_GH_ACTIONS_VERSION" "cffi==1.12.3" "udatetime==0.0.16" "requests"
+          # Needed for snappy library
+          sudo apt-get update
+          sudo apt-get install -y libsnappy-dev
 
       - name: Run Benchmarks
         run: tox -e micro-benchmarks

--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -1,0 +1,85 @@
+name: Codespeed Benchmarks
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  # Special job which automatically cancels old runs for the same branch, prevents runs for the
+  # same file set which has already passed, etc.
+  pre_job:
+    name: Skip Duplicate Jobs Pre Job
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write  # Needed for skip-duplicate-jobs job
+      contents: read
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@9d116fa7e55f295019cfab7e3ab72b478bcf7fdd # v4.0.0
+        with:
+          cancel_others: 'true'
+          github_token: ${{ github.token }}
+
+  codespeed-micro-benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        id: setup-python
+        with:
+          python-version: 3.8
+
+      - name: Install tox
+        env:
+          TOX_VERSION: 3.20.1
+          TOX_GH_ACTIONS_VERSION: 2.9.1
+        run: |
+          python -m pip install --upgrade pip
+          pip install "tox==$TOX_VERSION" "tox-gh-actions==$TOX_GH_ACTIONS_VERSION"
+
+      - name: Run Benchmarks
+        run: tox -e micro-benchmarks
+
+      - name: Process and submit results to CodeSpeed
+        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master')
+        env:
+          PYTHONPATH: .
+          CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"
+          CODESPEED_PROJECT: "scalyr-agent-2-microbenchmarks"
+          CODESPEED_EXECUTABLE: ${{ steps.setup-python.outputs.python-version }}
+          # don't know what this next var should be yet
+          # CODESPEED_ENVIRONMENT: Circle CI Docker Executor Medium Size
+          CODESPEED_AUTH: ${{ secrets.CODESPEED_AUTH }}
+        run: python benchmarks/scripts/send_microbenchmarks_data_to_codespeed.py --data-path="benchmark_results/*.json" --debug
+
+      - name: Store artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: codespeed-micro-benchmarks
+          path: |
+            benchmark_results/
+            benchmark_histograms/
+
+      - name: Notify Slack on Failure
+        # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull
+        # requests and that's why we need this special conditional and check for github.head_ref in
+        # case of PRs
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || github.head_ref == 'master') }}
+        uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1.6.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#cloud-tech'

--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -33,8 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "2.7"
-          - "3.5"
+          - "2.7.17"
+          - "3.5.9"
 
     steps:
       - name: Checkout Repository
@@ -67,11 +67,9 @@ jobs:
         env:
           PYTHONPATH: .
           CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"
-          CODESPEED_PROJECT: "scalyr-agent-2-microbenchmarks--uploadertest"
+          CODESPEED_PROJECT: "scalyr-agent-2-microbenchmarks"
           CODESPEED_EXECUTABLE: ${{ steps.setup-python.outputs.python-version }}
-          # don't know what this next var should be yet
-          # CODESPEED_ENVIRONMENT: Circle CI Docker Executor Medium Size
-          CODESPEED_ENVIRONMENT: gha uploader test
+          CODESPEED_ENVIRONMENT: GitHub Hosted Action Runner
           CODESPEED_AUTH: ${{ secrets.CODESPEED_AUTH }}
         run: python benchmarks/scripts/send_microbenchmarks_data_to_codespeed.py --data-path="benchmark_results/*.json" --debug
 

--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -28,6 +28,14 @@ jobs:
 
   codespeed-micro-benchmarks:
     runs-on: ubuntu-latest
+    needs: pre_job
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "2.7"
+          - "3.5"
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -38,7 +46,7 @@ jobs:
         uses: actions/setup-python@v4
         id: setup-python
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
 
       - name: Install tox
         env:
@@ -66,7 +74,7 @@ jobs:
       - name: Store artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: codespeed-micro-benchmarks
+          name: codespeed-micro-benchmarks-${{ matrix.python-version }}
           path: |
             benchmark_results/
             benchmark_histograms/

--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -63,14 +63,15 @@ jobs:
         run: tox -e micro-benchmarks
 
       - name: Process and submit results to CodeSpeed
-        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master')
+        # if: (github.ref == 'refs/heads/master' || github.head_ref == 'master')
         env:
           PYTHONPATH: .
           CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"
-          CODESPEED_PROJECT: "scalyr-agent-2-microbenchmarks"
+          CODESPEED_PROJECT: "scalyr-agent-2-microbenchmarks--uploadertest"
           CODESPEED_EXECUTABLE: ${{ steps.setup-python.outputs.python-version }}
           # don't know what this next var should be yet
           # CODESPEED_ENVIRONMENT: Circle CI Docker Executor Medium Size
+          CODESPEED_ENVIRONMENT: gha uploader test
           CODESPEED_AUTH: ${{ secrets.CODESPEED_AUTH }}
         run: python benchmarks/scripts/send_microbenchmarks_data_to_codespeed.py --data-path="benchmark_results/*.json" --debug
 


### PR DESCRIPTION
Adds codespeed workflow and micro-benchmark job to GHA.

The value of `CODESPEED_ENVIRONMENT` does not match what is used in CircleCI. I did this because the hardware configuration is different, so I thought it made sense to reflect that. I had to create the Environment database record by hand in the codespeed django admin interface.

CT-578