### PR TITLE
Agent connection logging improvements and misc changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ Packaged by Joseph Makar <joseph.makar@sentinelone.com> on Sep 17, 2022 12:31 -0
 
 Kubernetes:
 * Fix a bug / edge case in the Kubernetes caching PodProcessor code which could cause an agent to get stuck in an infinite loop when processing controllers which have a custom Kind which is not supported by the agent defined. Contributed by #xdvpser #998 #999.
+* Allows user to configure Docker client library connection timeout and maximum connection pool size when using Docker container enumerator via new `k8s_docker_client_timeout` and `k8s_docker_client_max_pool_size` config option.
 
 Docker Images:
 * Upgrade Linux Docker images to use Python 3.8.14.
 
 Windows:
 * Upgrade agent Windows binary to use Python 3.10.7.
+
+Other:
+* Log how long it took (in milliseconds) to read data from socket when we encounter HTTP errors (e.g. connection aborted, connection reset, etc.).
+* Log which version of docker-py and requests Python library is being used so it's easier to spot if bundled / vendored or system version is used.
 
 ## 2.1.36 "Corrntos" - September 15, 2022
 <!---

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -2749,8 +2749,10 @@ class ContainerChecker(object):
             if self.__always_use_docker or (
                 self._container_runtime == "docker" and not self.__always_use_cri
             ):
+                docker_py_version = getattr(docker, "__version__", "unknown")
                 global_log.info(
-                    "kubernetes_monitor is using docker for listing containers"
+                    "kubernetes_monitor is using docker for listing containers (docker_py_version=%s)"
+                    % (docker_py_version)
                 )
                 self._validate_socket_file()
                 self.__client = DockerClient(

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1143,7 +1143,7 @@ class Configuration(object):
         If not set (None), it defaults to the docker-py library default (60s in October 2022 -
         https://github.com/docker/docker-py/blob/bc0a5fbacd7617fd338d121adca61600fc70d221/docker/constants.py#L6).
         """
-        return self.__get_config().get_int("k8s_docker_client_timeout")
+        return self.__get_config().get_int("k8s_docker_client_timeout", none_if_missing=True)
 
     @property
     def k8s_docker_client_max_pool_size(self):
@@ -1152,7 +1152,7 @@ class Configuration(object):
         library default (10 in October 2022 -
         https://github.com/docker/docker-py/blob/bc0a5fbacd7617fd338d121adca61600fc70d221/docker/constants.py#L39).
         """
-        return self.__get_config().get_int("k8s_docker_client_timeout")
+        return self.__get_config().get_int("k8s_docker_client_timeout", none_if_missing=True)
 
     @property
     def enforce_monotonic_timestamps(self):

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1137,6 +1137,24 @@ class Configuration(object):
         return self.__get_config().get_int("k8s_ratelimit_max_concurrency")
 
     @property
+    def k8s_docker_client_timeout(self):
+        """
+        Timeout when connecting to Docker API via socket when using Docker container listing mode.
+        If not set (None), it defaults to the docker-py library default (60s in October 2022 -
+        https://github.com/docker/docker-py/blob/bc0a5fbacd7617fd338d121adca61600fc70d221/docker/constants.py#L6).
+        """
+        return self.__get_config().get_int("k8s_docker_client_timeout")
+
+    @property
+    def k8s_docker_client_max_pool_size(self):
+        """
+        Docker client maximum connection pol size. If not set (None), it defaults to the docker-py
+        library default (10 in October 2022 -
+        https://github.com/docker/docker-py/blob/bc0a5fbacd7617fd338d121adca61600fc70d221/docker/constants.py#L39).
+        """
+        return self.__get_config().get_int("k8s_docker_client_timeout")
+
+    @property
     def enforce_monotonic_timestamps(self):
         # UNDOCUMENTED_CONFIG
         return self.__get_config().get_bool("enforce_monotonic_timestamps")
@@ -3091,6 +3109,22 @@ class Configuration(object):
             config,
             "k8s_ratelimit_max_concurrency",
             1,
+            description,
+            apply_defaults,
+            env_aware=True,
+        )
+        self.__verify_or_set_optional_int(
+            config,
+            "k8s_docker_client_timeout",
+            None,
+            description,
+            apply_defaults,
+            env_aware=True,
+        )
+        self.__verify_or_set_optional_int(
+            config,
+            "k8s_docker_client_max_pool_size",
+            None,
             description,
             apply_defaults,
             env_aware=True,

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1143,7 +1143,9 @@ class Configuration(object):
         If not set (None), it defaults to the docker-py library default (60s in October 2022 -
         https://github.com/docker/docker-py/blob/bc0a5fbacd7617fd338d121adca61600fc70d221/docker/constants.py#L6).
         """
-        return self.__get_config().get_int("k8s_docker_client_timeout", none_if_missing=True)
+        return self.__get_config().get_int(
+            "k8s_docker_client_timeout", none_if_missing=True
+        )
 
     @property
     def k8s_docker_client_max_pool_size(self):
@@ -1152,7 +1154,9 @@ class Configuration(object):
         library default (10 in October 2022 -
         https://github.com/docker/docker-py/blob/bc0a5fbacd7617fd338d121adca61600fc70d221/docker/constants.py#L39).
         """
-        return self.__get_config().get_int("k8s_docker_client_timeout", none_if_missing=True)
+        return self.__get_config().get_int(
+            "k8s_docker_client_timeout", none_if_missing=True
+        )
 
     @property
     def enforce_monotonic_timestamps(self):

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -733,6 +733,8 @@ class Configuration(object):
             "max_log_offset_size",
             "max_existing_log_offset_size",
             "json_library",
+            "docker_py_version",
+            "requests_version",
             "use_requests_lib",
             "use_multiprocess_workers",
             "default_sessions_per_worker",
@@ -771,6 +773,20 @@ class Configuration(object):
             if option == "json_library" and value == "auto":
                 json_lib = scalyr_util.get_json_lib()
                 value = "%s (%s)" % (value, json_lib)
+            elif option == "docker_py_version":
+                try:
+                    import docker
+                except Exception:
+                    value = "none"
+                else:
+                    value = getattr(docker, "__version__", None)
+            elif option == "requests_version":
+                try:
+                    import requests
+                except Exception:
+                    value = "none"
+                else:
+                    value = getattr(requests, "__version__", None)
 
             if print_value:
                 # if this is the first option we are printing, output a header

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -693,7 +693,8 @@ class ScalyrClientSession(object):
             log.log(
                 scalyr_logging.DEBUG_LEVEL_5,
                 'Response was received with body "%s" (duration_ms=%s)',
-                response, duration_ms,
+                response,
+                duration_ms,
             )
 
             if status_code == 429:

--- a/scalyr_agent/scalyr_client.py
+++ b/scalyr_agent/scalyr_client.py
@@ -628,6 +628,9 @@ class ScalyrClientSession(object):
         bytes_received = 0
 
         try:
+            start_ts = 0
+            end_ts = 0
+
             try:
                 if self.__disable_send_requests:
                     response = '{ "status":"success" }'
@@ -686,10 +689,11 @@ class ScalyrClientSession(object):
                 # contains non utf-8 characters
                 pass
 
+            duration_ms = int((end_ts - start_ts) * 1000)
             log.log(
                 scalyr_logging.DEBUG_LEVEL_5,
-                'Response was received with body "%s"',
-                response,
+                'Response was received with body "%s" (duration_ms=%s)',
+                response, duration_ms,
             )
 
             if status_code == 429:


### PR DESCRIPTION
This pull request updates scalyr client code to log how long it takes to read / process the response from the socket.

This will hopefully make it slightly easier to see what is going on when we see connection reset by peer / connection timeout and similar errors.

It also includes some other changes:

* Log which version of docker-py and requests library is used so we can see if it's using system version or bundled / vendored one
* Allows user to configure Docker client library connection timeout and maximum connection pool size when using Docker container enumerator via new `k8s_docker_client_timeout` and `k8s_docker_client_max_pool_size` config option.