### PR TITLE
DSET-2112 Support SSL connections to PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Packaged by Arthur Kamalov <arthurk@sentinelone.com> on Jan 19, 2023 00:00 -0800
 
 Other:
 * Linux `deb` and `rpm` packages are now shipped with its own Python interpreter, so agent does not have to rely on system Python interpreter anymore. Please refer to the RELEASE_NOTES document, for more information.
+* The PostgreSQL monitor now supports connecting to servers over SSL. Configure the monitor with the setting `use_ssl` set to `True` to enable this.
 
 Bug fixes:
 * Fix bug in the Docker monitor which would, under some edge cases, cause a specific log messages to be logged very often and as such, exhausting the CPU cycles available to the Docker monitor.

--- a/docs/monitors/postgres_monitor.md
+++ b/docs/monitors/postgres_monitor.md
@@ -86,6 +86,7 @@ For help, contact us at [support@scalyr.com](mailto:support@scalyr.com).
 | `id`                | Optional. An id, included with each event. Shows in the UI as a value for the `instance` field. If you are running multiple instances of this plugin, id lets you distinguish between them. This is especially useful if you are running multiple PostgreSQL instances on a single server. Each instance has a separate `{...}` stanza in the configuration file (`/etc/scalyr-agent-2/agent.json`). | 
 | `database_host`     | Optional (default to `localhost`). Name of the host on which PostgreSQL is running. | 
 | `database_port`     | Optional (defaults to `5432`). Port for PostgreSQL. | 
+| `use_ssl`           | Optional (defaults to False). Whether to connect to PostgreSQL over SSL. Note: Self-signed server certs are not supported at this time. Additionally, server cert validation and hostname checking is only performed on Python 2.7.9 and newer. Older Python versions are vulnerable to MitM attacks. | 
 | `database_name`     | Name of the PostgreSQL database the Scalyr Agent will connect to. | 
 | `database_username` | Username the Scalyr Agent connects with. | 
 | `database_password` | Password the Scalyr Agent connects with. | 

--- a/scalyr_agent/builtin_monitors/postgres_monitor.py
+++ b/scalyr_agent/builtin_monitors/postgres_monitor.py
@@ -74,7 +74,11 @@ define_config_option(
 define_config_option(
     __monitor__,
     "use_ssl",
-    "Optional (defaults to False). Whether to connect to PostgreSQL over SSL.",
+    ("Optional (defaults to False). Whether to connect to PostgreSQL over SSL. "
+     "Note: Self-signed server certs are not supported at this time. "
+     "Additionally, server cert validation and hostname checking is only "
+     "performed on Python 2.7.9 and newer. Older Python versions are vulnerable "
+     "to MitM attacks."),
     convert_to=bool,
     default=False,
 )

--- a/scalyr_agent/builtin_monitors/postgres_monitor.py
+++ b/scalyr_agent/builtin_monitors/postgres_monitor.py
@@ -74,11 +74,13 @@ define_config_option(
 define_config_option(
     __monitor__,
     "use_ssl",
-    ("Optional (defaults to False). Whether to connect to PostgreSQL over SSL. "
-     "Note: Self-signed server certs are not supported at this time. "
-     "Additionally, server cert validation and hostname checking is only "
-     "performed on Python 2.7.9 and newer. Older Python versions are vulnerable "
-     "to MitM attacks."),
+    (
+        "Optional (defaults to False). Whether to connect to PostgreSQL over SSL. "
+        "Note: Self-signed server certs are not supported at this time. "
+        "Additionally, server cert validation and hostname checking is only "
+        "performed on Python 2.7.9 and newer. Older Python versions are vulnerable "
+        "to MitM attacks."
+    ),
     convert_to=bool,
     default=False,
 )
@@ -410,7 +412,9 @@ class PostgreSQLDb(object):
     def __repr__(self):
         return self.__str__()
 
-    def __init__(self, host, port, database, username, password, use_ssl=False, logger=None):
+    def __init__(
+        self, host, port, database, username, password, use_ssl=False, logger=None
+    ):
         """Constructor:
 
         @param database: database we are connecting to
@@ -528,7 +532,7 @@ For help, contact us at [support@scalyr.com](mailto:support@scalyr.com).
         database = None
         host = "localhost"
         port = 5432
-        use_ssl = self._config.get('use_ssl', False)
+        use_ssl = self._config.get("use_ssl", False)
         username = None
         password = None
         if "database_host" in self._config:

--- a/scalyr_agent/builtin_monitors/postgres_monitor.py
+++ b/scalyr_agent/builtin_monitors/postgres_monitor.py
@@ -73,6 +73,13 @@ define_config_option(
 )
 define_config_option(
     __monitor__,
+    "use_ssl",
+    "Optional (defaults to False). Whether to connect to PostgreSQL over SSL.",
+    convert_to=bool,
+    default=False,
+)
+define_config_option(
+    __monitor__,
     "database_name",
     "Name of the PostgreSQL database the Scalyr Agent will connect to.",
     convert_to=six.text_type,
@@ -273,6 +280,7 @@ class PostgreSQLDb(object):
             conn = pg8000.connect(
                 user=self._user,
                 host=self._host,
+                ssl=self._use_ssl,
                 port=self._port,
                 database=self._database,
                 password=self._password,
@@ -398,7 +406,7 @@ class PostgreSQLDb(object):
     def __repr__(self):
         return self.__str__()
 
-    def __init__(self, host, port, database, username, password, logger=None):
+    def __init__(self, host, port, database, username, password, use_ssl=False, logger=None):
         """Constructor:
 
         @param database: database we are connecting to
@@ -410,6 +418,7 @@ class PostgreSQLDb(object):
 
         self._host = host
         self._port = port
+        self._use_ssl = use_ssl
         self._database = database
         self._user = username
         self._password = password
@@ -515,6 +524,7 @@ For help, contact us at [support@scalyr.com](mailto:support@scalyr.com).
         database = None
         host = "localhost"
         port = 5432
+        use_ssl = self._config.get('use_ssl', False)
         username = None
         password = None
         if "database_host" in self._config:
@@ -541,6 +551,7 @@ For help, contact us at [support@scalyr.com](mailto:support@scalyr.com).
             database=database,
             host=host,
             port=port,
+            use_ssl=use_ssl,
             username=username,
             password=password,
             logger=self._logger,


### PR DESCRIPTION
Support SSL connections to PostgreSQL. Enable by setting `use_ssl` to `True` in the `postgres_monitor` config.

DSET-2112