### PR TITLE
Also upgrade setuptools in the Alpine Docker image, pin setuptools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ Scalyr Agent 2 Changes By Release
 Packaged by Arthur Kamalov <arthurk@sentinelone.com> on Dec 15, 2022 00:00 -0800
 --->
 
-Docker Images:
-* Docker images now are built against Python:3.8.16 image.
+Docker Images / Kubernetes:
+* Docker images now are built against Python:3.8.16 image. Debian and Alpine based Docker images
+  have also been updated to include all the latest security updates for the system packages.
 
 ## 2.1.39 "Hroderich" - December 15, 2022
 <!---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ Packaged by Arthur Kamalov <arthurk@sentinelone.com> on Dec 15, 2022 00:00 -0800
 --->
 
 Docker Images / Kubernetes:
-* Docker images now are built against Python:3.8.16 image. Debian and Alpine based Docker images
-  have also been updated to include all the latest security updates for the system packages.
+* Docker images now are built against Python:3.8.16 image. Debian and Alpine based Docker images have also been updated to include all the latest security updates for the system packages.
 
 ## 2.1.39 "Hroderich" - December 15, 2022
 <!---

--- a/agent_build/docker/Dockerfile.base
+++ b/agent_build/docker/Dockerfile.base
@@ -71,6 +71,9 @@ RUN echo 'manylinux2014_compatible = True' > /usr/local/lib/python3.8/_manylinux
 RUN pip3 install --upgrade pip
 RUN pip3 --no-cache-dir install --root /tmp/dependencies -r agent_build/requirement-files/docker-image-requirements.txt
 
+# We upgrade current packages in order to keep everything up to date, including security updates.
+RUN python3 -m pip install --upgrade setuptools
+
 # Install coverage if its version if specified. Only used in testing.
 RUN if [ -n "${COVERAGE_VERSION}" ]; then pip3 install --root /tmp/dependencies coverage=="${COVERAGE_VERSION}"; fi
 

--- a/agent_build/docker/Dockerfile.base
+++ b/agent_build/docker/Dockerfile.base
@@ -72,7 +72,7 @@ RUN pip3 install --upgrade pip
 RUN pip3 --no-cache-dir install --root /tmp/dependencies -r agent_build/requirement-files/docker-image-requirements.txt
 
 # We upgrade current packages in order to keep everything up to date, including security updates.
-RUN python3 -m pip install --upgrade setuptools
+RUN python3 -m pip install --upgrade setuptools==66.0.0
 
 # Install coverage if its version if specified. Only used in testing.
 RUN if [ -n "${COVERAGE_VERSION}" ]; then pip3 install --root /tmp/dependencies coverage=="${COVERAGE_VERSION}"; fi
@@ -103,7 +103,7 @@ RUN apt-get update && apt-get install -y git tar curl
 
 # We upgrade current packages in order to keep everything up to date, including security updates.
 RUN apt-get update ; apt-get dist-upgrade -y
-RUN python3 -m pip install --upgrade setuptools
+RUN python3 -m pip install --upgrade setuptools==66.0.0
 RUN apt-get clean
 
 # Create a final base stage from one of the prefious OS-specific stages.

--- a/agent_build_refactored/tools/run_in_ec2/boto3_tools.py
+++ b/agent_build_refactored/tools/run_in_ec2/boto3_tools.py
@@ -341,7 +341,7 @@ def ssh_run_command(
 
     logger.info(f"STDERR: {sterr.read().decode()}")
 
-    exit_status = stdout.channel.exit_status
+    exit_status = stdout.channel.recv_exit_status()
     if exit_status != 0:
         raise Exception(
             f"SSH command '{command_str}' returned {exit_status}."


### PR DESCRIPTION
Small change on top of #1066 so we also upgrade ``setuptools`` in Alpine based Docker images to avoid setuptools related security alert.

In addition to that, I also pinned setuptools to a fixed version (latest stable) to ensure build is more reproducible.