### PR TITLE
DSET-1106: PR 1024 feedback

### DIFF
--- a/docs/monitors/windows_event_log_monitor.md
+++ b/docs/monitors/windows_event_log_monitor.md
@@ -146,20 +146,24 @@ Log into DataSet and query [monitor = 'windows_process_metrics'](https://app.sca
 <a name="options"></a>
 ## Configuration Options
 
-| Property                     | Description | 
-| ---                          | --- | 
-| `module`                     | Always `scalyr_agent.builtin_monitors.windows_event_log_monitor` | 
-| `sources`                    | Optional (defaults to `Application, Security, System`). A comma separated list of sources to import events from. (Not valid for Vista and later; use `channels` instead.) | 
-| `event_types`                | Optional (defaults to `All`). A comma separated list of event types to import. Valid values are: `All`, `Error`, `Warning`, `Information`, `AuditSuccess`, and `AuditFailure`. (Not valid for Vista and later; use `channels` instead.) | 
-| `channels`                   | Optional (defaults to `[{"channel" : ["Application", "Security", "System"], "query": "*"}]`). A list of dict objects specifying a list of channels, and an XPath query for those channels. (Only available on Windows Vista and later.) | 
-| `maximum_records_per_source` | Optional (defaults to `10000`). Maximum number of records to read from the end of each log source per gather_sample. | 
-| `error_repeat_interval`      | Optional (defaults to `300`). Number of seconds to wait before logging similar errors in the event log. | 
-| `server_name`                | Optional (defaults to `localhost`). The remote server to import events from. | 
-| `remote_user`                | Optional (defaults to `none`). Username for authentication on the remote server. This option is only valid on Windows Vista and above. | 
-| `remote_password`            | Optional (defaults to `none`). Password to use for authentication on the remote server.  This option is only valid on Windows Vista and above. | 
-| `remote_domain`              | Optional (defaults to `none`). The domain for the remote user account. This option is only valid on Windows Vista and above. | 
-| `json`                       | Optional (defaults to `false`). Format events as json? Supports inclusion of all event fields. This option is only valid on Windows Vista and above. | 
-| `placeholder_render`         | Optional (defaults to `false`). Render %%n placeholders in event data?  This option is only valid on Windows Vista and above. | 
+| Property                       | Description | 
+| ---                            | --- | 
+| `module`                       | Always `scalyr_agent.builtin_monitors.windows_event_log_monitor` | 
+| `sources`                      | Optional (defaults to `Application, Security, System`). A comma separated list of sources to import events from. (Not valid for Vista and later; use `channels` instead.) | 
+| `event_types`                  | Optional (defaults to `All`). A comma separated list of event types to import. Valid values are: `All`, `Error`, `Warning`, `Information`, `AuditSuccess`, and `AuditFailure`. (Not valid for Vista and later; use `channels` instead.) | 
+| `channels`                     | Optional (defaults to `[{"channel" : ["Application", "Security", "System"], "query": "*"}]`). A list of dict objects specifying a list of channels, and an XPath query for those channels. (Only available on Windows Vista and later.) | 
+| `maximum_records_per_source`   | Optional (defaults to `10000`). Maximum number of records to read from the end of each log source per gather_sample. | 
+| `error_repeat_interval`        | Optional (defaults to `300`). Number of seconds to wait before logging similar errors in the event log. | 
+| `server_name`                  | Optional (defaults to `localhost`). The remote server to import events from. | 
+| `remote_user`                  | Optional (defaults to `none`). Username for authentication on the remote server. This option is only valid on Windows Vista and above. | 
+| `remote_password`              | Optional (defaults to `none`). Password to use for authentication on the remote server.  This option is only valid on Windows Vista and above. | 
+| `remote_domain`                | Optional (defaults to `none`). The domain for the remote user account. This option is only valid on Windows Vista and above. | 
+| `json`                         | Optional (defaults to `false`). Format events as json? Supports inclusion of all event fields. This option is only valid on Windows Vista and above. | 
+| `placeholder_render`           | Optional (defaults to `false`). Render %%n placeholders in event data? This option is only valid on Windows Vista and above. | 
+| `dll_handle_cache_size`        | Optional (defaults to `10`). DLL handle cache size, applicable only if `placeholder_render` is set. This option is only valid on Windows Vista and above. | 
+| `placeholder_param_cache_size` | Optional (defaults to `1000`). Placeholder parameter cache size, applicable only if `placeholder_render` is set. This option is only valid on Windows Vista and above. | 
+| `dll_handle_cache_ttl`         | Optional (defaults to `86400` ie 24 hours). DLL handle cache TTL, applicable only if `placeholder_render` is set. This option is only valid on Windows Vista and above. | 
+| `placeholder_param_cache_ttl`  | Optional (defaults to `86400` ie 24 hours). Placeholder parameter cache TLL, applicable only if `placeholder_render` is set. This option is only valid on Windows Vista and above. | 
 
 <a name="events"></a>
 ## Event Reference

--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -830,10 +830,10 @@ class NewJsonApi(NewApi):
             if time.time() > self._next_cache_report:
                 self._next_cache_report = time.time() + self._cache_report_interval
                 self._logger.info(
-                    "placeholder param cache size = %d" % (len(self._param_cache),)
+                    "placeholder param cache size = %d" % len(self._param_cache)
                 )
                 self._logger.info(
-                    "dll handle cache size = %d" % (len(self._dll_cache),)
+                    "dll handle cache size = %d" % len(self._dll_cache)
                 )
 
         # Populate the record here with fields that would normally be added by the log formatter,

--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -832,9 +832,7 @@ class NewJsonApi(NewApi):
                 self._logger.info(
                     "placeholder param cache size = %d" % len(self._param_cache)
                 )
-                self._logger.info(
-                    "dll handle cache size = %d" % len(self._dll_cache)
-                )
+                self._logger.info("dll handle cache size = %d" % len(self._dll_cache))
 
         # Populate the record here with fields that would normally be added by the log formatter,
         # this avoids having to unmarshal and remarshal later in the log formatter.

--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -829,8 +829,12 @@ class NewJsonApi(NewApi):
             event_json = self._replace_param_placeholders(event_json)
             if time.time() > self._next_cache_report:
                 self._next_cache_report = time.time() + self._cache_report_interval
-                self._logger.info("placeholder param cache size = %d" % (len(self._param_cache),))
-                self._logger.info("dll handle cache size = %d" % (len(self._dll_cache),))
+                self._logger.info(
+                    "placeholder param cache size = %d" % (len(self._param_cache),)
+                )
+                self._logger.info(
+                    "dll handle cache size = %d" % (len(self._dll_cache),)
+                )
 
         # Populate the record here with fields that would normally be added by the log formatter,
         # this avoids having to unmarshal and remarshal later in the log formatter.
@@ -1028,9 +1032,9 @@ class _DLL:
 
 
 class Cache(collections.OrderedDict):
-    '''
+    """
     Fixed-size cache with entry TTL
-    '''
+    """
 
     def __init__(self, size, ttl):
         super().__init__()

--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -892,6 +892,11 @@ class NewJsonApi(NewApi):
                     self._dll_cache[dll_key] = _DLL(channel, provider)
                 except Exception as e:
                     self._dll_cache[dll_key] = e
+                    self._logger.error(
+                        "win32api.LoadLibraryEx exception: %s" % six.text_type(e),
+                        limit_once_per_x_secs=self._error_repeat_interval,
+                        limit_key="win32api.LoadLibraryEx",
+                    )
                     return param
 
         try:
@@ -1018,11 +1023,6 @@ class _DLL:
             )
         except Exception as e:
             self.handle = None
-            self._logger.error(
-                "win32api.LoadLibraryEx exception: %s" % six.text_type(e),
-                limit_once_per_x_secs=self._error_repeat_interval,
-                limit_key="win32api.LoadLibraryEx",
-            )
             raise e
 
     def __del__(self):

--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -156,10 +156,46 @@ define_config_option(
 define_config_option(
     __monitor__,
     "placeholder_render",
-    "Optional (defaults to `false`). Render %%n placeholders in event data?  "
-    "This option is only valid on Windows Vista and above.",
+    "Optional (defaults to `false`). Render %%n placeholders in event data? This option is only "
+    "valid on Windows Vista and above.",
     default=False,
     convert_to=bool,
+)
+
+define_config_option(
+    __monitor__,
+    "dll_handle_cache_size",
+    "Optional (defaults to `10`). DLL handle cache size, applicable only if `placeholder_render` "
+    "is set. This option is only valid on Windows Vista and above.",
+    default=10,
+    convert_to=int,
+)
+
+define_config_option(
+    __monitor__,
+    "placeholder_param_cache_size",
+    "Optional (defaults to `1000`). Placeholder parameter cache size, applicable only if "
+    "`placeholder_render` is set. This option is only valid on Windows Vista and above.",
+    default=1000,
+    convert_to=int,
+)
+
+define_config_option(
+    __monitor__,
+    "dll_handle_cache_ttl",
+    "Optional (defaults to `86400` ie 24 hours). DLL handle cache TTL, applicable only if "
+    "`placeholder_render` is set. This option is only valid on Windows Vista and above.",
+    default=86400,
+    convert_to=int,
+)
+
+define_config_option(
+    __monitor__,
+    "placeholder_param_cache_ttl",
+    "Optional (defaults to `86400` ie 24 hours). Placeholder parameter cache TLL, applicable only "
+    "if `placeholder_render` is set. This option is only valid on Windows Vista and above.",
+    default=86400,
+    convert_to=int,
 )
 
 define_log_field(__monitor__, "monitor", "Always ``windows_event_log_monitor``.")
@@ -738,8 +774,18 @@ class NewJsonApi(NewApi):
 
         self._placeholder_render = config.get("placeholder_render")
         if self._placeholder_render:
-            self._dll_cache = Cache(size=10)
-            self._param_cache = Cache(size=1000)
+            self._dll_cache = Cache(
+                size=config.get("dll_handle_cache_size"),
+                ttl=config.get("dll_handle_cache_ttl"),
+            )
+            self._param_cache = Cache(
+                size=config.get("placeholder_param_cache_size"),
+                ttl=config.get("placeholder_param_cache_ttl"),
+            )
+
+            self._cache_report_interval = 3600 * 12
+            self._next_cache_report = time.time() + self._cache_report_interval
+
             self._langid = win32api.MAKELANGID(
                 win32con.LANG_NEUTRAL, win32con.SUBLANG_NEUTRAL
             )
@@ -781,6 +827,10 @@ class NewJsonApi(NewApi):
         #      FormatMessage of https://github.com/mhammond/pywin32/blob/main/win32/Lib/win32evtlogutil.py
         if self._placeholder_render:
             event_json = self._replace_param_placeholders(event_json)
+            if time.time() > self._next_cache_report:
+                self._next_cache_report = time.time() + self._cache_report_interval
+                self._logger.info("placeholder param cache size = %d" % (len(self._param_cache),))
+                self._logger.info("dll handle cache size = %d" % (len(self._dll_cache),))
 
         # Populate the record here with fields that would normally be added by the log formatter,
         # this avoids having to unmarshal and remarshal later in the log formatter.
@@ -849,8 +899,13 @@ class NewJsonApi(NewApi):
                 None,
             )
             self._param_cache[param_key] = value.strip()
-        except:
+        except Exception as e:
             self._param_cache[param_key] = param
+            self._logger.error(
+                "win32api.FormatMessageW exception: %s" % six.text_type(e),
+                limit_once_per_x_secs=self._error_repeat_interval,
+                limit_key="win32api.FormatMessageW",
+            )
 
         return self._param_cache[param_key]
 
@@ -959,22 +1014,83 @@ class _DLL:
             )
         except Exception as e:
             self.handle = None
+            self._logger.error(
+                "win32api.LoadLibraryEx exception: %s" % six.text_type(e),
+                limit_once_per_x_secs=self._error_repeat_interval,
+                limit_key="win32api.LoadLibraryEx",
+            )
             raise e
 
     def __del__(self):
         if self.handle:
             win32api.FreeLibrary(self.handle)
+            self.handle = None
 
 
 class Cache(collections.OrderedDict):
-    def __init__(self, size):
+    '''
+    Fixed-size cache with entry TTL
+    '''
+
+    def __init__(self, size, ttl):
         super().__init__()
         self.__size = size
+        self.__ttl = ttl
 
     def __setitem__(self, key, val):
         while len(self) >= self.__size:
             self.popitem(last=False)
-        super().__setitem__(key, val)
+        super().__setitem__(key, (val, time.time()))
+
+    def __getitem__(self, key):
+        # Intentionally not evicting entries due to ttl here.
+        # Expecting checks via __contains__ followed immediately by __getitem__
+        val, _ = super().__getitem__(key)
+        return val
+
+    def __contains__(self, key):
+        try:
+            _, added = super().__getitem__(key)
+        except KeyError:
+            return False
+
+        if time.time() > added + self.__ttl:
+            del self[key]
+            return False
+        return True
+
+    def __iter__(self):
+        active = []
+        expired = []
+        for key in super().__iter__():
+            _, added = super().__getitem__(key)
+
+            if time.time() > added + self.__ttl:
+                expired += [key]
+            else:
+                active += [key]
+
+        for key in expired:
+            del self[key]
+        return iter(active)
+
+    def values(self):
+        active_vals = []
+        expired_keys = []
+        for key in super().__iter__():
+            val, added = super().__getitem__(key)
+
+            if time.time() > added + self.__ttl:
+                expired_keys += [key]
+            else:
+                active_vals += [val]
+
+        for key in expired_keys:
+            del self[key]
+        return iter(active_vals)
+
+    def __len__(self):
+        return len(list(iter(self)))
 
 
 class WindowEventLogMonitor(ScalyrMonitor):

--- a/tests/unit/cache_test.py
+++ b/tests/unit/cache_test.py
@@ -41,37 +41,37 @@ class CacheTest(BaseScalyrLogCaptureTestCase):
         self.assertTrue("a" not in cache)
 
     def test_ttl_via_contains(self):
-        cache = Cache(1000, 1)
+        cache = Cache(1000, 0.001)
 
         cache["a"] = 1
         self.assertTrue("a" in cache)
 
-        time.sleep(1)
+        time.sleep(0.001)
         self.assertTrue("a" not in cache)
 
     def test_ttl_via_iter(self):
-        cache = Cache(1000, 1)
+        cache = Cache(1000, 0.001)
 
         cache["a"] = 1
         self.assertTrue("a" in cache)
 
-        time.sleep(1)
+        time.sleep(0.001)
         self.assertTrue(len([k for k in cache]) == 0)
 
     def test_ttl_via_values(self):
-        cache = Cache(1000, 1)
+        cache = Cache(1000, 0.001)
 
         cache["a"] = 1
         self.assertTrue("a" in cache)
 
-        time.sleep(1)
+        time.sleep(0.001)
         self.assertTrue(len([v for v in cache.values()]) == 0)
 
     def test_ttl_via_len(self):
-        cache = Cache(1000, 1)
+        cache = Cache(1000, 0.001)
 
         cache["a"] = 1
         self.assertTrue("a" in cache)
 
-        time.sleep(1)
+        time.sleep(0.001)
         self.assertTrue(len(cache) == 0)

--- a/tests/unit/cache_test.py
+++ b/tests/unit/cache_test.py
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from scalyr_agent.builtin_monitors.windows_event_log_monitor import Cache
-from scalyr_agent.test_base import BaseScalyrLogCaptureTestCase
+try:
+    from scalyr_agent.builtin_monitors.windows_event_log_monitor import Cache
+except:
+    Cache = None
 
+from scalyr_agent.test_base import BaseScalyrLogCaptureTestCase, skipIf
+
+import sys
 import time
 
 
+@skipIf(sys.version_info < (3, 0, 0), "Skipping under Python 2")
 class CacheTest(BaseScalyrLogCaptureTestCase):
     def test_fixed_size(self):
         cache = Cache(3, 3600)

--- a/tests/unit/cache_test.py
+++ b/tests/unit/cache_test.py
@@ -1,0 +1,70 @@
+# Copyright 2022 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from scalyr_agent.builtin_monitors.windows_event_log_monitor import Cache
+from scalyr_agent.test_base import BaseScalyrLogCaptureTestCase
+
+import time
+
+class CacheTest(BaseScalyrLogCaptureTestCase):
+    def test_fixed_size(self):
+        cache = Cache(3, 3600)
+
+        cache['a'] = 1
+        cache['b'] = 2
+        cache['c'] = 3
+
+        self.assertTrue(len(cache) == 3)
+        self.assertTrue('a' in cache)
+
+        cache['d'] = 4
+
+        self.assertTrue(len(cache) == 3)
+        self.assertTrue('a' not in cache)
+
+    def test_ttl_via_contains(self):
+        cache = Cache(1000, 1)
+
+        cache['a'] = 1
+        self.assertTrue('a' in cache)
+
+        time.sleep(1)
+        self.assertTrue('a' not in cache)
+
+    def test_ttl_via_iter(self):
+        cache = Cache(1000, 1)
+
+        cache['a'] = 1
+        self.assertTrue('a' in cache)
+
+        time.sleep(1)
+        self.assertTrue(len([k for k in cache]) == 0)
+
+    def test_ttl_via_values(self):
+        cache = Cache(1000, 1)
+
+        cache['a'] = 1
+        self.assertTrue('a' in cache)
+
+        time.sleep(1)
+        self.assertTrue(len([v for v in cache.values()]) == 0)
+
+    def test_ttl_via_len(self):
+        cache = Cache(1000, 1)
+
+        cache['a'] = 1
+        self.assertTrue('a' in cache)
+
+        time.sleep(1)
+        self.assertTrue(len(cache) == 0)

--- a/tests/unit/cache_test.py
+++ b/tests/unit/cache_test.py
@@ -17,36 +17,37 @@ from scalyr_agent.test_base import BaseScalyrLogCaptureTestCase
 
 import time
 
+
 class CacheTest(BaseScalyrLogCaptureTestCase):
     def test_fixed_size(self):
         cache = Cache(3, 3600)
 
-        cache['a'] = 1
-        cache['b'] = 2
-        cache['c'] = 3
+        cache["a"] = 1
+        cache["b"] = 2
+        cache["c"] = 3
 
         self.assertTrue(len(cache) == 3)
-        self.assertTrue('a' in cache)
+        self.assertTrue("a" in cache)
 
-        cache['d'] = 4
+        cache["d"] = 4
 
         self.assertTrue(len(cache) == 3)
-        self.assertTrue('a' not in cache)
+        self.assertTrue("a" not in cache)
 
     def test_ttl_via_contains(self):
         cache = Cache(1000, 1)
 
-        cache['a'] = 1
-        self.assertTrue('a' in cache)
+        cache["a"] = 1
+        self.assertTrue("a" in cache)
 
         time.sleep(1)
-        self.assertTrue('a' not in cache)
+        self.assertTrue("a" not in cache)
 
     def test_ttl_via_iter(self):
         cache = Cache(1000, 1)
 
-        cache['a'] = 1
-        self.assertTrue('a' in cache)
+        cache["a"] = 1
+        self.assertTrue("a" in cache)
 
         time.sleep(1)
         self.assertTrue(len([k for k in cache]) == 0)
@@ -54,8 +55,8 @@ class CacheTest(BaseScalyrLogCaptureTestCase):
     def test_ttl_via_values(self):
         cache = Cache(1000, 1)
 
-        cache['a'] = 1
-        self.assertTrue('a' in cache)
+        cache["a"] = 1
+        self.assertTrue("a" in cache)
 
         time.sleep(1)
         self.assertTrue(len([v for v in cache.values()]) == 0)
@@ -63,8 +64,8 @@ class CacheTest(BaseScalyrLogCaptureTestCase):
     def test_ttl_via_len(self):
         cache = Cache(1000, 1)
 
-        cache['a'] = 1
-        self.assertTrue('a' in cache)
+        cache["a"] = 1
+        self.assertTrue("a" in cache)
 
         time.sleep(1)
         self.assertTrue(len(cache) == 0)


### PR DESCRIPTION
- Added debug logs for couple scenarios
- Periodically (every 12 hours) log cache usage stats
- Ensured safe to call `_DLL.__del__` multiple times
- Added support for entry ttl in Cache, added unit test
- Made cache sizes and ttls configurable