### PR TITLE
Update setup minikube GHA action to latest version

### DIFF
--- a/.github/actions/setup-minikube-cluster/action.yml
+++ b/.github/actions/setup-minikube-cluster/action.yml
@@ -30,7 +30,7 @@ runs:
     - name: Create minikube Kubernetes ${{ inputs.k8s_version }} Cluster
       id: create-minikube-cluster
       if: ${{ inputs.k8s_version != '' && inputs.k8s_version != 'v1.24.0' }}
-      uses: manusa/actions-setup-minikube@f6ceea1a32df47f602b1345bd8ad7da7c5824cbf # v2.4.3
+      uses: manusa/actions-setup-minikube@aa7a69c8cdc3e095a90e146e8f96cdaf950e2e7e # v2.7.2
       with:
         minikube version: '${{ inputs.minikube_version }}'
         kubernetes version: '${{ inputs.k8s_version }}'
@@ -41,7 +41,7 @@ runs:
     - name: Create minikube Kubernetes ${{ inputs.k8s_version }} Cluster
       id: create-minikube-cluster-124
       if: ${{ inputs.k8s_version != '' && inputs.k8s_version == 'v1.24.0' }}
-      uses: manusa/actions-setup-minikube@f6ceea1a32df47f602b1345bd8ad7da7c5824cbf # v2.4.3
+      uses: manusa/actions-setup-minikube@aa7a69c8cdc3e095a90e146e8f96cdaf950e2e7e # v2.7.2
       with:
         minikube version: '${{ inputs.minikube_version }}'
         kubernetes version: '${{ inputs.k8s_version }}'


### PR DESCRIPTION
This pull request updates ``manusa/actions-setup-minikube`` action to the latest version which supports Ubuntu 22.04.

Builds in other repos which utilize Ubuntu 22.04 runner started failing and hopefully this change will fix it.