### PR TITLE
Use upstream apache-libcloud library from PyPi

### DIFF
--- a/tests/ami/requirements.txt
+++ b/tests/ami/requirements.txt
@@ -1,6 +1,4 @@
-# Includes paramiko >= 2.9.0 workaround
-git+https://github.com/scalyr/libcloud.git@paramiko_2_9_compatibility_requests_2200#egg=apache-libcloud
-#apache-libcloud==3.4.1
+apache-libcloud==3.7.0
 paramiko==2.11.0
 Jinja2==3.0.3
 xmltodict==0.13.0


### PR DESCRIPTION
This pull request updates AMI tests dependencies to use apache-libcloud from official PyPi package instead from our git fork.

Bug fix which we relied on has been merged upstream so we can now utilize upstream version again.