### PR TITLE
Also run some micro + process level benchmarks under Python 3.11

### DIFF
--- a/.github/workflows/codespeed-microbenchmarks.yml
+++ b/.github/workflows/codespeed-microbenchmarks.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - release
+      - py311_benchmarks
   schedule:
     - cron: '0 4 * * *'
 
@@ -65,7 +66,7 @@ jobs:
         run: tox -e micro-benchmarks
 
       - name: Process and submit results to CodeSpeed
-        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master')
+        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master' || github.head_ref == 'py311_benchmarks' || github.ref == 'refs/heads/py311_benchmarks')
         env:
           PYTHONPATH: .
           CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"

--- a/.github/workflows/codespeed-microbenchmarks.yml
+++ b/.github/workflows/codespeed-microbenchmarks.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - release
-      - py311_benchmarks
   schedule:
     - cron: '0 4 * * *'
 
@@ -66,7 +65,7 @@ jobs:
         run: tox -e micro-benchmarks
 
       - name: Process and submit results to CodeSpeed
-        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master' || github.head_ref == 'py311_benchmarks' || github.ref == 'refs/heads/py311_benchmarks')
+        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master')
         env:
           PYTHONPATH: .
           CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"

--- a/.github/workflows/codespeed-microbenchmarks.yml
+++ b/.github/workflows/codespeed-microbenchmarks.yml
@@ -1,4 +1,4 @@
-name: Codespeed Benchmarks
+name: Codespeed Micro Benchmarks
 
 on:
   push:

--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - release
+      - py311_benchmarks
   schedule:
     - cron: '0 4 * * *'
 
@@ -36,6 +37,7 @@ jobs:
         python-version:
           - "2.7.17"
           - "3.5.9"
+          - "3.11.0"
 
     steps:
       - name: Checkout Repository
@@ -55,7 +57,7 @@ jobs:
           TOX_GH_ACTIONS_VERSION: 2.9.1
         run: |
           python -m pip install --upgrade pip
-          pip install "tox==$TOX_VERSION" "tox-gh-actions==$TOX_GH_ACTIONS_VERSION" "cffi==1.12.3" "udatetime==0.0.16" "requests"
+          pip install "tox==$TOX_VERSION" "tox-gh-actions==$TOX_GH_ACTIONS_VERSION" "cffi==1.15.1" "udatetime==0.0.17" "requests"
           # Needed for snappy library
           sudo apt-get update
           sudo apt-get install -y libsnappy-dev
@@ -64,7 +66,7 @@ jobs:
         run: tox -e micro-benchmarks
 
       - name: Process and submit results to CodeSpeed
-        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master')
+        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master' || github.head_ref == 'py311_benchmarks' || github.ref == 'refs/heads/py311_benchmarks')
         env:
           PYTHONPATH: .
           CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"
@@ -119,6 +121,19 @@ jobs:
       codespeed_executable: "Python 3.5.9 - idle conf 1"
       agent_config: "benchmarks/configs/agent_no_monitored_logs.json"
       agent_server_host: "ci-codespeed-benchmarks-py35-idle-conf-1"
+      capture_line_counts: true
+
+  benchmarks-idle-agent-py-311:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    secrets: inherit
+    with:
+      job_name: benchmarks-idle-agent-py-311
+      python-version: 3.11.0
+      codespeed_executable: "Python 3.11.0 - idle conf 1"
+      agent_config: "benchmarks/configs/agent_no_monitored_logs.json"
+      agent_server_host: "ci-codespeed-benchmarks-py311-idle-conf-1"
       capture_line_counts: true
 
   benchmarks-idle-agent-no-monitors-py-27:
@@ -213,6 +228,22 @@ jobs:
       agent_server_host: "ci-codespeed-benchmarks-py35-loaded-conf-2"
       capture_line_counts: true
 
+  benchmarks-loaded-agent-single-growing-log-file-20mb-py-311:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    secrets: inherit
+    with:
+      job_name: benchmarks-loaded-agent-single-growing-log-file-20mb-py-311
+      python-version: 3.11.0
+      codespeed_executable: "Python 3.11.0 - loaded conf 2"
+      agent_config: "benchmarks/configs/agent_single_growing_log_file_with_shell_and_url_monitor.json"
+      run_time: 140
+      agent_pre_run_command: "touch /tmp/random.log"
+      agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 2M 10 100 1"
+      agent_server_host: "ci-codespeed-benchmarks-py311-loaded-conf-2"
+      capture_line_counts: true
+
   benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
@@ -278,6 +309,22 @@ jobs:
       agent_config: "benchmarks/configs/agent_single_50mb_genlog_500k_line_file.json"
       agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/scalyr_genlog_500k_line_50_mb.log"
       agent_server_host: "ci-codespeed-benchmarks-py35-loaded-conf-5"
+      run_time: 140
+      capture_agent_status_metrics: true
+      capture_line_counts: true
+
+  benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-311:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
+    secrets: inherit
+    with:
+      job_name: benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35
+      python-version: 3.11.0
+      codespeed_executable: "Python 3.11.0 - loaded conf 5"
+      agent_config: "benchmarks/configs/agent_single_50mb_genlog_500k_line_file.json"
+      agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/scalyr_genlog_500k_line_50_mb.log"
+      agent_server_host: "ci-codespeed-benchmarks-py311-loaded-conf-5"
       run_time: 140
       capture_agent_status_metrics: true
       capture_line_counts: true

--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - release
-      - py311_benchmarks
   schedule:
     - cron: '0 4 * * *'
 
@@ -66,7 +65,7 @@ jobs:
         run: tox -e micro-benchmarks
 
       - name: Process and submit results to CodeSpeed
-        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master' || github.head_ref == 'py311_benchmarks' || github.ref == 'refs/heads/py311_benchmarks')
+        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master')
         env:
           PYTHONPATH: .
           CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"

--- a/agent_build/requirement-files/compression-requirements.txt
+++ b/agent_build/requirement-files/compression-requirements.txt
@@ -1,7 +1,8 @@
 # Compression libraries
 # NOTE: zstandard don't include pre-built wheels for ARMv7 for glibc and
 # musl.
-zstandard==0.18.0; python_version >= '3.6' and 'armv7' not in platform_machine
+zstandard==0.19.0; python_version >= '3.7' and 'armv7' not in platform_machine
+zstandard==0.18.0; python_version == '3.6' and 'armv7' not in platform_machine
 zstandard==0.15.2; python_version >= '3.5' and python_version < '3.6' and 'armv7' not in platform_machine
 zstandard==0.14.1; python_version < '3.5' and 'armv7' not in platform_machine
 

--- a/agent_build/requirement-files/docker-image-requirements.txt
+++ b/agent_build/requirement-files/docker-image-requirements.txt
@@ -9,7 +9,7 @@ udatetime==0.0.17; platform_system != 'Windows'
 # default. We include it in the Docker image to make  troubleshooting (profiling) easier for the
 # end user (no need to rebuild Docker image - user can simply enable the corresponding agent config
 # option)
-yappi==1.3.6; python_version >= '3.7'
+yappi==1.3.6; python_version >= '3.7' and python_version < '3.11'
 pympler==1.0.1; python_version >= '3.7'
 # used by Python 2.7 tests
 pympler==0.8; python_version < '3.7'

--- a/agent_build/requirement-files/testing-requirements.txt
+++ b/agent_build/requirement-files/testing-requirements.txt
@@ -14,8 +14,10 @@ requests_mock==1.9.3
 # transitive dependency of pytest-benchmark, pinned since pytest-benchmark
 # doesn't pin it and new version drops support for Python 3
 # NOTE: For snyk false positive, see https://github.com/scalyr/scalyr-agent-2/pull/791#issuecomment-981771502
-pygal==2.4.0
-pytest-benchmark==3.2.3
+pygal==2.4.0; python_version == '2.7'
+pygal==3.0.0; python_version > '2.7'
+pytest-benchmark==3.2.3; python_version < '3.11'
+pytest-benchmark==4.0.0; python_version == '3.11'
 pytest-xdist==1.31.0
 coverage==4.5.4
 codecov==2.1.9

--- a/benchmarks/micro/test_compression_algorithms.py
+++ b/benchmarks/micro/test_compression_algorithms.py
@@ -25,6 +25,8 @@ This way we get accurate CPU utilization information.
 from __future__ import absolute_import
 from __future__ import print_function
 
+import sys
+
 import pytest
 
 from scalyr_agent.util import get_compress_and_decompress_func
@@ -32,6 +34,76 @@ from scalyr_agent.util import get_compress_and_decompress_func
 
 from .utils import read_bytes_from_log_fixture_file
 from .time_utils import process_time
+
+if sys.version_info < (3, 11, 0):
+    compression_algorithm_tuples = [
+        ("deflate", 3),
+        ("deflate", 6),
+        ("deflate", 9),
+        ("bz2", 9),
+        ("snappy", None),
+        ("zstandard", 3),
+        ("zstandard", 5),
+        ("zstandard", 10),
+        ("zstandard", 12),
+        ("brotli", 3),
+        ("brotli", 5),
+        ("brotli", 8),
+        ("lz4", 0),
+        ("lz4", 3),
+        ("lz4", 16),
+    ]
+    compression_algorithm_tuple_ids = [
+        "deflate_level_3",
+        "deflate_level_6_default",
+        "deflate_level_9",
+        "bz2_level_6_default",
+        "snappy",
+        "zstandard_level_3_default",
+        "zstandard_level_5",
+        "zstandard_level_10",
+        "zstandard_level_12",
+        "brotli_quality_3",
+        "brotli_quality_5",
+        "brotli_quality_8",
+        "lz4_level_0_default",
+        "lz4_level_3",
+        "lz4_level_16",
+    ]
+else:
+    # NOTE: snappy library (c extension) doesn't work under Python 3.11 yet
+    compression_algorithm_tuples = [
+        ("deflate", 3),
+        ("deflate", 6),
+        ("deflate", 9),
+        ("bz2", 9),
+        ("zstandard", 3),
+        ("zstandard", 5),
+        ("zstandard", 10),
+        ("zstandard", 12),
+        ("brotli", 3),
+        ("brotli", 5),
+        ("brotli", 8),
+        ("lz4", 0),
+        ("lz4", 3),
+        ("lz4", 16),
+    ]
+    compression_algorithm_tuple_ids = [
+        "deflate_level_3",
+        "deflate_level_6_default",
+        "deflate_level_9",
+        "bz2_level_6_default",
+        "zstandard_level_3_default",
+        "zstandard_level_5",
+        "zstandard_level_10",
+        "zstandard_level_12",
+        "brotli_quality_3",
+        "brotli_quality_5",
+        "brotli_quality_8",
+        "lz4_level_0_default",
+        "lz4_level_3",
+        "lz4_level_16",
+    ]
 
 
 # fmt: off
@@ -68,40 +140,8 @@ from .time_utils import process_time
 # fmt: on
 @pytest.mark.parametrize(
     "compression_algorithm_tuple",
-    [
-        ("deflate", 3),
-        ("deflate", 6),
-        ("deflate", 9),
-        ("bz2", 9),
-        ("snappy", None),
-        ("zstandard", 3),
-        ("zstandard", 5),
-        ("zstandard", 10),
-        ("zstandard", 12),
-        ("brotli", 3),
-        ("brotli", 5),
-        ("brotli", 8),
-        ("lz4", 0),
-        ("lz4", 3),
-        ("lz4", 16),
-    ],
-    ids=[
-        "deflate_level_3",
-        "deflate_level_6_default",
-        "deflate_level_9",
-        "bz2_level_6_default",
-        "snappy",
-        "zstandard_level_3_default",
-        "zstandard_level_5",
-        "zstandard_level_10",
-        "zstandard_level_12",
-        "brotli_quality_3",
-        "brotli_quality_5",
-        "brotli_quality_8",
-        "lz4_level_0_default",
-        "lz4_level_3",
-        "lz4_level_16",
-    ],
+    compression_algorithm_tuples,
+    ids=compression_algorithm_tuple_ids
 )
 @pytest.mark.benchmark(group="compress", timer=process_time)
 def test_compress_bytes(benchmark, compression_algorithm_tuple, log_tuple):
@@ -140,40 +180,8 @@ def test_compress_bytes(benchmark, compression_algorithm_tuple, log_tuple):
     ],
 )
 @pytest.mark.parametrize("compression_algorithm_tuple",
-    [
-        ("deflate", 3),
-        ("deflate", 6),
-        ("deflate", 9),
-        ("bz2", 9),
-        ("snappy", None),
-        ("zstandard", 3),
-        ("zstandard", 5),
-        ("zstandard", 10),
-        ("zstandard", 12),
-        ("brotli", 3),
-        ("brotli", 5),
-        ("brotli", 8),
-        ("lz4", 0),
-        ("lz4", 3),
-        ("lz4", 16),
-    ],
-    ids=[
-        "deflate_level_3",
-        "deflate_level_6_default",
-        "deflate_level_9",
-        "bz2_level_6_default",
-        "snappy",
-        "zstandard_level_3_default",
-        "zstandard_level_5",
-        "zstandard_level_10",
-        "zstandard_level_12",
-        "brotli_quality_3",
-        "brotli_quality_5",
-        "brotli_quality_8",
-        "lz4_level_0_default",
-        "lz4_level_3",
-        "lz4_level_16",
-    ],
+    compression_algorithm_tuples,
+    ids=compression_algorithm_tuple_ids
 )
 # fmt: on
 @pytest.mark.benchmark(group="decompress", timer=process_time)

--- a/benchmarks/scripts/requirements.txt
+++ b/benchmarks/scripts/requirements.txt
@@ -1,4 +1,6 @@
-requests==2.25.1
+requests==2.28.1; python_version >= '3.7'
+# used by Python 2.7 tests
+requests==2.25.1; python_version < '3.7'
 # TODO: Add back latest version when we switch to Python 3 only and update benchmarks/scripts/send_usage_data_to_codespeed.py file
 #numpy
 psutil==5.7.0

--- a/tox.ini
+++ b/tox.ini
@@ -366,8 +366,8 @@ deps =
     -r benchmarks/micro/requirements-compression-algorithms.txt
     # need < 9.0.0 for python 2.7
     py-cpuinfo==8.0.0
-    pytest-benchmark[histogram]==3.2.3; python_version < '3.1'
-    pytest-benchmark[histogram]==4.0.0; python_version == '3.1'
+    pytest-benchmark[histogram]==3.2.3; python_version < '3.11'
+    pytest-benchmark[histogram]==4.0.0; python_version == '3.11'
     # Depends on libsnappy-dev / snappy-devel
     # NOTE: We don't include this dependency in requirements.txt to avoid having
     # developer to install it for lint tox target

--- a/tox.ini
+++ b/tox.ini
@@ -364,11 +364,14 @@ deps =
     -r dev-requirements.txt
     -r benchmarks/scripts/requirements.txt
     -r benchmarks/micro/requirements-compression-algorithms.txt
-    pytest-benchmark[histogram]
+    # need < 9.0.0 for python 2.7
+    py-cpuinfo==8.0.0
+    pytest-benchmark[histogram]==3.2.3; python_version < '3.1'
+    pytest-benchmark[histogram]==4.0.0; python_version == '3.1'
     # Depends on libsnappy-dev / snappy-devel
     # NOTE: We don't include this dependency in requirements.txt to avoid having
     # developer to install it for lint tox target
-    python-snappy==0.5.4
+    python-snappy==0.5.4; python_version < '3.11'
 commands =
     bash -c "rm -rf benchmark_results/*"
     bash -c "rm -rf benchmark_histograms/*"
@@ -386,11 +389,11 @@ deps =
     -r dev-requirements.txt
     -r benchmarks/scripts/requirements.txt
     -r benchmarks/micro/requirements-compression-algorithms.txt
-    pytest-benchmark[histogram]
+    pytest-benchmark[histogram]==4.0.0
     # Depends on libsnappy-dev / snappy-devel
     # NOTE: We don't include this dependency in requirements.txt to avoid having
     # developer to install it for lint tox target
-    python-snappy==0.5.4
+    python-snappy==0.5.4; python_version < '3.11'
     prettytable
 commands =
     bash -c "rm -rf benchmark_results/*"


### PR DESCRIPTION
This pull request updates micro + process level benchmarks to also run under new Python 3.11 to see how it impacts those benchmarks.