### PR TITLE
Update k8s monitor to also log value of SCALYR_K8S_EVENTS_DISABLE environment variable

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -4440,6 +4440,7 @@ cluster.
             "SCALYR_K8S_KUBELET_CA_CERT",
             "SCALYR_REPORT_K8S_METRICS",
             "SCALYR_REPORT_CONTAINER_METRICS",
+            "SCALYR_K8S_EVENTS_DISABLE",
         ]
         for envar in envars_to_log:
             self._logger.info(


### PR DESCRIPTION
Small logging change to also log the value of ``SCALYR_K8S_EVENTS_DISABLE`` environment variable in the Kubernetes monitor to make it more easy to see which value is currently in effect.