### PR TITLE
Packages updated to fix vulnerabilities.

### DIFF
--- a/dev-requirements-new.txt
+++ b/dev-requirements-new.txt
@@ -13,7 +13,10 @@ repoze.lru==0.7
 six==1.14.0
 
 # Required for redis monitor.
-redis==4.6.0
+redis==2.10.5; python_version == '3.6'
+redis==4.6.0; python_version >= '3.7'
+
+
 
 # Required for mysql monitor
 PyMySQL==0.9.3

--- a/dev-requirements-new.txt
+++ b/dev-requirements-new.txt
@@ -13,8 +13,7 @@ repoze.lru==0.7
 six==1.14.0
 
 # Required for redis monitor.
-redis==2.10.5; python_version == '3.6'
-redis==4.6.0; python_version >= '3.7'
+redis==2.10.5
 
 
 
@@ -25,7 +24,7 @@ PyMySQL==0.9.3
 pg8000==1.10.6
 
 # Required for snmp monitor
-pysnmp==4.4.12; platform_system != 'Windows' and platform_system != 'Darwin'
+pysnmp==4.3.0; platform_system != 'Windows' and platform_system != 'Darwin'
 
 # Required for syslog monitor
 syslogmp==0.3; python_version >= '3.6'

--- a/dev-requirements-new.txt
+++ b/dev-requirements-new.txt
@@ -29,7 +29,7 @@ pysnmp==4.3.0; platform_system != 'Windows' and platform_system != 'Darwin'
 # Required for syslog monitor
 syslogmp==0.3; python_version >= '3.6'
 
-docker==6.0.0; python_version >= '3.7'
+docker==6.1.3; python_version >= '3.7'
 docker==5.0.3; python_version == '3.6'
 docker==4.4.4; python_version < '3.6'
 

--- a/dev-requirements-new.txt
+++ b/dev-requirements-new.txt
@@ -6,14 +6,14 @@
 
 # Agent's common requirements. Expected to installed on any type of agent.
 # <COMPONENT:COMMON>
-requests==2.28.1; python_version >= '3.7'
+requests==2.31.0; python_version >= '3.7'
 requests==2.25.1; python_version < '3.7'
 python-dateutil==2.8.2
 repoze.lru==0.7
 six==1.14.0
 
 # Required for redis monitor.
-redis==2.10.5
+redis==4.6.0
 
 # Required for mysql monitor
 PyMySQL==0.9.3
@@ -22,7 +22,7 @@ PyMySQL==0.9.3
 pg8000==1.10.6
 
 # Required for snmp monitor
-pysnmp==4.3.0; platform_system != 'Windows' and platform_system != 'Darwin'
+pysnmp==4.4.12; platform_system != 'Windows' and platform_system != 'Darwin'
 
 # Required for syslog monitor
 syslogmp==0.3; python_version >= '3.6'

--- a/dev-requirements-new.txt
+++ b/dev-requirements-new.txt
@@ -15,8 +15,6 @@ six==1.14.0
 # Required for redis monitor.
 redis==2.10.5
 
-
-
 # Required for mysql monitor
 PyMySQL==0.9.3
 
@@ -24,7 +22,7 @@ PyMySQL==0.9.3
 pg8000==1.10.6
 
 # Required for snmp monitor
-pysnmp==4.3.0; platform_system != 'Windows' and platform_system != 'Darwin'
+pysnmp==4.4.12; platform_system != 'Windows' and platform_system != 'Darwin'
 
 # Required for syslog monitor
 syslogmp==0.3; python_version >= '3.6'

--- a/tests/unit/scalyr_client_test.py
+++ b/tests/unit/scalyr_client_test.py
@@ -1039,7 +1039,7 @@ class ClientSessionTest(BaseScalyrLogCaptureTestCase):
 
         user_agent = session._ScalyrClientSession__standard_headers["User-Agent"]
         split = user_agent.split(";")
-        self.assertEqual(split[-1], "requests-2.28.1")
+        self.assertEqual(split[-1], "requests-2.31.0")
         self.assertEqual(split[-4], "o-1.0.2-13")
         self.assertTrue(split[1].startswith("python-"))
 


### PR DESCRIPTION
https://sentinelone.atlassian.net/browse/DTIN-2974

requests==2.31.0 - in order to get certifi==2023.7.22
docker==6.1.3 - version compatible with the new requests
pysnmp==4.4.12 - to in order to fix the pycrypto vulnerability

All effective changes:
```
2,3c2,3
< charset-normalizer==2.1.1
< docker==6.0.0
---
> charset-normalizer==3.2.0
> docker==6.1.3
4a5,6
> lz4==4.0.2
> orjson==3.8.0
10c12
< pycrypto==2.6.1
---
> pycryptodomex==3.18.0
13c15
< pysnmp==4.3.0
---
> pysnmp==4.4.12
17c19
< requests==2.28.1
---
> requests==2.31.0
21c23
< urllib3==1.26.16
---
> urllib3==2.0.4
22a25
> zstandard==0.19.0
```