### PR TITLE
CT-573 Fix coverage issues with smoke tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ source =
     /Users/runner/work/scalyr-agent-2/scalyr-agent-2/
     /home/runner/work/scalyr-agent-2/scalyr-agent-2/
     /home/runner/scalyr-agent-2/scalyr-agent-2/
+    /usr/share/scalyr-agent-2/py/
     D:\a\scalyr-agent-2\scalyr-agent-2\
 
 [run]

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -43,6 +43,38 @@ jobs:
           do_not_skip: "${{ steps.get_events_to_not_skip.outputs.events_to_not_skip }}"
           github_token: ${{ github.token }}
 
+  coverage:
+    runs-on: ubuntu-latest
+    if: success() || failure()
+    needs:
+      - pre_job
+      - k8s-smoketest
+      - docker-smoketest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        id: setup-python
+        with:
+          python-version: 3.8
+      - name: Install pycoverage
+        run: pip install coverage==4.5.4
+      - name: Download coverage reports
+        uses: actions/download-artifact@v3
+        with:
+          path: reports
+
+      - name: Prepare Coverage Data for codecov.io
+        run: |
+          coverage combine reports/**/.coverage
+          coverage xml -i -o coverage.xml
+
+      - name: Upload Coverage to Codecov.io
+        uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # pin@v3
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: true
 
   # Jobs which performs basic sanity checks for the Kubernetes Monitor and Kubernetes Events Monitor
   k8s_kubernetes_monitor_tests:
@@ -434,31 +466,13 @@ jobs:
         run: |
           source ./.circleci/smoketest_k8s.sh scalyr/scalyr-agent-ci-unittest:4 150 no_delete_existing_k8s_objs
 
-      - name: Prepare Coverage Data for codecov.io and Combine it and Upload it to S3
-        env:
-          COVERAGE_AWS_ACCESS_KEY_ID: ${{ secrets.COVERAGE_AWS_ACCESS_KEY_ID }}
-          COVERAGE_AWS_ACCESS_KEY_SECRET: ${{ secrets.COVERAGE_AWS_ACCESS_KEY_SECRET }}
-          CIRCLE_BRANCH: ${{ github.head_ref || github.ref_name}}
-          CIRCLE_SHA1: ${{ github.sha }}
-        run: |
-          ls -la .coverage* || true
-
-          # Ensure consistent paths for all the code coverage reports
-          sed -i "s#/usr/share/scalyr-agent-2/py/#${{ github.workspace }}#g" .coverage
-
-          # Prepare coverage for codecov.io
-          coverage xml --rcfile=.coveragerc_ci -i -o coverage.xml
-
-          # Combine it and upload it to S3
-          coverage combine --rcfile=.coveragerc_ci || true
-          export PYTHONPATH=.
-          ./scripts/circleci/upload-coverage-data-to-s3.py ".coverage"
-
-      - name: Upload Coverage to Codecov.io
-        uses: codecov/codecov-action@v3
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
         with:
-          files: ./coverage.xml
-          fail_ci_if_error: true
+          name: k8s-smoketest
+          path: |
+            .coverage
+        if: ${{ success() || failure() }}
 
       - name: Notify Slack on Failure
         # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull
@@ -510,31 +524,13 @@ jobs:
         run: |
           source ./.circleci/smoketest_docker.sh scalyr/scalyr-agent-ci-unittest:4 docker-${{ matrix.variant.log_mode }} ${{ matrix.variant.timeout }}
 
-      - name: Prepare Coverage Data for codecov.io and Combine it and Upload it to S3
-        env:
-          COVERAGE_AWS_ACCESS_KEY_ID: ${{ secrets.COVERAGE_AWS_ACCESS_KEY_ID }}
-          COVERAGE_AWS_ACCESS_KEY_SECRET: ${{ secrets.COVERAGE_AWS_ACCESS_KEY_SECRET }}
-          CIRCLE_BRANCH: ${{ github.head_ref || github.ref_name}}
-          CIRCLE_SHA1: ${{ github.sha }}
-        run: |
-          ls -la .coverage* || true
-
-          # Ensure consistent paths for all the code coverage reports
-          sed -i "s#/usr/share/scalyr-agent-2/py/#${{ github.workspace }}#g" .coverage
-
-          # Prepare coverage for codecov.io
-          coverage xml --rcfile=.coveragerc_ci -i -o coverage.xml
-
-          # Combine it and upload it to S3
-          coverage combine --rcfile=.coveragerc_ci || true
-          export PYTHONPATH=.
-          ./scripts/circleci/upload-coverage-data-to-s3.py ".coverage"
-
-      - name: Upload Coverage to Codecov.io
-        uses: codecov/codecov-action@v3
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
         with:
-          files: ./coverage.xml
-          fail_ci_if_error: true
+          name: docker-smoketest-${{ matrix.variant.log_mode }}
+          path: |
+            .coverage
+        if: ${{ success() || failure() }}
 
       - name: Notify Slack on Failure
         # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull

--- a/codecov.yml
+++ b/codecov.yml
@@ -31,6 +31,7 @@ fixes:
   - "/home/circleci/scalyr-agent-2/::"
   - "/home/runner/work/scalyr-agent-2/scalyr-agent-2/::"
   - "/Users/runner/work/scalyr-agent-2/scalyr-agent-2/::"
+  - "/usr/share/scalyr-agent-2/py/::"
 
 ignore:
   # Ignore tests directories for which we currently don't generate coverage


### PR DESCRIPTION
This PR is to fix the issue identified in the following comment:  https://github.com/scalyr/scalyr-agent-2/pull/961#issuecomment-1216311694

The problem was the sed processing of the coverage files was creating bad paths. Instead of fixing the issue, I decided to use the same coverage reporting pattern used in the unittests workflow. Changes made:

- Add agent code path in smoke test docker image to .coveragerc and
  codecov fixes config.
- Use same coverage reporting pattern as unittests (as we know that
  workflow works).
- Remove manual processing of coverage files via sed.

CT-573