### PR TITLE
Decrease cert expiration alerting threshold from 2 years to 1 year

### DIFF
--- a/scripts/check-bundled-ca-certs-expirations.py
+++ b/scripts/check-bundled-ca-certs-expirations.py
@@ -31,8 +31,8 @@ from io import open
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 
-# By default we fail if any of the bundled cert expires in 2 years or sooner
-DEFAULT_EXPIRE_THRESHOLD_TIMEDELTA = datetime.timedelta(days=(12 * 30 * 2))
+# By default we fail if any of the bundled cert expires in 1 year or sooner
+DEFAULT_EXPIRE_THRESHOLD_TIMEDELTA = datetime.timedelta(days=(12 * 30 * 1))
 
 
 def fail_if_cert_expires_in_timedelta(cert_path, expire_in_threshold_timedelta):


### PR DESCRIPTION
Lint check has recently started failing with this error:

```bash
(2028-12-31 23:59:59)
  Traceback (most recent call last):
    File "./scripts/check-bundled-ca-certs-expirations.py", line 91, in <module>
      main()
    File "./scripts/check-bundled-ca-certs-expirations.py", line 86, in main
      cert_path, expire_in_threshold_timedelta=DEFAULT_EXPIRE_THRESHOLD_TIMEDELTA
    File "./scripts/check-bundled-ca-certs-expirations.py", line 56, in fail_if_cert_expires_in_timedelta
      % (cert_path, expire_in_days, cert.not_valid_after)
  Exception: Certificate /home/runner/work/scalyr-agent-2/scalyr-agent-2/certs/scalyr_agent_ca_root.pem will expire in 703 days (2024-09-06 21:52:05), please update!
  ERROR: InvocationError for command /usr/bin/bash -c 'python ./scripts/check-bundled-ca-certs-expirations.py' (exited with code 1)
```

This PR decreases alerting threshold from 2 years to 1 year.