### PR TITLE
[WIP] Upgrade agent docker image to use Python 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ Packaged by Joseph Makar <joseph.makar@sentinelone.com> on Oct 17, 2022 12:31 -0
 
 Kubernetes:
 * Add ``securityContext.allowPrivilegeEscalation: false`` annotation to the Scalyr Agent DaemonSet container specification.
-* Fix bug that caused logging of the Kubernetes cache stats to agent status. 
+* Fix bug that caused logging of the Kubernetes cache stats to agent status.
 * More accurate docker.mem.usage metric (no longer includes filesystem cache).
+
+Docker Images:
+* Upgrade Linux Docker images to use Python 3.11.0.
 
 Other
 * Added support for ``--debug`` flag to the scalyr-agent-2 status command. When this flag is used, agent prints additional debug related information with the status output. NOTE: Right now it's only supported with the healthcheck option (``--health_check``, ``-H``).

--- a/agent_build/docker/Dockerfile
+++ b/agent_build/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN tar -xf /tmp/build/scalyr-agent.tar.gz
 WORKDIR /
 
 # Copy result files to a new base stage.
-FROM python:3.8.13-$BASE_IMAGE_SUFFIX as scalyr-base
+FROM python:3.11.0-$BASE_IMAGE_SUFFIX as scalyr-base
 MAINTAINER Scalyr Inc <support@scalyr.com>
 # Copy Agent's Python dependencies. Those dependencies were built in the base image,
 # which is given by 'BASE_IMAGE' arg.

--- a/agent_build/docker/Dockerfile.base
+++ b/agent_build/docker/Dockerfile.base
@@ -7,7 +7,7 @@
 ARG BASE_IMAGE_SUFFIX
 
 # Install dependency packages for debian.
-FROM python:3.8.14-slim as scalyr-dependencies-slim
+FROM python:3.11.0-slim as scalyr-dependencies-slim
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 # Workaround for weird build failure on Circle CI, see
@@ -20,7 +20,7 @@ RUN ln -s /bin/tar /usr/sbin/tar
 RUN apt-get update && apt-get install -y build-essential git tar curl
 
 # Install dependency packages for alpine.
-FROM python:3.8.14-alpine as scalyr-dependencies-alpine
+FROM python:3.11.0-alpine as scalyr-dependencies-alpine
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 RUN apk update && apk add --virtual build-dependencies \
@@ -60,7 +60,7 @@ RUN sed -i '/^lz4/d' agent_build/requirement-files/compression-requirements.txt
 # If we don't that and we include orjson and zstandard, we need rust chain and building the image
 # will be very slow due to cross compilation in emulated environment (QEMU)
 # TODO: Remove once orjson and zstandard musl wheel is available - https://github.com/pypa/auditwheel/issues/305#issuecomment-922251777
-RUN echo 'manylinux2014_compatible = True' > /usr/local/lib/python3.8/_manylinux.py
+RUN echo 'manylinux2014_compatible = True' > /usr/local/lib/python3.11/_manylinux.py
 
 # Install agent dependencies.
 RUN pip3 install --upgrade pip
@@ -70,18 +70,18 @@ RUN pip3 --no-cache-dir install --root /tmp/dependencies -r agent_build/requirem
 RUN if [ -n "${COVERAGE_VERSION}" ]; then pip3 install --root /tmp/dependencies coverage=="${COVERAGE_VERSION}"; fi
 
 # Clean up files which were installed to use manylinux2014 workaround
-RUN rm /usr/local/lib/python3.8/_manylinux.py
+RUN rm /usr/local/lib/python3.11/_manylinux.py
 
 # Install packages and tools that will be required during the final image build.
 
 # Install tools for alpine
-FROM python:3.8.14-alpine as ready-base-alpine
+FROM python:3.11.0-alpine as ready-base-alpine
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 RUN apk update && apk add --virtual curl git
 
 # Install tools for debian.
-FROM python:3.8.14-slim as ready-base-slim
+FROM python:3.11.0-slim as ready-base-slim
 MAINTAINER Scalyr Inc <support@scalyr.com>
 
 # Workaround for weird build failure on Circle CI, see

--- a/agent_build/requirement-files/main-requirements.txt
+++ b/agent_build/requirement-files/main-requirements.txt
@@ -2,7 +2,7 @@
 # orjson is not available for armv7 + musl yet, but it's available for armv7 +
 # libc. we handle that in dockerfile since python environment markers are not
 # specific enough.
-orjson==3.8.0; python_version >= '3.7' and platform_system != 'Darwin'
+orjson==3.8.2; python_version >= '3.7' and platform_system != 'Darwin'
 orjson==3.6.1; python_version == '3.6' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 orjson==2.0.11; python_version == '3.5' and 'armv7' not in platform_machine and platform_system != 'Darwin'
 

--- a/agent_build_refactored/docker_image_builders.py
+++ b/agent_build_refactored/docker_image_builders.py
@@ -60,7 +60,7 @@ from agent_build_refactored.tools.runner import (
 log = logging.getLogger(__name__)
 
 # Python version that is used in docker images.
-IMAGES_PYTHON_VERSION = "3.8.13"
+IMAGES_PYTHON_VERSION = "3.11.0"
 
 _AGENT_REQUIREMENT_FILES_PATH = AGENT_BUILD_PATH / "requirement-files"
 _TEST_REQUIREMENTS_FILE_PATH = (

--- a/agent_build_refactored/scripts/get_github_actions_job_matrices.py
+++ b/agent_build_refactored/scripts/get_github_actions_job_matrices.py
@@ -228,7 +228,7 @@ def main():
                 "name": f"Pre-build: {pre_built_step_runner.REQUIRED_STEPS[0].name}",
                 "step-runner-fqdn": pre_built_step_runner.get_fully_qualified_name(),
                 "os": "ubuntu-20.04",
-                "python-version": "3.8.13",
+                "python-version": "3.11.0",
             }
         )
 


### PR DESCRIPTION
Small change to the agent docker images to utilize Python 3.11 (which should bring nice CPU utilization improvements).