### PR TITLE
Window event log monitor NewJsonApi to set monitor field

### DIFF
--- a/docs/monitors/windows_event_log_monitor.md
+++ b/docs/monitors/windows_event_log_monitor.md
@@ -87,3 +87,12 @@ and System sources:
 | `remote_password`            | Optional (defaults to ``None``). The password to use for authentication on the remote server.  This option is only valid on Windows Vista and above. | 
 | `remote_domain`              | Optional (defaults to ``None``). The domain to which the remote user account belongs.  This option is only valid on Windows Vista and above. | 
 | `json`                       | Optional (defaults to ``False``). Format events as json? Supports inclusion of all event fields. This option is only valid on Windows Vista and above. | 
+
+<a name="events"></a>
+## Event Reference
+
+In the UI, each event has the fields:
+
+| Field     | Description | 
+| ---       | --- | 
+| `monitor` | Always ``windows_event_log_monitor``. | 

--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -41,7 +41,7 @@ except ImportError as e:
     windll = None
 
 import scalyr_agent.util as scalyr_util
-from scalyr_agent import ScalyrMonitor, define_config_option
+from scalyr_agent import ScalyrMonitor, define_config_option, define_log_field
 import scalyr_agent.scalyr_logging as scalyr_logging
 
 __author__ = "imron@scalyr.com"
@@ -146,6 +146,8 @@ define_config_option(
     default=False,
     convert_to=bool,
 )
+
+define_log_field(__monitor__, "monitor", "Always ``windows_event_log_monitor``.")
 
 
 class Api(object):
@@ -683,6 +685,7 @@ class NewJsonApi(NewApi):
             "SystemTime"
         ]
         event_json["name"] = self._logger.name
+        event_json["monitor"] = "windows_event_log_monitor"
         self._logger.emit_value("unused", scalyr_util.json_encode(event_json))
 
         self._bookmark_lock.acquire()


### PR DESCRIPTION
From DSET-368, note that the existing implementations (ie OldApi, NewApi) already set the monitor field via scalyr_logging.AgentLogger.emit_value
(ref: https://app.scalyr.com/y/2eXCRLjoJjF)

Changes:
- Set the monitor field in NewJsonApi for each event
- Added a define_log_field entry for monitor (for consistency with other monitors)