### PR TITLE
CT-577 Add codespeed agent benchmark jobs to GHA

### DIFF
--- a/.github/workflows/codespeed-agent-benchmarks.yaml
+++ b/.github/workflows/codespeed-agent-benchmarks.yaml
@@ -108,6 +108,8 @@ jobs:
           RUN_TIME: ${{ inputs.run_time }}
           CAPTURE_INTERVAL: ${{ inputs.capture_interval }}
           AGENT_CONFIG_FILE: ${{ inputs.agent_config }}
+          SCALYR_SERVER: https://agent.scalyr.com
+          SCALYR_API_KEY: ${{ secrets.SCALYR_API_KEY }}
           SCALYR_SERVER_ATTRIBUTES: "{\"serverHost\": \"${{ inputs.agent_server_host }}\"}"
           CAPTURE_AGENT_STATUS_METRICS: ${{ inputs.capture_agent_status_metrics }}
           DRY_RUN: ${{ inputs.dry_run }}

--- a/.github/workflows/codespeed-agent-benchmarks.yaml
+++ b/.github/workflows/codespeed-agent-benchmarks.yaml
@@ -150,6 +150,7 @@ jobs:
       - name: Upload log artifacts
         uses: actions/upload-artifact@v3
         with:
+          name: agent-logs-${{ github.job }}
           path: |
             ~/scalyr-agent-dev/log
         if: ${{ success() || failure() }}

--- a/.github/workflows/codespeed-agent-benchmarks.yaml
+++ b/.github/workflows/codespeed-agent-benchmarks.yaml
@@ -90,7 +90,7 @@ jobs:
         run: echo ::set-output name=commit-date::$(git show --quiet --date='format-local:%Y-%m-%d %H:%M:%S' --format="%cd" ${{ github.sha }} )
 
       - name: Pre-Run Command
-        if: inputs.agent_pre_run_command != ""
+        if: inputs.agent_pre_run_command != ''
         run: ${{ inputs.agent_pre_run_command }}
 
       - name: Run Agent And Capture Resource Utilization
@@ -121,7 +121,7 @@ jobs:
           echo ::set-output name=bg-pid::$!
 
       - name: Run any post agent run script
-        if: inputs.agent_post_run_command != ""
+        if: inputs.agent_post_run_command != ''
         run: |
           sleep 2
           ${{ inputs.agent_post_run_command }}

--- a/.github/workflows/codespeed-agent-benchmarks.yaml
+++ b/.github/workflows/codespeed-agent-benchmarks.yaml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Wait for agent to finish
         timeout-minutes: 10
-        run: wait ${{ steps.run-agent.outputs.bg-pid }} || true
+        run: tail --pid ${{ steps.run-agent.outputs.bg-pid }} -f /dev/null || true
 
       - name: Send line count values for various log levels
         if: inputs.capture_line_counts && ! inputs.dry_run
@@ -142,6 +142,8 @@ jobs:
           CODESPEED_ENVIRONMENT: ${{ inputs.codespeed_environment }}
           CODESPEED_BRANCH: ${{ github.head_ref || github.ref_name }}
           COMMIT_DATE: ${{ steps.commit-date.outputs.commit-date }}
+          CAPTURE_AGENT_STATUS_METRICS: ${{ inputs.capture_agent_status_metrics }}
+          DRY_RUN: ${{ inputs.dry_run }}
           PYTHONPATH: .
         run: ./benchmarks/scripts/send-log-level-counts-to-codespeed.sh "${{ github.sha }}"
 

--- a/.github/workflows/codespeed-agent-benchmarks.yaml
+++ b/.github/workflows/codespeed-agent-benchmarks.yaml
@@ -150,7 +150,7 @@ jobs:
       - name: Upload log artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: agent-logs-${{ github.job }}
+          name: agent-logs-${{ inputs.agent_server_host }}
           path: |
             ~/scalyr-agent-dev/log
         if: ${{ success() || failure() }}

--- a/.github/workflows/codespeed-agent-benchmarks.yaml
+++ b/.github/workflows/codespeed-agent-benchmarks.yaml
@@ -1,0 +1,170 @@
+name: Codespeed Agent Benchmark Reusable Workflow
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: Python Version
+        type: string
+        required: true
+      agent_config:
+        description: "Path to the agent config file to use."
+        type: string
+        required: true
+      codespeed_executable:
+        description: "CodeSpeed executable name."
+        type: string
+        required: true
+      codespeed_environment:
+        description: "CodeSpeed environment name."
+        type: string
+        default: GitHub Hosted Action Runner
+        required: false
+      run_time:
+        description: "How long to run the capture for (in seconds)."
+        type: number
+        default: 120
+        required: false
+      capture_interval:
+        description: "How often to capture agent process level metrics during the process run time (in seconds)."
+        type: number
+        default: 5
+        required: false
+      agent_pre_run_command:
+        description: "Optional bash command / script to run before starting the agent and the metrics capture script."
+        type: string
+        default: ""
+        required: false
+      agent_post_run_command:
+        description: "Optional bash command / script to run after starting the agent and the metrics capture script."
+        type: string
+        default: ""
+        required: false
+      agent_server_host:
+        description: "Value for the server_attributes.serverHost agent configuration option."
+        type: string
+        default: "ci-codespeed-benchmarks"
+        required: false
+      capture_agent_status_metrics:
+        description: "True to capture additional metrics exposed via agent status command."
+        type: boolean
+        default: false
+        required: false
+      capture_line_counts:
+        description: "True to submit log line counts for each log level to CodeSpeed."
+        type: boolean
+        default: false
+        required: false
+      dry_run:
+        description: "True to enable dry run which runs the benchmarks without submitting data to CodeSpeed."
+        type: boolean
+        default: false
+        required: false
+
+jobs:
+  codespeed-reusable-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        id: setup-python
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install Deps
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r benchmarks/scripts/requirements.txt
+
+          # Workaround for issue with cffi library on the system using
+          # different version than the one which is bundled with the agent
+          pip install "cffi==1.12.3"
+
+      - name: Run Agent And Capture Resource Utilization
+        shell: bash
+        env:
+          CODESPEED_AUTH: ${{ secrets.CODESPEED_AUTH }}
+          CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"
+          CODESPEED_PROJECT: "scalyr-agent-2-procbenchmarks"
+          CODESPEED_EXECUTABLE: ${{ inputs.codespeed_executable }}
+          CODESPEED_ENVIRONMENT: ${{ inputs.codespeed_environment }}
+          CODESPEED_BRANCH: ${{ github.head_ref || github.ref_name }}
+          # NOTE: "idle" agent process (which monitors no logs but just runs the linux process
+          # monitor for the agent process) should stabilize in a couple of minutes so it makes
+          # no sense to run that benchmark longer.
+          RUN_TIME: ${{ inputs.run_time }}
+          CAPTURE_INTERVAL: ${{ inputs.capture_interval }}
+          AGENT_CONFIG_FILE: ${{ inputs.agent_config }}
+          SCALYR_SERVER_ATTRIBUTES: "{\"serverHost\": \"${{ inputs.agent_server_host }}\"}"
+          CAPTURE_AGENT_STATUS_METRICS: ${{ inputs.capture_agent_status_metrics }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          # Create directories which are needed by the agent process
+          mkdir -p ~/scalyr-agent-dev/{log,config,data}
+
+          # NOTE: We explicitly specify a commit date to avoid CodeSpeed from
+          # late setting the actual date once it fetches all the commits for a
+          # branch / revision
+          export TZ=UTC
+          export COMMIT_DATE=$(git show --quiet --date='format-local:%Y-%m-%d %H:%M:%S' --format="%cd" ${{ github.sha }} )
+          export PYTHONPATH=.
+
+          # Run any pre agent run script (if defined)
+          if [ ! -z "${{ inputs.agent_pre_run_command }}" ]; then
+              echo "::group::Running agent pre run command..."
+              ${{ inputs.agent_pre_run_command }}
+              echo "::endgroup::"
+          fi
+
+          # Run the agent process and capture the metrics
+          ./benchmarks/scripts/start-agent-and-capture-metrics.sh "${{ github.sha }}" &> /tmp/capture_script.log &
+          CAPTURE_SCRIPT_PID=$!
+
+          # Run any post agent run script (if defined)
+          # NOTE: We intentionally sleep for a bit to give agent time to fully
+          # start up
+          if [ ! -z "${{ inputs.agent_post_run_command }}" ]; then
+              echo "::group::Running agent post run command..."
+              sleep 2
+              ${{ inputs.agent_post_run_command }}
+              echo "::endgroup::"
+          fi
+
+          # Wait for capture script to finish
+          echo "::group::Waiting for capture script to finish"
+          set +e
+          sh -c 'tail -n +0 -F /tmp/capture_script.log | { sed "/Run completed, stopping the agent process./ q" && kill $$ ;}'
+          wait ${CAPTURE_SCRIPT_PID} || true
+          set -e
+          echo "::endgroup::"
+
+          # Send line count values for various log levels (if enabled)
+          if [ "${{ inputs.capture_line_counts }}" = "true" ]; then
+              echo "::group::Sending log level line count values to codespeed"
+              ./benchmarks/scripts/send-log-level-counts-to-codespeed.sh "${{ github.sha }}"
+              echo "::endgroup::"
+          fi
+
+      - name: Upload log artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            ~/scalyr-agent-dev/log
+        if: ${{ success() || failure() }}
+
+      - name: Notify Slack on Failure
+        # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull
+        # requests and that's why we need this special conditional and check for github.head_ref in
+        # case of PRs
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || github.head_ref == 'master') }}
+        uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1.6.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#cloud-tech'

--- a/.github/workflows/codespeed-agent-benchmarks.yaml
+++ b/.github/workflows/codespeed-agent-benchmarks.yaml
@@ -75,7 +75,6 @@ jobs:
           python-version: ${{ inputs.python-version }}
 
       - name: Install Deps
-        shell: bash
         run: |
           python -m pip install --upgrade pip
           pip install -r benchmarks/scripts/requirements.txt
@@ -84,8 +83,18 @@ jobs:
           # different version than the one which is bundled with the agent
           pip install "cffi==1.12.3"
 
+      - name: Capture commit date
+        id: commit-date
+        env:
+          TZ: UTC
+        run: echo ::set-output name=commit-date::$(git show --quiet --date='format-local:%Y-%m-%d %H:%M:%S' --format="%cd" ${{ github.sha }} )
+
+      - name: Pre-Run Command
+        if: inputs.agent_pre_run_command != ""
+        run: ${{ inputs.agent_pre_run_command }}
+
       - name: Run Agent And Capture Resource Utilization
-        shell: bash
+        id: run-agent
         env:
           CODESPEED_AUTH: ${{ secrets.CODESPEED_AUTH }}
           CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"
@@ -102,52 +111,37 @@ jobs:
           SCALYR_SERVER_ATTRIBUTES: "{\"serverHost\": \"${{ inputs.agent_server_host }}\"}"
           CAPTURE_AGENT_STATUS_METRICS: ${{ inputs.capture_agent_status_metrics }}
           DRY_RUN: ${{ inputs.dry_run }}
+          COMMIT_DATE: ${{ steps.commit-date.outputs.commit-date }}
+          PYTHONPATH: .
         run: |
           # Create directories which are needed by the agent process
           mkdir -p ~/scalyr-agent-dev/{log,config,data}
-
-          # NOTE: We explicitly specify a commit date to avoid CodeSpeed from
-          # late setting the actual date once it fetches all the commits for a
-          # branch / revision
-          export TZ=UTC
-          export COMMIT_DATE=$(git show --quiet --date='format-local:%Y-%m-%d %H:%M:%S' --format="%cd" ${{ github.sha }} )
-          export PYTHONPATH=.
-
-          # Run any pre agent run script (if defined)
-          if [ ! -z "${{ inputs.agent_pre_run_command }}" ]; then
-              echo "::group::Running agent pre run command..."
-              ${{ inputs.agent_pre_run_command }}
-              echo "::endgroup::"
-          fi
-
           # Run the agent process and capture the metrics
-          ./benchmarks/scripts/start-agent-and-capture-metrics.sh "${{ github.sha }}" &> /tmp/capture_script.log &
-          CAPTURE_SCRIPT_PID=$!
+          ./benchmarks/scripts/start-agent-and-capture-metrics.sh "${{ github.sha }}" &
+          echo ::set-output name=bg-pid::$!
 
-          # Run any post agent run script (if defined)
-          # NOTE: We intentionally sleep for a bit to give agent time to fully
-          # start up
-          if [ ! -z "${{ inputs.agent_post_run_command }}" ]; then
-              echo "::group::Running agent post run command..."
-              sleep 2
-              ${{ inputs.agent_post_run_command }}
-              echo "::endgroup::"
-          fi
+      - name: Run any post agent run script
+        if: inputs.agent_post_run_command != ""
+        run: |
+          sleep 2
+          ${{ inputs.agent_post_run_command }}
 
-          # Wait for capture script to finish
-          echo "::group::Waiting for capture script to finish"
-          set +e
-          sh -c 'tail -n +0 -F /tmp/capture_script.log | { sed "/Run completed, stopping the agent process./ q" && kill $$ ;}'
-          wait ${CAPTURE_SCRIPT_PID} || true
-          set -e
-          echo "::endgroup::"
+      - name: Wait for agent to finish
+        timeout-minutes: 10
+        run: wait ${{ steps.run-agent.outputs.bg-pid }} || true
 
-          # Send line count values for various log levels (if enabled)
-          if [ "${{ inputs.capture_line_counts }}" = "true" ]; then
-              echo "::group::Sending log level line count values to codespeed"
-              ./benchmarks/scripts/send-log-level-counts-to-codespeed.sh "${{ github.sha }}"
-              echo "::endgroup::"
-          fi
+      - name: Send line count values for various log levels
+        if: inputs.capture_line_counts && ! inputs.dry_run
+        env:
+          CODESPEED_AUTH: ${{ secrets.CODESPEED_AUTH }}
+          CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"
+          CODESPEED_PROJECT: "scalyr-agent-2-procbenchmarks"
+          CODESPEED_EXECUTABLE: ${{ inputs.codespeed_executable }}
+          CODESPEED_ENVIRONMENT: ${{ inputs.codespeed_environment }}
+          CODESPEED_BRANCH: ${{ github.head_ref || github.ref_name }}
+          COMMIT_DATE: ${{ steps.commit-date.outputs.commit-date }}
+          PYTHONPATH: .
+        run: ./benchmarks/scripts/send-log-level-counts-to-codespeed.sh "${{ github.sha }}"
 
       - name: Upload log artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -124,7 +124,7 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     with:
-      python-version: 3.5.9
+      python-version: 2.7.17
       codespeed_executable: "Python 2.7.17 - idle conf 2"
       agent_config: "benchmarks/configs/agent_no_monitored_logs_no_monitors.json"
       agent_server_host: "ci-codespeed-benchmarks-py27-idle-conf-2"
@@ -146,7 +146,7 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     with:
-      python-version: 3.5.9
+      python-version: 2.7.17
       codespeed_executable: "Python 2.7.17 - loaded conf 1"
       agent_config: "benchmarks/configs/agent_single_50mb_access_log_file.json"
       agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/access_log_50_mb.log"
@@ -176,7 +176,7 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     with:
-      python-version: 3.5.9
+      python-version: 2.7.17
       codespeed_executable: "Python 2.7.17 - loaded conf 2"
       agent_config: "benchmarks/configs/agent_single_growing_log_file_with_shell_and_url_monitor.json"
       run_time: 140
@@ -204,7 +204,7 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     with:
-      python-version: 3.5.9
+      python-version: 2.7.17
       codespeed_executable: "Python 2.7.17 - loaded conf 3"
       agent_config: "benchmarks/configs/agent_single_growing_log_file.json"
       # NOTE: We set agent run time slightly longer than the insert script time run so we give a chance for memory and
@@ -237,7 +237,7 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     with:
-      python-version: 3.5.9
+      python-version: 2.7.17
       codespeed_executable: "Python 2.7.17 - loaded conf 5"
       agent_config: "benchmarks/configs/agent_single_50mb_genlog_500k_line_file.json"
       agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/scalyr_genlog_500k_line_50_mb.log"

--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -101,6 +101,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    secrets: inherit
     with:
       python-version: 2.7.17
       codespeed_executable: "Python 2.7.17 - idle conf 1"
@@ -112,6 +113,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    secrets: inherit
     with:
       python-version: 3.5.9
       codespeed_executable: "Python 3.5.9 - idle conf 1"
@@ -123,6 +125,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    secrets: inherit
     with:
       python-version: 2.7.17
       codespeed_executable: "Python 2.7.17 - idle conf 2"
@@ -134,6 +137,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    secrets: inherit
     with:
       python-version: 3.5.9
       codespeed_executable: "Python 3.5.9 - idle conf 2"
@@ -145,6 +149,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    secrets: inherit
     with:
       python-version: 2.7.17
       codespeed_executable: "Python 2.7.17 - loaded conf 1"
@@ -159,6 +164,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    secrets: inherit
     with:
       python-version: 3.5.9
       codespeed_executable: "Python 3.5.9 - loaded conf 1"
@@ -175,6 +181,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    secrets: inherit
     with:
       python-version: 2.7.17
       codespeed_executable: "Python 2.7.17 - loaded conf 2"
@@ -189,6 +196,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    secrets: inherit
     with:
       python-version: 3.5.9
       codespeed_executable: "Python 3.5.9 - loaded conf 2"
@@ -203,6 +211,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    secrets: inherit
     with:
       python-version: 2.7.17
       codespeed_executable: "Python 2.7.17 - loaded conf 3"
@@ -222,6 +231,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    secrets: inherit
     with:
       python-version: 3.5.9
       codespeed_executable: "Python 3.5.9 - loaded conf 4"
@@ -236,6 +246,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    secrets: inherit
     with:
       python-version: 2.7.17
       codespeed_executable: "Python 2.7.17 - loaded conf 5"
@@ -250,6 +261,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    secrets: inherit
     with:
       python-version: 3.5.9
       codespeed_executable: "Python 3.5.9 - loaded conf 5"

--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
+      - release
   schedule:
     - cron: '0 4 * * *'
 

--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -31,6 +31,7 @@ jobs:
   codespeed-micro-benchmarks:
     runs-on: ubuntu-latest
     needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -95,3 +96,166 @@ jobs:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
           channel: '#cloud-tech'
+
+  benchmarks-idle-agent-py-27:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    with:
+      python-version: 2.7.17
+      codespeed_executable: "Python 2.7.17 - idle conf 1"
+      agent_config: "benchmarks/configs/agent_no_monitored_logs.json"
+      agent_server_host: "ci-codespeed-benchmarks-py27-idle-conf-1"
+      capture_line_counts: true
+
+  benchmarks-idle-agent-py-35:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    with:
+      python-version: 3.5.9
+      codespeed_executable: "Python 3.5.9 - idle conf 1"
+      agent_config: "benchmarks/configs/agent_no_monitored_logs.json"
+      agent_server_host: "ci-codespeed-benchmarks-py35-idle-conf-1"
+      capture_line_counts: true
+
+  benchmarks-idle-agent-no-monitors-py-27:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    with:
+      python-version: 3.5.9
+      codespeed_executable: "Python 2.7.17 - idle conf 2"
+      agent_config: "benchmarks/configs/agent_no_monitored_logs_no_monitors.json"
+      agent_server_host: "ci-codespeed-benchmarks-py27-idle-conf-2"
+      capture_line_counts: true
+
+  benchmarks-idle-agent-no-monitors-py-35:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    with:
+      python-version: 3.5.9
+      codespeed_executable: "Python 3.5.9 - idle conf 2"
+      agent_config: "benchmarks/configs/agent_no_monitored_logs_no_monitors.json"
+      agent_server_host: "ci-codespeed-benchmarks-py35-idle-conf-2"
+      capture_line_counts: true
+
+  benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    with:
+      python-version: 3.5.9
+      codespeed_executable: "Python 2.7.17 - loaded conf 1"
+      agent_config: "benchmarks/configs/agent_single_50mb_access_log_file.json"
+      agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/access_log_50_mb.log"
+      agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-1"
+      run_time: 140
+      capture_agent_status_metrics: true
+      capture_line_counts: true
+
+  benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    with:
+      python-version: 3.5.9
+      codespeed_executable: "Python 3.5.9 - loaded conf 1"
+      agent_config: "benchmarks/configs/agent_single_50mb_access_log_file.json"
+      agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/access_log_50_mb.log"
+      agent_server_host: "ci-codespeed-benchmarks-py35-loaded-conf-1"
+      run_time: 140
+      capture_line_counts: true
+
+  # NOTE: For the benchmarks below to work correctly "/tmp/random.log" file
+  # which is being written to during the benchmark must existing before the
+  # agent process is started.
+  benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    with:
+      python-version: 3.5.9
+      codespeed_executable: "Python 2.7.17 - loaded conf 2"
+      agent_config: "benchmarks/configs/agent_single_growing_log_file_with_shell_and_url_monitor.json"
+      run_time: 140
+      agent_pre_run_command: "touch /tmp/random.log"
+      agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 2M 10 100 1"
+      agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-2"
+      capture_line_counts: true
+
+  benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    with:
+      python-version: 3.5.9
+      codespeed_executable: "Python 3.5.9 - loaded conf 2"
+      agent_config: "benchmarks/configs/agent_single_growing_log_file_with_shell_and_url_monitor.json"
+      run_time: 140
+      agent_pre_run_command: "touch /tmp/random.log"
+      agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 2M 10 100 1"
+      agent_server_host: "ci-codespeed-benchmarks-py35-loaded-conf-2"
+      capture_line_counts: true
+
+  benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    with:
+      python-version: 3.5.9
+      codespeed_executable: "Python 2.7.17 - loaded conf 3"
+      agent_config: "benchmarks/configs/agent_single_growing_log_file.json"
+      # NOTE: We set agent run time slightly longer than the insert script time run so we give a chance for memory and
+      # other metrics to stabilize.
+      run_time: 390
+      agent_pre_run_command: "touch /tmp/random.log"
+      # NOTE: We write a chunk every 1 seconds for a total of 6 minutes.
+      # Each chunk is 0.5 MB in size which means we write a total of 360 * 1
+      # / 0.5 MB of data
+      agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 500K 360 100 1 &> /tmp/write_lines_script.log &"
+      agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-3"
+      capture_line_counts: true
+
+  benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    with:
+      python-version: 3.5.9
+      codespeed_executable: "Python 3.5.9 - loaded conf 4"
+      agent_config: "benchmarks/configs/agent_2-growing_logs-monitors-multiprocess-2-worker.json"
+      run_time: 140
+      agent_pre_run_command: "touch /tmp/random.log & touch /tmp/random2.log"
+      agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 2M 10 100 1 & benchmarks/scripts/write-random-lines.sh /tmp/random2.log 2M 10 100 1 &"
+      agent_server_host: "ci-codespeed-benchmarks-py35-loaded-conf-4"
+      capture_line_counts: true
+
+  benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    with:
+      python-version: 3.5.9
+      codespeed_executable: "Python 2.7.17 - loaded conf 5"
+      agent_config: "benchmarks/configs/agent_single_50mb_genlog_500k_line_file.json"
+      agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/scalyr_genlog_500k_line_50_mb.log"
+      agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-5"
+      run_time: 140
+      capture_agent_status_metrics: true
+      capture_line_counts: true
+
+  benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    with:
+      python-version: 3.5.9
+      codespeed_executable: "Python 3.5.9 - loaded conf 5"
+      agent_config: "benchmarks/configs/agent_single_50mb_genlog_500k_line_file.json"
+      agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/scalyr_genlog_500k_line_50_mb.log"
+      agent_server_host: "ci-codespeed-benchmarks-py35-loaded-conf-5"
+      run_time: 140
+      capture_agent_status_metrics: true
+      capture_line_counts: true

--- a/benchmarks/scripts/requirements.txt
+++ b/benchmarks/scripts/requirements.txt
@@ -2,3 +2,4 @@ requests==2.25.1
 # TODO: Add back latest version when we switch to Python 3 only and update benchmarks/scripts/send_usage_data_to_codespeed.py file
 #numpy
 psutil==5.7.0
+six==1.13.0


### PR DESCRIPTION
Port codespeed agent benchmark jobs from circleci to GHA.

FYI the job fails unless it is run on the master branch or release branch due to codespeed not accepting results for any other branch.

CT-577