### PR TITLE
Fix post-uninstall warnings

### DIFF
--- a/.github/workflows/agent-build-new.yml
+++ b/.github/workflows/agent-build-new.yml
@@ -88,7 +88,10 @@ jobs:
   # so it's just need to download only one artifact, for example during a release process.
   prepare-artifacts:
     runs-on: ubuntu-20.04
-    needs: build-linux-packages
+    needs:
+      - build-linux-packages
+      - build-windows-package
+      - build_tarball
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/agent-build-new.yml
+++ b/.github/workflows/agent-build-new.yml
@@ -41,6 +41,12 @@ jobs:
       CT_SCALYR_TOKEN_PROD_US_CLOUDTECH_TESTING_WRITE: ${{ secrets.CT_SCALYR_TOKEN_PROD_US_CLOUDTECH_TESTING_WRITE }}
       CT_SCALYR_TOKEN_PROD_US_CLOUDTECH_TESTING_READ: ${{ secrets.CT_SCALYR_TOKEN_PROD_US_CLOUDTECH_TESTING_READ }}
 
+  build-windows-package:
+    name: "Build Windows package"
+    uses: ./.github/workflows/reusable-agent-build-windows.yml
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   build_tarball:
     runs-on: ubuntu-20.04
 
@@ -99,6 +105,9 @@ jobs:
           mkdir -p /tmp/result_artifacts
           cp -a /tmp/all_artifacts/linux-packages-*/. /tmp/result_artifacts
           cp -a /tmp/all_artifacts/tarball-noarch/. /tmp/result_artifacts
+          cp -a /tmp/all_artifacts/windows-msi/. /tmp/result_artifacts
+          
+          
 
       - name: Save result artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/reusable-agent-build-windows.yml
+++ b/.github/workflows/reusable-agent-build-windows.yml
@@ -1,33 +1,15 @@
 name: agent-build-windows
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  workflow_call:
+    secrets:
+        SLACK_WEBHOOK_URL:
+          required: true
 
 jobs:
-  pre_job:
-    name: Skip Duplicate Jobs Pre Job
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write  # Needed for skip-duplicate-jobs job
-      contents: read
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@12aca0a884f6137d619d6a8a09fcc3406ced5281 # v4.0.0
-        with:
-          cancel_others: 'true'
-          github_token: ${{ github.token }}
-
   build-windows-package:
     name: Build windows MSI installer
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref_name == 'master' }}
     runs-on: windows-latest
     steps:
       - name: Checkout Repository
@@ -50,6 +32,7 @@ jobs:
       - name: Save installer as artifact
         uses: actions/upload-artifact@v3
         with:
+          name: windows-msi
           path: ScalyrAgentInstaller-*.msi
 
       - name: Notify Slack on Failure

--- a/.github/workflows/reusable-agent-build-windows.yml
+++ b/.github/workflows/reusable-agent-build-windows.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   build-windows-package:
     name: Build windows MSI installer
-    needs: pre_job
     runs-on: windows-latest
     steps:
       - name: Checkout Repository

--- a/agent_build_refactored/managed_packages/files/bin/agent-libs-config
+++ b/agent_build_refactored/managed_packages/files/bin/agent-libs-config
@@ -52,6 +52,7 @@ def initialize():
             "pip",
             "install",
             "--quiet",
+            # TODO: Do a periodical check of the available new version of the pip in the CI/CD
             "--disable-pip-version-check",
             # Core agent requirements are already installed in this "pre-created" venv, but
             # we still add their requirements file to be sure that pip will throw an error if

--- a/agent_build_refactored/managed_packages/files/bin/agent-libs-config
+++ b/agent_build_refactored/managed_packages/files/bin/agent-libs-config
@@ -52,6 +52,7 @@ def initialize():
             "pip",
             "install",
             "--quiet",
+            "--disable-pip-version-check",
             # Core agent requirements are already installed in this "pre-created" venv, but
             # we still add their requirements file to be sure that pip will throw an error if
             # additional requirements conflict with core ones.

--- a/agent_build_refactored/managed_packages/install-scriptlets/preuninstall.sh
+++ b/agent_build_refactored/managed_packages/install-scriptlets/preuninstall.sh
@@ -39,6 +39,8 @@ if [ "$1" == "0" ] || [ "$1" == "remove" ]; then
     done
   fi
   # Remove dynamically generated venv.
+  # It is important to remove this only during the uninstallation of the package, not the upgrade. During the upgrade,
+  # the deletion of the old venv has to be on the package's "post-install" script.
   rm -r "/var/opt/scalyr-agent-2/venv"
 fi
 

--- a/agent_build_refactored/managed_packages/install-scriptlets/preuninstall.sh
+++ b/agent_build_refactored/managed_packages/install-scriptlets/preuninstall.sh
@@ -38,16 +38,14 @@ if [ "$1" == "0" ] || [ "$1" == "remove" ]; then
       rm /etc/rc$x.d/S98scalyr-agent-2;
     done
   fi
+  # Remove dynamically generated venv.
+  rm -r "/var/opt/scalyr-agent-2/venv"
 fi
 
 # Always remove the .pyc files and __pycache__ directories
-
 # It should be more logical to remove only  the __pycache__ directories, but that causes repeated deletion,
 # which leads to warning messages, so we delete files and directories in different conditions,
 find /usr/share/scalyr-agent-2 -type f -path "*/__pycache__/*" -delete -o -type d  -name __pycache__ -delete
 find /opt/scalyr-agent-2 -type f -path "*/__pycache__/*" -delete -o -type d  -name __pycache__ -delete
-
-# Remove dynamically generated venv.
-rm -r "/var/opt/scalyr-agent-2/venv"
 
 exit 0;

--- a/agent_build_refactored/managed_packages/install-scriptlets/preuninstall.sh
+++ b/agent_build_refactored/managed_packages/install-scriptlets/preuninstall.sh
@@ -41,12 +41,12 @@ if [ "$1" == "0" ] || [ "$1" == "remove" ]; then
 fi
 
 # Always remove the .pyc files and __pycache__ directories
-find /usr/share/scalyr-agent-2 -type d -name -prune __pycache__ -exec rm -r {} \;
+find /usr/share/scalyr-agent-2 -type f -path "*/__pycache__/*" -delete -o -type d  -name __pycache__ -exec rm -r {} \;
 
 # Remove dynamically generated venv.
 rm -r "/var/opt/scalyr-agent-2/venv"
 
 # Collect garbage after Python.
-find /opt/scalyr-agent-2 -type d -name -prune __pycache__ -exec rm -r {} \;
+find /opt/scalyr-agent-2 -type f -path "*/__pycache__/*" -delete -o -type d  -name __pycache__ -exec rm -r {} \;
 
 exit 0;

--- a/agent_build_refactored/managed_packages/install-scriptlets/preuninstall.sh
+++ b/agent_build_refactored/managed_packages/install-scriptlets/preuninstall.sh
@@ -41,12 +41,12 @@ if [ "$1" == "0" ] || [ "$1" == "remove" ]; then
 fi
 
 # Always remove the .pyc files and __pycache__ directories
-find /usr/share/scalyr-agent-2 -type d -name __pycache__ -exec rm -r {} \;
+find /usr/share/scalyr-agent-2 -type d -name -prune __pycache__ -exec rm -r {} \;
 
 # Remove dynamically generated venv.
 rm -r "/var/opt/scalyr-agent-2/venv"
 
 # Collect garbage after Python.
-find /opt/scalyr-agent-2 -type d -name __pycache__ -exec rm -r {} \;
+find /opt/scalyr-agent-2 -type d -name -prune __pycache__ -exec rm -r {} \;
 
 exit 0;

--- a/agent_build_refactored/managed_packages/install-scriptlets/preuninstall.sh
+++ b/agent_build_refactored/managed_packages/install-scriptlets/preuninstall.sh
@@ -42,8 +42,8 @@ fi
 
 # Always remove the .pyc files and __pycache__ directories
 
-# Removing only directories causes repeated deletion of some directories, which lead to warning messages,
-# so we delete files in the pycache folders first and only then the folders themselves.
+# It should be more logical to remove only  the __pycache__ directories, but that causes repeated deletion,
+# which leads to warning messages, so we delete files and directories in different conditions,
 find /usr/share/scalyr-agent-2 -type f -path "*/__pycache__/*" -delete -o -type d  -name __pycache__ -delete
 find /opt/scalyr-agent-2 -type f -path "*/__pycache__/*" -delete -o -type d  -name __pycache__ -delete
 

--- a/agent_build_refactored/managed_packages/install-scriptlets/preuninstall.sh
+++ b/agent_build_refactored/managed_packages/install-scriptlets/preuninstall.sh
@@ -41,12 +41,13 @@ if [ "$1" == "0" ] || [ "$1" == "remove" ]; then
 fi
 
 # Always remove the .pyc files and __pycache__ directories
-find /usr/share/scalyr-agent-2 -type f -path "*/__pycache__/*" -delete -o -type d  -name __pycache__ -exec rm -r {} \;
+
+# Removing only directories causes repeated deletion of some directories, which lead to warning messages,
+# so we delete files in the pycache folders first and only then the folders themselves.
+find /usr/share/scalyr-agent-2 -type f -path "*/__pycache__/*" -delete -o -type d  -name __pycache__ -delete
+find /opt/scalyr-agent-2 -type f -path "*/__pycache__/*" -delete -o -type d  -name __pycache__ -delete
 
 # Remove dynamically generated venv.
 rm -r "/var/opt/scalyr-agent-2/venv"
-
-# Collect garbage after Python.
-find /opt/scalyr-agent-2 -type f -path "*/__pycache__/*" -delete -o -type d  -name __pycache__ -exec rm -r {} \;
 
 exit 0;

--- a/agent_build_refactored/managed_packages/managed_packages_builders.py
+++ b/agent_build_refactored/managed_packages/managed_packages_builders.py
@@ -610,6 +610,13 @@ class LinuxDependencyPackagesBuilder(Runner):
             third_party_libs_dir / "__init__.py",
         )
 
+        # remove Python cache directories from agent's source code.
+        for path in agent_module_path.rglob("__pycache__/"):
+            if path.is_file():
+                continue
+            shutil.rmtree(path)
+
+
         version = (SOURCE_ROOT / "VERSION").read_text().strip()
 
         scriptlets_path = (

--- a/tests/end_to_end_tests/managed_packages_tests/test_packages.py
+++ b/tests/end_to_end_tests/managed_packages_tests/test_packages.py
@@ -189,7 +189,7 @@ def test_packages(
 
     logger.info("Start agent")
 
-    agent_commander.start_and_wait(env=_ADDITIONAL_ENVIRONMENT)
+    agent_commander.start_and_wait(env=_ADDITIONAL_ENVIRONMENT, logger=logger)
 
     verify_agent_status(
         agent_version=agent_version,
@@ -417,7 +417,7 @@ repo_gpgcheck=0
     assert LINUX_PACKAGE_AGENT_PATHS.agent_config_path.exists()
     assert server_host in LINUX_PACKAGE_AGENT_PATHS.agent_config_path.read_text()
 
-    agent_commander.start_and_wait()
+    agent_commander.start_and_wait(logger=logger)
 
     verify_agent_status(
         agent_version=agent_version,

--- a/tests/end_to_end_tests/managed_packages_tests/test_packages.py
+++ b/tests/end_to_end_tests/managed_packages_tests/test_packages.py
@@ -376,7 +376,7 @@ repo_gpgcheck=0
         yum_repo_file_path.write_text(yum_repo_file_content)
         _call_yum(["install", "-y", system_python_package_name])
         _call_yum(
-            ["install", "-y", f"{AGENT_PACKAGE_NAME}-{stable_agent_package_version}"]
+            ["install", "-y", f"{AGENT_PACKAGE_NAME}-{stable_agent_package_version}-1"]
         )
     else:
         raise Exception(f"Unknown package type: {package_builder.PACKAGE_TYPE}")
@@ -405,11 +405,12 @@ repo_gpgcheck=0
                 "-y",
                 "--only-upgrade",
                 "--allow-unauthenticated",
-                f"{AGENT_PACKAGE_NAME}={AGENT_VERSION}",
+                f"{AGENT_PACKAGE_NAME}",
             ]
         )
     elif package_builder.PACKAGE_TYPE == "rpm":
-        _call_yum(["install", "-y", f"{AGENT_PACKAGE_NAME}-{AGENT_VERSION}"])
+        _call_yum(["install", "-y", f"{AGENT_PACKAGE_NAME}"])
+        #_call_yum(["update", "-y"])
     else:
         raise Exception(f"Unknown package type: {package_builder.PACKAGE_TYPE}")
 

--- a/tests/end_to_end_tests/managed_packages_tests/test_packages.py
+++ b/tests/end_to_end_tests/managed_packages_tests/test_packages.py
@@ -189,7 +189,7 @@ def test_packages(
 
     logger.info("Start agent")
 
-    agent_commander.start(env=_ADDITIONAL_ENVIRONMENT)
+    agent_commander.start_and_wait(env=_ADDITIONAL_ENVIRONMENT)
 
     verify_agent_status(
         agent_version=agent_version,
@@ -417,7 +417,7 @@ repo_gpgcheck=0
     assert LINUX_PACKAGE_AGENT_PATHS.agent_config_path.exists()
     assert server_host in LINUX_PACKAGE_AGENT_PATHS.agent_config_path.read_text()
 
-    agent_commander.start()
+    agent_commander.start_and_wait()
 
     verify_agent_status(
         agent_version=agent_version,

--- a/tests/end_to_end_tests/tools.py
+++ b/tests/end_to_end_tests/tools.py
@@ -109,7 +109,9 @@ class AgentCommander:
                 if attempts >= 10:
                     agent_log = self.agent_paths.agent_log_path.read_text()
                     agent_log_tail = "".join(agent_log.splitlines()[:20])
-                    logger.error(f"Can not start agent and get it status. Give up.\nAgent log: {agent_log_tail}")
+                    logger.error(
+                        f"Can not start agent and get it status. Give up.\nAgent log: {agent_log_tail}"
+                    )
                     raise e
                 time.sleep(1)
                 attempts += 1

--- a/tests/end_to_end_tests/tools.py
+++ b/tests/end_to_end_tests/tools.py
@@ -89,14 +89,15 @@ class AgentCommander:
 
         self._check_call_command(cmd, env=env)
 
-    def start_and_wait(self, env: Dict = None):
+    def start_and_wait(self, logger, env: Dict = None):
         """
         Start the Agent and wait for a successful status.
+        :param logger: Logger instance.
         :param env: Optional environment variables for the agent process.
         """
         self.start(env=env)
 
-        time.sleep(0.2)
+        time.sleep(0.5)
 
         attempts = 0
 
@@ -104,7 +105,11 @@ class AgentCommander:
             try:
                 self.get_status_json()
             except subprocess.CalledProcessError as e:
+                logger.warning(f"Can not get agent status. Error: {e}\nRetry")
                 if attempts >= 10:
+                    agent_log = self.agent_paths.agent_log_path.read_text()
+                    agent_log_tail = "".join(agent_log.splitlines()[:20])
+                    logger.error(f"Can not start agent and get it status. Give up.\nAgent log: {agent_log_tail}")
                     raise e
                 time.sleep(1)
                 attempts += 1

--- a/tests/end_to_end_tests/tools.py
+++ b/tests/end_to_end_tests/tools.py
@@ -17,7 +17,7 @@ import json
 import pathlib as pl
 import subprocess
 import time
-from typing import List, Union
+from typing import List, Union, Dict
 
 
 @dataclasses.dataclass
@@ -88,6 +88,28 @@ class AgentCommander:
             cmd.append("--no-fork")
 
         self._check_call_command(cmd, env=env)
+
+    def start_and_wait(self, env: Dict = None):
+        """
+        Start the Agent and wait for a successful status.
+        :param env: Optional environment variables for the agent process.
+        """
+        self.start(env=env)
+
+        time.sleep(0.2)
+
+        attempts = 0
+
+        while True:
+            try:
+                self.get_status_json()
+            except subprocess.CalledProcessError as e:
+                if attempts >= 10:
+                    raise e
+                time.sleep(1)
+                attempts += 1
+            else:
+                break
 
     def get_status(self) -> str:
         return self._check_output_command(["status", "-v"]).decode()


### PR DESCRIPTION
This PR, to reduce noise, removes some warnings that are produced during the package uninstallation. 

Other changes: 
* It also disables check of the new version of the pip, so the update suggestion message won't shown every time.

* Also corrected venv removal during the `pre-uninstall` script execution.

* Retries added to the package status tests to reduce overall flakiness.