### PR TITLE
Use non-EOL Node.js 16 instead of Node.js 12 in our custom GHA actions

### DIFF
--- a/.github/actions/execute-runner/action.yml
+++ b/.github/actions/execute-runner/action.yml
@@ -20,5 +20,5 @@ inputs:
     default: v21
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/.github/actions/perform-deployment/action.yml
+++ b/.github/actions/perform-deployment/action.yml
@@ -21,5 +21,5 @@ inputs:
     default: v9
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
This pull request updates our custom GHA actions to use Node.js 16 instead of Node.js 12 which is EOL and unsupported.

More context - https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

![Screenshot 2022-10-17 at 12 23 14](https://user-images.githubusercontent.com/125088/196154118-b09cef60-e4e5-421b-926e-77ec6df8b2d4.png)
