### PR TITLE
Use non vulnerable requests version in the windows unit tests

### DIFF
--- a/windows-unit-tests-requirements.txt
+++ b/windows-unit-tests-requirements.txt
@@ -13,10 +13,7 @@ codecov==2.1.9
 decorator==4.4.1
 six==1.13.0
 docker==4.1.0
-# the version of 'requests' library that 'docker' uses as a dependency is higher than we use in agent,
-# to prevent versions conflict, install the appropriate version of 'requests', to force 'docker' to reuse it.
-# NOTE: We can't use requests >= 2.22.0 since we still need to support Python 2.6
-requests==2.20.0
+requests==2.28.1; python_version >= '3.7'
 orjson==3.6.7; python_version >= '3.6'
 orjson==2.0.11; python_version == '3.5'
 # Needed by MockHTTPServer class and related tests


### PR DESCRIPTION
Small change to use newer requests version inside Windows unit tests. Older version we previously used has known security vulnerabilities.