### PR TITLE
Fix tox.ini to be compatible with latest version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.6
+  python: python3.10
 
 exclude: '(third_party.*|third_party_tls.*)'
 repos:

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,9 @@ envlist = py{27,36,37,38,39,310}-{linux,macos,windows}-unittests, py{27,36,37,38
 skipsdist = true
 ignore_basepython_conflict = true
 # NOTE: We pass the TERM env to preserve colors
-passenv = TERM XDG_CACHE_HOME
+passenv =
+    TERM
+    XDG_CACHE_HOME
 setenv =
   PY_COLORS=1
 
@@ -39,7 +41,10 @@ basepython =
     {py3.9-unit-tests}: python3.9
     {py3.10-unit-tests}: python3.10
 # NOTE: We pass the TERM env to preserve colors
-passenv = TERM XDG_CACHE_HOME PYTEST_BENCH_FORCE_UNIT
+passenv =
+    TERM
+    XDG_CACHE_HOME
+    PYTEST_BENCH_FORCE_UNIT
 setenv =
   LINT_FILES_TO_CHECK={env:LINT_FILES_TO_CHECK:*.py scripts/*.py scripts/circleci/*.py scripts/cicd/*.py benchmarks/scripts/*.py tests/ pylint_plugins/*.py .circleci/*.py .circleci/modernize/ scalyr_agent/ scalyr_agent/third_party/tcollector/ agent_build/}
   # Which Python binary to use for various lint targets
@@ -54,7 +59,7 @@ install_command = pip install -U --force-reinstall {opts} {packages}
 deps =
     -r dev-requirements.txt
     -r benchmarks/micro/requirements-compression-algorithms.txt
-whitelist_externals =
+allowlist_externals =
     rm
     bash
 commands =
@@ -93,7 +98,7 @@ commands =
 [testenv:generate-monitor-docs]
 deps =
     -r dev-requirements.txt
-whitelist_externals =
+allowlist_externals =
     bash
 commands =
     bash -c "scripts/generate-docs-for-all-monitors.sh"
@@ -211,7 +216,10 @@ commands =
 # Smoke tests related targets
 [testenv:py{27,36,37,38,39,310}-std-smoketests]
 passenv =
-    SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
 commands =
     rm -rf test-results .coverage
     py.test tests/smoke_tests/standalone_test -vv --durations=5 --junitxml=test-results/junit-1.xml
@@ -226,38 +234,56 @@ setenv =
     SCALYR_MAX_REQUEST_SPACING_INTERVAL=0.5
     {[testenv]setenv}
 passenv =
-    SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
 commands =
     rm -rf test-results .coverage
     py.test tests/smoke_tests/standalone_test_rate_limited.py -vv --durations=5 --junitxml=test-results/junit-1.xml
 
 [testenv:py2.7-smoke-tests]
 passenv =
-    SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
 commands =
     py.test tests/smoke_tests/standalone_test -s -vv --durations=5
 
 [testenv:py3.5-smoke-tests]
 passenv =
-    SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
 commands =
     py.test tests/smoke_tests/standalone_test -s -vv --durations=5
 
 [testenv:py3.6-smoke-tests]
 passenv =
-    SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
 commands =
     py.test tests/smoke_tests/standalone_test -s -vv --durations=5
 
 [testenv:py3.7-smoke-tests]
 passenv =
-    SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
 commands =
     py.test tests/smoke_tests/standalone_test -s -vv --durations=5
 
 [testenv:py3.8-smoke-tests]
 passenv =
-    SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
 commands =
     py.test tests/smoke_tests/standalone_test -s -vv --durations=5
 
@@ -265,7 +291,10 @@ commands =
 setenv =
     SCALYR_MAX_SEND_RATE_ENFORCEMENT="500KB/s" SCALYR_DISABLE_MAX_SEND_RATE_ENFORCEMENT_OVERRIDES="true" SCALYR_MIN_ALLOWED_REQUEST_SIZE="100" SCALYR_MAX_ALLOWED_REQUEST_SIZE="500000" SCALYR_MIN_REQUEST_SPACING_INTERVAL="0.0" SCALYR_MAX_REQUEST_SPACING_INTERVAL="0.5"
 passenv =
-    SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
 commands =
     py.test tests/smoke_tests/standalone_test_rate_limited.py -s -vv --durations=5
 
@@ -273,35 +302,70 @@ commands =
 [testenv:agent_package_smoke_test_amazonlinux_python2]
 basepython = python3.6
 passenv =
-    TERM SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
+    TERM
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
+    DOCKER_CERT_PATH
+    DOCKER_HOST
+    DOCKER_TLS_VERIFY
 commands =
     py.test tests/smoke_tests/package_test.py::test_smoke_package_rpm_python2 -s -vv --durations=5 {posargs}
 
 [testenv:agent_package_smoke_test_amazonlinux_python3]
 basepython = python3.6
 passenv =
-    TERM SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
+    TERM
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
+    DOCKER_CERT_PATH
+    DOCKER_HOST
+    DOCKER_TLS_VERIFY
 commands =
     py.test tests/smoke_tests/package_test.py::test_smoke_package_rpm_python3 -s -vv --durations=5 {posargs}
 
 [testenv:agent_package_smoke_test_ubuntu_python2]
 basepython = python3.6
 passenv =
-    TERM SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
+    TERM
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
+    DOCKER_CERT_PATH
+    DOCKER_HOST
+    DOCKER_TLS_VERIFY
 commands =
     py.test tests/smoke_tests/package_test.py::test_smoke_package_deb_python2 -s -vv --durations=5 {posargs}
 
 [testenv:agent_package_smoke_test_ubuntu_python3]
 basepython = python3.6
 passenv =
-    TERM SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
+    TERM
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
+    DOCKER_CERT_PATH
+    DOCKER_HOST
+    DOCKER_TLS_VERIFY
 commands =
     py.test tests/smoke_tests/package_test.py::test_smoke_package_deb_python3 -s -vv --durations=5 {posargs}
 
 [testenv:agent_distributions_tests_ubuntu1604]
 basepython = python3.6
 passenv =
-    TERM SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
+    TERM
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
+    DOCKER_CERT_PATH
+    DOCKER_HOST
+    DOCKER_TLS_VERIFY
 commands =
     # NOTE: We use short traceback formatting since we run py.test inside py.test which results in hard to read output
     py.test tests/distribution/python_version_change_tests/ubuntu1604 -s -vv --tb=short --durations=5 {posargs}
@@ -309,7 +373,14 @@ commands =
 [testenv:agent_distributions_tests_ubuntu2204]
 basepython = python3.6
 passenv =
-    TERM SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
+    TERM
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
+    DOCKER_CERT_PATH
+    DOCKER_HOST
+    DOCKER_TLS_VERIFY
 commands =
     # NOTE: We use short traceback formatting since we run py.test inside py.test which results in hard to read output
     py.test tests/distribution/basic_sanity_deb.py tests/distribution/python_version_change_tests/ubuntu2204 -s -vv --tb=short --durations=5 {posargs}
@@ -317,7 +388,14 @@ commands =
 [testenv:agent_distributions_tests_amazonlinux2]
 basepython = python3.6
 passenv =
-    TERM SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
+    TERM
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
+    DOCKER_CERT_PATH
+    DOCKER_HOST
+    DOCKER_TLS_VERIFY
 commands =
     # NOTE: We use short traceback formatting since we run py.test inside py.test which results in hard to read output
     py.test tests/distribution/basic_sanity_rpm.py tests/distribution/python_version_change_tests/amazonlinux2_test.py -s -vv --tb=short --durations=5 {posargs}
@@ -325,7 +403,14 @@ commands =
 [testenv:agent_distributions_tests_centos7]
 basepython = python3.6
 passenv =
-    TERM SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
+    TERM
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
+    DOCKER_CERT_PATH
+    DOCKER_HOST
+    DOCKER_TLS_VERIFY
 commands =
     # NOTE: We use short traceback formatting since we run py.test inside py.test which results in hard to read output
     py.test tests/distribution/python_version_change_tests/centos7 -s -vv --tb=short --durations=5 {posargs}
@@ -333,7 +418,14 @@ commands =
 [testenv:agent_distributions_tests_centos8]
 basepython = python3.6
 passenv =
-    TERM SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
+    TERM
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
+    DOCKER_CERT_PATH
+    DOCKER_HOST
+    DOCKER_TLS_VERIFY
 commands =
     # NOTE: We use short traceback formatting since we run py.test inside py.test which results in hard to read output
     py.test tests/distribution/python_version_change_tests/centos8_test.py -s -vv --tb=short --durations=5 {posargs}
@@ -341,21 +433,42 @@ commands =
 [testenv:agent_deb_package]
 basepython = python3.6
 passenv =
-    TERM SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
+    TERM
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
+    DOCKER_CERT_PATH
+    DOCKER_HOST
+    DOCKER_TLS_VERIFY
 commands =
     py.test tests/distribution/deb_package.py -s -vv --tb=short --durations=5 {posargs}
 
 [testenv:agent_rpm_package]
 basepython = python3.6
 passenv =
-    TERM SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
+    TERM
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
+    DOCKER_CERT_PATH
+    DOCKER_HOST
+    DOCKER_TLS_VERIFY
 commands =
     py.test tests/distribution/rpm_package.py -s -vv --tb=short --durations=5 {posargs}
 
 [testenv:agent_monitors_ubuntu]
 basepython = python3.6
 passenv =
-    TERM SCALYR_API_KEY READ_API_KEY SCALYR_SERVER AGENT_HOST_NAME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
+    TERM
+    SCALYR_API_KEY
+    READ_API_KEY
+    SCALYR_SERVER
+    AGENT_HOST_NAME
+    DOCKER_CERT_PATH
+    DOCKER_HOST
+    DOCKER_TLS_VERIFY
 commands =
     py.test tests/utils/tests/ tests/smoke_tests/monitors_test/ -s -vv --tb=short --durations=5 --cov=scalyr_agent --cov=tests/ {posargs}
 


### PR DESCRIPTION
When I was following README.md how to test scalyr agent, I was not able to finish it for the following reasons:
1. Configuration `passenv`: Values cannot no longer be separated by spaces - https://github.com/tox-dev/tox/issues/2615
2. Configuration `whitelist_externals`: This config option no longer exists and was replaces with `allowlist_externals` - https://github.com/tox-dev/tox/pull/2134 + https://github.com/tox-dev/tox/pull/2600

When I was trying to commit changes, it has failed since `pre-commit` was configured to use `Python 3.6` - https://devguide.python.org/versions/ - which is no longer supported. So I have bumped it to `3.10`.