### PR TITLE
DSET-1301: windows_event_log_monitor: exclude cached errors when chec…

### DIFF
--- a/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
+++ b/scalyr_agent/builtin_monitors/windows_event_log_monitor.py
@@ -880,6 +880,8 @@ class NewJsonApi(NewApi):
 
             found = False
             for dll in self._dll_cache.values():
+                if not isinstance(dll, _DLL):
+                    continue
                 if dll.path == dllpath:
                     self._dll_cache[dll_key] = dll
                     found = True


### PR DESCRIPTION
…king dll cache

Context: Exceptions/errors are cached when attempting to open dlls, when searching the dll handle cache those errors should be excluded
