### PR TITLE
Fix logging bug in the Docker monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ Scalyr Agent 2 Changes By Release
 Packaged by Arthur Kamalov <arthurk@sentinelone.com> on Jan 19, 2023 00:00 -0800
 --->
 
-Other: Linux `deb` and `rpm` packages are now shipped with its own Python interpreter, so agent does not have to rely on system Python interpreter anymore. Please refer to the RELEASE_NOTES document, for more information.
- 
+Other:
+* Linux `deb` and `rpm` packages are now shipped with its own Python interpreter, so agent does not have to rely on system Python interpreter anymore. Please refer to the RELEASE_NOTES document, for more information.
+
+Bug fixes:
+* Fix bug in the Docker monitor which would, under some edge cases, cause a specific log messages to be logged very often and as such, exhausting the CPU cycles available to the Docker monitor.
+
 ## 2.1.40 "Onone" - Jan 19, 2023
 <!---
 Packaged by Arthur Kamalov <arthurk@sentinelone.com> on Jan 19, 2023 00:00 -0800

--- a/scalyr_agent/builtin_monitors/docker_monitor.py
+++ b/scalyr_agent/builtin_monitors/docker_monitor.py
@@ -1634,7 +1634,11 @@ class DockerLogger(object):
                         # split the docker timestamp from the frest of the line
                         dt, log_line = _split_datetime_from_line(line)
                         if not dt:
-                            global_log.error("No timestamp found on line: '%s'", line)
+                            # Under some edge cases this message can be logged a lot (which can
+                            # exhaust the CPU) so we need to make sure rate limit is in place.
+                            global_log.error("No timestamp found on line: '%s'", line,
+                                             limit_once_per_x_secs=300,
+                                             limit_key="docker-monitor-line-missing-ts")
                         else:
                             timestamp = scalyr_util.seconds_since_epoch(dt, epoch)
 

--- a/scalyr_agent/builtin_monitors/docker_monitor.py
+++ b/scalyr_agent/builtin_monitors/docker_monitor.py
@@ -1636,9 +1636,12 @@ class DockerLogger(object):
                         if not dt:
                             # Under some edge cases this message can be logged a lot (which can
                             # exhaust the CPU) so we need to make sure rate limit is in place.
-                            global_log.error("No timestamp found on line: '%s'", line,
-                                             limit_once_per_x_secs=300,
-                                             limit_key="docker-monitor-line-missing-ts")
+                            global_log.error(
+                                "No timestamp found on line: '%s'",
+                                line,
+                                limit_once_per_x_secs=300,
+                                limit_key="docker-monitor-line-missing-ts",
+                            )
                         else:
                             timestamp = scalyr_util.seconds_since_epoch(dt, epoch)
 


### PR DESCRIPTION
## Description

This PR ensures we have a rate limit in place for the ``No timestamp found on line:`` log message in the Docker monitor.

## Background, Context

Agent on one of my servers some how ended up in a bad state where ``No timestamp found on line:`` log message would get logged very often. This would cause the agent to exhaust all the CPU cycles just by logging this message.

I don't know the exact root cause for that edge case (it could be something related to Docker daemon upgrade or similar), but it doesn't matter that much since we need a rate limit (aka this fix) regardless.

Here is the message which appeared in the logs:

> 21:33:12.017​nuc.tomaz.me​/var/log/scalyr-agent-2/agent.log​2023-02-25 20:33:12.017Z ERROR [monitor:docker_monitor] [scalyr_agent.builtin_monitors.docker_monitor:1637] No timestamp found on line: 'Error grabbing logs: invalid character '\x00' looking for beginning of value

This message does potentially indicate another issue which we should handle and log differently, but that can be handled in a future PR.