### PR TITLE
DSET-528: Windows event log monitor NewJsonApi metadata fix

### DIFF
--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -660,9 +660,16 @@ class NewJsonApi(NewApi):
             event, win32evtlog.EvtRenderEventValues, Context=self._render_context
         )
 
-        metadata = win32evtlog.EvtOpenPublisherMetadata(
-            values[win32evtlog.EvtSystemProviderName][0]
-        )
+        # (Publisher) metadata is used to populate the RenderingInfo section,
+        # which is already populated for forwarded events and would throw an exception here.
+        # Ref: https://docs.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtformatmessage
+        metadata = None
+        try:
+            metadata = win32evtlog.EvtOpenPublisherMetadata(
+                values[win32evtlog.EvtSystemProviderName][0]
+            )
+        except Exception:
+            pass
 
         event_json = xmltodict.parse(
             win32evtlog.EvtFormatMessage(


### PR DESCRIPTION
Notes in DSET-528

Wrapping the call to EvtOpenPublisherMetadata call in a try/except block to allow the publisher metadata to be null/None (which would occur for forwarded events).  Verified this will not cause problems downstream, worst case scenario is that the RenderingInfo section will be mostly empty, moreover this is the approach being done for the older non-json implementation in the monitor (ie NewApi)