### PR TITLE
Thread pool per monitor, so monitors don't block each other

### DIFF
--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1007,7 +1007,7 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
             six.moves.socketserver.BaseRequestHandler.__init__(self, *args, **kwargs)
 
     @staticmethod
-    def __request_stream_read(syslog_request, server_is_funning_fn):
+    def __request_stream_read(syslog_request, server_is_running_fn):
         count = 1
         while not syslog_request.is_closed:
             check_running = False
@@ -1027,7 +1027,7 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
             except SocketClosed:
                 continue
 
-            if check_running and not server_is_funning_fn():
+            if check_running and not server_is_running_fn():
                 return
 
             count += 1
@@ -1068,12 +1068,12 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
 
     @staticmethod
     def __worker(data_processor, data, last_processing_future):
-        # Hardcoded timeout total time to stop polluting Thread Pool in case of a bug or an unexpected error
+        # Hardcoded timeout total time to stop populating Thread Pool in case of a bug or an unexpected error
         TIMEOUT_TOTAL_TIME = 10
         CANCEL_FURTHER_PROCESSING_MSG = "Cancelling further processing for this request."
         TIMEOUT_ERROR_MSG = "Timeout error while waiting for previous message being parsed. If the server is not shutting down, this may be a bug or an unexpected error." + " " + CANCEL_FURTHER_PROCESSING_MSG
-        CANCELLED_ERROR_MSG = "Future of the revious message parser cancelled. The server is probably shutting down. " + " " + CANCEL_FURTHER_PROCESSING_MSG
-        PREVIOUS_CANCELEED_ERROR_MSG = "Previous message parser encountered an error. " + " " + CANCEL_FURTHER_PROCESSING_MSG
+        CANCELLED_ERROR_MSG = "Future of the previous message parser cancelled. The server is probably shutting down. " + " " + CANCEL_FURTHER_PROCESSING_MSG
+        PREVIOUS_CANCELLED_ERROR_MSG = "Previous message parser encountered an error. " + " " + CANCEL_FURTHER_PROCESSING_MSG
         GENERIC_EXCEPTION_MSG = "Exception from the previous message handler. " + " " + CANCEL_FURTHER_PROCESSING_MSG
 
         try:
@@ -1087,8 +1087,8 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
                     global_log.warn(CANCELLED_ERROR_MSG)
                     raise SyslogTCPHandler.PreviousMessageHandlingError(CANCELLED_ERROR_MSG)
                 except SyslogTCPHandler.PreviousMessageHandlingError as e:
-                    global_log.debug(PREVIOUS_CANCELEED_ERROR_MSG, exc_info=e)
-                    raise SyslogTCPHandler.PreviousMessageHandlingError(PREVIOUS_CANCELEED_ERROR_MSG)
+                    global_log.debug(PREVIOUS_CANCELLED_ERROR_MSG, exc_info=e)
+                    raise SyslogTCPHandler.PreviousMessageHandlingError(PREVIOUS_CANCELLED_ERROR_MSG)
                 except Exception as e:
                     global_log.error(GENERIC_EXCEPTION_MSG, exc_info=e)
                     raise SyslogTCPHandler.PreviousMessageHandlingError(GENERIC_EXCEPTION_MSG)
@@ -1121,15 +1121,15 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
                         global_log.warn("Cannot submit futher data for processing. The server is probably shutting down.")
                         break
             else:
-                try:
-                    for data in self.__request_stream_read(syslog_request, self.server.is_running):
+                for data in self.__request_stream_read(syslog_request, self.server.is_running):
+                    try:
                         syslog_parser.process(data)
-                except Exception as e:
-                    global_log.warning(
-                        "Error processing request: %s\n\t%s",
-                        six.text_type(e),
-                        traceback.format_exc(),
-                    )
+                    except Exception as e:
+                        global_log.warning(
+                            "Error processing request: %s\n\t%s",
+                            six.text_type(e),
+                            traceback.format_exc(),
+                        )
 
 
         except Exception as e:

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1,4 +1,5 @@
 # Copyright 2017-2023 Scalyr Inc.
+# Copyright 2017-2023 Scalyr Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -96,6 +97,17 @@ except ImportError:
 import scalyr_agent.scalyr_logging as scalyr_logging
 
 global_log = scalyr_logging.getLogger(__name__)
+def syslog_log(msg, exc_info=None):
+    try:
+        threads = "\n".join(
+            str((t.name, t.is_alive(), t.native_id, t.ident))
+            for t in threading.enumerate()
+            if t.name.startswith("request_")
+        )
+    except Exception as e:
+        threads = "Error getting threads: %s" % e
+    global_log.info(msg, exc_info=exc_info)
+    global_log.info(f"SYSLOG threads: {threads}")
 
 __monitor__ = __name__
 
@@ -695,97 +707,106 @@ class SyslogRequestParser(object):
             self.process(data)
 
     def process(self, data):
-        """Processes data returned from a previous call to read
-        :type data: six.binary_type
-        """
-        if not data:
-            global_log.warning(
-                "Syslog has seen an empty request, could be an indication of missing data",
-                limit_once_per_x_secs=600,
-                limit_key="syslog-empty-request",
-            )
-            return
+        try:
+            syslog_log(f"SYSLOG {threading.current_thread().name} - {self.__class__}.process {data}")
+            """Processes data returned from a previous call to read
+            :type data: six.binary_type
+            """
+            if not data:
+                global_log.warning(
+                    "Syslog has seen an empty request, could be an indication of missing data",
+                    limit_once_per_x_secs=600,
+                    limit_key="syslog-empty-request",
+                )
+                return
 
-        # append data to what we had remaining from the previous call
-        if self._remaining:
-            self._remaining += data
-        else:
-            self._remaining = data
-            self._offset = 0
-
-        size = len(self._remaining)
-
-        # process the buffer until we are out of bytes
-        frames_handled = 0
-
-        extra = {
-            "proto": "tcp",
-            "srcip": self._client_address[0],
-            "destport": self._server_address[1],
-        }
-
-        while self._offset < size:
-            # get the first byte to determine if framed or not
-            # 2->TODO use slicing to get bytes in both python versions.
-            c = self._remaining[self._offset : self._offset + 1]
-            framed = b"0" <= c <= b"9"
-
-            skip = 0  # do we need to skip any bytes at the end of the frame (e.g. newlines)
-
-            # if framed, read the frame size
-            if framed:
-                frame_end = -1
-                pos = self._remaining.find(b" ", self._offset)
-                if pos != -1:
-                    frame_size = int(self._remaining[self._offset : pos])
-                    message_offset = pos + 1
-                    if size - message_offset >= frame_size:
-                        self._offset = message_offset
-                        frame_end = self._offset + frame_size
+            # append data to what we had remaining from the previous call
+            if self._remaining:
+                self._remaining += data
             else:
-                # not framed, find the first newline
-                frame_end = self._remaining.find(b"\n", self._offset)
-                skip = 1
+                self._remaining = data
+                self._offset = 0
 
-            # if we couldn't find the end of a frame, then it's time
-            # to exit the loop and wait for more data
-            if frame_end == -1:
-                if not self._message_size_can_exceed_tcp_buffer and (
-                    size - self._offset >= self._max_buffer_size
-                ):
-                    global_log.warning(
-                        "Syslog frame exceeded maximum buffer size of %s bytes. You should either "
-                        'increase the value of "tcp_buffer_size" monitor config option or set '
-                        '"message_size_can_exceed_tcp_buffer" monitor config option to True.'
-                        % (self._max_buffer_size),
-                        limit_once_per_x_secs=300,
-                        limit_key="syslog-max-buffer-exceeded",
-                    )
+            size = len(self._remaining)
 
-                    # skip invalid bytes which can appear because of the buffer overflow.
-                    frame_data = six.ensure_text(
-                        self._remaining, "utf-8", errors="ignore"
-                    )
-                    self._handle_frame(frame_data, extra)
+            # process the buffer until we are out of bytes
+            frames_handled = 0
 
-                    frames_handled += 1
-                    # add a space to ensure the next frame won't start with a number
-                    # and be incorrectly interpreted as a framed message
-                    self._remaining = b" "
-                    self._offset = 0
+            extra = {
+                "proto": "tcp",
+                "srcip": self._client_address[0],
+                "destport": self._server_address[1],
+            }
 
-                break
+            while self._offset < size:
+                syslog_log(f"SYSLOG {threading.current_thread().name} - {self.__class__}.process LOOP {self._offset}<{size} {data}")
+                # get the first byte to determine if framed or not
+                # 2->TODO use slicing to get bytes in both python versions.
+                c = self._remaining[self._offset : self._offset + 1]
+                framed = b"0" <= c <= b"9"
 
-            # output the frame
-            frame_length = frame_end - self._offset
+                skip = 0  # do we need to skip any bytes at the end of the frame (e.g. newlines)
 
-            frame_data = six.ensure_text(
-                self._remaining[self._offset : frame_end].strip(), "utf-8", "ignore"
-            )
-            self._handle_frame(frame_data, extra)
-            frames_handled += 1
+                # if framed, read the frame size
+                if framed:
+                    syslog_log(f"SYSLOG {threading.current_thread().name} - {self.__class__}.process FRAMED {data}")
+                    frame_end = -1
+                    pos = self._remaining.find(b" ", self._offset)
+                    if pos != -1:
+                        frame_size = int(self._remaining[self._offset : pos])
+                        message_offset = pos + 1
+                        if size - message_offset >= frame_size:
+                            self._offset = message_offset
+                            frame_end = self._offset + frame_size
+                else:
+                    syslog_log(f"SYSLOG {threading.current_thread().name} - {self.__class__}.process NOT_FRAMED {data}")
+                    # not framed, find the first newline
+                    frame_end = self._remaining.find(b"\n", self._offset)
+                    skip = 1
 
-            self._offset += frame_length + skip
+                # if we couldn't find the end of a frame, then it's time
+                # to exit the loop and wait for more data
+                if frame_end == -1:
+                    if not self._message_size_can_exceed_tcp_buffer and (
+                        size - self._offset >= self._max_buffer_size
+                    ):
+                        global_log.warning(
+                            "Syslog frame exceeded maximum buffer size of %s bytes. You should either "
+                            'increase the value of "tcp_buffer_size" monitor config option or set '
+                            '"message_size_can_exceed_tcp_buffer" monitor config option to True.'
+                            % (self._max_buffer_size),
+                            limit_once_per_x_secs=300,
+                            limit_key="syslog-max-buffer-exceeded",
+                        )
+
+                        # skip invalid bytes which can appear because of the buffer overflow.
+                        frame_data = six.ensure_text(
+                            self._remaining, "utf-8", errors="ignore"
+                        )
+                        self._handle_frame(frame_data, extra)
+
+                        frames_handled += 1
+                        # add a space to ensure the next frame won't start with a number
+                        # and be incorrectly interpreted as a framed message
+                        self._remaining = b" "
+                        self._offset = 0
+
+                    break
+
+                # output the frame
+                frame_length = frame_end - self._offset
+
+                frame_data = six.ensure_text(
+                    self._remaining[self._offset : frame_end].strip(), "utf-8", "ignore"
+                )
+                self._handle_frame(frame_data, extra)
+                frames_handled += 1
+
+                self._offset += frame_length + skip
+                syslog_log(f"SYSLOG {threading.current_thread().name} - {self.__class__}.process frames_handled {frames_handled} {data}")
+        except Exception as e:
+            syslog_log(f"SYSLOG EXCEPTION {threading.current_thread().name} - {self.__class__}.process EXCEPTION {e}", exc_info=e)
+            raise e
 
         if frames_handled == 0:
             global_log.info(
@@ -796,6 +817,7 @@ class SyslogRequestParser(object):
 
         self._remaining = self._remaining[self._offset :]
         self._offset = 0
+        syslog_log(f"SYSLOG {threading.current_thread().name} - {self.__class__}.process FINISHED {data}")
 
 
 class SyslogRawRequestParser(SyslogRequestParser):
@@ -812,6 +834,7 @@ class SyslogRawRequestParser(SyslogRequestParser):
     """
 
     def process(self, data):
+        syslog_log(f"SYSLOG {threading.current_thread().name} - {self.__class__}.process {data}")
         extra = {
             "proto": "tcp",
             "srcip": self._client_address[0],
@@ -862,6 +885,7 @@ class SyslogBatchedRequestParser(SyslogRequestParser):
         self.is_closed = False
 
     def process(self, data):
+        syslog_log(f"SYSLOG {threading.current_thread().name} - {self.__class__}.process {data}")
         """Processes data returned from a previous call to read
         :type data: six.binary_type
         """
@@ -1034,6 +1058,7 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
     @staticmethod
     def __request_data_process(syslog_parser, data):
         try:
+            syslog_log(f"SYSLOG {threading.current_thread().name} - __request_data_process {data}")
             syslog_parser.process(data)
         except Exception as e:
             global_log.warning(
@@ -1070,7 +1095,44 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
         else:
             raise ValueError("Invalid request parser: %s" % (self.request_parser))
 
+    @staticmethod
+    def __worker(work_queue, is_shutdown, data_processor, done_token, grace_period):
+        try:
+            syslog_log(f"SYSLOG {threading.current_thread().name} - Worker starting ")
+            data = None
+            shutdown_started = None
+            data_empty_limit = 200
+            data_empty_count = 0
+            while data != done_token and data_empty_count < data_empty_limit:
+                if is_shutdown():
+                    syslog_log(f"SYSLOG {threading.current_thread().name} - Worker is_shutdown")
+                    if shutdown_started is None:
+                        shutdown_started = time.time()
+                    elif time.time() - shutdown_started > grace_period:
+                        syslog_log(f"SYSLOG {threading.current_thread().name} - Worker grace period exceeded")
+                        break
+                    syslog_log(f"SYSLOG {threading.current_thread().name} - Worker grace period not exceeded")
+                if data is not None:
+                    syslog_log(f"SYSLOG {threading.current_thread().name} - Worker processing {data}")
+                    data_processor(data)
+                    work_queue.task_done()
+                    data_empty_count = 0
+                else:
+                    data_empty_count += 1
+
+                try:
+                    data = work_queue.get(block=True, timeout=0.1)
+                    syslog_log(f"SYSLOG {threading.current_thread().name} - Worker got data: {data} from the queue")
+                except queue.Empty:
+                    data = None
+            syslog_log(f"SYSLOG {threading.current_thread().name} - Worker Loop finished, last data: {data}, data_empty_count: {data_empty_count}")
+        except Exception as e:
+            syslog_log(f"SYSLOG {threading.current_thread().name} - Worker EXCEPTION {e}", exc_info=e)
+
+
+
     def handle(self):
+        syslog_log(f"SYSLOG {threading.current_thread().name} Incoming request for {self.request_parser}")
         syslog_request = SyslogRequest(
             socket=self.request,
             max_buffer_size=self.server.tcp_buffer_size
@@ -1090,32 +1152,20 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
                 DONE = "DONE"
                 work_queue = queue.Queue()
                 GRACE_PERIOD = self.__global_config.syslog_monitors_shutdown_grace_period if self.__global_config else 5
-                def worker(queue, is_shutdown):
-                    data = None
-                    shutdown_started = None
-                    while data != DONE:
-                        if is_shutdown():
-                            if shutdown_started is None:
-                                shutdown_started = time.time()
-                            elif time.time() - shutdown_started > GRACE_PERIOD:
-                                break
-                        if data is not None:
-                            self.__request_data_process(syslog_parser, data)
-                            queue.task_done()
 
-                        try:
-                            data = queue.get(block=True, timeout=0.1)
-                        except queue.Empty:
-                            data = None
-
-                self.__request_processing_executor.submit(worker, work_queue, lambda: self.__request_processing_executor._shutdown)
+                self.__request_processing_executor.submit(
+                    self.__worker, work_queue, lambda: self.__request_processing_executor._shutdown,
+                    lambda data: self.__request_data_process(syslog_parser, data), DONE, GRACE_PERIOD
+                )
 
                 for data in self.__request_stream_read(syslog_request, self.server.is_running):
+                    syslog_log(f"SYSLOG {threading.current_thread().name} - Adding to the queue: {data}")
                     work_queue.put(data)
 
                 work_queue.put(DONE)
             else:
                 for data in self.__request_stream_read(syslog_request, self.server.is_running):
+                    syslog_log(f"SYSLOG {threading.current_thread().name} - Processing in the current thread: {data}")
                     self.__request_data_process(syslog_parser, data)
 
 
@@ -1584,6 +1634,7 @@ class SyslogHandler(object):
         return six.text_type(result)
 
     def __handle_docker_logs(self, data):
+        syslog_log(f"SYSLOG {threading.current_thread().name} - {self.__class__}.__handle_docker_logs {data}")
 
         watcher = None
         module = None
@@ -1594,6 +1645,7 @@ class SyslogHandler(object):
         (cname, cid, labels, line_content) = self.__extract_container_info(data)
 
         if cname is None:
+            syslog_log(f"SYSLOG {threading.current_thread().name} - {self.__class__}.__handle_docker_logs CNAME is None {data}")
             return
 
         current_time = time.time()
@@ -1635,6 +1687,8 @@ class SyslogHandler(object):
                         self.__docker_loggers[cname] = info
                     else:
                         global_log.warn("Unable to create logger for %s." % cname)
+                        global_log.info(
+                            f"SYSLOG {threading.current_thread().name} - {self.__class__}.__handle_docker_logs Unable to create logger {data}")
                         return
 
                 # at this point __docker_loggers will always contain
@@ -1686,7 +1740,11 @@ class SyslogHandler(object):
         if self.__docker_log_deleter:
             self.__docker_log_deleter.check_for_old_logs(current_log_files)
 
+        syslog_log(f"SYSLOG {threading.current_thread().name} - {self.__class__}.__handle_docker_logs FINISHED {data}")
+
     def __handle_syslog_logs(self, data, extra):
+        global_log.info(
+            f"SYSLOG {threading.current_thread().name} - {self.__class__}.__handle_syslog_logs {data}")
         extra.update(SyslogHandler._parse_syslog(data))
         extra = {k.upper(): v for k, v in extra.items()}
 
@@ -1828,6 +1886,8 @@ class SyslogHandler(object):
                 limit_key="syslog-not-template-log",
             )
             self.__logger.info(data)
+        global_log.info(
+            f"SYSLOG {threading.current_thread().name} - {self.__class__}.__handle_syslog_logs FINISHED {data}")
 
     @staticmethod
     def _parse_syslog(msg):
@@ -1854,6 +1914,7 @@ class SyslogHandler(object):
         return rv
 
     def handle(self, data, extra):  # type: (six.text_type, dict) -> None
+        syslog_log(f"SYSLOG {threading.current_thread().name} - {self.__class__}.handle {data}")
         """ 
         Feed syslog messages to the appropriate loggers.
         """
@@ -1865,10 +1926,13 @@ class SyslogHandler(object):
         elif self.__syslog_file_template:
             self.__handle_syslog_logs(data, extra)
         else:
+            syslog_log(f"SYSLOG {threading.current_thread().name} - self.__logger.info(data) {data}")
             self.__logger.info(data)
+            syslog_log(f"SYSLOG {threading.current_thread().name} - self.__logger.info(data) FINISHED {data}")
 
         # We add plus one because the calling code strips off the trailing new lines.
         self.__line_reporter(data.count("\n") + 1)
+        syslog_log(f"SYSLOG {threading.current_thread().name} - {self.__class__}.handle FINISHED {data}")
 
 
 class RequestVerifier(object):

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1,5 +1,4 @@
 # Copyright 2017-2023 Scalyr Inc.
-# Copyright 2017-2023 Scalyr Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -788,7 +787,6 @@ class SyslogRequestParser(object):
                 frames_handled += 1
 
                 self._offset += frame_length + skip
-                syslog_log(f"SYSLOG {threading.current_thread().name} - {self.__class__}.process frames_handled {frames_handled} {data}")
         except Exception as e:
             raise e
 

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -26,6 +26,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import queue
+from concurrent.futures import ThreadPoolExecutor, CancelledError
+from socketserver import ThreadingMixIn
 
 from scalyr_agent import compat
 
@@ -1095,6 +1097,7 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
                             global_log.info("ThreadPool shutting down, skipping further request processing.")
                             break
                         self.__request_data_process(syslog_parser, data)
+                        queue.task_done()
                         data = queue.get(block=True)
 
                 self.__request_processing_executor.submit(worker, work_queue, lambda: self.__request_processing_executor._shutdown)

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1133,7 +1133,7 @@ class SyslogUDPServer(
 
         ExecutorMixIn.__init__(self, global_config=global_config)
 
-        self.allow_reuse_address = True
+        self.allow_reuse_address = False
         six.moves.socketserver.UDPServer.__init__(self, address, SyslogUDPHandler.factory_method(self._request_processing_executor))
 
     def verify_request(self, request, client_address):

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1085,11 +1085,10 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
                     raise SyslogTCPHandler.PreviousMessageHandlingError(TIMEOUT_ERROR_MSG)
                 except concurrent.futures.CancelledError as e:
                     global_log.warn(CANCELLED_ERROR_MSG)
-                    global_log.info(f"Thread: {threading.current_thread().name} __worker {e}")
                     raise SyslogTCPHandler.PreviousMessageHandlingError(CANCELLED_ERROR_MSG)
                 except SyslogTCPHandler.PreviousMessageHandlingError as e:
                     global_log.debug(PREVIOUS_CANCELEED_ERROR_MSG, exc_info=e)
-                    raise e
+                    raise SyslogTCPHandler.PreviousMessageHandlingError(PREVIOUS_CANCELEED_ERROR_MSG)
                 except Exception as e:
                     global_log.error(GENERIC_EXCEPTION_MSG, exc_info=e)
                     raise SyslogTCPHandler.PreviousMessageHandlingError(GENERIC_EXCEPTION_MSG)
@@ -1115,7 +1114,12 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
                 # Using last_future to ensure the data from one requests is processed in the same order as it was received
                 last_future = None
                 for data in self.__request_stream_read(syslog_request, self.server.is_running):
-                    last_future = self.__request_processing_executor.submit(self.__worker, syslog_parser.process, data, last_future)
+                    try:
+                        last_future = self.__request_processing_executor.submit(self.__worker, syslog_parser.process, data, last_future)
+                    except RuntimeError:
+                        # There's no way of telling what happened to the executor, it does not have a specific exception class for this case.
+                        global_log.warn(f"Cannot submit futher data for processing. The server is probably shutting down.")
+                        break
             else:
                 try:
                     for data in self.__request_stream_read(syslog_request, self.server.is_running):

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1133,7 +1133,7 @@ class SyslogUDPServer(
 
         ExecutorMixIn.__init__(self, global_config=global_config)
 
-        self.allow_reuse_address = False
+        self.allow_reuse_address = True
         six.moves.socketserver.UDPServer.__init__(self, address, SyslogUDPHandler.factory_method(self._request_processing_executor))
 
     def verify_request(self, request, client_address):

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1118,7 +1118,7 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
                         last_future = self.__request_processing_executor.submit(self.__worker, syslog_parser.process, data, last_future)
                     except RuntimeError:
                         # There's no way of telling what happened to the executor, it does not have a specific exception class for this case.
-                        global_log.warn(f"Cannot submit futher data for processing. The server is probably shutting down.")
+                        global_log.warn("Cannot submit futher data for processing. The server is probably shutting down.")
                         break
             else:
                 try:

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -1078,7 +1078,7 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
         try:
             if last_processing_future:
                 try:
-                    last_processing_future.done(timeout=TIMEOUT_TOTAL_TIME)
+                    last_processing_future.result(timeout=TIMEOUT_TOTAL_TIME)
                 except concurrent.futures.TimeoutError as e:
                     global_log.error(TIMEOUT_ERROR_MSG, exc_info=e)
                     raise SyslogTCPHandler.PreviousMessageHandlingError(TIMEOUT_ERROR_MSG)

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -988,7 +988,6 @@ class SyslogTCPHandler(six.moves.socketserver.BaseRequestHandler):
 
     def __init__(self, *args, **kwargs):
         self.__request_processing_executor = kwargs.pop("request_processing_executor", None)
-        self.__global_config = kwargs.pop("global_config", None)
 
         self.request_parser = kwargs.pop("request_parser", "default")
         self.incomplete_frame_timeout = kwargs.pop("incomplete_frame_timeout", None)
@@ -1175,7 +1174,6 @@ class SyslogTCPServer(
         handler_cls = functools.partial(
             SyslogTCPHandler,
             request_processing_executor=self._request_processing_executor,
-            global_config=global_config,
             request_parser=request_parser,
             incomplete_frame_timeout=incomplete_frame_timeout,
             message_delimiter=message_delimiter,

--- a/scalyr_agent/builtin_monitors/syslog_monitor.py
+++ b/scalyr_agent/builtin_monitors/syslog_monitor.py
@@ -26,8 +26,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import queue
-from concurrent.futures import ThreadPoolExecutor, CancelledError
-from socketserver import ThreadingMixIn
 
 from scalyr_agent import compat
 

--- a/scalyr_agent/builtin_monitors/thread_pool.py
+++ b/scalyr_agent/builtin_monitors/thread_pool.py
@@ -64,25 +64,3 @@ class ExecutorMixIn:
         self._request_reading_executor.shutdown(wait=False)
         self._request_processing_executor.shutdown(wait=False)
         super().server_close()
-
-class ThreadPoolExecutorFactory():
-    __lock = threading.Lock()
-    __instances = {}
-
-    @classmethod
-    def get_singleton(cls, name, max_workers=None):
-        if name not in cls.__instances:
-            with cls.__lock:
-                if name not in cls.__instances:
-                    cls.__instances[name] = ThreadPoolExecutor(thread_name_prefix=name, max_workers=max_workers)
-        return cls.__instances[name]
-
-    @classmethod
-    def shutdown(cls, wait=True, cancel_futures=False):
-        wait_on_futures_str = " and waiting on futures" if wait else ""
-        for name, executor in cls.__instances.items():
-            global_log.info("Shutting down ThreadPoolExecutor%s: %s", wait_on_futures_str, name)
-            try:
-                executor.shutdown(wait=wait, cancel_futures=cancel_futures)
-            except Exception as e:
-                global_log.error("Failed shutting down the ThreadPoolExecutor %s", executor, exc_info=e)

--- a/scalyr_agent/builtin_monitors/thread_pool.py
+++ b/scalyr_agent/builtin_monitors/thread_pool.py
@@ -39,7 +39,7 @@ class ExecutorMixIn:
             processing_threads = global_config.syslog_processing_thread_count
             self._shutdown_grace_period = global_config.syslog_monitors_shutdown_grace_period
         else:
-            _shutdown_grace_period = 5
+            self._shutdown_grace_period = 5
 
         self._request_reading_executor = ThreadPoolExecutor(max_workers=reading_threads, thread_name_prefix="request_reading_executor")
         self._request_processing_executor = ThreadPoolExecutor(max_workers=processing_threads, thread_name_prefix="request_processing_executor")

--- a/scalyr_agent/builtin_monitors/thread_pool.py
+++ b/scalyr_agent/builtin_monitors/thread_pool.py
@@ -37,6 +37,9 @@ class ExecutorMixIn:
         if global_config:
             reading_threads = global_config.syslog_socket_thread_count
             processing_threads = global_config.syslog_processing_thread_count
+            self._shutdown_grace_period = global_config.syslog_monitors_shutdown_grace_period
+        else:
+            _shutdown_grace_period = 5
 
         self._request_reading_executor = ThreadPoolExecutor(max_workers=reading_threads, thread_name_prefix="request_reading_executor")
         self._request_processing_executor = ThreadPoolExecutor(max_workers=processing_threads, thread_name_prefix="request_processing_executor")
@@ -75,7 +78,7 @@ class ExecutorMixIn:
     def server_close(self):
         super().server_close()
 
-        self.__wait_for_tasks_to_complete(self._request_reading_executor, self._request_processing_executor, timeout=5)
+        self.__wait_for_tasks_to_complete(self._request_reading_executor, self._request_processing_executor, timeout=self._shutdown_grace_period)
 
         try:
             self._request_reading_executor.shutdown(wait=False, cancel_futures=True)

--- a/scalyr_agent/builtin_monitors/thread_pool.py
+++ b/scalyr_agent/builtin_monitors/thread_pool.py
@@ -54,20 +54,11 @@ class ExecutorMixIn:
 
         """
         try:
-            global_log.info(f"SYSLOG {threading.current_thread().name} - {self.__class__}.process_request_thread - processing request ")
             self.finish_request(request, client_address)
-            global_log.info(
-                f"SYSLOG {threading.current_thread().name} - {self.__class__}.process_request_thread - finished request ")
         except Exception:
-            global_log.info(
-                f"SYSLOG {threading.current_thread().name} - {self.__class__}.process_request_thread - exception in request ")
             self.handle_error(request, client_address)
         finally:
-            global_log.info(
-                f"SYSLOG {threading.current_thread().name} - {self.__class__}.process_request_thread - shutting down request ")
             self.shutdown_request(request)
-        global_log.info(
-            f"SYSLOG {threading.current_thread().name} - {self.__class__}.process_request_thread - FINISHED ")
 
     def process_request(self, request, client_address):
         if not self._request_processing_executor:

--- a/scalyr_agent/builtin_monitors/thread_pool.py
+++ b/scalyr_agent/builtin_monitors/thread_pool.py
@@ -45,7 +45,7 @@ class ExecutorMixIn:
     def __warmup_thread_pool(self, thread_pool):
         # Warmup the thread pool
         for _ in range(thread_pool._max_workers):
-            thread_pool.submit(lambda: None)
+            thread_pool._adjust_thread_count()
 
     def process_request_thread(self, request, client_address):
         """Same as in BaseServer but as a thread.
@@ -54,11 +54,20 @@ class ExecutorMixIn:
 
         """
         try:
+            global_log.info(f"SYSLOG {threading.current_thread().name} - {self.__class__}.process_request_thread - processing request ")
             self.finish_request(request, client_address)
+            global_log.info(
+                f"SYSLOG {threading.current_thread().name} - {self.__class__}.process_request_thread - finished request ")
         except Exception:
+            global_log.info(
+                f"SYSLOG {threading.current_thread().name} - {self.__class__}.process_request_thread - exception in request ")
             self.handle_error(request, client_address)
         finally:
+            global_log.info(
+                f"SYSLOG {threading.current_thread().name} - {self.__class__}.process_request_thread - shutting down request ")
             self.shutdown_request(request)
+        global_log.info(
+            f"SYSLOG {threading.current_thread().name} - {self.__class__}.process_request_thread - FINISHED ")
 
     def process_request(self, request, client_address):
         if not self._request_processing_executor:

--- a/scalyr_agent/builtin_monitors/thread_pool.py
+++ b/scalyr_agent/builtin_monitors/thread_pool.py
@@ -78,11 +78,11 @@ class ThreadPoolExecutorFactory():
         return cls.__instances[name]
 
     @classmethod
-    def shutdown(cls, wait=True):
+    def shutdown(cls, wait=True, cancel_futures=False):
         wait_on_futures_str = " and waiting on futures" if wait else ""
         for name, executor in cls.__instances.items():
             global_log.info("Shutting down ThreadPoolExecutor%s: %s", wait_on_futures_str, name)
             try:
-                executor.shutdown(wait=wait)
+                executor.shutdown(wait=wait, cancel_futures=cancel_futures)
             except Exception as e:
                 global_log.error("Failed shutting down the ThreadPoolExecutor %s", executor, exc_info=e)

--- a/scalyr_agent/builtin_monitors/thread_pool_dummy.py
+++ b/scalyr_agent/builtin_monitors/thread_pool_dummy.py
@@ -4,8 +4,3 @@ class ExecutorMixIn(ThreadingMixIn):
     def __init__(self, global_config):
         self._request_reading_executor = None
         self._request_processing_executor = None
-
-class ThreadPoolExecutorFactory():
-    @classmethod
-    def shutdown(cls, wait=True):
-        pass

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1006,10 +1006,6 @@ class Configuration(object):
         return monitor_config
 
     @property
-    def syslog_monitors_shutdown_grace_period(self):
-        return self.__get_config().get_int("syslog_monitors_shutdown_grace_period")
-
-    @property
     def allow_http_monitors(self):
         return self.__get_config().get_bool("allow_http_monitors")
 
@@ -2268,9 +2264,6 @@ class Configuration(object):
         )
         self.__verify_or_set_optional_bool(
             config, "allow_http_monitors", True, description, apply_defaults, env_aware=True
-        )
-        self.__verify_or_set_optional_int(
-            config, "syslog_monitors_shutdown_grace_period", 10, description, apply_defaults, env_aware=True
         )
         self.__verify_or_set_optional_bool(
             config,

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1006,6 +1006,10 @@ class Configuration(object):
         return monitor_config
 
     @property
+    def syslog_monitors_shutdown_grace_period(self):
+        return self.__get_config().get_int("syslog_monitors_shutdown_grace_period")
+
+    @property
     def allow_http_monitors(self):
         return self.__get_config().get_bool("allow_http_monitors")
 
@@ -2264,6 +2268,9 @@ class Configuration(object):
         )
         self.__verify_or_set_optional_bool(
             config, "allow_http_monitors", True, description, apply_defaults, env_aware=True
+        )
+        self.__verify_or_set_optional_int(
+            config, "syslog_monitors_shutdown_grace_period", 10, description, apply_defaults, env_aware=True
         )
         self.__verify_or_set_optional_bool(
             config,

--- a/scalyr_agent/monitors_manager.py
+++ b/scalyr_agent/monitors_manager.py
@@ -39,13 +39,6 @@ import scalyr_agent.scalyr_logging as scalyr_logging
 
 import six
 
-if six.PY2:
-    from scalyr_agent.builtin_monitors.thread_pool_dummy import ThreadPoolExecutorFactory
-else:
-    from scalyr_agent.builtin_monitors.thread_pool import ThreadPoolExecutorFactory
-
-
-
 log = scalyr_logging.getLogger(__name__)
 
 # Holds reference to the currently active MonitorsManager instance (singleton). Reference to this

--- a/scalyr_agent/monitors_manager.py
+++ b/scalyr_agent/monitors_manager.py
@@ -215,10 +215,6 @@ class MonitorsManager(StoppableThread):
 
         start_time = time.time()
 
-        log.info("Stopping shared thread pools")
-        ThreadPoolExecutorFactory.shutdown(wait=False)
-
-
         for monitor in self.__running_monitors:
             # noinspection PyBroadException
             try:
@@ -239,7 +235,6 @@ class MonitorsManager(StoppableThread):
                     monitor.stop(join_timeout=max_wait)
                 except Exception:
                     log.exception("Failed to stop the metric log due to an exception")
-
 
 
         for monitor in self.__running_monitors:

--- a/scalyr_agent/platform_posix.py
+++ b/scalyr_agent/platform_posix.py
@@ -721,7 +721,7 @@ class PosixPlatformController(PlatformController):
         # Try killing the daemon process
         try:
             # Do 5 seconds worth of TERM signals.  If that doesn't work, KILL it.
-            term_attempts = 50
+            term_attempts = 500
             while term_attempts > 0:
                 os.kill(pid, signal.SIGTERM)
                 PosixPlatformController.__sleep(0.1)

--- a/scalyr_agent/platform_posix.py
+++ b/scalyr_agent/platform_posix.py
@@ -720,7 +720,7 @@ class PosixPlatformController(PlatformController):
 
         # Try killing the daemon process
         try:
-            # Do 5 seconds worth of TERM signals.  If that doesn't work, KILL it.
+            # Do 50 seconds worth of TERM signals.  If that doesn't work, KILL it.
             term_attempts = 500
             while term_attempts > 0:
                 os.kill(pid, signal.SIGTERM)

--- a/scalyr_agent/platform_posix.py
+++ b/scalyr_agent/platform_posix.py
@@ -720,8 +720,8 @@ class PosixPlatformController(PlatformController):
 
         # Try killing the daemon process
         try:
-            # Do 50 seconds worth of TERM signals.  If that doesn't work, KILL it.
-            term_attempts = 500
+            # Do 5 seconds worth of TERM signals.  If that doesn't work, KILL it.
+            term_attempts = 50
             while term_attempts > 0:
                 os.kill(pid, signal.SIGTERM)
                 PosixPlatformController.__sleep(0.1)

--- a/tests/unit/builtin_monitors/syslog_monitor_test.py
+++ b/tests/unit/builtin_monitors/syslog_monitor_test.py
@@ -281,7 +281,7 @@ class SyslogMonitorThreadingTest(ScalyrTestCase):
                 EXPECTED_MESSAGES_PROCESSED_IN_GRACE_PERIOD = int((time.time() - time_start) / HANDLING_TIME)
 
                 time.sleep(
-                    mock_config.syslog_processing_thread_count * 10 * HANDLING_TIME + 2
+                    mock_config.syslog_processing_thread_count * 10 * HANDLING_TIME + 3
                 )
 
                 assert len(server.syslog_handler.logged_data) >= EXPECTED_MESSAGES_PROCESSED_IN_GRACE_PERIOD

--- a/tests/unit/builtin_monitors/syslog_monitor_test.py
+++ b/tests/unit/builtin_monitors/syslog_monitor_test.py
@@ -281,7 +281,7 @@ class SyslogMonitorThreadingTest(ScalyrTestCase):
         handling_time = 0.01
         advantage_time = handling_time * 10
         warmup_messages = (udp_servers_count + tcp_servers_count) * connections * messages_per_connection // 5
-        message_window = (udp_servers_count + tcp_servers_count) * 5
+        message_window = (udp_servers_count + tcp_servers_count) * 10
         shutdown_time = connections * messages_per_connection * handling_time + 3
 
         with self.start_servers(udp_servers_count, tcp_servers_count, handling_time) as (udp_servers, tcp_servers):

--- a/tests/unit/builtin_monitors/syslog_monitor_test.py
+++ b/tests/unit/builtin_monitors/syslog_monitor_test.py
@@ -251,7 +251,7 @@ class SyslogMonitorThreadingTest(ScalyrTestCase):
     def test_shutdown_with_pending_requests(self):
         with self.start_servers(udp_servers_count=0, tcp_servers_count=1, handling_time=0.2) as (udp_servers, tcp_servers):
             for server in tcp_servers:
-                MESSAGES_COUNT = 10
+                MESSAGES_COUNT = 30
                 t = self.__send_syslog_messages(
                     server.socket.getsockname(),
                     server.socket.type,

--- a/tests/unit/builtin_monitors/syslog_monitor_test.py
+++ b/tests/unit/builtin_monitors/syslog_monitor_test.py
@@ -288,10 +288,11 @@ class SyslogMonitorThreadingTest(ScalyrTestCase):
 
                 msg_count_after_grace_period_elapsed = len(server.syslog_handler.logged_data)
 
-                time.sleep(1)
-
-                # No new messages processed
-                assert len(server.syslog_handler.logged_data) == msg_count_after_grace_period_elapsed
+                # Cancel futures introduced in 3.9
+                if sys.version_info[0:2] >= (3, 9):
+                    time.sleep(1)
+                    # No new messages processed
+                    assert len(server.syslog_handler.logged_data) == msg_count_after_grace_period_elapsed
 
     def test_fair_workers_distribution(self):
         # Given

--- a/tests/unit/builtin_monitors/syslog_monitor_test.py
+++ b/tests/unit/builtin_monitors/syslog_monitor_test.py
@@ -274,8 +274,8 @@ class SyslogMonitorThreadingTest(ScalyrTestCase):
 
     def test_fair_workers_distribution(self):
         # Given
-        udp_servers_count = 5
-        tcp_servers_count = 5
+        udp_servers_count = 3
+        tcp_servers_count = 3
         connections = 10
         messages_per_connection = 50
         handling_time = 0.01

--- a/tests/unit/builtin_monitors/syslog_monitor_test.py
+++ b/tests/unit/builtin_monitors/syslog_monitor_test.py
@@ -286,7 +286,7 @@ class SyslogMonitorThreadingTest(ScalyrTestCase):
     def test_shutdown_with_pending_requests(self):
         HANDLING_TIME = 0.1
         mock_config = self.MockConfig()
-        with self.start_servers(udp_servers_count=0, tcp_servers_count=1, handling_time=HANDLING_TIME) as (udp_servers, tcp_servers):
+        with self.start_servers(udp_servers_count=0, tcp_servers_count=1, handling_time=HANDLING_TIME, global_config=mock_config) as (udp_servers, tcp_servers):
             for server in tcp_servers:
                 MESSAGES_PER_CONNECTION = 300
                 CONNECTIONS = 10
@@ -331,7 +331,7 @@ class SyslogMonitorThreadingTest(ScalyrTestCase):
         message_window = (udp_servers_count + tcp_servers_count) * 15
         shutdown_time = connections * messages_per_connection * handling_time + 3
 
-        with self.start_servers(udp_servers_count, tcp_servers_count, handling_time) as (udp_servers, tcp_servers):
+        with self.start_servers(udp_servers_count, tcp_servers_count, handling_time, global_config=self.MockConfig()) as (udp_servers, tcp_servers):
             # When
             # Send some data to the servers
             def send_data_to_servers(servers):

--- a/tests/unit/builtin_monitors/syslog_monitor_test.py
+++ b/tests/unit/builtin_monitors/syslog_monitor_test.py
@@ -280,8 +280,8 @@ class SyslogMonitorThreadingTest(ScalyrTestCase):
         messages_per_connection = 50
         handling_time = 0.01
         advantage_time = handling_time * 10
-        warmup_messages = (udp_servers_count + tcp_servers_count) * connections * messages_per_connection // 5
-        message_window = (udp_servers_count + tcp_servers_count) * 10
+        warmup_messages = (udp_servers_count + tcp_servers_count) * connections * messages_per_connection // 4
+        message_window = (udp_servers_count + tcp_servers_count) * 15
         shutdown_time = connections * messages_per_connection * handling_time + 3
 
         with self.start_servers(udp_servers_count, tcp_servers_count, handling_time) as (udp_servers, tcp_servers):
@@ -331,6 +331,7 @@ class SyslogMonitorThreadingTest(ScalyrTestCase):
 
             # Check that the workers are distributed evenly
             for start in range(warmup_messages, len(logged_port_sorted) - warmup_messages):
+                print(f"{start}-{start+message_window}: {len(set(logged_port_sorted[start:start+message_window]))}")
                 assert len(set(logged_port_sorted[start:start+message_window])) == len(udp_servers + tcp_servers)
 
 

--- a/tests/unit/builtin_monitors/syslog_monitor_test.py
+++ b/tests/unit/builtin_monitors/syslog_monitor_test.py
@@ -331,7 +331,6 @@ class SyslogMonitorThreadingTest(ScalyrTestCase):
 
             # Check that the workers are distributed evenly
             for start in range(warmup_messages, len(logged_port_sorted) - warmup_messages):
-                print(f"{start}-{start+message_window}: {len(set(logged_port_sorted[start:start+message_window]))}")
                 assert len(set(logged_port_sorted[start:start+message_window])) == len(udp_servers + tcp_servers)
 
 

--- a/tests/unit/builtin_monitors/syslog_monitor_test.py
+++ b/tests/unit/builtin_monitors/syslog_monitor_test.py
@@ -278,15 +278,15 @@ class SyslogMonitorThreadingTest(ScalyrTestCase):
                 server.shutdown()
                 server.server_close()
 
-                EXPECTED_MESSAGES_PROCESSED_IN_GRACE_PERIOD = int((time.time() - time_start) / HANDLING_TIME)
+                msg_count_before_grace_period_elapsed = len(server.syslog_handler.logged_data)
 
                 time.sleep(
                     mock_config.syslog_processing_thread_count * 10 * HANDLING_TIME + 3
                 )
 
-                assert len(server.syslog_handler.logged_data) >= EXPECTED_MESSAGES_PROCESSED_IN_GRACE_PERIOD
-
                 msg_count_after_grace_period_elapsed = len(server.syslog_handler.logged_data)
+
+                assert msg_count_after_grace_period_elapsed > msg_count_before_grace_period_elapsed
 
                 # Cancel futures introduced in 3.9
                 if sys.version_info[0:2] >= (3, 9):

--- a/tests/unit/builtin_monitors/syslog_monitor_test.py
+++ b/tests/unit/builtin_monitors/syslog_monitor_test.py
@@ -281,7 +281,7 @@ class SyslogMonitorThreadingTest(ScalyrTestCase):
                 EXPECTED_MESSAGES_PROCESSED_IN_GRACE_PERIOD = int((time.time() - time_start) / HANDLING_TIME)
 
                 time.sleep(
-                    mock_config.syslog_processing_thread_count * 10 * HANDLING_TIME
+                    mock_config.syslog_processing_thread_count * 10 * HANDLING_TIME + 2
                 )
 
                 assert len(server.syslog_handler.logged_data) >= EXPECTED_MESSAGES_PROCESSED_IN_GRACE_PERIOD

--- a/tests/unit/builtin_monitors/syslog_template_test.py
+++ b/tests/unit/builtin_monitors/syslog_template_test.py
@@ -94,6 +94,9 @@ class ConfigurationMock(Configuration):
     def syslog_socket_thread_count(self):
         return 4
 
+    @property
+    def syslog_monitors_shutdown_grace_period(self):
+        return 1
 
 class LogWatcherMock(LogWatcher):
     def __init__(self):

--- a/tests/unit/builtin_monitors/syslog_template_test.py
+++ b/tests/unit/builtin_monitors/syslog_template_test.py
@@ -94,6 +94,10 @@ class ConfigurationMock(Configuration):
     def syslog_socket_thread_count(self):
         return 4
 
+    @property
+    def syslog_monitors_shutdown_grace_period(self):
+        return 5
+
 
 class LogWatcherMock(LogWatcher):
     def __init__(self):

--- a/tests/unit/builtin_monitors/syslog_template_test.py
+++ b/tests/unit/builtin_monitors/syslog_template_test.py
@@ -94,10 +94,6 @@ class ConfigurationMock(Configuration):
     def syslog_socket_thread_count(self):
         return 4
 
-    @property
-    def syslog_monitors_shutdown_grace_period(self):
-        return 5
-
 
 class LogWatcherMock(LogWatcher):
     def __init__(self):


### PR DESCRIPTION
This PR fixes the issue of agent not stopping gracefully and producing logs only for one syslog monitor under load:
https://sentinelone.atlassian.net/browse/DTIN-3231

*  processing_threads set to 4 and reading_threads  to auto (that was the intention from the start, I just mixed it up)
* Thread pool is not shared anymore, but one per syslog server. When share it the threads were not being evenly distributed across monitors and one monitor under load caused other monitors to stop producing any logs. 
* Removed ThreadPoolExecutorFactory
* queue.task_done call added to avoid any future regression bugs when expecting the consistency of the queue object
* Extended the time to wait for the agent to stop gracefully before killing it.

 