### PR TITLE
fix empty tags error on ec2 instances cleanup.

### DIFF
--- a/agent_build_refactored/tools/run_in_ec2/cleanup_ec2_objects.py
+++ b/agent_build_refactored/tools/run_in_ec2/cleanup_ec2_objects.py
@@ -167,6 +167,10 @@ def cleanup_volumes(
 
 
 def _get_instance_name(instance):
+
+    if instance.tags is None:
+        return None
+
     for tag in instance.tags:
         if tag["Key"] == "Name":
             return tag["Value"]


### PR DESCRIPTION
This small PR handles edge case in ec2 cleanup script when running instance does not have any tags.