### PR TITLE
Configure cron job and slack notifications for new GHA workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: '0 4 * * *'
 
 permissions:
   actions: write  # Needed for skip-duplicate-jobs job
@@ -88,3 +90,16 @@ jobs:
           # that some files are not up to date
           git status
           git status -- *docs/monitors/*.md */docs/monitorsDmd | (grep -q "nothing to commit" || (echo "Auto-generate monitor doc files are not up to date. Make sure you run tox -e generate-monitor-docs and commit any changed files." && exit 1))
+
+      - name: Notify Slack on Failure
+        # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull
+        # requests and that's why we need this special conditional and check for github.head_ref in
+        # case of PRs
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || github.head_ref == 'master') }}
+        uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1.6.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#cloud-tech'

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: '0 4 * * *'
 
 jobs:
   # Special job which automatically cancels old runs for the same branch, prevents runs for the
@@ -115,6 +117,19 @@ jobs:
             test-results/junit*.xml
             .coverage
         if: ${{ success() || failure() }}
+
+      - name: Notify Slack on Failure
+        # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull
+        # requests and that's why we need this special conditional and check for github.head_ref in
+        # case of PRs
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || github.head_ref == 'master') }}
+        uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1.6.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#cloud-tech'
 
   publish-test-results:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Create cron jobs and slack notifications on failure for new GHA
workflows as requested in #961 

CT-573