### PR TITLE
Update Kubernetes OpenMetrics monitor to also calculate rate for "container_network_transmit_bytes_total" and "container_network_receive_bytes_total" metric

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -42,7 +42,7 @@ jobs:
           concurrent_skipping: 'same_content'
           do_not_skip: "${{ steps.get_events_to_not_skip.outputs.events_to_not_skip }}"
           github_token: ${{ github.token }}
-          
+
 
   # Jobs which performs basic sanity checks for the Kubernetes Monitor and Kubernetes Events Monitor
   k8s_kubernetes_monitor_tests:
@@ -352,6 +352,8 @@ jobs:
           MINIMUM_RESULTS=2 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'-kubernetes-api-cadvisor-metrics" "container_cpu_load_average_10s "'
           # Verify locally calculated rate metrics
           ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'-kubernetes-api-cadvisor-metrics" "container_cpu_usage_seconds_total_rate "'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'-kubernetes-api-cadvisor-metrics" "container_network_receive_bytes_total_rate "'
+          ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile contains "openmetrics_monitor-'${K8S_NODE_NAME}'-kubernetes-api-cadvisor-metrics" "container_network_transmit_bytes_total_rate "'
 
           # 2. Verify node exporter metrics
           echo "Node exporter metrics monitor checks"

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -446,6 +446,7 @@ CALCULATE_RATE_METRIC_NAMES = {
     "kubernetes-api-cadvisor": [
         # Kubernetes API cAdvisor metrics
         "openmetrics_monitor:container_cpu_usage_seconds_total",
+        "openmetrics_monitor:container_network_transmit_bytes_total",
     ],
 }
 

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -446,6 +446,7 @@ CALCULATE_RATE_METRIC_NAMES = {
     "kubernetes-api-cadvisor": [
         # Kubernetes API cAdvisor metrics
         "openmetrics_monitor:container_cpu_usage_seconds_total",
+        "openmetrics_monitor:container_network_receive_bytes_total",
         "openmetrics_monitor:container_network_transmit_bytes_total",
     ],
 }

--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -377,6 +377,7 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
             "metric_name_include_list": ["*"],
             "calculate_rate_metric_names": [
                 "openmetrics_monitor:container_cpu_usage_seconds_total",
+                "openmetrics_monitor:container_network_receive_bytes_total",
                 "openmetrics_monitor:container_network_transmit_bytes_total",
             ],
             "module": "scalyr_agent.builtin_monitors.openmetrics_monitor",
@@ -510,6 +511,7 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
                 "metric2",
                 "metric3:label=value",
                 "openmetrics_monitor:container_cpu_usage_seconds_total",
+                "openmetrics_monitor:container_network_receive_bytes_total",
                 "openmetrics_monitor:container_network_transmit_bytes_total",
             ],
             "module": "scalyr_agent.builtin_monitors.openmetrics_monitor",

--- a/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_openmetrics_monitor_test.py
@@ -377,6 +377,7 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
             "metric_name_include_list": ["*"],
             "calculate_rate_metric_names": [
                 "openmetrics_monitor:container_cpu_usage_seconds_total",
+                "openmetrics_monitor:container_network_transmit_bytes_total",
             ],
             "module": "scalyr_agent.builtin_monitors.openmetrics_monitor",
             "sample_interval": 10,
@@ -509,6 +510,7 @@ class KubernetesOpenMetricsMonitorTestCase(ScalyrTestCase):
                 "metric2",
                 "metric3:label=value",
                 "openmetrics_monitor:container_cpu_usage_seconds_total",
+                "openmetrics_monitor:container_network_transmit_bytes_total",
             ],
             "module": "scalyr_agent.builtin_monitors.openmetrics_monitor",
             "sample_interval": 10,


### PR DESCRIPTION
Per @juldasentinel, we also need to calculate rate metric for ``container_network_transmit_bytes_total`` + ``container_network_receive_bytes_total`` (cAdvisor API) metric.