### PR TITLE
DSET-840: Adjust memory_stats.usage for consistency with other tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ Packaged by Joseph Makar <joseph.makar@sentinelone.com> on Oct 17, 2022 12:31 -0
 Kubernetes:
 * Add ``securityContext.allowPrivilegeEscalation: false`` annotation to the Scalyr Agent DaemonSet container specification.
 * Fix bug that caused logging of the Kubernetes cache stats to agent status. 
+* More accurate docker.mem.usage metric (no longer includes filesystem cache).
 
 Other
 * Added support for ``--debug`` flag to the scalyr-agent-2 status command. When this flag is used, agent prints additional debug related information with the status output. NOTE: Right now it's only supported with the healthcheck option (``--health_check``, ``-H``).
+
 ## 2.1.37 "Penvolea" - October 17, 2022
 <!---
 Packaged by Joseph Makar <joseph.makar@sentinelone.com> on Oct 17, 2022 12:31 -0800

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,13 @@ incompatible changes have been made in that release.
 For a list of all the changes in a particular release, please refer to the changelog file -
 https://github.com/scalyr/scalyr-agent-2/blob/master/CHANGELOG.md.
 
+## 2.1.38 "TBD" - TBD
+
+* This release updates the Kubernetes monitor to more accurately calculate used memory.
+
+  Formerly `docker.mem.usage` was equal to `memory_stats.usage` now it it equal to `memory_stats.usage` minus
+  `memory_stats.stats.cache` which represents file system cache usage.
+
 ## 2.1.21 "Ultramarine" - Jun 1, 2021
 
 * This is the last release that still supports Python 2.6. This version of the agent will emit a

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -3858,6 +3858,12 @@ cluster.
                 container, self.__mem_stat_metrics, metrics["stats"], k8s_extra
             )
 
+        # This adjustment is for consistency with the Kubelet api metrics / metrics-server, docker stats, etc
+        # used_memory = memory_stats.usage - memory_stats.stats.cache
+        # Ref: https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerExport
+        if "usage" in metrics and "cache" in metrics.get("stats", {}):
+            metrics["usage"] -= metrics["stats"]["cache"]
+
         self.__log_metrics(container, self.__mem_metrics, metrics, k8s_extra)
 
     def __log_cpu_stats_metrics(self, container, metrics, k8s_extra):


### PR DESCRIPTION
From DSET-840:

The memory usage metric retrieved from the Docker api has the filesystem cache included, this change removes the cache value (if present) for consistency with the Kubelet api (kubectl top) / metrics-server, docker stats, etc

Ref: https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerStats

```
import docker
client = docker.APIClient(base_url='unix://var/run/docker.sock', version='auto')
client.stats(container='<container-id>', stream=False)['memory_stats']
```