### PR TITLE
Added quoted text to windows event log monitor ami test

### DIFF
--- a/tests/ami/scripts/test_windows.ps1.j2
+++ b/tests/ami/scripts/test_windows.ps1.j2
@@ -221,7 +221,7 @@ if ("$event_log_output" -notmatch "Level")   { Throw "Event log monitor didnt em
 # Verify that the event we inserted exists
 if ("$event_log_output" -notmatch "ScalyrAgentTest")   { Throw "Matching event not found in event log" };
 # TODO: Find out how to make this powershell script to write event logs with non-ASCII characters.
-if ("$event_log_output" -notmatch 'Scalyr automated tests event \\\\"with quoted text\\\\" .+')   { Throw "Matching event not found in event log" };
+if ("$event_log_output" -notmatch 'Scalyr automated tests event \\"with quoted text\\" .+')   { Throw "Matching event not found in event log" };
 
 #
 # Verify agent start up line

--- a/tests/ami/scripts/test_windows.ps1.j2
+++ b/tests/ami/scripts/test_windows.ps1.j2
@@ -199,7 +199,7 @@ Copy-Item ".\agent.json_event_log_monitor" -Destination "C:\Program Files (x86)\
 # Write mock entry to event log and ensure Scalyr picks it up
 New-EventLog –LogName Application –Source “ScalyrAgentTest”
 #[system.diagnostics.EventLog]::CreateEventSource("ScalyrAgentTest", "Application")
-Write-EventLog -LogName "Application" -Source "ScalyrAgentTest" -EventID 30001 -EntryType Information -Message "Scalyr automated tests event 要讲话要讲话要讲话." -Category 1 -RawData 10,20
+Write-EventLog -LogName "Application" -Source "ScalyrAgentTest" -EventID 30001 -EntryType Information -Message 'Scalyr automated tests event "with quoted text" 要讲话要讲话要讲话.' -Category 1 -RawData 10,20
 
 Start-Sleep 10
 
@@ -221,7 +221,7 @@ if ("$event_log_output" -notmatch "Level")   { Throw "Event log monitor didnt em
 # Verify that the event we inserted exists
 if ("$event_log_output" -notmatch "ScalyrAgentTest")   { Throw "Matching event not found in event log" };
 # TODO: Find out how to make this powershell script to write event logs with non-ASCII characters.
-if ("$event_log_output" -notmatch "Scalyr automated tests event .+")   { Throw "Matching event not found in event log" };
+if ("$event_log_output" -notmatch 'Scalyr automated tests event \\\\"with quoted text\\\\" .+')   { Throw "Matching event not found in event log" };
 
 #
 # Verify agent start up line


### PR DESCRIPTION
The intention here was to add an additional test to help cover the change introduced by DSET-355 / PR #983 

However the DSET-355 change doesn't manifest until after the event has been received by the Scalyr servers (because it relies on a specific parser), so it's debatable whether this added check is worth including as it is.

Alternatively a check could be added to the ami test script that queries for the event from Scalyr and verifies it's what is expected.  There are some challenges associated with this:
- Will need to make the server hostname & api key available to the powershell script
- Will need to take care that simultaneous executions don't interfere with each other (by introducing a random value in the checked message?)

Let me know what you think