### PR TITLE
Update syslog monitor to ignore invalid utf-8 byte sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Improvements:
 * Add new ``memory_profiler_max_items`` config option which sets maximum number of items by memory usage reported by the memory profiler.
 * Add new ``enable_cpu_profiling`` and ``enable_memory_profiling`` config option with which user can enable either CPU or memory profiler, or both. Existing ``enable_profiling`` config behavior didn't change and setting it to ``true`` will enable both profilers (CPU and memory).
 * Allow user to specify additional trace filters (path globs) for tracemalloc memory profiler using ``memory_profiler_ignore_path_globs`` config option. (e.g. ``memory_profiler_ignore_path_globs: ["**/scalyr_agent/util.py", "**/scalyr_agent/json_lib/**"]``).
+* Update syslog_monitor to ignore errors when decoding data from bytes into unicode if data falls outside of the utf-8 range.
 
 ## 2.1.33 "Chaavis" - August 17, 2022
 <!---

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -490,7 +490,7 @@ class SyslogUDPHandler(six.moves.socketserver.BaseRequestHandler):
     """
 
     def handle(self):
-        data = six.ensure_text(self.request[0].strip(), errors="ignore")
+        data = six.ensure_text(self.request[0].strip(), "utf-8", errors="ignore")
         self.server.syslog_handler.handle(data)
 
 
@@ -613,7 +613,9 @@ class SyslogRequestParser(object):
                     )
 
                     # skip invalid bytes which can appear because of the buffer overflow.
-                    frame_data = six.ensure_text(self._remaining, errors="ignore")
+                    frame_data = six.ensure_text(
+                        self._remaining, "utf-8", errors="ignore"
+                    )
                     handle_frame(frame_data)
 
                     frames_handled += 1
@@ -1421,9 +1423,8 @@ class SyslogHandler(object):
         """
         Feed syslog messages to the appropriate loggers.
         """
-
         # one more time ensure that we don't have binary string.
-        data = six.ensure_text(data)
+        data = six.ensure_text(data, "utf-8", errors="ignore")
 
         if self.__docker_logging:
             self.__handle_docker_logs(data)

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -490,7 +490,7 @@ class SyslogUDPHandler(six.moves.socketserver.BaseRequestHandler):
     """
 
     def handle(self):
-        data = six.ensure_text(self.request[0].strip())
+        data = six.ensure_text(self.request[0].strip(), errors="ignore")
         self.server.syslog_handler.handle(data)
 
 
@@ -628,7 +628,7 @@ class SyslogRequestParser(object):
             frame_length = frame_end - self._offset
 
             frame_data = six.ensure_text(
-                self._remaining[self._offset : frame_end].strip()
+                self._remaining[self._offset : frame_end].strip(), "utf-8", "ignore"
             )
             handle_frame(frame_data)
             frames_handled += 1

--- a/tests/unit/syslog_monitor_test.py
+++ b/tests/unit/syslog_monitor_test.py
@@ -952,6 +952,8 @@ class SyslogDefaultRequestParserTestCase(SyslogMonitorTestCase):
 
         # byte sequence which falls outside of utf-8 range should be ignored
         mock_msg_1_expected = b"<14>Dec 24 16:12:48 hosttest.example.com tag-1-0-17[2593]: Hey diddle diddle ~\x01, The Cat and the Fiddle, The Cow jump'd over the Spoon\n"
+        mock_msg_2_expected = b"<14>Dec 24 16:12:48 hosttest.example.com tag-2-0-17[2593]: Hey diddle diddle ~\x01, The Cat and the Fiddle, The Cow jump'd over the Spoon\n"
+        mock_msg_3_expected = b"<14>Dec 24 16:12:48 hosttest.example.com tag-3-0-17[2593]: Hey diddle diddle ~\x01, The Cat and the Fiddle, The Cow jump'd over the Spoon\n"
 
         parser = SyslogRequestParser(
             socket=mock_socket, max_buffer_size=max_buffer_size
@@ -963,6 +965,14 @@ class SyslogDefaultRequestParserTestCase(SyslogMonitorTestCase):
         self.assertEqual(
             six.ensure_binary(mock_handle_frame.call_args_list[0][0][0]),
             mock_msg_1_expected.strip(),
+        )
+        self.assertEqual(
+            six.ensure_binary(mock_handle_frame.call_args_list[1][0][0]),
+            mock_msg_2_expected.strip(),
+        )
+        self.assertEqual(
+            six.ensure_binary(mock_handle_frame.call_args_list[2][0][0]),
+            mock_msg_3_expected.strip(),
         )
 
         # Verify internal state is correctly reset

--- a/tests/unit/syslog_monitor_test.py
+++ b/tests/unit/syslog_monitor_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014 Scalyr Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This pull request updates ``SyslogRequestParser`` class in the syslog monitor to ignore errors which may error when trying to decode byte sequence into utf-8 unicode string. This class is used when TCP transport is used and when ``tcp_request_parser`` parser is set to ``default`` (aka default behavior).

Previously an exception would be thrown in case we encountered invalid utf-8 sequence, but now we simply ignore non valid utf-8 data.

It's worth noting that exactly the same thing already happens inside ``SyslogBatchedRequestParser`` class which is used when ``tcp_request_parser`` is set to ``batch``.