### PR TITLE
Upgrade Python version uses by Docker images, Windows binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,7 +500,7 @@ jobs:
     parameters:
       python-version:
         description: Version of the Python interpreter to use.
-        default: 3.10.4
+        default: 3.10.7
         type: string
     steps:
       - checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
+## 2.1.37 "TBD" - November 15, 2022
+<!---
+Packaged by Joseph Makar <joseph.makar@sentinelone.com> on Sep 17, 2022 12:31 -0800
+--->
+
+Docker Images:
+* Upgrade Linux Docker images to use Python 3.8.14.
+
+Windows:
+* Upgrade agent Windows binary to use Python 3.10.7.
+
 ## 2.1.36 "Corrntos" - September 15, 2022
 <!---
 Packaged by Joseph Makar <joseph.makar@sentinelone.com> on Sep 17, 2022 12:31 -0800

--- a/agent_build/docker/Dockerfile.base
+++ b/agent_build/docker/Dockerfile.base
@@ -7,7 +7,7 @@
 ARG BASE_IMAGE_SUFFIX
 
 # Install dependency packages for debian.
-FROM python:3.8.13-slim as scalyr-dependencies-slim
+FROM python:3.8.14-slim as scalyr-dependencies-slim
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 # Workaround for weird build failure on Circle CI, see
@@ -20,7 +20,7 @@ RUN ln -s /bin/tar /usr/sbin/tar
 RUN apt-get update && apt-get install -y build-essential git tar curl
 
 # Install dependency packages for alpine.
-FROM python:3.8.13-alpine as scalyr-dependencies-alpine
+FROM python:3.8.14-alpine as scalyr-dependencies-alpine
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 RUN apk update && apk add --virtual build-dependencies \
@@ -74,13 +74,13 @@ RUN rm /usr/local/lib/python3.8/_manylinux.py
 # Install packages and tools that will be required during the final image build.
 
 # Install tools for alpine
-FROM python:3.8.13-alpine as ready-base-alpine
+FROM python:3.8.14-alpine as ready-base-alpine
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 RUN apk update && apk add --virtual curl git
 
 # Install tools for debian.
-FROM python:3.8.13-slim as ready-base-slim
+FROM python:3.8.14-slim as ready-base-slim
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 # Workaround for weird build failure on Circle CI, see


### PR DESCRIPTION
This PR updates Docker images to use latest Python 3.8 version (3.8.4). There was a highly debated bug / potential security issue fixed recently in that release - https://www.python.org/downloads/release/python-3814/.

> CVE-2020-10735: converting between int and str in bases other than 2 (binary), 4, 8 (octal), 16 (hexadecimal), or 32 such as base 10 (decimal) now raises a ValueError if the number of digits in string form is above a limit to avoid potential denial of service attacks due to the algorithmic complexity.

In addition to that, it also updates Windows binary to use latest Python 3.10 version (3.10.7) - https://docs.python.org/release/3.9.14/whatsnew/changelog.html. This version includes fix for the same CVE.