### PR TITLE
Allow access to replicasets/scale (for kubernetes_events_monitor.py)

### DIFF
--- a/k8s/default-namespace/scalyr-service-account.yaml
+++ b/k8s/default-namespace/scalyr-service-account.yaml
@@ -18,7 +18,7 @@ rules:
   resources: ["nodes"]
   verbs: ["get","list"]
 - apiGroups: ["apps"]
-  resources: ["daemonsets","deployments","replicasets","statefulsets","namespaces"]
+  resources: ["daemonsets","deployments","replicasets","replicasets/scale","statefulsets","namespaces"]
   verbs: ["get","list"]
 - apiGroups: ["batch", "extensions"]
   resources: ["cronjobs","jobs"]

--- a/k8s/no-kustomize/scalyr-service-account.yaml
+++ b/k8s/no-kustomize/scalyr-service-account.yaml
@@ -18,7 +18,7 @@ rules:
   resources: ["nodes"]
   verbs: ["get","list"]
 - apiGroups: ["apps"]
-  resources: ["daemonsets","deployments","replicasets","statefulsets","namespaces"]
+  resources: ["daemonsets","deployments","replicasets","replicasets/scale","statefulsets","namespaces"]
   verbs: ["get","list"]
 - apiGroups: ["batch", "extensions"]
   resources: ["cronjobs","jobs"]

--- a/k8s/scalyr-service-account.yaml
+++ b/k8s/scalyr-service-account.yaml
@@ -17,7 +17,7 @@ rules:
   resources: ["nodes"]
   verbs: ["get","list"]
 - apiGroups: ["apps"]
-  resources: ["daemonsets","deployments","replicasets","statefulsets","namespaces"]
+  resources: ["daemonsets","deployments","replicasets","replicasets/scale","statefulsets","namespaces"]
   verbs: ["get","list"]
 - apiGroups: ["batch", "extensions"]
   resources: ["cronjobs","jobs"]


### PR DESCRIPTION
While writing a test Deployment manifest for the Kubernetes event monitor, I found that the scalyr-service-account needs access to replicates/scale.

This is needed in the Kubernetes event monitor (specifically leader election) & is deployed using a Deployment.  Typically DaemonSets have been used.

More notes can be found in PLAT-3671