### PR TITLE
[DSET-1379] [DSET-1600] Add initial baseline microbenchmarks for syslog parsing code

### DIFF
--- a/.github/workflows/codespeed-agent-benchmarks.yaml
+++ b/.github/workflows/codespeed-agent-benchmarks.yaml
@@ -91,7 +91,7 @@ jobs:
         env:
           TZ: UTC
         run: |
-          echo "commit-date=$(git show --quiet --date='format-local:%Y-%m-%d %H:%M:%S' --format='%cd; ${{ github.sha }})" >> $GITHUB_OUTPUT
+          echo "commit-date=$(git show --quiet --date='format-local:%Y-%m-%d %H:%M:%S' --format='%cd' ${{ github.sha }})" >> $GITHUB_OUTPUT
 
       - name: Pre-Run Command
         if: inputs.agent_pre_run_command != ''

--- a/.github/workflows/codespeed-agent-benchmarks.yaml
+++ b/.github/workflows/codespeed-agent-benchmarks.yaml
@@ -70,7 +70,7 @@ on:
 jobs:
   codespeed-agent-benchmark:
     name: ${{ inputs.job_name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/codespeed-agent-benchmarks.yaml
+++ b/.github/workflows/codespeed-agent-benchmarks.yaml
@@ -90,7 +90,8 @@ jobs:
         id: commit-date
         env:
           TZ: UTC
-        run: echo ::set-output name=commit-date::$(git show --quiet --date='format-local:%Y-%m-%d %H:%M:%S' --format="%cd" ${{ github.sha }} )
+        run: |
+          echo "commit-date=$(git show --quiet --date='format-local:%Y-%m-%d %H:%M:%S' --format='%cd; ${{ github.sha }})" >> $GITHUB_OUTPUT
 
       - name: Pre-Run Command
         if: inputs.agent_pre_run_command != ''
@@ -123,7 +124,8 @@ jobs:
           mkdir -p ~/scalyr-agent-dev/{log,config,data}
           # Run the agent process and capture the metrics
           ./benchmarks/scripts/start-agent-and-capture-metrics.sh "${{ github.sha }}" &
-          echo ::set-output name=bg-pid::$!
+          bg_pid=$!
+          echo "bg-pid=${bg_pid}" >> $GITHUB_OUTPUT
 
       - name: Run any post agent run script
         if: inputs.agent_post_run_command != ''

--- a/.github/workflows/codespeed-microbenchmarks.yml
+++ b/.github/workflows/codespeed-microbenchmarks.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - release
+      - syslog_microbenchmark
   schedule:
     - cron: '0 4 * * *'
 
@@ -65,7 +66,7 @@ jobs:
         run: tox -e micro-benchmarks
 
       - name: Process and submit results to CodeSpeed
-        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master')
+        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master' || github.ref == 'syslog_microbenchmark' || github.ref == 'refs/heads/syslog_microbenchmark')
         env:
           PYTHONPATH: .
           CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"

--- a/.github/workflows/codespeed-microbenchmarks.yml
+++ b/.github/workflows/codespeed-microbenchmarks.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - release
-      - syslog_microbenchmark
   schedule:
     - cron: '0 4 * * *'
 
@@ -66,7 +65,7 @@ jobs:
         run: tox -e micro-benchmarks
 
       - name: Process and submit results to CodeSpeed
-        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master' || github.ref == 'syslog_microbenchmark' || github.ref == 'refs/heads/syslog_microbenchmark')
+        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master')
         env:
           PYTHONPATH: .
           CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"

--- a/.github/workflows/codespeed-microbenchmarks.yml
+++ b/.github/workflows/codespeed-microbenchmarks.yml
@@ -66,7 +66,7 @@ jobs:
         run: tox -e micro-benchmarks
 
       - name: Process and submit results to CodeSpeed
-        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master')
+        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master' || github.ref == 'syslog_microbenchmark' || github.ref == 'refs/heads/syslog_microbenchmark')
         env:
           PYTHONPATH: .
           CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"

--- a/.github/workflows/codespeed-microbenchmarks.yml
+++ b/.github/workflows/codespeed-microbenchmarks.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - release
+      - syslog_microbenchmark
   schedule:
     - cron: '0 4 * * *'
 
@@ -27,7 +28,7 @@ jobs:
           github_token: ${{ github.token }}
 
   codespeed-micro-benchmarks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     strategy:

--- a/.github/workflows/codespeed-microbenchmarks.yml
+++ b/.github/workflows/codespeed-microbenchmarks.yml
@@ -28,15 +28,13 @@ jobs:
           github_token: ${{ github.token }}
 
   codespeed-micro-benchmarks:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     strategy:
       fail-fast: false
       matrix:
         python-version:
-          - "2.7.17"
-          - "3.5.9"
           - "3.11.0"
 
     steps:
@@ -99,32 +97,6 @@ jobs:
           steps: ${{ toJson(steps) }}
           channel: '#eng-dataset-cloud-tech'
 
-  benchmarks-idle-agent-py-27:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
-    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
-    secrets: inherit
-    with:
-      job_name: benchmarks-idle-agent-py-27
-      python-version: 2.7.17
-      codespeed_executable: "Python 2.7.17 - idle conf 1"
-      agent_config: "benchmarks/configs/agent_no_monitored_logs.json"
-      agent_server_host: "ci-codespeed-benchmarks-py27-idle-conf-1"
-      capture_line_counts: true
-
-  benchmarks-idle-agent-py-35:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
-    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
-    secrets: inherit
-    with:
-      job_name: benchmarks-idle-agent-py-35
-      python-version: 3.5.9
-      codespeed_executable: "Python 3.5.9 - idle conf 1"
-      agent_config: "benchmarks/configs/agent_no_monitored_logs.json"
-      agent_server_host: "ci-codespeed-benchmarks-py35-idle-conf-1"
-      capture_line_counts: true
-
   benchmarks-idle-agent-py-311:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
@@ -138,98 +110,37 @@ jobs:
       agent_server_host: "ci-codespeed-benchmarks-py311-idle-conf-1"
       capture_line_counts: true
 
-  benchmarks-idle-agent-no-monitors-py-27:
+  benchmarks-idle-agent-no-monitors-py-311:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
-      job_name: benchmarks-idle-agent-no-monitors-py-27
-      python-version: 2.7.17
-      codespeed_executable: "Python 2.7.17 - idle conf 2"
+      job_name: benchmarks-idle-agent-no-monitors-py-311
+      python-version: 3.11.0
+      codespeed_executable: "Python 3.11.0 - idle conf 2"
       agent_config: "benchmarks/configs/agent_no_monitored_logs_no_monitors.json"
-      agent_server_host: "ci-codespeed-benchmarks-py27-idle-conf-2"
+      agent_server_host: "ci-codespeed-benchmarks-py311-idle-conf-2"
       capture_line_counts: true
 
-  benchmarks-idle-agent-no-monitors-py-35:
+  benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-311:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
-      job_name: benchmarks-idle-agent-no-monitors-py-35
-      python-version: 3.5.9
-      codespeed_executable: "Python 3.5.9 - idle conf 2"
-      agent_config: "benchmarks/configs/agent_no_monitored_logs_no_monitors.json"
-      agent_server_host: "ci-codespeed-benchmarks-py35-idle-conf-2"
-      capture_line_counts: true
-
-  benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
-    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
-    secrets: inherit
-    with:
-      job_name: benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-27
-      python-version: 2.7.17
-      codespeed_executable: "Python 2.7.17 - loaded conf 1"
+      job_name: benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-311
+      python-version: 3.11.0
+      codespeed_executable: "Python 3.11.0 - loaded conf 1"
       agent_config: "benchmarks/configs/agent_single_50mb_access_log_file.json"
       agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/access_log_50_mb.log"
-      agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-1"
-      run_time: 140
-      capture_agent_status_metrics: true
-      capture_line_counts: true
-
-  benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
-    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
-    secrets: inherit
-    with:
-      job_name: benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-35
-      python-version: 3.5.9
-      codespeed_executable: "Python 3.5.9 - loaded conf 1"
-      agent_config: "benchmarks/configs/agent_single_50mb_access_log_file.json"
-      agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/access_log_50_mb.log"
-      agent_server_host: "ci-codespeed-benchmarks-py35-loaded-conf-1"
+      agent_server_host: "ci-codespeed-benchmarks-py311-loaded-conf-1"
       run_time: 140
       capture_line_counts: true
 
   # NOTE: For the benchmarks below to work correctly "/tmp/random.log" file
   # which is being written to during the benchmark must existing before the
   # agent process is started.
-  benchmarks-loaded-agent-single-growing-log-file-20mb-py-27:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
-    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
-    secrets: inherit
-    with:
-      job_name: benchmarks-loaded-agent-single-growing-log-file-20mb-py-27
-      python-version: 2.7.17
-      codespeed_executable: "Python 2.7.17 - loaded conf 2"
-      agent_config: "benchmarks/configs/agent_single_growing_log_file_with_shell_and_url_monitor.json"
-      run_time: 140
-      agent_pre_run_command: "touch /tmp/random.log"
-      agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 2M 10 100 1"
-      agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-2"
-      capture_line_counts: true
-
-  benchmarks-loaded-agent-single-growing-log-file-20mb-py-35:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
-    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
-    secrets: inherit
-    with:
-      job_name: benchmarks-loaded-agent-single-growing-log-file-20mb-py-35
-      python-version: 3.5.9
-      codespeed_executable: "Python 3.5.9 - loaded conf 2"
-      agent_config: "benchmarks/configs/agent_single_growing_log_file_with_shell_and_url_monitor.json"
-      run_time: 140
-      agent_pre_run_command: "touch /tmp/random.log"
-      agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 2M 10 100 1"
-      agent_server_host: "ci-codespeed-benchmarks-py35-loaded-conf-2"
-      capture_line_counts: true
-
   benchmarks-loaded-agent-single-growing-log-file-20mb-py-311:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
@@ -246,73 +157,20 @@ jobs:
       agent_server_host: "ci-codespeed-benchmarks-py311-loaded-conf-2"
       capture_line_counts: true
 
-  benchmarks-loaded-agent-single-growing-log-file-180mb-py-27:
+  benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-311:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
-      job_name: benchmarks-loaded-agent-single-growing-log-file-180mb-py-27
-      python-version: 2.7.17
-      codespeed_executable: "Python 2.7.17 - loaded conf 3"
-      agent_config: "benchmarks/configs/agent_single_growing_log_file.json"
-      # NOTE: We set agent run time slightly longer than the insert script time run so we give a chance for memory and
-      # other metrics to stabilize.
-      run_time: 390
-      agent_pre_run_command: "touch /tmp/random.log"
-      # NOTE: We write a chunk every 1 seconds for a total of 6 minutes.
-      # Each chunk is 0.5 MB in size which means we write a total of 360 * 1
-      # / 0.5 MB of data
-      agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 500K 360 100 1 &> /tmp/write_lines_script.log &"
-      agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-3"
-      capture_line_counts: true
-
-  benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
-    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
-    secrets: inherit
-    with:
-      job_name: benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-35
-      python-version: 3.5.9
-      codespeed_executable: "Python 3.5.9 - loaded conf 4"
+      job_name: benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-31
+      python-version: 3.11.0
+      codespeed_executable: "Python 3.11.0 - loaded conf 4"
       agent_config: "benchmarks/configs/agent_2-growing_logs-monitors-multiprocess-2-worker.json"
       run_time: 140
       agent_pre_run_command: "touch /tmp/random.log & touch /tmp/random2.log"
       agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 2M 10 100 1 & benchmarks/scripts/write-random-lines.sh /tmp/random2.log 2M 10 100 1 &"
-      agent_server_host: "ci-codespeed-benchmarks-py35-loaded-conf-4"
-      capture_line_counts: true
-
-  benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
-    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
-    secrets: inherit
-    with:
-      job_name: benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-27
-      python-version: 2.7.17
-      codespeed_executable: "Python 2.7.17 - loaded conf 5"
-      agent_config: "benchmarks/configs/agent_single_50mb_genlog_500k_line_file.json"
-      agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/scalyr_genlog_500k_line_50_mb.log"
-      agent_server_host: "ci-codespeed-benchmarks-py27-loaded-conf-5"
-      run_time: 140
-      capture_agent_status_metrics: true
-      capture_line_counts: true
-
-  benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
-    uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
-    secrets: inherit
-    with:
-      job_name: benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35
-      python-version: 3.5.9
-      codespeed_executable: "Python 3.5.9 - loaded conf 5"
-      agent_config: "benchmarks/configs/agent_single_50mb_genlog_500k_line_file.json"
-      agent_pre_run_command: "wget --directory-prefix=/tmp https://github.com/scalyr/codespeed-agent-fixtures/raw/master/fixtures/logs/scalyr_genlog_500k_line_50_mb.log"
-      agent_server_host: "ci-codespeed-benchmarks-py35-loaded-conf-5"
-      run_time: 140
-      capture_agent_status_metrics: true
+      agent_server_host: "ci-codespeed-benchmarks-py311-loaded-conf-4"
       capture_line_counts: true
 
   benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-311:
@@ -321,7 +179,7 @@ jobs:
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
-      job_name: benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-35
+      job_name: benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-311
       python-version: 3.11.0
       codespeed_executable: "Python 3.11.0 - loaded conf 5"
       agent_config: "benchmarks/configs/agent_single_50mb_genlog_500k_line_file.json"

--- a/.github/workflows/codespeed-microbenchmarks.yml
+++ b/.github/workflows/codespeed-microbenchmarks.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - release
-      - syslog_microbenchmark
   schedule:
     - cron: '0 4 * * *'
 
@@ -64,7 +63,7 @@ jobs:
         run: tox -e micro-benchmarks
 
       - name: Process and submit results to CodeSpeed
-        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master' || github.ref == 'syslog_microbenchmark' || github.ref == 'refs/heads/syslog_microbenchmark')
+        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master')
         env:
           PYTHONPATH: .
           CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -30,9 +30,9 @@ jobs:
         id: get_events_to_not_skip
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo '::set-output name=events_to_not_skip::["workflow_dispatch", "schedule", "pull_request"]'
+            echo 'events_to_not_skip=["workflow_dispatch", "schedule", "pull_request"]' >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=events_to_not_skip::["workflow_dispatch", "schedule"]'
+            echo 'events_to_not_skip=["workflow_dispatch", "schedule"]' >> $GITHUB_OUTPUT
           fi
 
       - id: skip_check

--- a/benchmarks/micro/test_syslog_parsing.py
+++ b/benchmarks/micro/test_syslog_parsing.py
@@ -15,6 +15,11 @@
 """
 Benchmarks which measure how long it takes to parse syslog data in the syslog monitor with
 extended parsing (message templates) enabled.
+
+TODO: Also exercise the following scenarios / code paths:
+
+* Different syslog messages
+* Log watcher management, file creation, expiration, locking
 """
 
 import os
@@ -26,7 +31,6 @@ from faker import Faker
 
 from scalyr_agent.builtin_monitors.syslog_monitor import SyslogHandler
 
-# TODO: Use Fixtures for various different types of syslog messages
 MOCK_MESSAGE =  "<34>Oct 11 22:14:15 mymachine su: \'su root\' failed for lonvick on /dev/pts/8"
 
 # NOTE: We use faker + same static seed to ensure the result is fully repetable / deterministic
@@ -43,9 +47,6 @@ class MockConfig(object):
         except KeyError:
             return None
 
-# TODO: Also exercise the following scenarios
-# * Different syslog messages
-# * Log watcher management, file creation, expiration
 TEMP_DIRECTORY = tempfile.gettempdir()
 
 MOCK_EXTRAS = []
@@ -54,7 +55,7 @@ for i in range(0, 1000):
     extra = {
         "proto": FAKER.random_element(["tcp", "udp"]),
         "srcip": "127.0.0." + str(FAKER.random_int(0, 250)),
-        "destport": str(FAKER.random_int(10000, 50000))
+        "destport": str(FAKER.random_int(10000, 60000))
     }
     MOCK_EXTRAS.append(extra)
 
@@ -110,7 +111,7 @@ def test_handle_syslog_logs(benchmark, message_template):
             extra = FAKER.random_element(MOCK_EXTRAS)
             handler.handle(MOCK_MESSAGE, extra=extra)
 
-        benchmark.pedantic(run_benchmark, iterations=100, rounds=100)
+        benchmark.pedantic(run_benchmark, iterations=200, rounds=100)
 
         # Verify that files which match message template notation have been created
         file_names = os.listdir(tmp_directory)

--- a/benchmarks/micro/test_syslog_parsing.py
+++ b/benchmarks/micro/test_syslog_parsing.py
@@ -1,0 +1,96 @@
+# Copyright 2014-2023 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Benchmarks which measure how long it takes to parse syslog data in the syslog monitor with
+extended parsing (message templates) enabled.
+"""
+
+import mock
+import pytest
+
+from scalyr_agent.builtin_monitors.syslog_monitor import SyslogHandler
+
+# TODO: Use Fixtures for various different types of syslog messages
+MOCK_MESSAGE =  "<34>Oct 11 22:14:15 mymachine su: \'su root\' failed for lonvick on /dev/pts/8"
+
+class MockConfig(object):
+    def __init__(self, values):
+        self._values = values
+
+    def get(self, key):
+        try:
+            return self._values[key]
+        except KeyError:
+            return None
+
+# TODO: Also exercise the following scenarios
+# * Different syslog messages
+# * Log watcher management, file creation, expiration
+
+@pytest.mark.submit_result_to_codespeed
+# fmt: off
+@pytest.mark.parametrize(
+    "message_template",
+    [
+        True,
+        False,
+    ],
+    ids=[
+        "message_template",
+        "no_message_template",
+    ],
+)
+# fmt: on
+@pytest.mark.benchmark(group="syslog_monitor")
+def test_handle_syslog_logs(benchmark, message_template):
+    """
+    Right now this micro benchmarks just measures how much overhead parsing message takes, but it
+    doesn't really measure how much overhead other things such as logging, managing log watchers,
+    etc. add.
+    """
+    extra = {
+        "protoc": "tcp",
+        "srcip": "127.0.0.1",
+        "destport": 6000
+    }
+
+    if message_template:
+        message_log_template = "test-$PROTO-$SRCIP.txt"
+    else:
+        message_log_template = None
+
+    mock_logger = mock.Mock()
+    mock_line_reporter = mock.Mock()
+    mock_config = MockConfig(
+        values={
+            "expire_log": 300,
+            "check_for_unused_logs_mins": 100,
+            "check_for_unused_logs_hours": 10,
+            "delete_unused_logs_hours": 10,
+            "check_rotated_timestamps": False,
+            "max_log_files": 1000,
+            "message_log_template": message_log_template,
+        }
+    )
+
+    handler = SyslogHandler(logger=mock_logger, line_reporter=mock_line_reporter, config=mock_config,
+                            server_host="localhost", log_path="/tmp/", get_log_watcher=mock.Mock(),
+                            rotate_options=(2, 200000), docker_options=mock.Mock())
+    handler._SyslogHandler__get_log_watcher.return_value = mock.Mock(), mock.Mock()
+
+    def run_benchmark():
+        handler.handle(MOCK_MESSAGE, extra=extra)
+
+    benchmark.pedantic(run_benchmark, iterations=100, rounds=100)

--- a/benchmarks/micro/test_syslog_parsing.py
+++ b/benchmarks/micro/test_syslog_parsing.py
@@ -25,7 +25,7 @@ TODO: Also exercise the following scenarios / code paths:
 # Workaround since this file is not Python 2 compatible
 import sys
 
-if sys.version_info < (3, 5, 0):
+if sys.version_info >= (3, 5, 0):
     import os
     import tempfile
 
@@ -126,3 +126,8 @@ if sys.version_info < (3, 5, 0):
                     assert (file_name.startswith("test-tcp-") or file_name.startswith("test-udp-"))
             else:
                 assert len(file_names) == 0
+else:
+    # Needed so pytest doesn't exit with non-zero under Python 2.7. We can get rid of this once we
+    # remove Python 2.7 support.
+    def test_noop():
+        pass

--- a/benchmarks/micro/test_syslog_parsing.py
+++ b/benchmarks/micro/test_syslog_parsing.py
@@ -22,112 +22,103 @@ TODO: Also exercise the following scenarios / code paths:
 * Log watcher management, file creation, expiration, locking
 """
 
-# Workaround since this file is not Python 2 compatible
-import sys
+import os
+import tempfile
 
-if sys.version_info >= (3, 5, 0):
-    import os
-    import tempfile
+import mock
+import pytest
+from faker import Faker
 
-    import mock
-    import pytest
-    from faker import Faker
+from scalyr_agent.builtin_monitors.syslog_monitor import SyslogHandler
 
-    from scalyr_agent.builtin_monitors.syslog_monitor import SyslogHandler
+MOCK_MESSAGE =  "<34>Oct 11 22:14:15 mymachine su: \'su root\' failed for lonvick on /dev/pts/8"
 
-    MOCK_MESSAGE =  "<34>Oct 11 22:14:15 mymachine su: \'su root\' failed for lonvick on /dev/pts/8"
+# NOTE: We use faker + same static seed to ensure the result is fully repetable / deterministic
+FAKER = Faker()
+Faker.seed(1000)
 
-    # NOTE: We use faker + same static seed to ensure the result is fully repetable / deterministic
-    FAKER = Faker()
-    Faker.seed(1000)
+class MockConfig(object):
+    def __init__(self, values):
+        self._values = values
 
-    class MockConfig(object):
-        def __init__(self, values):
-            self._values = values
+    def get(self, key):
+        try:
+            return self._values[key]
+        except KeyError:
+            return None
 
-        def get(self, key):
-            try:
-                return self._values[key]
-            except KeyError:
-                return None
+TEMP_DIRECTORY = tempfile.gettempdir()
 
-    TEMP_DIRECTORY = tempfile.gettempdir()
+MOCK_EXTRAS = []
 
-    MOCK_EXTRAS = []
-
-    for i in range(0, 1000):
-        extra = {
-            "proto": FAKER.random_element(["tcp", "udp"]),
-            "srcip": "127.0.0." + str(FAKER.random_int(0, 250)),
-            "destport": str(FAKER.random_int(10000, 60000))
-        }
-        MOCK_EXTRAS.append(extra)
+for i in range(0, 1000):
+    extra = {
+        "proto": FAKER.random_element(["tcp", "udp"]),
+        "srcip": "127.0.0." + str(FAKER.random_int(0, 250)),
+        "destport": str(FAKER.random_int(10000, 60000))
+    }
+    MOCK_EXTRAS.append(extra)
 
 
-    # fmt: off
-    @pytest.mark.parametrize(
+# fmt: off
+@pytest.mark.parametrize(
+    "message_template",
+    [
+        True,
+        False,
+    ],
+    ids=[
         "message_template",
-        [
-            True,
-            False,
-        ],
-        ids=[
-            "message_template",
-            "no_message_template",
-        ],
+        "no_message_template",
+    ],
+)
+# fmt: on
+@pytest.mark.benchmark(group="syslog_monitor")
+def test_handle_syslog_logs(benchmark, message_template):
+    """
+    Right now this micro benchmarks just measures how much overhead parsing message takes, but it
+    doesn't really measure how much overhead other things such as logging, managing log watchers,
+    etc. add.
+    """
+    if message_template:
+        message_log_template = "test-$PROTO-$SRCIP.txt"
+    else:
+        message_log_template = None
+
+    mock_logger = mock.Mock()
+    mock_line_reporter = mock.Mock()
+    mock_config = MockConfig(
+        values={
+            "expire_log": 300,
+            "check_for_unused_logs_mins": 100,
+            "check_for_unused_logs_hours": 10,
+            "delete_unused_logs_hours": 10,
+            "check_rotated_timestamps": False,
+            "max_log_files": 1000,
+            "message_log_template": message_log_template,
+        }
     )
-    # fmt: on
-    @pytest.mark.benchmark(group="syslog_monitor")
-    def test_handle_syslog_logs(benchmark, message_template):
-        """
-        Right now this micro benchmarks just measures how much overhead parsing message takes, but it
-        doesn't really measure how much overhead other things such as logging, managing log watchers,
-        etc. add.
-        """
+
+    with tempfile.TemporaryDirectory() as tmp_directory:
+        handler = SyslogHandler(logger=mock_logger, line_reporter=mock_line_reporter, config=mock_config,
+                                server_host="localhost", log_path=tmp_directory, get_log_watcher=mock.Mock(),
+                                rotate_options=(2, 200000), docker_options=mock.Mock())
+        handler._SyslogHandler__get_log_watcher.return_value = mock.Mock(), mock.Mock()
+
+        assert len(os.listdir(tmp_directory)) == 0
+
+        def run_benchmark():
+            extra = FAKER.random_element(MOCK_EXTRAS)
+            handler.handle(MOCK_MESSAGE, extra=extra)
+
+        benchmark.pedantic(run_benchmark, iterations=200, rounds=100)
+
+        # Verify that files which match message template notation have been created
+        file_names = os.listdir(tmp_directory)
+
         if message_template:
-            message_log_template = "test-$PROTO-$SRCIP.txt"
+            assert len(file_names) >= 100
+            for file_name in file_names:
+                assert (file_name.startswith("test-tcp-") or file_name.startswith("test-udp-"))
         else:
-            message_log_template = None
-
-        mock_logger = mock.Mock()
-        mock_line_reporter = mock.Mock()
-        mock_config = MockConfig(
-            values={
-                "expire_log": 300,
-                "check_for_unused_logs_mins": 100,
-                "check_for_unused_logs_hours": 10,
-                "delete_unused_logs_hours": 10,
-                "check_rotated_timestamps": False,
-                "max_log_files": 1000,
-                "message_log_template": message_log_template,
-            }
-        )
-
-        with tempfile.TemporaryDirectory() as tmp_directory:
-            handler = SyslogHandler(logger=mock_logger, line_reporter=mock_line_reporter, config=mock_config,
-                                    server_host="localhost", log_path=tmp_directory, get_log_watcher=mock.Mock(),
-                                    rotate_options=(2, 200000), docker_options=mock.Mock())
-            handler._SyslogHandler__get_log_watcher.return_value = mock.Mock(), mock.Mock()
-
-            assert len(os.listdir(tmp_directory)) == 0
-
-            def run_benchmark():
-                extra = FAKER.random_element(MOCK_EXTRAS)
-                handler.handle(MOCK_MESSAGE, extra=extra)
-
-            benchmark.pedantic(run_benchmark, iterations=200, rounds=100)
-
-            # Verify that files which match message template notation have been created
-            file_names = os.listdir(tmp_directory)
-
-            if message_template:
-                assert len(file_names) >= 100
-                for file_name in file_names:
-                    assert (file_name.startswith("test-tcp-") or file_name.startswith("test-udp-"))
-            else:
-                assert len(file_names) == 0
-else:
-    # Needed so pytest doesn't exit with non-zero under Python 2.7. We can get rid of this once we
-    # remove Python 2.7 support.
-    def test_noop():
-        pass
+            assert len(file_names) == 0

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1671,8 +1671,8 @@ class SyslogHandler(object):
         rv = {"hostname": None, "appname": None}
         try:
             parsed = syslogmp.parse(msg.encode("utf-8"))
-        except:
-            global_log.log(scalyr_logging.DEBUG_LEVEL_4, "Unable to parse: %s" % msg)
+        except Exception as e:
+            global_log.log(scalyr_logging.DEBUG_LEVEL_4, "Unable to parse: %s. Error: %s" % (msg, e))
             return rv
 
         rv["hostname"] = parsed.hostname

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1523,6 +1523,9 @@ class SyslogHandler(object):
                 logger["last_seen"] = current_time
 
             if self.__expire_count >= RUN_EXPIRE_COUNT:
+                # TODO (Tomaz): We run this function on every single log line so running this check
+                # every 100 iterations / log lines seems excesive. We should likely do it less
+                # often.
                 self.__expire_count = 0
 
                 # find out which if any of the loggers in __docker_loggers have
@@ -1622,6 +1625,9 @@ class SyslogHandler(object):
                 logger["last_seen"] = time.time()
 
             if self.__expire_count >= RUN_EXPIRE_COUNT:
+                # TODO (Tomaz): We run this function on every single log line so running this check
+                # every 100 iterations / log lines seems excesive. We should likely do it less
+                # often.
                 self.__expire_count = 0
 
                 now = time.time()

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -430,7 +430,6 @@ define_config_option(
     default=True,
 )
 
-
 # NOTE: On Windows on newer Python 3 versions, BlockingIOError is thrown instead of
 # socket.error with EAGAIN when there is no data to be read yet on non blocking socket. And this
 # error is not instanceof socket.error!
@@ -1672,7 +1671,12 @@ class SyslogHandler(object):
         try:
             parsed = syslogmp.parse(msg.encode("utf-8"))
         except Exception as e:
-            global_log.log(scalyr_logging.DEBUG_LEVEL_4, "Unable to parse: %s. Error: %s" % (msg, e))
+            # TODO: We should probably also track this as a counter + periodically log a warning in
+            # case we see more errors of a specific type or similar
+            global_log.log(
+                scalyr_logging.DEBUG_LEVEL_4,
+                "Unable to parse: %s. Error: %s" % (msg, e),
+            )
             return rv
 
         rv["hostname"] = parsed.hostname

--- a/tests/end_to_end_tests/run_in_remote_machine/__init__.py
+++ b/tests/end_to_end_tests/run_in_remote_machine/__init__.py
@@ -35,7 +35,7 @@ DISTROS: Dict[str, Dict[str, Dict[Architecture, EC2DistroImage]]] = {
                 image_id="ami-09d56f8956ab235b3",
                 image_name="Ubuntu Server 22.04 (HVM), SSD Volume Type",
                 short_name="ubuntu2204",
-                size_id="m1.small",
+                size_id="t2.small",
                 ssh_username="ubuntu",
             )
         },
@@ -47,7 +47,7 @@ DISTROS: Dict[str, Dict[str, Dict[Architecture, EC2DistroImage]]] = {
                 image_id="ami-0149b2da6ceec4bb0",
                 image_name="Ubuntu Server 20.04 LTS (HVM), SSD Volume Type",
                 short_name="ubuntu2004",
-                size_id="m1.small",
+                size_id="t2.small",
                 ssh_username="ubuntu",
             )
         },
@@ -59,7 +59,7 @@ DISTROS: Dict[str, Dict[str, Dict[Architecture, EC2DistroImage]]] = {
                 image_id="ami-07ebfd5b3428b6f4d",
                 image_name="Ubuntu Server 18.04 LTS (HVM), SSD Volume Type",
                 short_name="ubuntu1804",
-                size_id="m1.small",
+                size_id="t2.small",
                 ssh_username="ubuntu",
             )
         },
@@ -71,7 +71,7 @@ DISTROS: Dict[str, Dict[str, Dict[Architecture, EC2DistroImage]]] = {
                 image_id="ami-08bc77a2c7eb2b1da",
                 image_name="Ubuntu Server 16.04 LTS (HVM), SSD Volume Type",
                 short_name="ubuntu1604",
-                size_id="m1.small",
+                size_id="t2.small",
                 ssh_username="ubuntu",
             )
         },

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ setenv =
   PYTHONPATH={toxinidir}
   PY_COLORS=1
   PYTEST_COMMON_OPTS=-vv -s
+  PYTEST_COMMON_OPTS_BENCHMARKS=-vv -s
   PYTEST_COMMON_BENCHMARK_OPTS=--benchmark-only --benchmark-name=short --benchmark-columns=min,max,mean,stddev,median,ops,rounds --benchmark-histogram=benchmark_histograms/benchmark
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps =
@@ -379,13 +380,13 @@ commands =
     bash -c "rm -rf benchmark_results/*"
     bash -c "rm -rf benchmark_histograms/*"
     bash -c "mkdir -p benchmark_results/"
-    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/1.json benchmarks/micro/test_add_events_request_serialization.py
-    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/2.json --benchmark-group-by=group benchmarks/micro/test_event_serialization.py
-    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/3.json --benchmark-group-by=group,param:log_tuple benchmarks/micro/test_json_serialization.py -k "not test_json_encode_with_custom_options"
-    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/4.json --benchmark-group-by=group,param:keys_count benchmarks/micro/test_json_serialization.py -k "test_json_encode_with_custom_options"
-    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/5.json --benchmark-group-by=group,param:log_tuple benchmarks/micro/test_compression_algorithms.py
-    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/6.json --benchmark-group-by=group,param:with_fraction benchmarks/micro/test_date_parsing.py
-    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/7.json --benchmark-group-by=group,param:message_template benchmarks/micro/test_syslog_parsing.py
+    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/1.json benchmarks/micro/test_add_events_request_serialization.py
+    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/2.json --benchmark-group-by=group benchmarks/micro/test_event_serialization.py
+    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/3.json --benchmark-group-by=group,param:log_tuple benchmarks/micro/test_json_serialization.py -k "not test_json_encode_with_custom_options"
+    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/4.json --benchmark-group-by=group,param:keys_count benchmarks/micro/test_json_serialization.py -k "test_json_encode_with_custom_options"
+    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/5.json --benchmark-group-by=group,param:log_tuple benchmarks/micro/test_compression_algorithms.py
+    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/6.json --benchmark-group-by=group,param:with_fraction benchmarks/micro/test_date_parsing.py
+    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/7.json --benchmark-group-by=group,param:message_template benchmarks/micro/test_syslog_parsing.py
 
 [testenv:micro-benchmarks-compression-algorithms]
 basepython = python

--- a/tox.ini
+++ b/tox.ini
@@ -373,8 +373,8 @@ deps =
     # developer to install it for lint tox target
     python-snappy==0.5.4; python_version < '3.11'
     syslogmp==0.3; python_version >= '3.6'
+    faker==4.18.0; python_version > '3.0' and python_version < '3.6'
     faker==14.2.1; python_version >= '3.6'
-    faker==4.18.0; python_version < '3.6'; python_version > '3.0'
 commands =
     bash -c "rm -rf benchmark_results/*"
     bash -c "rm -rf benchmark_histograms/*"

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,6 @@ setenv =
   PYTEST_COMMON_OPTS=-vv -s
   # We make benchmark output less verbose so it's easier to find actual benchmarking data among
   # all the noise
-  PYTEST_COMMON_OPTS_BENCHMARKS=
   PYTEST_COMMON_BENCHMARK_OPTS=--benchmark-only --benchmark-name=short --benchmark-columns=min,max,mean,stddev,median,ops,rounds --benchmark-histogram=benchmark_histograms/benchmark
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps =
@@ -382,13 +381,13 @@ commands =
     bash -c "rm -rf benchmark_results/*"
     bash -c "rm -rf benchmark_histograms/*"
     bash -c "mkdir -p benchmark_results/"
-    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/1.json benchmarks/micro/test_add_events_request_serialization.py
-    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/2.json --benchmark-group-by=group benchmarks/micro/test_event_serialization.py
-    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/3.json --benchmark-group-by=group,param:log_tuple benchmarks/micro/test_json_serialization.py -k "not test_json_encode_with_custom_options"
-    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/4.json --benchmark-group-by=group,param:keys_count benchmarks/micro/test_json_serialization.py -k "test_json_encode_with_custom_options"
-    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/5.json --benchmark-group-by=group,param:log_tuple benchmarks/micro/test_compression_algorithms.py
-    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/6.json --benchmark-group-by=group,param:with_fraction benchmarks/micro/test_date_parsing.py
-    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/7.json --benchmark-group-by=group,param:message_template benchmarks/micro/test_syslog_parsing.py || true
+    py.test {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/1.json benchmarks/micro/test_add_events_request_serialization.py
+    py.test {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/2.json --benchmark-group-by=group benchmarks/micro/test_event_serialization.py
+    py.test {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/3.json --benchmark-group-by=group,param:log_tuple benchmarks/micro/test_json_serialization.py -k "not test_json_encode_with_custom_options"
+    py.test {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/4.json --benchmark-group-by=group,param:keys_count benchmarks/micro/test_json_serialization.py -k "test_json_encode_with_custom_options"
+    py.test {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/5.json --benchmark-group-by=group,param:log_tuple benchmarks/micro/test_compression_algorithms.py
+    py.test {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/6.json --benchmark-group-by=group,param:with_fraction benchmarks/micro/test_date_parsing.py
+    py.test {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/7.json --benchmark-group-by=group,param:message_template benchmarks/micro/test_syslog_parsing.py
 
 [testenv:micro-benchmarks-compression-algorithms]
 basepython = python

--- a/tox.ini
+++ b/tox.ini
@@ -374,6 +374,7 @@ deps =
     # developer to install it for lint tox target
     python-snappy==0.5.4; python_version < '3.11'
     syslogmp==0.3; python_version >= '3.6'
+    faker==3.0.1; python_version <= '2.7'
     faker==4.18.0; python_version > '3.0' and python_version < '3.6'
     faker==14.2.1; python_version >= '3.6'
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -376,7 +376,6 @@ deps =
     # developer to install it for lint tox target
     python-snappy==0.5.4; python_version < '3.11'
     syslogmp==0.3; python_version >= '3.6'
-    faker==3.0.1; python_version <= '2.7'
     faker==4.18.0; python_version > '3.0' and python_version < '3.6'
     faker==14.2.1; python_version >= '3.6'
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -373,6 +373,7 @@ deps =
     # developer to install it for lint tox target
     python-snappy==0.5.4; python_version < '3.11'
     syslogmp==0.3; python_version >= '3.6'
+    faker==14.2.1
 commands =
     bash -c "rm -rf benchmark_results/*"
     bash -c "rm -rf benchmark_histograms/*"

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,9 @@ setenv =
   PYTHONPATH={toxinidir}
   PY_COLORS=1
   PYTEST_COMMON_OPTS=-vv -s
-  PYTEST_COMMON_OPTS_BENCHMARKS=-vv -s
+  # We make benchmark output less verbose so it's easier to find actual benchmarking data among
+  # all the noise
+  PYTEST_COMMON_OPTS_BENCHMARKS=
   PYTEST_COMMON_BENCHMARK_OPTS=--benchmark-only --benchmark-name=short --benchmark-columns=min,max,mean,stddev,median,ops,rounds --benchmark-histogram=benchmark_histograms/benchmark
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -373,7 +373,7 @@ deps =
     # developer to install it for lint tox target
     python-snappy==0.5.4; python_version < '3.11'
     syslogmp==0.3; python_version >= '3.6'
-    faker==14.2.1
+    faker==14.2.1; python_version >= '3.6'
 commands =
     bash -c "rm -rf benchmark_results/*"
     bash -c "rm -rf benchmark_histograms/*"

--- a/tox.ini
+++ b/tox.ini
@@ -372,6 +372,7 @@ deps =
     # NOTE: We don't include this dependency in requirements.txt to avoid having
     # developer to install it for lint tox target
     python-snappy==0.5.4; python_version < '3.11'
+    syslogmp==0.3; python_version >= '3.6'
 commands =
     bash -c "rm -rf benchmark_results/*"
     bash -c "rm -rf benchmark_histograms/*"
@@ -382,6 +383,7 @@ commands =
     py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/4.json --benchmark-group-by=group,param:keys_count benchmarks/micro/test_json_serialization.py -k "test_json_encode_with_custom_options"
     py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/5.json --benchmark-group-by=group,param:log_tuple benchmarks/micro/test_compression_algorithms.py
     py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/6.json --benchmark-group-by=group,param:with_fraction benchmarks/micro/test_date_parsing.py
+    py.test {env:PYTEST_COMMON_OPTS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/7.json --benchmark-group-by=group,param:message_template benchmarks/micro/test_syslog_parsing.py
 
 [testenv:micro-benchmarks-compression-algorithms]
 basepython = python

--- a/tox.ini
+++ b/tox.ini
@@ -374,6 +374,7 @@ deps =
     python-snappy==0.5.4; python_version < '3.11'
     syslogmp==0.3; python_version >= '3.6'
     faker==14.2.1; python_version >= '3.6'
+    faker==4.18.0; python_version < '3.6'; python_version > '3.0'
 commands =
     bash -c "rm -rf benchmark_results/*"
     bash -c "rm -rf benchmark_histograms/*"

--- a/tox.ini
+++ b/tox.ini
@@ -388,7 +388,7 @@ commands =
     py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/4.json --benchmark-group-by=group,param:keys_count benchmarks/micro/test_json_serialization.py -k "test_json_encode_with_custom_options"
     py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/5.json --benchmark-group-by=group,param:log_tuple benchmarks/micro/test_compression_algorithms.py
     py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/6.json --benchmark-group-by=group,param:with_fraction benchmarks/micro/test_date_parsing.py
-    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/7.json --benchmark-group-by=group,param:message_template benchmarks/micro/test_syslog_parsing.py
+    py.test {env:PYTEST_COMMON_OPTS_BENCHMARKS} {env:PYTEST_COMMON_BENCHMARK_OPTS} --benchmark-json=benchmark_results/7.json --benchmark-group-by=group,param:message_template benchmarks/micro/test_syslog_parsing.py || true
 
 [testenv:micro-benchmarks-compression-algorithms]
 basepython = python


### PR DESCRIPTION
This pull request includes initial very basic baseline micro benchmark for the new extended syslog message parsing code which is exercised when message templates functionality is used.

Right now this is just an initial benchmark which measures overhead of message parsing. In the future we should extend it so it also covers / measures the following scenarios:

* Exercise various difference message formats
* Also take into account / measure log watcher management and log file creation (for that we will also need to use dynamic protos, src ips, etc. and parameterize those values)