### PR TITLE
Update slack channel for GHA notifications to renamed channel

### DIFF
--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
-          channel: '#cloud-tech'
+          channel: '#eng-dataset-cloud-tech'
 
   publish-images:
     if: ${{ github.ref == 'refs/heads/master' || github.ref_type == 'tag' }}

--- a/.github/workflows/codespeed-agent-benchmarks.yaml
+++ b/.github/workflows/codespeed-agent-benchmarks.yaml
@@ -169,4 +169,4 @@ jobs:
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
-          channel: '#cloud-tech'
+          channel: '#eng-dataset-cloud-tech'

--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
-          channel: '#cloud-tech'
+          channel: '#eng-dataset-cloud-tech'
 
   benchmarks-idle-agent-py-27:
     needs: pre_job

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -250,7 +250,7 @@ jobs:
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
-          channel: '#cloud-tech'
+          channel: '#eng-dataset-cloud-tech'
 
   k8s_open_metrics_monitor_tests:
     name: OpenMetrics Monitor - k8s ${{ matrix.k8s_version.version }}-${{ matrix.k8s_version.runtime}}
@@ -429,7 +429,7 @@ jobs:
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
-          channel: '#cloud-tech'
+          channel: '#eng-dataset-cloud-tech'
 
   k8s-smoketest:
     runs-on: ubuntu-latest
@@ -485,7 +485,7 @@ jobs:
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
-          channel: '#cloud-tech'
+          channel: '#eng-dataset-cloud-tech'
 
   docker-smoketest:
     name: Docker Smoketest - ${{ matrix.variant.log_mode }}
@@ -543,7 +543,7 @@ jobs:
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
-          channel: '#cloud-tech'
+          channel: '#eng-dataset-cloud-tech'
 
   # Runs agent from it source and performs some basic sanity checks.
   agent-source-tests:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -102,4 +102,4 @@ jobs:
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
-          channel: '#cloud-tech'
+          channel: '#eng-dataset-cloud-tech'

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
-          channel: '#cloud-tech'
+          channel: '#eng-dataset-cloud-tech'
 
   publish-release:
     needs: [ publish-temp-release ]
@@ -122,4 +122,4 @@ jobs:
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
-          channel: '#cloud-tech'
+          channel: '#eng-dataset-cloud-tech'

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -139,7 +139,7 @@ jobs:
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
-          channel: '#cloud-tech'
+          channel: '#eng-dataset-cloud-tech'
 
   standalone-smoketests:
     name: Standalone Smoketests - Python ${{ matrix.python-version }} - ${{ matrix.variant }}
@@ -215,7 +215,7 @@ jobs:
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
-          channel: '#cloud-tech'
+          channel: '#eng-dataset-cloud-tech'
 
   monitor-smoketests:
     name: Monitor Smoketests - Python ${{ matrix.python-version }}
@@ -284,7 +284,7 @@ jobs:
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
-          channel: '#cloud-tech'
+          channel: '#eng-dataset-cloud-tech'
 
   publish-test-results:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The cloud-tech channel was renamed a while ago. Update the GHA workflows
with the current channel name to fix notifications.