### PR TITLE
Add hard guard rail for leader election to prevent OOM conditions

### DIFF
--- a/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_events_monitor.py
@@ -512,9 +512,9 @@ This monitor was released and enabled by default in Scalyr Agent version `2.0.43
         """
         # Hard guard-rails to prevent the agent from consuming large amounts of memory.
         if query_fields:
-            query_fields += '&limit=1000'
+            query_fields += "&limit=1000"
         else:
-            query_fields = '?limit=1000'
+            query_fields = "?limit=1000"
 
         response = k8s.query_api_with_retries(
             "/api/v1/nodes%s" % query_fields,


### PR DESCRIPTION
Add a hard guard rail that stops the k8s events monitor if leader election detects more than 1000 nodes that are eligible for leader election.

This is to prevent the agent from consumer gobs of memory and getting OOM killed. The k8s events monitor should stop and produce a very nervous-making error message, but the rest of the agent should continue to work as though nothing was wrong.

The k8s events monitor can still be used in clusters containing 1000+ nodes. The user just needs to configure the use of labels to restrict the number of nodes that are considered for leader election.

DSET-424