### PR TITLE
Don't skip Github Action job runs on master branch merge / push

### DIFF
--- a/.github/actions/setup-minikube-cluster/action.yml
+++ b/.github/actions/setup-minikube-cluster/action.yml
@@ -52,6 +52,11 @@ runs:
       if: ${{ inputs.k8s_version != '' }}
       shell: bash
       run: |
+        # Workaround to ensure we use kubectl version which comes with specific k8s release as part
+        # of minikube and not system level kubectl
+        which kubectl
+        rm /usr/local/bin/kubectl || true
+        ln -sf $(which minikube) /usr/local/bin/kubectl
         echo "kubectl version"
         kubectl version
         echo ""

--- a/.github/actions/setup-minikube-cluster/action.yml
+++ b/.github/actions/setup-minikube-cluster/action.yml
@@ -5,7 +5,7 @@ inputs:
   minikube_version:
     description: "Minikube version to use"
     required: false
-    default: "v1.26.0"
+    default: "v1.26.1"
   k8s_version:
     description: "Kubernetes version to be installed by minikube (if any)"
     required: false
@@ -52,8 +52,10 @@ runs:
       if: ${{ inputs.k8s_version != '' }}
       shell: bash
       run: |
-        # Workaround to ensure we use kubectl version which comes with specific k8s release as part
-        # of minikube and not system level kubectl
+        # Workaround to ensure we use kubectl version which comes with a specific k8s release as
+        # part of minikube and not system level kubectl. This is important because system version
+        # of kubectl may be different and incompatible with the k8s version we are installing via
+        # minikube.
         which kubectl
         rm /usr/local/bin/kubectl || true
         ln -sf $(which minikube) /usr/local/bin/kubectl

--- a/.github/workflows/agent-build-refactored.yml
+++ b/.github/workflows/agent-build-refactored.yml
@@ -66,13 +66,12 @@ jobs:
               { "name": "k8s-alpine", "master_run_only": true }
             ]
 
-
   # This job pre-executes and caches Runner steps that has to be executed in a separate job.
   # For example, we build platform-specific base docker images in a separate jobs to reduce overall build time, because
   # some of base images are built with using QEMU.
   pre-build-cached-step:
     name: ${{ matrix.name }}
-    if: needs.pre-job.outputs.should_skip != 'true'
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     needs:
       - pre-job
 

--- a/.github/workflows/agent-build-refactored.yml
+++ b/.github/workflows/agent-build-refactored.yml
@@ -20,7 +20,7 @@ env:
 # Since we can do a "master" run (on push and PR to a master branch) and "non-master" run, it generates matrices with different
 #  size according to that information.
 jobs:
-  pre-job:
+  pre_job:
     runs-on: ubuntu-20.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -73,17 +73,17 @@ jobs:
     name: ${{ matrix.name }}
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     needs:
-      - pre-job
+      - pre_job
 
     runs-on: ${{ matrix.os }}
     strategy:
-      # This job receives its matrix from the 'pre-job' job. The matrix itself is created by the .github/actions/init-job-matrices action.
+      # This job receives its matrix from the 'pre_job' job. The matrix itself is created by the .github/actions/init-job-matrices action.
       # The matrix, for now, consists only from the 'include' part with following fields:
       #   "name": Name of the build job. (Not used in actiual build process, but just gives meaningful name to the job).
       #   "step-runner-fqdn": Fully qualified name of the builder class that has to run the cached step.
       #   "python-version": Version of python to setup on this runner. (NOTE: version of python used in images may differ, and it specified in the source code.)
       #   "os": Runner OS.
-      matrix: ${{ fromJSON(needs.pre-job.outputs.pre_build_steps_matrix_json) }}
+      matrix: ${{ fromJSON(needs.pre_job.outputs.pre_build_steps_matrix_json) }}
 
     steps:
       - name: Checkout repository
@@ -110,12 +110,12 @@ jobs:
   build-images:
     name: Build image '${{ matrix.name }}'
     needs:
-      - pre-job
+      - pre_job
       - pre-build-cached-step
     runs-on: ${{ matrix.os }}
 
     strategy:
-      # This job receives its matrix from the 'pre-job' job. The matrix itself is created by the .github/actions/init-job-matrices action.
+      # This job receives its matrix from the 'pre_job' job. The matrix itself is created by the .github/actions/init-job-matrices action.
       # The matrix, for now, consists only from the 'include' part with following fields:
       #   "name": name of the builder that builds the target images.
       #   "master_run_only": If 'true' then it this package will be included only in a "master" workflow run.
@@ -124,7 +124,7 @@ jobs:
       #   "builder-fqdn": Fully qualified name of the builder to find its cached steps.
       #   "python-version": Version of python to set up on this runner. (NOTE: version of python used in images may differ, and it specified in the source code.)
       #   "os": Runner OS.
-      matrix: ${{ fromJSON(needs.pre-job.outputs.agent_image_build_matrix_json) }}
+      matrix: ${{ fromJSON(needs.pre_job.outputs.agent_image_build_matrix_json) }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -29,7 +29,7 @@ jobs:
   codespeed-micro-benchmarks:
     runs-on: ubuntu-latest
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     strategy:
       fail-fast: false
       matrix:
@@ -97,7 +97,7 @@ jobs:
 
   benchmarks-idle-agent-py-27:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -110,7 +110,7 @@ jobs:
 
   benchmarks-idle-agent-py-35:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -123,7 +123,7 @@ jobs:
 
   benchmarks-idle-agent-no-monitors-py-27:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -136,7 +136,7 @@ jobs:
 
   benchmarks-idle-agent-no-monitors-py-35:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -149,7 +149,7 @@ jobs:
 
   benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -165,7 +165,7 @@ jobs:
 
   benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -183,7 +183,7 @@ jobs:
   # agent process is started.
   benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -199,7 +199,7 @@ jobs:
 
   benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -215,7 +215,7 @@ jobs:
 
   benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -236,7 +236,7 @@ jobs:
 
   benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -252,7 +252,7 @@ jobs:
 
   benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -268,7 +268,7 @@ jobs:
 
   benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -84,7 +84,7 @@ jobs:
 
     needs: pre_job
     # NOTE: We always want to run job on master branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' && (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
 
     strategy:
       fail-fast: false
@@ -259,7 +259,7 @@ jobs:
 
     needs: pre_job
     # NOTE: We always want to run job on master branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' && ( github.ref == 'refs/heads/master' || github.base_ref == 'master' ) }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || ( github.ref == 'refs/heads/master' || github.base_ref == 'master' ) }}
 
     strategy:
       fail-fast: false
@@ -434,7 +434,7 @@ jobs:
   k8s-smoketest:
     runs-on: ubuntu-latest
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' && (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -490,7 +490,7 @@ jobs:
   docker-smoketest:
     name: Docker Smoketest - ${{ matrix.variant.log_mode }}
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' && (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -549,7 +549,7 @@ jobs:
   agent-source-tests:
     runs-on: ${{ matrix.os }}
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' && (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     container: ${{ matrix.container }}
     strategy:
       matrix:

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -360,7 +360,7 @@ jobs:
           K8S_NODE_NAME: "${{ env.K8S_NODE_NAME }}"
           K8S_CLUSTER_NAME: "${{ env.K8S_CLUSTER_NAME }}"
         run: |
-          export RETRY_ATTEMPTS="8"
+          export RETRY_ATTEMPTS="10"
           export SLEEP_DELAY="10"
 
           # Verify agent is running

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -434,7 +434,7 @@ jobs:
   k8s-smoketest:
     runs-on: ubuntu-latest
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' && (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -452,7 +452,7 @@ jobs:
       - name: Setup minikube k8s cluster
         uses: ./.github/actions/setup-minikube-cluster/
         with:
-          k8s_version: v1.18.0
+          k8s_version: v1.22.0
           minikube_driver: ""
           container_runtime: "docker"
           github_token: "${{ secrets.GITHUB_TOKEN }}"
@@ -490,7 +490,7 @@ jobs:
   docker-smoketest:
     name: Docker Smoketest - ${{ matrix.variant.log_mode }}
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' && (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -549,7 +549,7 @@ jobs:
   agent-source-tests:
     runs-on: ${{ matrix.os }}
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' && (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     container: ${{ matrix.container }}
     strategy:
       matrix:

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -173,14 +173,14 @@ jobs:
           daemonset_yaml_path: "tests/e2e/scalyr-agent-2-daemonset.yaml"
 
       - name: Verify data has been ingested
-        timeout-minutes: 5
+        timeout-minutes: 14
         env:
           # Needed for scalyr-tool
           scalyr_readlog_token: "${{ secrets.SCALYR_CLOUDTECH_TESTING_DEV_SCALYR_READ_API_KEY }}"
           SCALYR_AGENT_POD_NAME: "${{ env.SCALYR_AGENT_POD_NAME }}"
           K8S_NODE_NAME: "${{ env.K8S_NODE_NAME }}"
         run: |
-          export RETRY_ATTEMPTS="10"
+          export RETRY_ATTEMPTS="14"
           export SLEEP_DELAY="10"
 
           # Verify agent is running
@@ -360,7 +360,7 @@ jobs:
           K8S_NODE_NAME: "${{ env.K8S_NODE_NAME }}"
           K8S_CLUSTER_NAME: "${{ env.K8S_CLUSTER_NAME }}"
         run: |
-          export RETRY_ATTEMPTS="10"
+          export RETRY_ATTEMPTS="14"
           export SLEEP_DELAY="10"
 
           # Verify agent is running

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -65,6 +65,11 @@ jobs:
   unittests:
     name: Unittests - Python ${{ matrix.python-version }} - ${{ matrix.platform }}
     runs-on: ${{ matrix.platform }}-latest
+
+    needs: pre_job
+    # NOTE: We always want to run job on master branch
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' && (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+
     timeout-minutes: 10
     defaults:
       run:
@@ -140,6 +145,11 @@ jobs:
   standalone-smoketests:
     name: Standalone Smoketests - Python ${{ matrix.python-version }} - ${{ matrix.variant }}
     runs-on: ubuntu-latest
+
+    needs: pre_job
+    # NOTE: We always want to run job on master branch
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' && (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+
     timeout-minutes: 10
     defaults:
       run:
@@ -213,6 +223,11 @@ jobs:
     name: Monitor Smoketests - Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+
+    needs: pre_job
+    # NOTE: We always want to run job on master branch
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' && (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+
     defaults:
       run:
         shell: bash

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -30,7 +30,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    if: success() || failure()
+    if: (success() || failure()) && (${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }})
     needs:
       - pre_job
       - unittests
@@ -68,13 +68,12 @@ jobs:
 
     needs: pre_job
     # NOTE: We always want to run job on master branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' && (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    if: (success() || failure()) && (${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }})
 
     timeout-minutes: 10
     defaults:
       run:
         shell: bash
-    needs: pre_job
     strategy:
       fail-fast: false
       matrix:
@@ -148,13 +147,12 @@ jobs:
 
     needs: pre_job
     # NOTE: We always want to run job on master branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' && (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
 
     timeout-minutes: 10
     defaults:
       run:
         shell: bash
-    needs: pre_job
     strategy:
       fail-fast: false
       matrix:
@@ -226,7 +224,7 @@ jobs:
 
     needs: pre_job
     # NOTE: We always want to run job on master branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' && (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
 
     defaults:
       run:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -229,7 +229,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    needs: pre_job
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/cicd/scalyr-query.sh
+++ b/scripts/cicd/scalyr-query.sh
@@ -28,23 +28,27 @@ MINIMUM_RESULTS=${MINIMUM_RESULTS:-"1"}
 
 SCALYR_TOOL_QUERY=$1
 
+echo_with_date() {
+    date +"[%Y-%m-%d %H:%M:%S] $*"
+}
+
 function retry_on_failure {
   i=1
 
   until [ "${i}" -gt "${RETRY_ATTEMPTS}" ]
   do
-     echo ""
+     echo_with_date ""
      # shellcheck disable=SC2145
-     echo "Running function \"$@\" attempt ${i}/${RETRY_ATTEMPTS}..."
-     echo ""
+     echo_with_date "Running function \"$@\" attempt ${i}/${RETRY_ATTEMPTS}..."
+     echo_with_date ""
 
      exit_code=0
      "$@" && break
      exit_code=$?
 
-     echo ""
-     echo "Function returned non-zero status code, sleeping ${SLEEP_DELAY}s before next attempt.."
-     echo ""
+     echo_with_date ""
+     echo_with_date "Function returned non-zero status code, sleeping ${SLEEP_DELAY}s before next attempt.."
+     echo_with_date ""
 
      i=$((i+1))
 
@@ -60,22 +64,22 @@ function retry_on_failure {
 }
 
 function query_scalyr {
-    echo "Using query '${SCALYR_TOOL_QUERY}'"
+    echo_with_date "Using query '${SCALYR_TOOL_QUERY}'"
 
     RESULT=$(eval "scalyr query '${SCALYR_TOOL_QUERY}' --columns='timestamp,severity,message' --start='20m' --count='100' --output multiline")
     RESULT_LINES=$(echo -e "${RESULT}" | sed '/^$/d' | wc -l)
 
-    echo "Results for query '${SCALYR_TOOL_QUERY}':"
-    echo ""
+    echo_with_date "Results for query '${SCALYR_TOOL_QUERY}':"
+    echo_with_date ""
     echo -e "${RESULT}"
 
     if [ "${RESULT_LINES}" -lt ${MINIMUM_RESULTS} ]; then
-        echo ""
-        echo "Expected at least ${MINIMUM_RESULTS} matching lines, got ${RESULT_LINES}."
+        echo_with_date ""
+        echo_with_date "Expected at least ${MINIMUM_RESULTS} matching lines, got ${RESULT_LINES}."
         return 1
     fi
 
-    echo ""
+    echo_with_date ""
     echo -e "\xE2\x9C\x94 Found ${RESULT_LINES} matching log lines"
     return 0
 }


### PR DESCRIPTION
I noticed some of the Github action jobs were being incorrectly skipped on master branch runs (e.g. https://github.com/scalyr/scalyr-agent-2/runs/8068790013).

We always want to run jobs on master branch merge / push and only skip duplicate / redundant jobs on pull request.

This pull request fixes all the jobs to make sure we don't skip run on master branch and also fixes the conditional which were likely unintentionally changed from "or" to "and" which won't produce the desired behavior.

```dif
 -    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
 +    if: ${{ needs.pre_job.outputs.should_skip != 'true' && (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
```

We always want to run checks on master branch to catch any issues which may only manifests itself on merging and since some Jenkins jobs depend on master runs.

Technically, if we strictly enforce "branch / pr must be up to date before merging" rule, we may also be able to safely skip redundant builds on master merge / run as well.