### PR TITLE
windows_event_log_monitor: NewJsonApi: Ensure formatting when RateLim…

### DIFF
--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -928,8 +928,13 @@ and System sources:
         return result
 
     def open_metric_log(self):
-        class DummyFormatter:
+        class DummyFormatter(scalyr_logging.MetricLogFormatter):
             def format(self, record):
+                # Ensure the LogRecord has a message attribute.
+                # If the rate limit is disabled, formatting is not applied by RateLimitLogFilter.
+                # Ref: scalyr_logging.MetricLoggingHandler.__init__
+                if not hasattr(record, 'message'):
+                    super(DummyFormatter, self).format(record)
                 return record.message[len("unused ") + 1 : -1].replace('\\"', '"')
 
         rv = super(WindowEventLogMonitor, self).open_metric_log()

--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -933,7 +933,7 @@ and System sources:
                 # Ensure the LogRecord has a message attribute.
                 # If the rate limit is disabled, formatting is not applied by RateLimitLogFilter.
                 # Ref: scalyr_logging.MetricLoggingHandler.__init__
-                if not hasattr(record, 'message'):
+                if not hasattr(record, "message"):
                     super(DummyFormatter, self).format(record)
                 return record.message[len("unused ") + 1 : -1].replace('\\"', '"')
 

--- a/tests/unit/builtin_monitors/windows_event_log_monitor_test.py
+++ b/tests/unit/builtin_monitors/windows_event_log_monitor_test.py
@@ -231,7 +231,10 @@ class WindowsEventLogMonitorTest(ScalyrTestCase):
 
 @pytest.mark.windows_platform
 class WindowsEventLogMonitorTest2(BaseScalyrLogCaptureTestCase):
-    @skipIf(sys.platform not in ["Windows", "win32"], "Skipping tests under non-Windows platform")
+    @skipIf(
+        sys.platform not in ["Windows", "win32"],
+        "Skipping tests under non-Windows platform",
+    )
     def test_newjsonapi_with_no_rate_limit(self):
         config = {
             "module": "windows_event_log_monitor",
@@ -256,9 +259,11 @@ class WindowsEventLogMonitorTest2(BaseScalyrLogCaptureTestCase):
         # Normally called when the monitor is started (via MonitorsManager.__start_monitor)
         monitor.open_metric_log()
 
-        logger.emit_value("unused", "{\"foo\":\"bar\"}")
+        logger.emit_value("unused", '{"foo":"bar"}')
 
         self.assertEquals(monitor.reported_lines(), 1)
-        self.assertLogFileContainsLineRegex(file_path=metric_file_path, expression="foo")
+        self.assertLogFileContainsLineRegex(
+            file_path=metric_file_path, expression="foo"
+        )
 
         logger.closeMetricLog()


### PR DESCRIPTION
…itLogFilter is not applied

From investigation into DSET-536 I came across an issue if the scalyr_logging.RateLimiterLogFilter is not applied (eg when monitor_log_write_rate & monitor_log_max_write_burst are both -1: ref scalyr_logging.MetricLogHandler.__init__) then the LogRecord generated by the NewJsonApi will not have a message attribute (note that RateLimiterLogFilter has a formater as its first argument).  This change resolves that issue
