### PR TITLE
Fix an edge case with the client side metric rate calculation

### DIFF
--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -204,6 +204,11 @@ could add overhead in terms of CPU and memory usage.
         # qualified monitor name.
         # Since same metric name can be used by values with different extra fields, we also include
         # extra fields as part of the dictionary key.
+        if "timestamp" in extra_fields:
+            del extra_fields["timestamp"]
+
+        # "timestamp" fiels is a bit special since it changes as part of every gather sample
+        # interval and we don't want to include
         extra_fields_hash = get_hash_for_flat_dictionary(extra_fields)
         dict_key = monitor.short_hash + "." + metric_name + "." + extra_fields_hash
 

--- a/scalyr_agent/metrics/functions.py
+++ b/scalyr_agent/metrics/functions.py
@@ -204,11 +204,13 @@ could add overhead in terms of CPU and memory usage.
         # qualified monitor name.
         # Since same metric name can be used by values with different extra fields, we also include
         # extra fields as part of the dictionary key.
+
+        # "timestamp" field is a bit special since it changes as part of every gather sample
+        # interval and we don't want to include it as part of the unique metric id which includes
+        # all the metric labels / extra_fields values
         if "timestamp" in extra_fields:
             del extra_fields["timestamp"]
 
-        # "timestamp" fiels is a bit special since it changes as part of every gather sample
-        # interval and we don't want to include
         extra_fields_hash = get_hash_for_flat_dictionary(extra_fields)
         dict_key = monitor.short_hash + "." + metric_name + "." + extra_fields_hash
 


### PR DESCRIPTION
This pull request fixes a bug / edge case with the client side rate calculation where metric extra_field (label / tag) contains a special ``timestamp`` value which changes during each gather sample interval.

This ``timestamp`` extra field value is special because it changes during each sample gather interval and we don't want to include it when calculating unique identifier for high cardinality metric (including it would means that during each new sample gather we would create a new unique id for a high cardinality metric which has all the fields except ``timestamp`` the same, but that's not something we want).

This pull request fixes this edge case and makes sure ``timestamp`` extra field value is not used when calculating unique id for a high cardinality metric. This value itself is excluded from the id calculation, but it's still included with the actual log line when emitting derived ``_rate`` metric.

I guess long term we may want to support specifying those "special" labels which should not be included when calculating metric it as part of the config option / similar, but that's not needed right now.