### PR TITLE
Fix build due to the missing codecov dependency

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -73,7 +73,7 @@ jobs:
           coverage xml -i -o coverage.xml
 
       - name: Upload Coverage to Codecov.io
-        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3
+        uses: codecov/codecov-action@40a12dcee2df644d47232dde008099a3e9e4f865 # pin@v3.1.2
         with:
           files: ./coverage.xml
           fail_ci_if_error: true

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -57,7 +57,7 @@ jobs:
           coverage xml -i -o coverage.xml
 
       - name: Upload Coverage to Codecov.io
-        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3
+        uses: codecov/codecov-action@40a12dcee2df644d47232dde008099a3e9e4f865 # pin@v3.1.2
         with:
           files: ./coverage.xml
           fail_ci_if_error: true

--- a/agent_build/requirement-files/testing-requirements.txt
+++ b/agent_build/requirement-files/testing-requirements.txt
@@ -20,7 +20,6 @@ pytest-benchmark==3.2.3; python_version < '3.11'
 pytest-benchmark==4.0.0; python_version == '3.11'
 pytest-xdist==1.31.0
 coverage==4.5.4
-codecov==2.1.9
 decorator==4.4.1
 requests-mock==1.9.3
 six==1.13.0

--- a/dev-requirements-new.txt
+++ b/dev-requirements-new.txt
@@ -55,7 +55,6 @@ pygal==3.0.0
 pytest-benchmark==4.0.0
 pytest-xdist==1.31.0
 coverage==4.5.4
-codecov==2.1.9
 decorator==4.4.1
 requests-mock==1.9.3
 docker==6.0.0

--- a/windows-unit-tests-requirements.txt
+++ b/windows-unit-tests-requirements.txt
@@ -9,7 +9,6 @@ pytest-timeout==1.3.4
 pytest-benchmark==3.2.3
 pytest-xdist==1.31.0
 coverage==4.5.4
-codecov==2.1.9
 decorator==4.4.1
 six==1.13.0
 docker==4.1.0


### PR DESCRIPTION
This pull request fixes a build which was failing due to the missing ``codecov`` PyPi package / dependency.

## Background, Context

codecov Python package has been deprecated for a while and replaced by the codecov uploader GHA action (https://docs.codecov.com/docs/deprecated-uploader-migration-guide#python-uploader). Now the package has been fully removed from PyPi which started to cause build failures.