### PR TITLE
Update scalyr query utility script

### DIFF
--- a/scripts/cicd/scalyr-query.sh
+++ b/scripts/cicd/scalyr-query.sh
@@ -26,7 +26,15 @@ SLEEP_DELAY=${SLEEP_DELAY:-"15"}
 # Script will fail if query doesn't return at least this number of results / lines
 MINIMUM_RESULTS=${MINIMUM_RESULTS:-"1"}
 
-SCALYR_TOOL_QUERY=$1
+if [ $# -eq 1 ]; then
+    # Query passed in as a single string argument
+    echo "Query passed in as a single string argument"
+    SCALYR_TOOL_QUERY=$1
+else
+    # Query passed in as multiple arguments
+    echo "Query passed in as multiple arguments"
+    SCALYR_TOOL_QUERY="$*"
+fi
 
 echo_with_date() {
     date +"[%Y-%m-%d %H:%M:%S] $*"


### PR DESCRIPTION
This pull request makes a small change to the scalyr query script which is used by end to end tests so we can specify the actual query as a single command line argument or as multiple ones.

Previously, only notation like this was supported:

```bash
./scalyr-agent-2/scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_SERVER_HOST}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Starting scalyr agent..."'
```

And now we can also do things like this:

```bash
./scalyr-agent-2/scripts/cicd/scalyr-query.sh \
            '$serverHost="'${SCALYR_AGENT_SERVER_HOST}'"' \
            '$logfile="/var/log/scalyr-agent-2/agent.log"' \
            '"Starting scalyr agent..."'
```

This allows us to split long queries over multiple lines to make things a bit more readable.

It's worth noting that somewhat similar thing could already be achieved before, but it would require a lot more indirection and bash foo (string concat, etc.).

Technically, this change should be fully backward compatible, but will see once the tests pass.