### PR TITLE
Windows event monitor json api to use dottedEscapedJson parser

### DIFF
--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -879,7 +879,7 @@ and System sources:
             result = api_class(self._config, self._logger, channels)
 
             if api_class == NewJsonApi:
-                self.log_config["parser"] = "dottedJson"
+                self.log_config["parser"] = "dottedEscapedJson"
         else:
             if channels:
                 msg = (


### PR DESCRIPTION
Changed the Windows event monitor NewJsonApi parser to be dottedEscapedJson to accommodate embedded double quotes.

More notes/details in [DSET-355](https://jira-ng.sentinelone.com/browse/DSET-355)
