### PR TITLE
Also run secrets scan workflow on the release branch

### DIFF
--- a/.github/workflows/secrets-scanner.yaml
+++ b/.github/workflows/secrets-scanner.yaml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - master
+      - release
   pull_request:
     branches:
       - master
+      - release
   schedule:
     - cron: '0 4 * * *'
 
@@ -13,7 +15,8 @@ permissions:
   contents: read
 
 jobs:
-  TruffleHog:
+  trufflehog_push_pull:
+    name: TruffleHog (push, pull)
     runs-on: ubuntu-latest
 
     steps:
@@ -51,18 +54,92 @@ jobs:
           head: ${{ github.ref_name }}
           extra_args: --debug --only-verified
 
+      - name: Notify Slack on Failure
+        if: ${{ failure() && (github.ref_name == 'master' || github.ref_name == 'release') }}
+        uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#eng-dataset-o11y'
+
+  trufflehog_cron_master_branch:
+    name: TruffleHog - cron (master branch)
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'schedule' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: "master"
+          fetch-depth: 0
+
+      # Special check which ensures that the clone performed above is not shallow. We need the
+      # complete git history for scanning to work correctly in all the situations. In some cases
+      # if a shallow clone is used, trufflehog won't not fail with an error, but it would simply
+      # not detect any files and that could be dangerous.
+      - name: Shallow repo check
+        run: |
+          if git rev-parse --is-shallow-repository | grep -q "true"; then
+            echo "Encountered a shallow repository, trufflehog may not work as expected!"
+            exit 1
+          fi
+
       # As part of cron trigger we scan the whole repo directory.
       # NOTE: Since trufflehog GHA is meant to be used in context of push / pr it can't be
       # used dorectly to scan the whole repo directory. This may take a while, but it's good idea
       # to run it on a daily basis.
-      - name: scan-cron
-        if: ${{ github.event_name == 'schedule' }}
+      - name: scan-cron-master
         run: |
           docker run --rm -v "$PWD:/workdir" trufflesecurity/trufflehog:latest git \
             file:///workdir --fail --no-update --debug --only-verified
 
       - name: Notify Slack on Failure
-        if: ${{ failure() && github.ref_name == 'master' }}
+        if: ${{ failure() && (github.ref_name == 'master' || github.ref_name == 'release') }}
+        uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#eng-dataset-o11y'
+
+  trufflehog_cron_release_branch:
+    name: TruffleHog - cron (release branch)
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'schedule' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: "release"
+          fetch-depth: 0
+
+      # Special check which ensures that the clone performed above is not shallow. We need the
+      # complete git history for scanning to work correctly in all the situations. In some cases
+      # if a shallow clone is used, trufflehog won't not fail with an error, but it would simply
+      # not detect any files and that could be dangerous.
+      - name: Shallow repo check
+        run: |
+          if git rev-parse --is-shallow-repository | grep -q "true"; then
+            echo "Encountered a shallow repository, trufflehog may not work as expected!"
+            exit 1
+          fi
+
+      # As part of cron trigger we scan the whole repo directory.
+      # NOTE: Since trufflehog GHA is meant to be used in context of push / pr it can't be
+      # used dorectly to scan the whole repo directory. This may take a while, but it's good idea
+      # to run it on a daily basis.
+      - name: scan-cron-master
+        run: |
+          docker run --rm -v "$PWD:/workdir" trufflesecurity/trufflehog:latest git \
+            file:///workdir --fail --no-update --debug --only-verified
+
+      - name: Notify Slack on Failure
+        if: ${{ failure() && (github.ref_name == 'master' || github.ref_name == 'release') }}
         uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This pull request updates secret scanner workflow to also run on the `release` branch - as part of the push, pr and cron trigger.