### PR TITLE
Update workflow trigger to make sure Docker image build is also triggered on push to a tag

### DIFF
--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*.*.*
   pull_request:
     branches:
       - master

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request updates Docker Image Build workflow trigger to make sure it's also triggered on push to a tag (which happens as part of the release process).