### PR TITLE
DSET-1628: message_log_template & attributes not applied without checkpoint

### DIFF
--- a/benchmarks/micro/test_syslog_parsing.py
+++ b/benchmarks/micro/test_syslog_parsing.py
@@ -47,6 +47,10 @@ class MockConfig(object):
         except KeyError:
             return None
 
+class MockGlobalConfig(object):
+    def __init__(self):
+        self.log_configs = []
+
 TEMP_DIRECTORY = tempfile.gettempdir()
 
 MOCK_EXTRAS = []
@@ -98,10 +102,12 @@ def test_handle_syslog_logs(benchmark, message_template):
             "message_log_template": message_log_template,
         }
     )
+    mock_global_config = MockGlobalConfig()
 
     with tempfile.TemporaryDirectory() as tmp_directory:
         handler = SyslogHandler(logger=mock_logger, line_reporter=mock_line_reporter, config=mock_config,
-                                server_host="localhost", log_path=tmp_directory, get_log_watcher=mock.Mock(),
+                                global_config=MockGlobalConfig(), server_host="localhost",
+                                log_path=tmp_directory, get_log_watcher=mock.Mock(),
                                 rotate_options=(2, 200000), docker_options=mock.Mock())
         handler._SyslogHandler__get_log_watcher.return_value = mock.Mock(), mock.Mock()
 

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -25,6 +25,7 @@ __author__ = "scalyr@sentinelone.com"
 import errno
 from fnmatch import fnmatch
 import glob
+import json
 import logging
 import logging.handlers
 import os
@@ -1619,6 +1620,21 @@ class SyslogHandler(object):
                             max_bytes=self.__max_log_size,
                             backup_count=self.__max_log_rotations,
                             flush_delay=self.__flush_delay,
+                        )
+
+                        global_log.log(
+                            scalyr_logging.DEBUG_LEVEL_1,
+                            "__syslog_attributes=%s log_config_attribs=%s extra=%s"
+                            % (
+                                json.dumps(
+                                    self.__syslog_attributes.to_dict(),
+                                    separators=(",", ":"),
+                                ),
+                                json.dumps(
+                                    log_config_attribs.to_dict(), separators=(",", ":")
+                                ),
+                                json.dumps(extra, separators=(",", ":")),
+                            ),
                         )
 
                         attribs = self.__syslog_attributes.copy()

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1204,6 +1204,7 @@ class SyslogHandler(object):
         logger,
         line_reporter,
         config,
+        global_config,
         server_host,
         log_path,
         get_log_watcher,
@@ -1604,6 +1605,7 @@ class SyslogHandler(object):
                     )
 
                     log_config = {
+                        # FIXME
                         "parser": self.__syslog_parser,
                         "attributes": attribs,
                         "path": path,
@@ -1746,6 +1748,7 @@ class SyslogServer(object):
         port,
         logger,
         config,
+        global_config,
         line_reporter,
         accept_remote=False,
         server_host=None,
@@ -1853,6 +1856,7 @@ class SyslogServer(object):
             logger,
             line_reporter,
             config,
+            global_config,
             server_host,
             log_path,
             get_log_watcher,
@@ -2237,6 +2241,7 @@ From Search view, query [monitor = 'syslog_monitor'](https://app.scalyr.com/even
                 protocol[1],
                 self.__disk_logger,
                 self._config,
+                self._global_config,
                 line_reporter,
                 accept_remote=self.__accept_remote_connections,
                 server_host=self.__server_host,
@@ -2253,6 +2258,7 @@ From Search view, query [monitor = 'syslog_monitor'](https://app.scalyr.com/even
                     p[1],
                     self.__disk_logger,
                     self._config,
+                    self._global_config,
                     line_reporter,
                     accept_remote=self.__accept_remote_connections,
                     server_host=self.__server_host,

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1255,7 +1255,7 @@ class SyslogHandler(object):
         self.__syslog_max_log_files = config.get("max_log_files")
         self.__syslog_loggers = {}
         self.__syslog_default_parser = config.get("parser")
-        self.__global_log_configs = global_config.log_configs
+        self.__global_log_configs = global_config.log_configs if global_config else []
         self.__syslog_attributes = JsonObject(config.get("attributes") or {})
 
         if docker_logging:
@@ -1613,14 +1613,19 @@ class SyslogHandler(object):
 
                         attribs = self.__syslog_attributes.copy()
                         attribs.update(
-                            {k: v for k, v in log_config_attribs.items() if k not in ["parser"]}
+                            {
+                                k: v
+                                for k, v in log_config_attribs.items()
+                                if k not in ["parser"]
+                            }
                         )
                         attribs.update(
                             {k.lower(): v for k, v in extra.items() if v is not None}
                         )
 
                         log_config = {
-                            "parser": log_config_attribs.get("parser") or self.__syslog_default_parser,
+                            "parser": log_config_attribs.get("parser")
+                            or self.__syslog_default_parser,
                             "attributes": attribs,
                             "path": path,
                         }

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1596,13 +1596,23 @@ class SyslogHandler(object):
                 else:
                     # Match the new log path with a global log config (generally globbed).
                     # Note that in log configs, .path is required but .attributes may be empty.
+                    # If no match is found then log to the base syslog file.
+
                     log_config_attribs = None
                     for log_config in self.__global_log_configs:
                         if fnmatch(path, log_config["path"]):
                             log_config_attribs = log_config["attributes"]
+                            global_log.log(
+                                scalyr_logging.DEBUG_LEVEL_1,
+                                f"Matched {path} to {log_config['path']}",
+                            )
                             break
 
-                    # No match logs to the base syslog file
+                    if log_config_attribs is None:
+                        global_log.log(
+                            scalyr_logging.DEBUG_LEVEL_1, f"No match found for {path}"
+                        )
+
                     if log_config_attribs is not None:
                         logfile = AutoFlushingRotatingFile(
                             filename=path,

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1605,13 +1605,13 @@ class SyslogHandler(object):
                             log_config_attribs = log_config["attributes"]
                             global_log.log(
                                 scalyr_logging.DEBUG_LEVEL_1,
-                                f"Matched {path} to {log_config['path']}",
+                                "Matched %s to %s" % (path, log_config["path"]),
                             )
                             break
 
                     if log_config_attribs is None:
                         global_log.log(
-                            scalyr_logging.DEBUG_LEVEL_1, f"No match found for {path}"
+                            scalyr_logging.DEBUG_LEVEL_1, "No match found for %s" % (path,)
                         )
 
                     if log_config_attribs is not None:

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1611,7 +1611,8 @@ class SyslogHandler(object):
 
                     if log_config_attribs is None:
                         global_log.log(
-                            scalyr_logging.DEBUG_LEVEL_1, "No match found for %s" % (path,)
+                            scalyr_logging.DEBUG_LEVEL_1,
+                            "No match found for %s" % (path,),
                         )
 
                     if log_config_attribs is not None:


### PR DESCRIPTION
- Pass the global config from SyslogMonitor (via SyslogServer) to SyslogHandler
- Then match current log path with potential log config from the global config
  - This is needed to know which parser & attributes to apply when creating the logger