### PR TITLE
DTIN-2823 - Scalyr Agent tests stability on local machine

### DIFF
--- a/agent_build/requirement-files/testing-requirements.txt
+++ b/agent_build/requirement-files/testing-requirements.txt
@@ -48,6 +48,7 @@ more-itertools==5.0.0; python_version <= '2.7'
 distro==1.6.0
 xmltodict==0.13.0; python_version >= '3.0'
 syslogmp==0.3; python_version >= '3.6'
+PyYAML==6.0
 
 paramiko==2.12.0; python_version >= '3.7'
 apache-libcloud==3.6.1; python_version >= '3.7'

--- a/tox.ini
+++ b/tox.ini
@@ -31,15 +31,6 @@ VARIANT =
     ratelimit: ratelimit
 
 [testenv]
-basepython =
-    {py2.7-unit-tests,py2.7-smoke-tests,coverage}: python2.7
-    {py3.5-unit-tests,py3.5-smoke-tests}: python3.5
-    {py3.6-unit-tests,py3.6-smoke-tests,lint,black,modernize,flake8,pylint,mypy,generate-monitor-docs}: python3.6
-    {lint,black,modernize,flake8,pylint,mypy}: {env:LINT_PYTHON_BINARY}
-    {py3.7-unit-tests,py3.7-smoke-tests}: python3.7
-    {py3.8-unit-tests,py3.8-smoke-tests}: python3.8
-    {py3.9-unit-tests}: python3.9
-    {py3.10-unit-tests}: python3.10
 # NOTE: We pass the TERM env to preserve colors
 passenv =
     TERM


### PR DESCRIPTION
testing-requirements.txt - Added pyyaml, it's needed for executing on a local dev machine to load config.yml.

tox.ini - removed unnecesary and incorrect basepython mappings. It prevents tox from automatically setting basepython from a pyXY factor.
Seemed like a legacy part and was causing tox to use a default version for all targets on a local machine. 
It has no effect on execution via github acitons.