### PR TITLE
allow_http_monitors config implementation

### DIFF
--- a/.github/workflows/reusable-agent-build-container-images.yml
+++ b/.github/workflows/reusable-agent-build-container-images.yml
@@ -632,7 +632,7 @@ jobs:
           K8S_NODE_NAME: "${{ env.K8S_NODE_NAME }}"
           K8S_CLUSTER_NAME: "${{ env.K8S_CLUSTER_NAME }}"
         run: |
-          export RETRY_ATTEMPTS="14"
+          export RETRY_ATTEMPTS="30"
           export SLEEP_DELAY="10"
 
           # Verify agent is running

--- a/agent_build_refactored/container_images/base_images/ubuntu-fips.Dockerfile
+++ b/agent_build_refactored/container_images/base_images/ubuntu-fips.Dockerfile
@@ -22,3 +22,4 @@ RUN DEBIANFRONTEND=noninteractive apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 ENV OPENSSL_CONF /etc/ssl/openssl.cnf.fips
+ENV SCALYR_ALLOW_HTTP_MONITORS false

--- a/scalyr_agent/builtin_monitors/__init__.py
+++ b/scalyr_agent/builtin_monitors/__init__.py
@@ -1,10 +1,1 @@
 all = ["linux_system_metrics"]
-
-unsecure_http_config_fields = [
-    "url",
-    "monitor_url",
-    "status_url",
-    "k8s_kubelet_api_url_template",
-    "k8s_api_url"
-]
-

--- a/scalyr_agent/builtin_monitors/__init__.py
+++ b/scalyr_agent/builtin_monitors/__init__.py
@@ -1,1 +1,10 @@
 all = ["linux_system_metrics"]
+
+unsecure_http_config_fields = [
+    "url",
+    "monitor_url",
+    "status_url",
+    "k8s_kubelet_api_url_template",
+    "k8s_api_url"
+]
+

--- a/scalyr_agent/builtin_monitors/apache_monitor.py
+++ b/scalyr_agent/builtin_monitors/apache_monitor.py
@@ -49,7 +49,7 @@ define_config_option(
     "number, at which the Apache status module is served. The URL should end in `/?auto` to "
     "indicate that the machine-readable version of the page should be returned.",
     default="http://localhost/server-status/?auto",
-    insecure_http_url=True
+    allow_http=False
 )
 define_config_option(
     __monitor__,

--- a/scalyr_agent/builtin_monitors/apache_monitor.py
+++ b/scalyr_agent/builtin_monitors/apache_monitor.py
@@ -49,6 +49,7 @@ define_config_option(
     "number, at which the Apache status module is served. The URL should end in `/?auto` to "
     "indicate that the machine-readable version of the page should be returned.",
     default="http://localhost/server-status/?auto",
+    insecure_http_url=True
 )
 define_config_option(
     __monitor__,

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -291,6 +291,7 @@ define_config_option(
     "DEPRECATED.",
     convert_to=six.text_type,
     default="https://kubernetes.default",
+    insecure_http_url=True
 )
 
 define_config_option(
@@ -418,6 +419,7 @@ define_config_option(
     convert_to=six.text_type,
     default="https://${host_ip}:10250",
     env_aware=True,
+    insecure_http_url=True
 )
 
 define_config_option(

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -291,7 +291,7 @@ define_config_option(
     "DEPRECATED.",
     convert_to=six.text_type,
     default="https://kubernetes.default",
-    insecure_http_url=True
+    allow_http=False
 )
 
 define_config_option(
@@ -419,7 +419,7 @@ define_config_option(
     convert_to=six.text_type,
     default="https://${host_ip}:10250",
     env_aware=True,
-    insecure_http_url=True
+    allow_http=False
 )
 
 define_config_option(

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -254,7 +254,7 @@ define_config_option(
     convert_to=six.text_type,
     default="https://${host_ip}:10250",
     env_aware=True,
-    insecure_http_url=True
+    allow_http=False
 )
 
 # Monitor specific options

--- a/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_openmetrics_monitor.py
@@ -254,6 +254,7 @@ define_config_option(
     convert_to=six.text_type,
     default="https://${host_ip}:10250",
     env_aware=True,
+    insecure_http_url=True
 )
 
 # Monitor specific options

--- a/scalyr_agent/builtin_monitors/nginx_monitor.py
+++ b/scalyr_agent/builtin_monitors/nginx_monitor.py
@@ -31,6 +31,7 @@ define_config_option(
     "Always `scalyr_agent.builtin_monitors.nginx_monitor`",
     convert_to=six.text_type,
     required_option=True,
+    insecure_http_url=True
 )
 define_config_option(
     __monitor__,

--- a/scalyr_agent/builtin_monitors/nginx_monitor.py
+++ b/scalyr_agent/builtin_monitors/nginx_monitor.py
@@ -31,7 +31,7 @@ define_config_option(
     "Always `scalyr_agent.builtin_monitors.nginx_monitor`",
     convert_to=six.text_type,
     required_option=True,
-    insecure_http_url=True
+    allow_http=False
 )
 define_config_option(
     __monitor__,

--- a/scalyr_agent/builtin_monitors/openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/openmetrics_monitor.py
@@ -129,7 +129,7 @@ define_config_option(
     "url",
     "URL to the OpenMetrics / Prometheus API endpoint (e.g. https://my.host:8080/metrics).",
     convert_to=six.text_type,
-    insecure_http_url=True
+    allow_http=False
 )
 
 define_config_option(

--- a/scalyr_agent/builtin_monitors/openmetrics_monitor.py
+++ b/scalyr_agent/builtin_monitors/openmetrics_monitor.py
@@ -129,6 +129,7 @@ define_config_option(
     "url",
     "URL to the OpenMetrics / Prometheus API endpoint (e.g. https://my.host:8080/metrics).",
     convert_to=six.text_type,
+    insecure_http_url=True
 )
 
 define_config_option(

--- a/scalyr_agent/builtin_monitors/tomcat_monitor.py
+++ b/scalyr_agent/builtin_monitors/tomcat_monitor.py
@@ -64,7 +64,7 @@ define_config_option(
     "Name of host machine the agent will connect to PostgreSQL to retrieve monitoring data.",
     convert_to=six.text_type,
     required_option=True,
-    insecure_http_url=True
+    allow_http=False
 )
 define_config_option(
     __monitor__,

--- a/scalyr_agent/builtin_monitors/tomcat_monitor.py
+++ b/scalyr_agent/builtin_monitors/tomcat_monitor.py
@@ -64,6 +64,7 @@ define_config_option(
     "Name of host machine the agent will connect to PostgreSQL to retrieve monitoring data.",
     convert_to=six.text_type,
     required_option=True,
+    insecure_http_url=True
 )
 define_config_option(
     __monitor__,

--- a/scalyr_agent/builtin_monitors/url_monitor.py
+++ b/scalyr_agent/builtin_monitors/url_monitor.py
@@ -58,7 +58,7 @@ define_config_option(
     "url",
     "URL for the request. Must be HTTP or HTTPS.",
     required_option=True,
-    insecure_http_url=True
+    allow_http=False
 )
 define_config_option(
     __monitor__,

--- a/scalyr_agent/builtin_monitors/url_monitor.py
+++ b/scalyr_agent/builtin_monitors/url_monitor.py
@@ -58,6 +58,7 @@ define_config_option(
     "url",
     "URL for the request. Must be HTTP or HTTPS.",
     required_option=True,
+    insecure_http_url=True
 )
 define_config_option(
     __monitor__,

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -523,12 +523,6 @@ class Configuration(object):
                 monitor_config[name] = ensure_https_url(value)
         return monitor_config
 
-        # from scalyr_agent.builtin_monitors import unsecure_http_config_fields
-        # for field in unsecure_http_config_fields:
-        #     if field in monitor_config:
-        #         monitor_config[field] = ensure_https_url(monitor_config[field])
-
-
     def __verify_workers(self):
         """
         Verify all worker config entries from the "workers" list in config.

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -515,6 +515,7 @@ class Configuration(object):
 
     @staticmethod
     def force_http_monitor_config(monitor_config):
+        # Loads a monitor module, checks for options marked as insecure_http_url and forces https scheme there.
         __import__(monitor_config["module"])
         monitor_info = MonitorInformation.get_monitor_info(monitor_config["module"])
         for name, value in monitor_config.iteritems():

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -515,12 +515,12 @@ class Configuration(object):
 
     @staticmethod
     def force_http_monitor_config(monitor_config):
-        # Loads a monitor module, checks for options marked as insecure_http_url and forces https scheme there.
+        # Loads a monitor module, checks for options marked as allow_http=False and forces https scheme there.
         __import__(monitor_config["module"])
         monitor_info = MonitorInformation.get_monitor_info(monitor_config["module"])
         for name, value in monitor_config.iteritems():
             monitor_config_option = monitor_info.config_option(name)
-            if monitor_config_option and monitor_config_option.insecure_http_url:
+            if monitor_config_option and not monitor_config_option.allow_http:
                 monitor_config[name] = ensure_https_url(value)
         return monitor_config
 

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -21,6 +21,8 @@ from __future__ import absolute_import
 
 __author__ = "czerwin@scalyr.com"
 
+from scalyr_agent.scalyr_monitor import MonitorInformation
+
 if False:
     from typing import Tuple
     from typing import Dict
@@ -76,6 +78,19 @@ MASKED_CONFIG_ITEM_VALUE = "********** MASKED **********"
 # prefix for the worker session log file name.
 AGENT_WORKER_SESSION_LOG_NAME_PREFIX = "agent-worker-session-"
 
+
+def ensure_https_url(server):
+    parts = six.moves.urllib.parse.urlparse(server)
+
+    # use index-based addressing for 2.4 compatibility
+    scheme = parts[0]
+
+    if not scheme:
+        return "https://" + server
+    elif scheme == "http":
+        return re.sub("^http://", "https://", server)
+    else:
+        return server
 
 class Configuration(object):
     """Encapsulates the results of a single read of the configuration file.
@@ -302,17 +317,8 @@ class Configuration(object):
             # force https unless otherwise instructed not to
             if not self.__config["allow_http"]:
                 server = self.__config["scalyr_server"].strip()
-                https_server = server
 
-                parts = six.moves.urllib.parse.urlparse(server)
-
-                # use index-based addressing for 2.4 compatibility
-                scheme = parts[0]
-
-                if not scheme:
-                    https_server = "https://" + server
-                elif scheme == "http":
-                    https_server = re.sub("^http://", "https://", server)
+                https_server = ensure_https_url(server)
 
                 if https_server != server:
                     self.__config["scalyr_server"] = https_server
@@ -484,7 +490,7 @@ class Configuration(object):
                 )
                 self.__log_configs.append(profile_config)
 
-            self.__monitor_configs = list(self.__config.get_json_array("monitors"))
+            self.__monitor_configs = self.__get_monitors_config()
 
             # Perform validation for k8s_logs option
             self._check_k8s_logs_config_option_and_warn()
@@ -498,6 +504,30 @@ class Configuration(object):
         except BadConfiguration as e:
             self.__last_error = e
             raise e
+
+    def __get_monitors_config(self):
+        monitors_config = list(self.__config.get_json_array("monitors"))
+        if not self.allow_http_monitors:
+            return list(map(
+                    self.force_http_monitor_config, monitors_config
+            ))
+        return monitors_config
+
+    @staticmethod
+    def force_http_monitor_config(monitor_config):
+        __import__(monitor_config["module"])
+        monitor_info = MonitorInformation.get_monitor_info(monitor_config["module"])
+        for name, value in monitor_config.iteritems():
+            monitor_config_option = monitor_info.config_option(name)
+            if monitor_config_option and monitor_config_option.insecure_http_url:
+                monitor_config[name] = ensure_https_url(value)
+        return monitor_config
+
+        # from scalyr_agent.builtin_monitors import unsecure_http_config_fields
+        # for field in unsecure_http_config_fields:
+        #     if field in monitor_config:
+        #         monitor_config[field] = ensure_https_url(monitor_config[field])
+
 
     def __verify_workers(self):
         """
@@ -979,6 +1009,10 @@ class Configuration(object):
         )
 
         return monitor_config
+
+    @property
+    def allow_http_monitors(self):
+        return self.__get_config().get_bool("allow_http_monitors")
 
     # k8s cache options
     @property
@@ -2232,6 +2266,9 @@ class Configuration(object):
         )
         self.__verify_or_set_optional_bool(
             config, "allow_http", False, description, apply_defaults, env_aware=True
+        )
+        self.__verify_or_set_optional_bool(
+            config, "allow_http_monitors", True, description, apply_defaults, env_aware=True
         )
         self.__verify_or_set_optional_bool(
             config,

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -591,7 +591,7 @@ def define_config_option(
     default=None,
     env_aware=False,
     env_name=None,
-    insecure_http_url=False,
+    allow_http=True,
 ):
     """Defines a configuration option for the specified monitor.
 
@@ -632,7 +632,7 @@ def define_config_option(
     option.default = default
     option.env_aware = env_aware
     option.env_name = env_name
-    option.insecure_http_url = insecure_http_url
+    option.allow_http = allow_http
 
 
     MonitorInformation.set_monitor_info(monitor_module, option=option)
@@ -901,7 +901,7 @@ class ConfigOption(object):
         # Customer environment variable name (instead of SCALYR_<option_name>
         self.env_name = None
         # Marks a possibly unsecure HTTP url
-        self.insecure_http_url = False
+        self.allow_http = True
 
     def __repr__(self):
         return "%s %s %s" % (self.option_name, self.env_aware, self.env_name)

--- a/scalyr_agent/scalyr_monitor.py
+++ b/scalyr_agent/scalyr_monitor.py
@@ -591,6 +591,7 @@ def define_config_option(
     default=None,
     env_aware=False,
     env_name=None,
+    insecure_http_url=False,
 ):
     """Defines a configuration option for the specified monitor.
 
@@ -631,6 +632,8 @@ def define_config_option(
     option.default = default
     option.env_aware = env_aware
     option.env_name = env_name
+    option.insecure_http_url = insecure_http_url
+
 
     MonitorInformation.set_monitor_info(monitor_module, option=option)
     return None
@@ -751,6 +754,17 @@ class MonitorInformation(object):
         return sorted(
             six.itervalues(self.__options), key=self.__get_insert_sort_position
         )
+
+    def config_option(self, name):
+        """Returns the configuration option with the specified name.
+
+        @param name: The name of the option
+        @type name: ConfigOption
+
+        @return: The option or None if not found
+        @rtype: ConfigOption
+        """
+        return self.__options.get(name)
 
     @property
     def metrics(self):
@@ -886,6 +900,8 @@ class ConfigOption(object):
         self.env_aware = False
         # Customer environment variable name (instead of SCALYR_<option_name>
         self.env_name = None
+        # Marks a possibly unsecure HTTP url
+        self.insecure_http_url = False
 
     def __repr__(self):
         return "%s %s %s" % (self.option_name, self.env_aware, self.env_name)

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -635,6 +635,29 @@ class TestConfiguration(TestConfigurationBase):
         self.assertEqual("http://rick.com", config.monitor_configs[0].get("secure_url"))
         self.assertEqual("https://morty.com", config.monitor_configs[0].get("insecure_url"))
 
+    def test_allow_http_monitors_force_https_http_env(self):
+        self._write_file_with_separator_conversion(
+            """ {
+            api_key: "hi there",
+            scalyr_server: "http://agent.scalyr.com",
+            monitors: [
+                {
+                    module: "tests.unit.test_monitor",
+                    secure_url: "http://rick.com",
+                    insecure_url: "http://morty.com"
+                }
+            ]
+          }
+        """
+        )
+
+        os.environ["SCALYR_ALLOW_HTTP_MONITORS"] = "false"
+
+        config = self._create_test_configuration_instance()
+        config.parse()
+        self.assertEqual("http://rick.com", config.monitor_configs[0].get("secure_url"))
+        self.assertEqual("https://morty.com", config.monitor_configs[0].get("insecure_url"))
+
     def test_allow_http_monitors_true(self):
         self._write_file_with_separator_conversion(
             """ {

--- a/tests/unit/configuration_test.py
+++ b/tests/unit/configuration_test.py
@@ -614,6 +614,68 @@ class TestConfiguration(TestConfigurationBase):
         config.parse()
         self.assertEqual("http://agent.scalyr.com", config.scalyr_server)
 
+    def test_allow_http_monitors_force_https_http(self):
+        self._write_file_with_separator_conversion(
+            """ {
+            api_key: "hi there",
+            allow_http_monitors: "false",
+            scalyr_server: "http://agent.scalyr.com",
+            monitors: [
+                {
+                    module: "tests.unit.test_monitor",
+                    secure_url: "http://rick.com",
+                    insecure_url: "http://morty.com"
+                }
+            ]
+          }
+        """
+        )
+        config = self._create_test_configuration_instance()
+        config.parse()
+        self.assertEqual("http://rick.com", config.monitor_configs[0].get("secure_url"))
+        self.assertEqual("https://morty.com", config.monitor_configs[0].get("insecure_url"))
+
+    def test_allow_http_monitors_true(self):
+        self._write_file_with_separator_conversion(
+            """ {
+            api_key: "hi there",
+            allow_http_monitors: "true",
+            scalyr_server: "http://agent.scalyr.com",
+            monitors: [
+                {
+                    module: "tests.unit.test_monitor",
+                    secure_url: "http://rick.com",
+                    insecure_url: "http://morty.com"
+                }
+            ]
+          }
+        """
+        )
+        config = self._create_test_configuration_instance()
+        config.parse()
+        self.assertEqual("http://rick.com", config.monitor_configs[0].get("secure_url"))
+        self.assertEqual("http://morty.com", config.monitor_configs[0].get("insecure_url"))
+
+    def test_allow_http_monitors_default(self):
+        self._write_file_with_separator_conversion(
+            """ {
+            api_key: "hi there",
+            scalyr_server: "http://agent.scalyr.com",
+            monitors: [
+                {
+                    module: "tests.unit.test_monitor",
+                    secure_url: "http://rick.com",
+                    insecure_url: "http://morty.com"
+                }
+            ]
+          }
+        """
+        )
+        config = self._create_test_configuration_instance()
+        config.parse()
+        self.assertEqual("http://rick.com", config.monitor_configs[0].get("secure_url"))
+        self.assertEqual("http://morty.com", config.monitor_configs[0].get("insecure_url"))
+
     def test_non_string_value(self):
         self._write_file_with_separator_conversion(
             """ {

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -1,3 +1,26 @@
+# Copyright 2023 Scalyr Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+#
+# An example ScalyrMonitor plugin to demonstrate how they can be written.
+#
+# Note, this can be run in standalone mode by:
+#     python -m scalyr_agent.run_monitor -c "{ gauss_mean: 0.5 }" scalyr_agent.builtin_monitors.test_monitor
+#
+# author:  Ales Novak <ales.novak@sentinelone.com>
+
+
 from scalyr_agent import ScalyrMonitor, define_config_option
 
 __monitor__ = __name__

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -49,7 +49,7 @@ define_config_option(
     "Considered insecure",
     convert_to=six.text_type,
     required_option=True,
-    insecure_http_url=True
+    allow_http=True
 )
 
 class TestMonitor(ScalyrMonitor):

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -49,7 +49,7 @@ define_config_option(
     "Considered insecure",
     convert_to=six.text_type,
     required_option=True,
-    allow_http=True
+    allow_http=False
 )
 
 class TestMonitor(ScalyrMonitor):

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -1,0 +1,33 @@
+from scalyr_agent import ScalyrMonitor, define_config_option
+
+__monitor__ = __name__
+
+import six
+
+define_config_option(
+    __monitor__,
+    "module",
+    "Always `tests.unit.test_monitor`",
+    convert_to=six.text_type,
+    required_option=True,
+)
+
+define_config_option(
+    __monitor__,
+    "secure_url",
+    "Considered secure",
+    convert_to=six.text_type,
+    required_option=True,
+)
+
+define_config_option(
+    __monitor__,
+    "insecure_url",
+    "Considered insecure",
+    convert_to=six.text_type,
+    required_option=True,
+    insecure_http_url=True
+)
+
+class TestMonitor(ScalyrMonitor):
+    pass


### PR DESCRIPTION
Implementation of https://sentinelone.atlassian.net/browse/DTIN-3192.
For FIPS compliant environments we want to have a config (env) flag that will force HTTPS configuration on all relevant monitors.

I've used the same patten as allow_http does.
