### PR TITLE
Disable Python 2 micro benchmark.

### DIFF
--- a/.github/workflows/codespeed.yml
+++ b/.github/workflows/codespeed.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "2.7.17"
+          #- "2.7.17"
           - "3.5.9"
 
     steps:


### PR DESCRIPTION
Disable python 2 benchmark since it has dependency issues. 