### PR TITLE
Pre release dependencies update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
-.coverage
+.coverage*
 .cache
 nosetests.xml
 coverage.xml

--- a/agent_build/requirement-files/compression-requirements.txt
+++ b/agent_build/requirement-files/compression-requirements.txt
@@ -5,6 +5,6 @@ zstandard==0.18.0; python_version >= '3.6' and 'armv7' not in platform_machine
 zstandard==0.15.2; python_version >= '3.5' and python_version < '3.6' and 'armv7' not in platform_machine
 zstandard==0.14.1; python_version < '3.5' and 'armv7' not in platform_machine
 
-lz4==4.0.1; python_version >= '3.7'
+lz4==4.0.2; python_version >= '3.7'
 lz4==3.1.1; python_version >= '3.5' and python_version <= '3.6'
 lz4==2.2.1; python_version < '3.5'

--- a/agent_build/requirement-files/docker-image-requirements.txt
+++ b/agent_build/requirement-files/docker-image-requirements.txt
@@ -17,5 +17,5 @@ pympler==1.0.1; python_version >= '3.7'
 pympler==0.8; python_version < '3.7'
 
 # note: 5.0 drops support for Python 2.7 so we can't use it for our Python 2.7 unit tests target
-docker==5.0.3; python_version > '2.7'
-docker==4.4.4; python_version <= '2.7'
+docker==5.0.3; python_version >= '3.6'
+docker==4.4.4; python_version < '3.6'

--- a/agent_build/requirement-files/docker-image-requirements.txt
+++ b/agent_build/requirement-files/docker-image-requirements.txt
@@ -16,7 +16,6 @@ pympler==1.0.1; python_version >= '3.7'
 # used by Python 2.7 tests
 pympler==0.8; python_version < '3.7'
 
-# note: 5.0 drops support for Python 2.7 so we can't use it for our Python 2.7
-# unit tests target
+# note: 5.0 drops support for Python 2.7 so we can't use it for our Python 2.7 unit tests target
 docker==5.0.3; python_version > '2.7'
 docker==4.4.4; python_version <= '2.7'

--- a/agent_build/requirement-files/docker-image-requirements.txt
+++ b/agent_build/requirement-files/docker-image-requirements.txt
@@ -16,4 +16,7 @@ pympler==1.0.1; python_version >= '3.7'
 # used by Python 2.7 tests
 pympler==0.8; python_version < '3.7'
 
-docker==4.4.4
+# note: 5.0 drops support for Python 2.7 so we can't use it for our Python 2.7
+# unit tests target
+docker==5.0.3; python_version > '2.7'
+docker==4.4.4; python_version <= '2.7'

--- a/agent_build/requirement-files/main-requirements.txt
+++ b/agent_build/requirement-files/main-requirements.txt
@@ -2,7 +2,7 @@
 # orjson is not available for armv7 + musl yet, but it's available for armv7 +
 # libc. we handle that in dockerfile since python environment markers are not
 # specific enough.
-orjson==3.7.7; python_version >= '3.7' and platform_system != 'Darwin'
+orjson==3.7.12; python_version >= '3.7' and platform_system != 'Darwin'
 orjson==3.6.1; python_version == '3.6' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 orjson==2.0.11; python_version == '3.5' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 

--- a/agent_build/requirement-files/testing-requirements.txt
+++ b/agent_build/requirement-files/testing-requirements.txt
@@ -23,8 +23,8 @@ decorator==4.4.1
 requests-mock==1.9.3
 six==1.13.0
 # note: 5.0 drops support for Python 2.7 so we can't use it for our Python 2.7 unit tests target
-docker==5.0.3; python_version > '2.7'
-docker==4.4.4; python_version <= '2.7'
+docker==5.0.3; python_version >= '3.6'
+docker==4.4.4; python_version < '3.6'
 # the version of 'requests' library that 'docker' uses as a dependency is higher than we use in agent,
 # to prevent versions conflict, install the appropriate version of 'requests', to force 'docker' to reuse it.
 # NOTE: We can't use requests >= 2.22.0 since we still need to support Python 2.6

--- a/agent_build/requirement-files/testing-requirements.txt
+++ b/agent_build/requirement-files/testing-requirements.txt
@@ -22,7 +22,9 @@ codecov==2.1.9
 decorator==4.4.1
 requests-mock==1.9.3
 six==1.13.0
-docker==4.4.4
+# note: 5.0 drops support for Python 2.7 so we can't use it for our Python 2.7 unit tests target
+docker==5.0.3; python_version > '2.7'
+docker==4.4.4; python_version <= '2.7'
 # the version of 'requests' library that 'docker' uses as a dependency is higher than we use in agent,
 # to prevent versions conflict, install the appropriate version of 'requests', to force 'docker' to reuse it.
 # NOTE: We can't use requests >= 2.22.0 since we still need to support Python 2.6


### PR DESCRIPTION
This pull request updates various dependencies before the release:

* orjson - https://github.com/ijl/orjson/blob/b9e8e7f88715b897c7f2b4cd15d1872c67240a06/CHANGELOG.md#3712---2022-08-14
* lz4 - https://github.com/python-lz4/python-lz4/releases/tag/v4.0.2
* docker - https://docker-py.readthedocs.io/en/stable/change-log.html