### PR TITLE
Log warning message in case of unknown connection error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Kubernetes Explorer:
 * Update code to calculate per second rate for various metrics used by Kubernetes Explorer on the client (agent) side. This may result in slight CPU and memory usage increase when using Kubernetes Explorer functionality.
 
 Other:
+* Changed log severity level from ``ERROR`` to ``WARNING`` for non-fatal and temporary network client error.
 * Update agent packages to also bundle new LetsEncrypt CA root certificate (ISRG Root X2). Some of the environments use LetsEncrypt issued certificates.
 * Update agent code base to log a warning with the server side SSL certificate in PEM format on SSL certificate validation failure for easier troubleshooting.
 

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -660,8 +660,9 @@ class ScalyrClientSession(object):
                         error_code="client/requestFailed",
                     )
                 else:
-                    log.exception(
+                    log.warning(
                         "Failed to receive response due to exception.  Closing connection, will re-attempt",
+                        exc_info=True,
                         error_code="requestFailed",
                     )
                 return "requestFailed", len(body_str), response


### PR DESCRIPTION
Make this exception log message as warning to calm down our tests, since they look for any ERROR log messages and this particular error is not fatal.

NOTE: Since it caches unknown error, we still have to provide exception traceback.