### PR TITLE
Increase timeout for non-amd64 tests

### DIFF
--- a/tests/end_to_end_tests/managed_packages_tests/test_packages.py
+++ b/tests/end_to_end_tests/managed_packages_tests/test_packages.py
@@ -187,7 +187,7 @@ def test_packages(
     _run_shell("ls -la /etc/rc*.d/ | grep scalyr-agent | wc -l | grep 7")
 
     server_host = (
-        f"package-{package_builder_name}-test-{test_session_suffix}-{int(time.time())}"
+        f"package-{package_builder_name}-{target_distro.name}-test-{test_session_suffix}-{int(time.time())}"
     )
 
     upload_test_log_path = LINUX_PACKAGE_AGENT_PATHS.logs_dir / "test.log"

--- a/tests/end_to_end_tests/managed_packages_tests/test_packages.py
+++ b/tests/end_to_end_tests/managed_packages_tests/test_packages.py
@@ -156,7 +156,11 @@ def test_packages(
     agent_version,
     tmp_path,
 ):
-    timeout_tracker = TimeoutTracker(400)
+    if "x86_64" not in package_builder_name:
+        timeout_tracker = TimeoutTracker(800)
+    else:
+        timeout_tracker = TimeoutTracker(400)
+
     _print_system_information()
     _prepare_environment(
         package_type=package_builder.PACKAGE_TYPE,


### PR DESCRIPTION
This PR increases timeout for e2e tests that run on non-amd64 CPU's because it takes more time to run tests on emulated environment.

Also add distro name as part of the `server_host`  value for the log tests, to be sure that this value is unique.