### PR TITLE
Upgrade docker-py to 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Kubernetes:
 
 Docker Images:
 * Upgrade Linux Docker images to use Python 3.8.14.
+* Upgrade docker-py dependency to v6.0.0.
 
 Windows:
 * Upgrade agent Windows binary to use Python 3.10.7.

--- a/agent_build/requirement-files/docker-image-requirements.txt
+++ b/agent_build/requirement-files/docker-image-requirements.txt
@@ -17,5 +17,5 @@ pympler==1.0.1; python_version >= '3.7'
 pympler==0.8; python_version < '3.7'
 
 # note: 5.0 drops support for Python 2.7 so we can't use it for our Python 2.7 unit tests target
-docker==5.0.3; python_version >= '3.6'
+docker==6.0.0; python_version >= '3.6'
 docker==4.4.4; python_version < '3.6'

--- a/agent_build/requirement-files/docker-image-requirements.txt
+++ b/agent_build/requirement-files/docker-image-requirements.txt
@@ -17,5 +17,6 @@ pympler==1.0.1; python_version >= '3.7'
 pympler==0.8; python_version < '3.7'
 
 # note: 5.0 drops support for Python 2.7 so we can't use it for our Python 2.7 unit tests target
-docker==6.0.0; python_version >= '3.6'
+docker==6.0.0; python_version >= '3.7'
+docker==5.0.3; python_version == '3.6'
 docker==4.4.4; python_version < '3.6'

--- a/agent_build/requirement-files/testing-requirements.txt
+++ b/agent_build/requirement-files/testing-requirements.txt
@@ -23,7 +23,8 @@ decorator==4.4.1
 requests-mock==1.9.3
 six==1.13.0
 # note: 5.0 drops support for Python 2.7 so we can't use it for our Python 2.7 unit tests target
-docker==6.0.0; python_version >= '3.6'
+docker==6.0.0; python_version >= '3.7'
+docker==5.0.3; python_version == '3.6'
 docker==4.4.4; python_version < '3.6'
 # the version of 'requests' library that 'docker' uses as a dependency is higher than we use in agent,
 # to prevent versions conflict, install the appropriate version of 'requests', to force 'docker' to reuse it.

--- a/agent_build/requirement-files/testing-requirements.txt
+++ b/agent_build/requirement-files/testing-requirements.txt
@@ -23,7 +23,7 @@ decorator==4.4.1
 requests-mock==1.9.3
 six==1.13.0
 # note: 5.0 drops support for Python 2.7 so we can't use it for our Python 2.7 unit tests target
-docker==5.0.3; python_version >= '3.6'
+docker==6.0.0; python_version >= '3.6'
 docker==4.4.4; python_version < '3.6'
 # the version of 'requests' library that 'docker' uses as a dependency is higher than we use in agent,
 # to prevent versions conflict, install the appropriate version of 'requests', to force 'docker' to reuse it.


### PR DESCRIPTION
This PR updates docker-py dependency to the latest stable version v6.0.0 (https://github.com/docker/docker-py/releases/tag/6.0.0).