### PR TITLE
Try adding "securityContext.allowPrivelegeEscalation: false" to the agent container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
+## 2.1.38 "TBD" - November 17, 2022
+<!---
+Packaged by Joseph Makar <joseph.makar@sentinelone.com> on Oct 17, 2022 12:31 -0800
+--->
+
+Kubernetes:
+* Add ``securityContext.allowPrivilegeEscalation: false`` annotation to the Scalyr Agent DaemonSet container specification.
+
 ## 2.1.37 "Penvolea" - October 17, 2022
 <!---
 Packaged by Joseph Makar <joseph.makar@sentinelone.com> on Oct 17, 2022 12:31 -0800

--- a/k8s/default-namespace/scalyr-agent-2.yaml
+++ b/k8s/default-namespace/scalyr-agent-2.yaml
@@ -53,6 +53,8 @@ spec:
         image: scalyr/scalyr-k8s-agent:2.1.37
         imagePullPolicy: Always
         name: scalyr-agent
+        securityContext:
+          allowPrivilegeEscalation: false
         resources:
           limits:
             memory: 500Mi
@@ -84,7 +86,6 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
       serviceAccount: scalyr-service-account
       serviceAccountName: scalyr-service-account
       terminationGracePeriodSeconds: 30

--- a/k8s/no-kustomize/scalyr-agent-2.yaml
+++ b/k8s/no-kustomize/scalyr-agent-2.yaml
@@ -53,6 +53,8 @@ spec:
         image: scalyr/scalyr-k8s-agent:2.1.37
         imagePullPolicy: Always
         name: scalyr-agent
+        securityContext:
+          allowPrivilegeEscalation: false
         resources:
           limits:
             memory: 500Mi
@@ -84,7 +86,6 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
       serviceAccount: scalyr-service-account
       serviceAccountName: scalyr-service-account
       terminationGracePeriodSeconds: 30

--- a/k8s/scalyr-agent-2-envfrom.yaml
+++ b/k8s/scalyr-agent-2-envfrom.yaml
@@ -52,6 +52,8 @@ spec:
         image: scalyr/scalyr-k8s-agent:2.1.37
         imagePullPolicy: Always
         name: scalyr-agent
+        securityContext:
+          allowPrivilegeEscalation: false
         resources:
           limits:
             memory: 500Mi
@@ -74,7 +76,6 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
       serviceAccount: scalyr-service-account
       serviceAccountName: scalyr-service-account
       terminationGracePeriodSeconds: 30

--- a/k8s/scalyr-agent-2.yaml
+++ b/k8s/scalyr-agent-2.yaml
@@ -52,6 +52,8 @@ spec:
         image: scalyr/scalyr-k8s-agent:2.1.37
         imagePullPolicy: Always
         name: scalyr-agent
+        securityContext:
+          allowPrivilegeEscalation: false
         resources:
           limits:
             memory: 500Mi
@@ -83,7 +85,6 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
       serviceAccount: scalyr-service-account
       serviceAccountName: scalyr-service-account
       terminationGracePeriodSeconds: 30

--- a/tests/e2e/scalyr-agent-2-daemonset.yaml
+++ b/tests/e2e/scalyr-agent-2-daemonset.yaml
@@ -53,6 +53,8 @@ spec:
         image: scalyr-k8s-agent:local_k8s_image
         imagePullPolicy: Never
         name: scalyr-agent
+        securityContext:
+          allowPrivilegeEscalation: false
         resources:
           limits:
             memory: 500Mi
@@ -84,7 +86,6 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
       serviceAccount: scalyr-service-account
       serviceAccountName: scalyr-service-account
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
This pull request adds ``securityContext.allowPrivelegeEscalation: false`` annotation to the agent container in the Kubernetes DaemonSet definition file to see if it works (best practice, least privilege mantra - albeit this is a bit moot here since agent is considered as a privileged process).

I don't think it would work with regular installation (iirc, tcollectors rely on setuid, but those don't run in k8s images), but we will see if tests pass or not.