### PR TITLE
Fix syslog micro benchmark, also run micro benchmarks on non-master branches

### DIFF
--- a/.github/workflows/codespeed-agent-benchmarks.yaml
+++ b/.github/workflows/codespeed-agent-benchmarks.yaml
@@ -150,7 +150,8 @@ jobs:
           CAPTURE_AGENT_STATUS_METRICS: ${{ inputs.capture_agent_status_metrics }}
           DRY_RUN: ${{ inputs.dry_run }}
           PYTHONPATH: .
-        run: ./benchmarks/scripts/send-log-level-counts-to-codespeed.sh "${{ github.sha }}"
+        run: |
+          ./benchmarks/scripts/send-log-level-counts-to-codespeed.sh "${{ github.sha }}"
 
       - name: Upload log artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/codespeed-microbenchmarks.yml
+++ b/.github/workflows/codespeed-microbenchmarks.yml
@@ -1,4 +1,4 @@
-name: Codespeed Micro Benchmarks
+name: Codespeed Benchmarks
 
 on:
   push:
@@ -30,6 +30,7 @@ jobs:
           github_token: ${{ github.token }}
 
   codespeed-micro-benchmarks:
+    name: Micro Benchmarks
     runs-on: ubuntu-latest
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
@@ -102,6 +103,7 @@ jobs:
           channel: '#eng-dataset-cloud-tech'
 
   benchmarks-idle-agent-py-311:
+    name: Process Benchmark
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
@@ -117,6 +119,7 @@ jobs:
       dry_run: ${{ ! github.ref == 'refs/heads/master' }}
 
   benchmarks-idle-agent-no-monitors-py-311:
+    name: Process Benchmark
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
@@ -132,6 +135,7 @@ jobs:
       dry_run: ${{ ! github.ref == 'refs/heads/master' }}
 
   benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-311:
+    name: Process Benchmark
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
@@ -152,6 +156,7 @@ jobs:
   # which is being written to during the benchmark must existing before the
   # agent process is started.
   benchmarks-loaded-agent-single-growing-log-file-20mb-py-311:
+    name: Process Benchmark
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
@@ -170,6 +175,7 @@ jobs:
       dry_run: ${{ ! github.ref == 'refs/heads/master' }}
 
   benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-311:
+    name: Process Benchmark
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
@@ -188,6 +194,7 @@ jobs:
       dry_run: ${{ ! github.ref == 'refs/heads/master' }}
 
   benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-311:
+    name: Process Benchmark
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml

--- a/.github/workflows/codespeed-microbenchmarks.yml
+++ b/.github/workflows/codespeed-microbenchmarks.yml
@@ -66,7 +66,8 @@ jobs:
         run: tox -e micro-benchmarks
 
       - name: Process and submit results to CodeSpeed
-        if: github.ref == 'refs/heads/master'
+        # We only want to submit results for master branch runs and not for scheduled runs
+        if: ${{ github.ref == 'refs/heads/master' && ! github.event_name == 'schedule' }}
         env:
           PYTHONPATH: .
           CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"

--- a/.github/workflows/codespeed-microbenchmarks.yml
+++ b/.github/workflows/codespeed-microbenchmarks.yml
@@ -113,6 +113,8 @@ jobs:
       agent_config: "benchmarks/configs/agent_no_monitored_logs.json"
       agent_server_host: "ci-codespeed-benchmarks-py311-idle-conf-1"
       capture_line_counts: true
+      # We only want to send data to CodeSpeed on master branch runs
+      dry_run: ${{ ! github.ref == 'refs/heads/master' }}
 
   benchmarks-idle-agent-no-monitors-py-311:
     needs: pre_job
@@ -126,6 +128,8 @@ jobs:
       agent_config: "benchmarks/configs/agent_no_monitored_logs_no_monitors.json"
       agent_server_host: "ci-codespeed-benchmarks-py311-idle-conf-2"
       capture_line_counts: true
+      # We only want to send data to CodeSpeed on master branch runs
+      dry_run: ${{ ! github.ref == 'refs/heads/master' }}
 
   benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-311:
     needs: pre_job
@@ -141,6 +145,8 @@ jobs:
       agent_server_host: "ci-codespeed-benchmarks-py311-loaded-conf-1"
       run_time: 140
       capture_line_counts: true
+      # We only want to send data to CodeSpeed on master branch runs
+      dry_run: ${{ ! github.ref == 'refs/heads/master' }}
 
   # NOTE: For the benchmarks below to work correctly "/tmp/random.log" file
   # which is being written to during the benchmark must existing before the
@@ -160,6 +166,8 @@ jobs:
       agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 2M 10 100 1"
       agent_server_host: "ci-codespeed-benchmarks-py311-loaded-conf-2"
       capture_line_counts: true
+      # We only want to send data to CodeSpeed on master branch runs
+      dry_run: ${{ ! github.ref == 'refs/heads/master' }}
 
   benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-311:
     needs: pre_job
@@ -176,6 +184,8 @@ jobs:
       agent_post_run_command: "benchmarks/scripts/write-random-lines.sh /tmp/random.log 2M 10 100 1 & benchmarks/scripts/write-random-lines.sh /tmp/random2.log 2M 10 100 1 &"
       agent_server_host: "ci-codespeed-benchmarks-py311-loaded-conf-4"
       capture_line_counts: true
+      # We only want to send data to CodeSpeed on master branch runs
+      dry_run: ${{ ! github.ref == 'refs/heads/master' }}
 
   benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-311:
     needs: pre_job
@@ -192,3 +202,5 @@ jobs:
       run_time: 140
       capture_agent_status_metrics: true
       capture_line_counts: true
+      # We only want to send data to CodeSpeed on master branch runs
+      dry_run: ${{ ! github.ref == 'refs/heads/master' }}

--- a/.github/workflows/codespeed-microbenchmarks.yml
+++ b/.github/workflows/codespeed-microbenchmarks.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
       - release
+  pull_request:
+    branches:
+      - master
   schedule:
     - cron: '0 4 * * *'
 
@@ -29,7 +32,7 @@ jobs:
   codespeed-micro-benchmarks:
     runs-on: ubuntu-latest
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codespeed-microbenchmarks.yml
+++ b/.github/workflows/codespeed-microbenchmarks.yml
@@ -116,7 +116,7 @@ jobs:
       agent_server_host: "ci-codespeed-benchmarks-py311-idle-conf-1"
       capture_line_counts: true
       # We only want to send data to CodeSpeed on master branch runs
-      dry_run: ${{ ! github.ref == 'refs/heads/master' }}
+      dry_run: ${{ github.ref != 'refs/heads/master' }}
 
   benchmarks-idle-agent-no-monitors-py-311:
     name: Process Benchmark
@@ -132,7 +132,7 @@ jobs:
       agent_server_host: "ci-codespeed-benchmarks-py311-idle-conf-2"
       capture_line_counts: true
       # We only want to send data to CodeSpeed on master branch runs
-      dry_run: ${{ ! github.ref == 'refs/heads/master' }}
+      dry_run: ${{ github.ref != 'refs/heads/master' }}
 
   benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-311:
     name: Process Benchmark
@@ -150,7 +150,7 @@ jobs:
       run_time: 140
       capture_line_counts: true
       # We only want to send data to CodeSpeed on master branch runs
-      dry_run: ${{ ! github.ref == 'refs/heads/master' }}
+      dry_run: ${{ github.ref != 'refs/heads/master' }}
 
   # NOTE: For the benchmarks below to work correctly "/tmp/random.log" file
   # which is being written to during the benchmark must existing before the
@@ -172,7 +172,7 @@ jobs:
       agent_server_host: "ci-codespeed-benchmarks-py311-loaded-conf-2"
       capture_line_counts: true
       # We only want to send data to CodeSpeed on master branch runs
-      dry_run: ${{ ! github.ref == 'refs/heads/master' }}
+      dry_run: ${{ github.ref != 'refs/heads/master' }}
 
   benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-311:
     name: Process Benchmark
@@ -191,7 +191,7 @@ jobs:
       agent_server_host: "ci-codespeed-benchmarks-py311-loaded-conf-4"
       capture_line_counts: true
       # We only want to send data to CodeSpeed on master branch runs
-      dry_run: ${{ ! github.ref == 'refs/heads/master' }}
+      dry_run: ${{ github.ref != 'refs/heads/master' }}
 
   benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-311:
     name: Process Benchmark
@@ -210,4 +210,4 @@ jobs:
       capture_agent_status_metrics: true
       capture_line_counts: true
       # We only want to send data to CodeSpeed on master branch runs
-      dry_run: ${{ ! github.ref == 'refs/heads/master' }}
+      dry_run: ${{ github.ref != 'refs/heads/master' }}

--- a/.github/workflows/codespeed-microbenchmarks.yml
+++ b/.github/workflows/codespeed-microbenchmarks.yml
@@ -63,7 +63,7 @@ jobs:
         run: tox -e micro-benchmarks
 
       - name: Process and submit results to CodeSpeed
-        if: (github.ref == 'refs/heads/master' || github.head_ref == 'master')
+        if: github.ref == 'refs/heads/master'
         env:
           PYTHONPATH: .
           CODESPEED_URL: "https://scalyr-agent-codespeed.herokuapp.com/"
@@ -71,7 +71,8 @@ jobs:
           CODESPEED_EXECUTABLE: Python ${{ steps.setup-python.outputs.python-version }}
           CODESPEED_ENVIRONMENT: GitHub Hosted Action Runner
           CODESPEED_AUTH: ${{ secrets.CODESPEED_AUTH }}
-        run: python benchmarks/scripts/send_microbenchmarks_data_to_codespeed.py --data-path="benchmark_results/*.json" --debug
+        run: |
+          python benchmarks/scripts/send_microbenchmarks_data_to_codespeed.py --data-path="benchmark_results/*.json" --debug
 
       - name: Store artifacts
         uses: actions/upload-artifact@v3
@@ -98,7 +99,7 @@ jobs:
 
   benchmarks-idle-agent-py-311:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -111,7 +112,7 @@ jobs:
 
   benchmarks-idle-agent-no-monitors-py-311:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -124,7 +125,7 @@ jobs:
 
   benchmarks-loaded-agent-single-50mb-log-file-with-parser-py-311:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -142,7 +143,7 @@ jobs:
   # agent process is started.
   benchmarks-loaded-agent-single-growing-log-file-20mb-py-311:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -158,7 +159,7 @@ jobs:
 
   benchmarks-loaded-agent_2-growing_logs-monitors-multiprocess-2-worker-20mb-py-311:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:
@@ -174,7 +175,7 @@ jobs:
 
   benchmarks-loaded-agent-single-50mb-log-file-with-500k-lines-py-311:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || (github.ref == 'refs/heads/master' || github.base_ref == 'master') }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     uses: ./.github/workflows/codespeed-agent-benchmarks.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
It looks like #1078 inadvertedly broke syslog micro benchmark.

This PR fixes it.

In the past we intentionally only ran benchmark jobs for master branch and not for every PR branch since that would be too slow, but maybe it make sense to also run microbenchmarks on all the PRs now that we have trimmed down the Python version matrix, but only submit results to CodeSpeed on master branch.