### PR TITLE
DTIN-3315

### DIFF
--- a/.github/workflows/reusable-agent-build-container-images.yml
+++ b/.github/workflows/reusable-agent-build-container-images.yml
@@ -349,24 +349,29 @@ jobs:
           fi
 
       # Here we build the dummy container which continuously prints data to stdout and stderr
-      - name: Build Dummy App Docker Image
+      - name: Build Dummy App Docker Images
         run: |
           docker build -f docker/Dockerfile.docker_monitor_testing_config -t std-printer scripts/
+          docker build -f docker/Dockerfile.long_message_printer -t long-message-printer scripts/
           docker image ls
 
           # Needed for containerd or cri-o runtime
           if [ "${{ matrix.k8s_version.runtime }}" = "containerd" ] || [ "${{ matrix.k8s_version.runtime }}" = "cri-o" ]; then
-            docker tag std-printer:latest docker.io/library/std-printer:latest
-            minikube image load docker.io/library/std-printer:latest
+            for IMAGE in std-printer long-message-printer; do
+              docker tag ${IMAGE}:latest docker.io/library/${IMAGE}:latest
+              minikube image load docker.io/library/${IMAGE}:latest
+            done
           fi
 
       # Create pod for our mock std printer container which logs will be ingested by the agent
-      - name: Create mock pod
+      - name: Create mock pods
         run: |
           minikube image ls
           kubectl apply -f tests/e2e/k8s_k8s_monitor/std_printer_deployment.yaml
+          kubectl apply -f tests/e2e/k8s_k8s_monitor/long_message_printer_deployment.yaml
           
           kubectl wait --for=condition=ready pod -l app=std-printer
+          kubectl wait --for=condition=ready pod -l app=long-message-printer
           kubectl get pods -A
 
           export APP_POD_NAME=$(kubectl get pod --namespace=default --selector=app=std-printer -o jsonpath="{.items[0].metadata.name}")
@@ -385,6 +390,7 @@ jobs:
           # We need to use a different file for different K8s versions due to promotion (removal of
           # old v1beta alias) from v1beta to v1 in v1.25.0. v1 has been available since v1.21.0
           kubectl apply -f tests/e2e/k8s_events_monitor/cronjob_v1.yaml
+
           kubectl get cronjob -A
 
       - name: Create scalyr-agent-2 daemonset
@@ -428,6 +434,7 @@ jobs:
           # annotation set as part of the deployment YAML.
           # After a while, we change that dynamically using kubectl and verify that this change has
           # been correctly picked up by the agent.
+          echo Waiting 20s for some data to be ingested
           sleep 20
 
           echo "Initial pod ingested data checks"
@@ -463,6 +470,25 @@ jobs:
             echo "Kubernetes event monitor log has to be handled by the agent 1 time, but it got ${k8s_event_log_files_number}"
             exit 1
           fi
+          
+          echo "Wait for BEGIN DELAYED MESSAGE-END DELAYED MESSAGE lines. They should not be splitted."
+          MINIMUM_RESULTS=10 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stdout" "BEGIN DELAYED MESSAGE"'
+          MINIMUM_RESULTS=10 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stderr" "BEGIN DELAYED MESSAGE"'
+          echo "Looking for partial lines."
+          ERR_MSG="\xE2\x9D\x8C Found partial line - CRI runtime split log implementation bug."
+          SUCCESS_MSG="\xE2\x9C\x94 Search failed as expected - no partial lines found. Success!"
+          
+          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stdout" "BEGIN DELAYED MESSAGE" !"BEGIN DELAYED MESSAGE-END DELAYED MESSAGE"' && echo -e $ERR_MSG && exit 1 || echo -e $SUCCESS_MSG    
+          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stderr" "BEGIN DELAYED MESSAGE" !"BEGIN DELAYED MESSAGE-END DELAYED MESSAGE"' && echo -e $ERR_MSG && exit 1 || echo -e $SUCCESS_MSG
+          
+          echo "Wait for BEGIN_LONG_MESSAGE .* END_LONG_MESSAGE lines. They should not be splitted."
+          MINIMUM_RESULTS=10 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="long-message-printer" parser="test-parser-2" stream="stdout" "BEGIN_LONG_MESSAGE"'
+          MINIMUM_RESULTS=10 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="long-message-printer" parser="test-parser-2" stream="stderr" "BEGIN_LONG_MESSAGE"'
+          echo "Looking for partial lines."
+          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="long-message-printer" parser="test-parser-2" stream="stdout" "BEGIN_LONG_MESSAGE" !(message matches 'BEGIN_LONG_MESSAGE.*END_LONG_MESSAGE')'  && echo -e $ERR_MSG && exit 1 || echo -e $SUCCESS_MSG
+          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="long-message-printer" parser="test-parser-2" stream="stderr" "BEGIN_LONG_MESSAGE" !(message matches 'BEGIN_LONG_MESSAGE.*END_LONG_MESSAGE')'  && echo -e $ERR_MSG && exit 1 || echo -e $SUCCESS_MSG
+          
+          echo ""
 
       # We only assert this under newer Kubernetes versions since in the old ones CronJobs were not
       # available out of the box
@@ -646,7 +672,7 @@ jobs:
         run: |
           export RETRY_ATTEMPTS="30"
           export SLEEP_DELAY="10"
-
+          
           # Verify agent is running
           echo "Agent running checks"
           ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Starting scalyr agent..."'

--- a/.github/workflows/reusable-agent-build-container-images.yml
+++ b/.github/workflows/reusable-agent-build-container-images.yml
@@ -472,21 +472,25 @@ jobs:
           fi
           
           echo "Wait for BEGIN DELAYED MESSAGE-END DELAYED MESSAGE lines. They should not be splitted."
-          MINIMUM_RESULTS=10 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stdout" "BEGIN DELAYED MESSAGE"'
-          MINIMUM_RESULTS=10 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stderr" "BEGIN DELAYED MESSAGE"'
+          MINIMUM_RESULTS=10 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stdout" "BEGIN DELAYED MESSAGE stdout"'
+          MINIMUM_RESULTS=10 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stderr" "BEGIN DELAYED MESSAGE stderr"'
           echo "Looking for partial lines."
-          ERR_MSG="\xE2\x9D\x8C Found partial line - CRI runtime split log implementation bug."
-          SUCCESS_MSG="\xE2\x9C\x94 Search failed as expected - no partial lines found. Success!"
-          
-          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stdout" "BEGIN DELAYED MESSAGE" !"BEGIN DELAYED MESSAGE-END DELAYED MESSAGE"' && echo -e $ERR_MSG && exit 1 || echo -e $SUCCESS_MSG    
-          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stderr" "BEGIN DELAYED MESSAGE" !"BEGIN DELAYED MESSAGE-END DELAYED MESSAGE"' && echo -e $ERR_MSG && exit 1 || echo -e $SUCCESS_MSG
+          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stdout" "BEGIN DELAYED MESSAGE stdout" !"BEGIN DELAYED MESSAGE stdout-END DELAYED MESSAGE stdout"' && echo -e $ERR_MSG && exit 1 || echo -e $SUCCESS_MSG
+          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stderr" "BEGIN DELAYED MESSAGE stderr" !"BEGIN DELAYED MESSAGE stderr-END DELAYED MESSAGE stderr"' && echo -e $ERR_MSG && exit 1 || echo -e $SUCCESS_MSG
+          echo 'Looking for mixed streams'
+          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stdout" "stderr"' && echo -e $MIXED_STREAMS_ERR_MSG && exit 1 || echo -e $MIXED_STREAMS_SUCCESS_MSG
+          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="std-printer" parser="test-parser-1" stream="stderr" "stdout"' && echo -e $MIXED_STREAMS_ERR_MSG && exit 1 || echo -e $MIXED_STREAMS_SUCCESS_MSG
           
           echo "Wait for BEGIN_LONG_MESSAGE .* END_LONG_MESSAGE lines. They should not be splitted."
-          MINIMUM_RESULTS=10 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="long-message-printer" parser="test-parser-2" stream="stdout" "BEGIN_LONG_MESSAGE"'
-          MINIMUM_RESULTS=10 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="long-message-printer" parser="test-parser-2" stream="stderr" "BEGIN_LONG_MESSAGE"'
+          MINIMUM_RESULTS=10 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="long-message-printer" parser="test-parser-2" stream="stdout" "stdout_BEGIN_LONG_MESSAGE"'
+          MINIMUM_RESULTS=10 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="long-message-printer" parser="test-parser-2" stream="stderr" "stderr_BEGIN_LONG_MESSAGE"'
           echo "Looking for partial lines."
-          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="long-message-printer" parser="test-parser-2" stream="stdout" "BEGIN_LONG_MESSAGE" !(message matches 'BEGIN_LONG_MESSAGE.*END_LONG_MESSAGE')'  && echo -e $ERR_MSG && exit 1 || echo -e $SUCCESS_MSG
-          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="long-message-printer" parser="test-parser-2" stream="stderr" "BEGIN_LONG_MESSAGE" !(message matches 'BEGIN_LONG_MESSAGE.*END_LONG_MESSAGE')'  && echo -e $ERR_MSG && exit 1 || echo -e $SUCCESS_MSG
+          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="long-message-printer" parser="test-parser-2" stream="stdout" "stdout_BEGIN_LONG_MESSAGE" !(message matches "BEGIN_LONG_MESSAGE.*END_LONG_MESSAGE")'  && echo -e $ERR_MSG && exit 1 || echo -e $SUCCESS_MSG
+          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="long-message-printer" parser="test-parser-2" stream="stderr" "stderr_BEGIN_LONG_MESSAGE" !(message matches "BEGIN_LONG_MESSAGE.*END_LONG_MESSAGE")'  && echo -e $ERR_MSG && exit 1 || echo -e $SUCCESS_MSG
+          echo 'Looking for mixed streams'
+          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="long-message-printer" parser="test-parser-2" stream="stdout" "stderr"'  && echo -e $MIXED_STREAMS_ERR_MSG && exit 1 || echo -e $MIXED_STREAMS_SUCCESS_MSG
+          RETRY_ATTEMPTS=1 ./scripts/cicd/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" app="long-message-printer" parser="test-parser-2" stream="stderr" "stdout"'  && echo -e $MIXED_STREAMS_ERR_MSG && exit 1 || echo -e $MIXED_STREAMS_SUCCESS_MSG
+
           
           echo ""
 

--- a/docker/Dockerfile.long_message_printer
+++ b/docker/Dockerfile.long_message_printer
@@ -1,0 +1,5 @@
+FROM python:3.11-alpine
+
+ADD long_message_printer.py /long_message_printer.py
+
+CMD ["python3", "-u", "/long_message_printer.py"]

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -88,45 +88,150 @@ COPY_STALENESS_THRESHOLD = 15 * 60
 
 log = scalyr_logging.getLogger(__name__)
 
+class CRIParseError(Exception):
+    def __init__(self, line, message):
+        self.line = line
+        self.message = message
 
-def _parse_cri_log(line):
-    """
-    Parse a log line that uses the K8S Container Runtime Interface (CRI) format
-    https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/kubelet-cri-logging.md
-    """
-    # find the end of the timestamp segment
-    index = line.find(" ")
-    if index < 0:
-        return None, None, None, None
+    def __repr__(self):
+        return "Error parsing line - %s: %s" % self.message, self.line
 
-    # parse the timestamp
-    timestamp = rfc3339_to_nanoseconds_since_epoch(line[:index])
-    if timestamp is None:
-        return None, None, None, None
+class CRILogLine(object):
+    __slots__ = ("timestamp", "stream", "tags", "message", "raw_timestamp", "is_partial", "is_full")
 
-    # skip over the ' ' delimiter and parse the stream type
-    line = line[index + 1 :]
-    index = line.find(" ")
-    if index < 0:
-        return None, None, None, None
+    def __init__(self, timestamp, stream, tags, message, raw_timestamp):
+        self.timestamp = timestamp
+        self.stream = stream
+        self.tags = tags
+        self.message = message
+        self.raw_timestamp = raw_timestamp
 
-    stream = line[:index]
-    if stream != "stdout" and stream != "stderr":
-        return None, None, None, None
+        self.is_partial = "P" in tags if tags else False
+        self.is_full = "F" in tags if tags else False
 
-    # skip over the ' ' delimiter and parse the tags
-    line = line[index + 1 :]
-    index = line.find(" ")
-    if index < 0:
-        return None, None, None, None
+    @classmethod
+    def from_raw_line(cls, raw_line):
+        decoded_raw_line = raw_line.decode("utf-8", "replace")
+        timestamp, stream, tags, message, raw_timestamp = cls.__parse_cri_log(
+            decoded_raw_line
+        )
 
-    tags = line[:index]
+        log_line = cls(timestamp, stream, tags, message, raw_timestamp)
 
-    # skip over the ' ' delimiter and get the log line
-    line = line[index + 1 :]
+        if not log_line.is_partial and not log_line.is_full:
+            raise CRIParseError("Expected tags to contain P or F", raw_line)
 
-    return timestamp, stream, tags, line
+        return log_line
 
+    @staticmethod
+    def __parse_cri_log(line):
+        """
+        Parse a log line that uses the K8S Container Runtime Interface (CRI) format
+        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/kubelet-cri-logging.md
+        """
+        parts = line.split(" ", maxsplit=3)
+        # The 4 parts are the timestamp, stream, tags, and message. The 4th part can contain spaces.
+        if len(parts) < 3:
+            raise CRIParseError("Expected 3 or 4 records (timestamp, stream, tags, optional message), got %d" % len(parts), line)
+
+        # parse the timestamp
+        timestamp = rfc3339_to_nanoseconds_since_epoch(parts[0])
+        if timestamp is None:
+            raise CRIParseError("Could not parse timestamp", line)
+        raw_timestamp = timestamp
+
+        # parse the stream type
+        stream = parts[1]
+        if stream != "stdout" and stream != "stderr":
+            raise CRIParseError("Unknown stream type", line)
+
+        tags = parts[2].split(":")
+        line = parts[3] if len(parts) == 4 else ""
+
+        return timestamp, stream, tags, line, raw_timestamp
+
+class CRILogLineBuffer(object):
+    def __init__(self, first_line_time):
+        self.__stream = None
+        self.__lines = []
+        self.__timestamp = None
+        self.__raw_timestamp = None
+        self.__is_partial = True
+        self.__first_line_time = first_line_time
+
+    def append(self, log_line):
+        if not self.__lines:
+            self.__timestamp = log_line.timestamp
+            self.__raw_timestamp = log_line.raw_timestamp
+            self.__stream = log_line.stream
+
+        self.__lines.append(log_line.message)
+
+        if log_line.is_full:
+            self.__is_partial = False
+
+    @property
+    def stream(self):
+        return self.__stream
+
+    @property
+    def first_line_time(self):
+        return self.__first_line_time
+
+    @property
+    def is_partial(self):
+        return self.__is_partial
+
+    def payload_length(self):
+        return sum(map(len, self.__lines))
+
+    def build_cri_result(self, include_raw_timestamp_field):
+        def strip_new_line(s):
+            if s and s[-1] == "\n":
+                return s[:-1]
+            return s
+
+        lines_string = "".join(map(strip_new_line, self.__lines)) + "\n"
+
+        result = LogLine(lines_string.encode("utf-8"))
+        result.timestamp = self.__timestamp
+        result.attrs = {"stream": self.__stream}
+        if include_raw_timestamp_field:
+            result.attrs["raw_timestamp"] = self.__raw_timestamp
+
+        return result
+
+class CRIStreamBuffers(object):
+    def __init__(self, max_line_size, line_completion_wait_time):
+        self.__max_line_size = max_line_size
+        self.__line_completion_wait_time = line_completion_wait_time
+        self.__buffers = {}
+
+    def append_log_line(self, log_line, current_time):
+        stream = log_line.stream
+        if stream not in self.__buffers:
+            self.__buffers[stream] = CRILogLineBuffer(current_time)
+
+        self.__buffers[stream].append(log_line)
+
+    def __buffer_completed(self, buffer, current_time):
+        return (
+                not buffer.is_partial
+                or current_time - buffer.first_line_time > self.__line_completion_wait_time
+                or buffer.payload_length() >= self.__max_line_size
+        )
+
+    def any_buffer_completed(self, current_time):
+        return any(
+            self.__buffer_completed(buffer, current_time)
+            for buffer in self.__buffers.values()
+        )
+
+    def pop_completed(self, current_time):
+        for stream, buffer in self.__buffers.items():
+            if self.__buffer_completed(buffer, current_time):
+                del self.__buffers[stream]
+                return buffer
 
 class LogLine(object):
     """A class representing a line from a log file.
@@ -315,6 +420,8 @@ class LogFileIterator(object):
 
         if self.__file_system is None:
             self.__file_system = FileSystem()
+
+        self.__cri_stream_buffers = CRIStreamBuffers(self.__max_line_length, self.__line_completion_wait_time)
 
         # If we have a checkpoint, then iterate over it, seeing if the contents are up-to-date.  If so, then
         # we will pick up from the left off point.
@@ -670,36 +777,38 @@ class LogFileIterator(object):
 
         # read a complete line from our line_matcher, with check to see if we allow for extended lines, and if so,
         # then read more pages so that we can parse an entire extended line.
-        next_line = self.__read_extended_line(current_time)
 
-        result = LogLine(line=next_line)
 
-        if len(result.line) == 0:
-            return result
 
         # check to see if we need to parse the line as cri.
-        # Note: we don't handle multi-line lines.
         if self.__parse_format == "cri":
-            # 2->TODO decode line to parse it.
-            timestamp, stream, tags, message = _parse_cri_log(
-                result.line.decode("utf-8", "replace")
-            )
-            if message is None:
-                log.warning(
-                    "Didn't find a valid log line in CRI format for log %s.  Logging full line."
-                    % (self.__path),
-                    limit_once_per_x_secs=300,
-                    limit_key=("invalid-cri-format-%s" % self.__path),
-                )
+            while not self.__cri_stream_buffers.any_buffer_completed(current_time):
+                next_line = self.__read_extended_line(current_time)
+                if len(next_line) == 0:
+                    break
+
+                try:
+                    log_line = CRILogLine.from_raw_line(next_line)
+                    self.__cri_stream_buffers.append_log_line(log_line, current_time)
+                except CRIParseError as e:
+                    log.error("Error parsing line: %s, reason: %s" % (e.line, e.message))
+
+            cri_buffer = self.__cri_stream_buffers.pop_completed(current_time)
+            if cri_buffer is None:
+                result = LogLine(line=b"")
             else:
-                result.line = message.encode("utf-8")
-                result.timestamp = timestamp
-                result.attrs = {"stream": stream}
-                if self.__include_raw_timestamp_field:
-                    result.attrs["raw_timestamp"] = timestamp
+                result = cri_buffer.build_cri_result(self.__include_raw_timestamp_field)
+
+            self.__sync_position_with_buffer()
+            return result
 
         # or see if we need to parse it as json
         elif self.__parse_format == "json":
+            next_line = self.__read_extended_line(current_time)
+            result = LogLine(line=next_line)
+            if len(result.line) == 0:
+                return result
+
             try:
                 # 2->TODO decode line to parse it.
                 # TODO: optimize
@@ -755,10 +864,7 @@ class LogFileIterator(object):
                                 current_time - self.__merge_json_line_time
                                 < self.__line_completion_wait_time
                             ):
-                                self.__buffer.seek(original_buffer_position)
-                                self.__position = self.__determine_mark_position(
-                                    self.__buffer.tell()
-                                )
+                                self.__seek_to(original_buffer_position)
                                 log.log(
                                     scalyr_logging.DEBUG_LEVEL_3,
                                     "Incomplete merged line found in file %s, will reattempt reading.",
@@ -806,6 +912,11 @@ class LogFileIterator(object):
                     limit_once_per_x_secs=300,
                     limit_key=("bad-json-%s" % self.__path),
                 )
+        else:
+            next_line = self.__read_extended_line(current_time)
+            result = LogLine(line=next_line)
+            if len(result.line) == 0:
+                return result
 
         raw_line_length = self.__buffer.tell() - original_buffer_position
 
@@ -846,7 +957,7 @@ class LogFileIterator(object):
 
             return self.__read_next_fragment_from_extended_line_buffer()
         else:
-            self.__position = self.__determine_mark_position(self.__buffer.tell())
+            self.__sync_position_with_buffer()
 
             # Just a sanity check.
             # if len(self.__buffer_contents_index) > 0:
@@ -857,6 +968,13 @@ class LogFileIterator(object):
             #                                              expected_size, actual_size)
 
         return result
+
+    def __sync_position_with_buffer(self):
+        self.__position = self.__determine_mark_position(self.__buffer.tell())
+
+    def __seek_to(self, original_buffer_position):
+        self.__buffer.seek(original_buffer_position)
+        self.__sync_position_with_buffer()
 
     def __read_extended_line(self, current_time):
         # read a complete line from our line_matcher
@@ -896,7 +1014,7 @@ class LogFileIterator(object):
         )
         if self.__extended_line_position is None:
             self.__buffer.seek(self.__extended_line_buffer.raw_size, 1)
-            self.__position = self.__determine_mark_position(self.__buffer.tell())
+            self.__sync_position_with_buffer()
 
         return result
 
@@ -1437,7 +1555,7 @@ class LogFileIterator(object):
 
         original_buffer_position = self.__buffer.tell()
         # Seek to the end
-        self.__buffer.seek(0, 2)
+        self.__buffer.seek(0, os.SEEK_END)
         initial_size = self.__buffer.tell()
 
         end_size = initial_size + page_size

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -89,10 +89,10 @@ COPY_STALENESS_THRESHOLD = 15 * 60
 log = scalyr_logging.getLogger(__name__)
 
 class CRIParseError(Exception):
-    def __init__(self, line, message):
-        # type: (str, str) -> None
-        self.line = line
+    def __init__(self, message, line):
+        # type: (str, Union[str,bytes]) -> None
         self.message = message
+        self.line = line
 
     def __repr__(self):
         return "Error parsing line - %s: %s" % self.message, self.line

--- a/scripts/cicd/scalyr-query.sh
+++ b/scripts/cicd/scalyr-query.sh
@@ -54,15 +54,14 @@ function retry_on_failure {
      "$@" && break
      exit_code=$?
 
-     echo_with_date ""
-     echo_with_date "Function returned non-zero status code, sleeping ${SLEEP_DELAY}s before next attempt.."
-     echo_with_date ""
-
-     i=$((i+1))
-
      if [ "${i}" -lt "${RETRY_ATTEMPTS}" ]; then
+       echo_with_date ""
+       echo_with_date "Function returned non-zero status code, sleeping ${SLEEP_DELAY}s before next attempt.."
+       echo_with_date ""
        sleep "${SLEEP_DELAY}"
      fi
+
+     i=$((i+1))
   done
 
   if [ "${exit_code}" -ne 0 ]; then

--- a/scripts/long_message_printer.py
+++ b/scripts/long_message_printer.py
@@ -1,0 +1,11 @@
+import time
+import sys
+
+def message(stream):
+    return f"{stream}_BEGIN_LONG_MESSAGE {'X' * 8192} {stream}_END_LONG_MESSAGE"
+
+if __name__ == "__main__":
+    while True:
+        print(message("stdout"))
+        print(message("stderr"), file=sys.stderr)
+        time.sleep(1)

--- a/scripts/print-to-stdout-stderr.sh
+++ b/scripts/print-to-stdout-stderr.sh
@@ -24,5 +24,9 @@ echo ""
 for i in {1..1000000}; do
     echo "stdout: line $i"
     echo "stderr: line $i" 1>&2
+    echo -n "line $i BEGIN DELAYED MESSAGE stdout"
+    echo -n "line $i BEGIN DELAYED MESSAGE stderr" 1>&2
     sleep "${SLEEP_DELAY}"
+    echo "-END DELAYED MESSAGE stdout line $i"
+    echo "-END DELAYED MESSAGE stderr line $i" 1>&2
 done

--- a/tests/e2e/k8s_k8s_monitor/long_message_printer_deployment.yaml
+++ b/tests/e2e/k8s_k8s_monitor/long_message_printer_deployment.yaml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: std-printer
+  name: long-message-printer
   namespace: default
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: std-printer
+      app: long-message-printer
   template:
     metadata:
       labels:
-        app: std-printer
+        app: long-message-printer
       annotations:
-        log.config.scalyr.com/attributes.parser: "test-parser-1"
+        log.config.scalyr.com/attributes.parser: "test-parser-2"
     spec:
       containers:
-      - name: std-printer
-        image: docker.io/library/std-printer:latest
+      - name: long-message-printer
+        image: docker.io/library/long-message-printer:latest
         imagePullPolicy: Never
       nodeSelector:
         kubernetes.io/os: linux

--- a/tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml
+++ b/tests/e2e/k8s_om_monitor/scalyr-agent-2-daemonset.yaml
@@ -60,7 +60,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: scalyr-config
-          image: k8s-image:test
+          image: docker.io/library/k8s-image:test
           imagePullPolicy: Never
           name: scalyr-agent
           resources:

--- a/tests/e2e/scalyr-agent-2-daemonset.yaml
+++ b/tests/e2e/scalyr-agent-2-daemonset.yaml
@@ -50,7 +50,7 @@ spec:
         envFrom:
         - configMapRef:
             name: scalyr-config
-        image: k8s-image:test
+        image: docker.io/library/k8s-image:test
         imagePullPolicy: Never
         name: scalyr-agent
         securityContext:

--- a/tests/unit/log_processing_test.py
+++ b/tests/unit/log_processing_test.py
@@ -27,7 +27,10 @@ import unittest
 import sys
 import time
 import platform
+from datetime import datetime, timezone, timedelta
 from io import open
+
+import pytest
 
 import scalyr_agent.util as scalyr_util
 
@@ -38,11 +41,11 @@ from scalyr_agent.log_processing import (
     LogLineSampler,
     LogLineRedacter,
     LogFileProcessor,
-    LogMatcher,
+    LogMatcher, CRILogLineBuffer, CRIStreamBuffers,
 )
 from scalyr_agent.line_matcher import LineGrouper
 from scalyr_agent.log_processing import FileSystem
-from scalyr_agent.log_processing import _parse_cri_log as parse_cri_log
+from scalyr_agent.log_processing import CRILogLine, CRIParseError
 from scalyr_agent.json_lib import JsonObject
 from scalyr_agent.json_lib import JsonArray
 from scalyr_agent.util import md5_hexdigest
@@ -57,94 +60,161 @@ from six import unichr
 from six.moves import range
 
 
+class Timestamp():
+    def __init__(self, iso, nanos):
+        self.iso = iso
+        self.nanos = nanos
+
+def timestamp_generator(seconds_ago_start):
+    now = datetime.now(timezone.utc).astimezone()
+    start_timestamp = now - timedelta(minutes=seconds_ago_start)
+    
+    for seconds_after in range(0, 1000):
+        timestamp = start_timestamp + timedelta(seconds=seconds_after)
+        yield Timestamp(bytes(timestamp.isoformat(), "utf-8"), round(timestamp.timestamp() * 1000 * 1000) * 1000)
+
+def assert_line(log_line, line, timestamp, stream):
+    assert log_line.line == line
+    assert log_line.timestamp == timestamp
+    assert log_line.attrs["stream"] == stream
+
+
+class TestCRILogLineBuffer(ScalyrTestCase):
+    def test_is_partial_on_empty(self):
+        assert CRILogLineBuffer(first_line_time=0).is_partial
+
+    def test_is_partial(self):
+        LINE_1 = "line 1"
+        LINE_2 = "line 2"
+
+        buffer = CRILogLineBuffer(first_line_time=0)
+        buffer.append(CRILogLine(0, "stdout", ["P"], LINE_1, None))
+
+        assert buffer.is_partial
+
+        buffer.append(CRILogLine(0, "stdout", ["F"], LINE_2, None))
+
+        assert not buffer.is_partial
+
+class TestCRIStreamBuffers(ScalyrTestCase):
+    def test_completed_on_empty(self):
+        assert not CRIStreamBuffers(max_line_size=10, line_completion_wait_time=10).any_buffer_completed(current_time=1)
+        assert None == CRIStreamBuffers(max_line_size=10, line_completion_wait_time=10).pop_completed(current_time=1)
+
+    def test_completed(self):
+        buffers = CRIStreamBuffers(max_line_size=100, line_completion_wait_time=10)
+        buffers.append_log_line(CRILogLine(0, "stdout", ["P"], "line 01 ", None), 0)
+        buffers.append_log_line(CRILogLine(1, "stderr", ["F"], "line 02 ", None), 1)
+
+        assert buffers.any_buffer_completed(current_time=1)
+        assert buffers.pop_completed(current_time=1).build_cri_result(True).line == b"line 02 \n"
+        assert not buffers.any_buffer_completed(current_time=1)
+
+        buffers.append_log_line(CRILogLine(2, "stderr", ["P"], "line 03 ", None), 2)
+        buffers.append_log_line(CRILogLine(3, "stdout", ["P"], "line 04 ", None), 3)
+        buffers.append_log_line(CRILogLine(4, "stderr", ["F"], "line 05 ", None), 4)
+
+        assert buffers.any_buffer_completed(current_time=5)
+        assert buffers.pop_completed(current_time=5).build_cri_result(True).line == b"line 03 line 05 \n"
+        assert not buffers.any_buffer_completed(current_time=5)
+
+        assert not buffers.any_buffer_completed(current_time=10)
+        assert buffers.any_buffer_completed(current_time=11)
+
+    def test_completed_max_length(self):
+        LINE_LEN = len("line 00 ")
+
+        buffers = CRIStreamBuffers(max_line_size=LINE_LEN * 2, line_completion_wait_time=10)
+        buffers.append_log_line(CRILogLine(0, "stdout", ["P"], "line 00 ", None), 0)
+        buffers.append_log_line(CRILogLine(1, "stderr", ["P"], "line 01 ", None), 1)
+
+        assert not buffers.any_buffer_completed(current_time=2)
+
+        buffers.append_log_line(CRILogLine(2, "stdout", ["P"], "line 02 ", None), 2)
+
+        assert buffers.any_buffer_completed(current_time=3)
+        assert buffers.pop_completed(current_time=1).build_cri_result(True).line == b"line 00 line 02 \n"
+
+
+
 class TestCRILogParsing(ScalyrTestCase):
     def test_invalid_line(self):
-        line = "sdflkjasdlfkjweirjlasdfj"
-        ts, stream, tags, msg = parse_cri_log(line)
-        self.assertIsNone(ts)
-        self.assertIsNone(stream)
-        self.assertIsNone(tags)
-        self.assertIsNone(msg)
+        line = b"sdflkjasdlfkjweirjlasdfj"
+        with pytest.raises(CRIParseError):
+            CRILogLine.from_raw_line(line)
 
     def test_invalid_timestamp(self):
-        line = "sdflkjasdlfk jweirjlasdfj"
-        ts, stream, tags, msg = parse_cri_log(line)
-        self.assertIsNone(ts)
-        self.assertIsNone(stream)
-        self.assertIsNone(tags)
-        self.assertIsNone(msg)
+        line = b"sdflkjasdlfk jweirjlasdfj"
+        with pytest.raises(CRIParseError):
+            CRILogLine.from_raw_line(line)
 
     def test_missing_stream(self):
-        line = "2019-04-08T15:18:20.56064743Z "
-        ts, stream, tags, msg = parse_cri_log(line)
-        self.assertIsNone(ts)
-        self.assertIsNone(stream)
-        self.assertIsNone(tags)
-        self.assertIsNone(msg)
+        line = b"2019-04-08T15:18:20.56064743Z "
+        with pytest.raises(CRIParseError):
+            CRILogLine.from_raw_line(line)
 
     def test_invalid_stream(self):
-        line = "2019-04-08T15:18:20.56064743Z foobar"
-        ts, stream, tags, msg = parse_cri_log(line)
-        self.assertIsNone(ts)
-        self.assertIsNone(stream)
-        self.assertIsNone(tags)
-        self.assertIsNone(msg)
+        line = b"2019-04-08T15:18:20.56064743Z foobar"
+        with pytest.raises(CRIParseError):
+            CRILogLine.from_raw_line(line)
 
     def test_missing_tags(self):
-        line = "2019-04-08T15:18:20.56064743Z stdout "
-        ts, stream, tags, msg = parse_cri_log(line)
-        self.assertIsNone(ts)
-        self.assertIsNone(stream)
-        self.assertIsNone(tags)
-        self.assertIsNone(msg)
+        line = b"2019-04-08T15:18:20.56064743Z stdout "
+        with pytest.raises(CRIParseError):
+            CRILogLine.from_raw_line(line)
 
     def test_multi_tags(self):
-        line = "2019-04-08T15:18:20.56064743Z stdout P:B:D message"
-        ts, stream, tags, msg = parse_cri_log(line)
-        self.assertEqual(1554736700560647430, ts)
-        self.assertEqual("stdout", stream)
-        self.assertEqual("P:B:D", tags)
-        self.assertEqual("message", msg)
+        line = b"2019-04-08T15:18:20.56064743Z stdout P:B:F message"
+        cri_log_line = CRILogLine.from_raw_line(line)
+        self.assertEqual(1554736700560647430, cri_log_line.timestamp)
+        self.assertEqual("stdout", cri_log_line.stream)
+        self.assertEqual(["P", "B", "F"], cri_log_line.tags)
+        self.assertEqual("message", cri_log_line.message)
+
+    def test_tags_full_and_partial_missing(self):
+        line = b"2019-04-08T15:18:20.56064743Z stdout A:B:D message"
+        with pytest.raises(CRIParseError):
+            CRILogLine.from_raw_line(line)
 
     def test_missing_log(self):
-        line = "2019-04-08T15:18:20.56064743Z stdout P "
-        ts, stream, tags, msg = parse_cri_log(line)
-        self.assertEqual(1554736700560647430, ts)
-        self.assertEqual("stdout", stream)
-        self.assertEqual("P", tags)
-        self.assertEqual("", msg)
+        line = b"2019-04-08T15:18:20.56064743Z stdout P "
+        cri_log_line = CRILogLine.from_raw_line(line)
+        self.assertEqual(1554736700560647430, cri_log_line.timestamp)
+        self.assertEqual("stdout", cri_log_line.stream)
+        self.assertEqual(["P"], cri_log_line.tags)
+        self.assertEqual("", cri_log_line.message)
 
     def test_valid_line_stdout(self):
-        line = "2019-04-08T15:18:20.56064743Z stdout P message"
-        ts, stream, tags, msg = parse_cri_log(line)
-        self.assertEqual(1554736700560647430, ts)
-        self.assertEqual("stdout", stream)
-        self.assertEqual("P", tags)
-        self.assertEqual("message", msg)
+        line = b"2019-04-08T15:18:20.56064743Z stdout P message"
+        cri_log_line = CRILogLine.from_raw_line(line)
+        self.assertEqual(1554736700560647430, cri_log_line.timestamp)
+        self.assertEqual("stdout", cri_log_line.stream)
+        self.assertEqual(["P"], cri_log_line.tags)
+        self.assertEqual("message", cri_log_line.message)
 
     def test_valid_line_stderr(self):
-        line = "2019-04-08T15:18:20.56064743Z stderr P message"
-        ts, stream, tags, msg = parse_cri_log(line)
-        self.assertEqual(1554736700560647430, ts)
-        self.assertEqual("stderr", stream)
-        self.assertEqual("P", tags)
-        self.assertEqual("message", msg)
+        line = b"2019-04-08T15:18:20.56064743Z stderr P message"
+        cri_log_line = CRILogLine.from_raw_line(line)
+        self.assertEqual(1554736700560647430, cri_log_line.timestamp)
+        self.assertEqual("stderr", cri_log_line.stream)
+        self.assertEqual(["P"], cri_log_line.tags)
+        self.assertEqual("message", cri_log_line.message)
 
     def test_valid_line_single(self):
-        line = "2019-04-08T15:18:20.56064743Z stdout F message"
-        ts, stream, tags, msg = parse_cri_log(line)
-        self.assertEqual(1554736700560647430, ts)
-        self.assertEqual("stdout", stream)
-        self.assertEqual("F", tags)
-        self.assertEqual("message", msg)
+        line = b"2019-04-08T15:18:20.56064743Z stdout F message"
+        cri_log_line = CRILogLine.from_raw_line(line)
+        self.assertEqual(1554736700560647430, cri_log_line.timestamp)
+        self.assertEqual("stdout", cri_log_line.stream)
+        self.assertEqual(["F"], cri_log_line.tags)
+        self.assertEqual("message", cri_log_line.message)
 
     def test_valid_line_partial(self):
-        line = "2019-04-08T15:18:20.56064743Z stdout P message"
-        ts, stream, tags, msg = parse_cri_log(line)
-        self.assertEqual(1554736700560647430, ts)
-        self.assertEqual("stdout", stream)
-        self.assertEqual("P", tags)
-        self.assertEqual("message", msg)
+        line = b"2019-04-08T15:18:20.56064743Z stdout P message"
+        cri_log_line = CRILogLine.from_raw_line(line)
+        self.assertEqual(1554736700560647430, cri_log_line.timestamp)
+        self.assertEqual("stdout", cri_log_line.stream)
+        self.assertEqual(["P"], cri_log_line.tags)
+        self.assertEqual("message", cri_log_line.message)
 
 
 class TestLogFileIterator(ScalyrTestCase):
@@ -269,6 +339,179 @@ class TestLogFileIterator(ScalyrTestCase):
 
         self.assertEqual(expected, self.readline().line)
         self.assertEqual(expected_next, self.readline().line)
+
+    def test_cri_partial_lines(self):
+        timestamp_gen = timestamp_generator(10)
+        self.log_file = self._create_iterator(
+            {"path": self.__path, "parse_format": "cri"}
+        )
+        self.scan_for_new_bytes()
+
+        lines = [
+            next(timestamp_gen).iso + b" stdout F full_content_1\n",
+            next(timestamp_gen).iso + b" stdout P partial_content_1\n",
+            next(timestamp_gen).iso + b" stdout F -full_content_2\n",
+            next(timestamp_gen).iso + b" stdout F full_content_3\n"
+        ]
+        self.append_file(self.__path, *lines)
+
+        self.scan_for_new_bytes()
+
+        assert self.readline().line == b"full_content_1\n"
+        assert self.readline().line == b"partial_content_1-full_content_2\n"
+        assert self.readline().line == b"full_content_3\n"
+
+    def test_cri_empty_lines(self):
+        timestamp_gen = timestamp_generator(10)
+        self.log_file = self._create_iterator(
+            {"path": self.__path, "parse_format": "cri"}
+        )
+        self.scan_for_new_bytes()
+
+        lines = [
+            next(timestamp_gen).iso + b" stdout F full_content_1\n",
+            next(timestamp_gen).iso + b" stdout P \n",
+            next(timestamp_gen).iso + b" stdout F full_content_2\n",
+            next(timestamp_gen).iso + b" stdout F \n"
+        ]
+        self.append_file(self.__path, *lines)
+
+        self.scan_for_new_bytes()
+
+        assert self.readline().line == b"full_content_1\n"
+        assert self.readline().line == b"full_content_2\n"
+        assert self.readline().line == b"\n"
+
+    def test_cri_split_messages_mixed_streams(self):
+        self.log_file = self._create_iterator(
+            {"path": self.__path, "parse_format": "cri"}
+        )
+        self.scan_for_new_bytes()
+
+        lines = [
+            b"2023-12-20T16:18:41.129027195+00:00 stdout F stdout: line 1\n",
+            b"2023-12-20T16:18:41.129027195+00:00 stdout P BEGIN PARTIAL_MESSAGE\n",
+            b"2023-12-20T16:18:41.129069776+00:00 stderr F stderr: line 1\n",
+            b"2023-12-20T16:18:41.129069776+00:00 stderr P BEGIN PARTIAL_MESSAGE\n",
+            b"2023-12-20T16:18:42.129069776+00:00 stderr P -MIDDLE OF PARTIAL_MESSAGE\n",
+            b"2023-12-20T16:18:43.186370550+00:00 stdout F -END PARTIAL_MESSAGE\n",
+            b"2023-12-20T16:18:43.187212946+00:00 stderr F -END PARTIAL_MESSAGE\n",
+            b"2023-12-20T16:18:43.194095421+00:00 stdout F stdout: line 2\n",
+        ]
+
+        self.append_file(self.__path, *lines)
+
+        self.scan_for_new_bytes()
+
+        assert_line(self.readline(), b"stdout: line 1\n", 1703089121129027195, "stdout")
+        assert_line(self.readline(), b"stderr: line 1\n", 1703089121129069776, "stderr")
+        assert_line(self.readline(), b"BEGIN PARTIAL_MESSAGE-END PARTIAL_MESSAGE\n", 1703089121129027195, "stdout")
+        assert_line(self.readline(), b"BEGIN PARTIAL_MESSAGE-MIDDLE OF PARTIAL_MESSAGE-END PARTIAL_MESSAGE\n", 1703089121129069776, "stderr")
+        assert_line(self.readline(), b"stdout: line 2\n", 1703089123194095421, "stdout")
+
+    def test_cri_split_messages_mixed_streams_small_page_size(self):
+        self.log_file = self._create_iterator(
+            {"path": self.__path, "parse_format": "cri"}
+        )
+        self.scan_for_new_bytes()
+
+        lines = [
+            b"2023-12-20T16:18:41.129027195+00:00 stdout F stdout: line 1\n",
+            b"2023-12-20T16:18:41.129027195+00:00 stdout P BEGIN PARTIAL_MESSAGE\n",
+            b"2023-12-20T16:18:41.129027195+00:00 stdout P -MIDDLE OF PARTIAL_MESSAGE\n",
+            b"2023-12-20T16:18:41.129069776+00:00 stderr F stderr: line 1\n",
+            b"2023-12-20T16:18:41.129069776+00:00 stderr P BEGIN PARTIAL_MESSAGE\n",
+            b"2023-12-20T16:18:42.129069776+00:00 stderr P -MIDDLE OF PARTIAL_MESSAGE\n",
+            b"2023-12-20T16:18:43.186370550+00:00 stdout F -END PARTIAL_MESSAGE\n",
+            b"2023-12-20T16:18:43.187212946+00:00 stderr F -END PARTIAL_MESSAGE\n",
+            b"2023-12-20T16:18:43.194095421+00:00 stdout F stdout: line 2\n",
+        ]
+
+        self.append_file(self.__path, *lines)
+
+        self.scan_for_new_bytes()
+
+        assert_line(self.readline(), b"stdout: line 1\n", 1703089121129027195, "stdout")
+        assert_line(self.readline(), b"stderr: line 1\n", 1703089121129069776, "stderr")
+        assert_line(self.readline(), b"BEGIN PARTIAL_MESSAGE-MIDDLE OF PARTIAL_MESSAGE-END PARTIAL_MESSAGE\n", 1703089121129027195, "stdout")
+        assert_line(self.readline(), b"BEGIN PARTIAL_MESSAGE-MIDDLE OF PARTIAL_MESSAGE-END PARTIAL_MESSAGE\n", 1703089121129069776, "stderr")
+        assert_line(self.readline(), b"stdout: line 2\n", 1703089123194095421, "stdout")
+
+    def test_line_completion_wait_time(self):
+        self.log_file = self._create_iterator(
+            log_config={"path": self.__path, "parse_format": "cri"},
+            config=_create_configuration({"line_completion_wait_time": 0.5})
+        )
+        self.scan_for_new_bytes()
+
+        lines = [
+            b"2024-01-02T12:27:16.290902843+00:00 " + body
+            for body in [
+                b"stdout P BEGIN PARTIAL MESSAGE\n",
+                b"stderr F line 1\n",
+                b"stderr F line 1\n",
+                b"stderr F line 1\n",
+                b"stdout P -MIDDLE PARTIAL MESSAGE\n",
+                b"stderr F line 1\n",
+                b"stderr F line 1\n",
+                b"stderr F line 1\n",
+                b"stderr F line 1\n",
+                b"stderr F line 1\n",
+                b"stderr F line 1\n",
+                b"stdout F END PARTIAL MESSAGE\n",
+            ]
+        ]
+
+        self.append_file(self.__path, *lines)
+
+        self.scan_for_new_bytes()
+
+        assert_line(self.readline(), b"line 1\n", 1704198436290902843, "stderr")
+        assert_line(self.readline(), b"line 1\n", 1704198436290902843, "stderr")
+        assert_line(self.readline(), b"line 1\n", 1704198436290902843, "stderr")
+        assert_line(self.readline(), b"line 1\n", 1704198436290902843, "stderr")
+        assert_line(self.readline(), b"BEGIN PARTIAL MESSAGE-MIDDLE PARTIAL MESSAGE\n", 1704198436290902843, "stdout")
+        assert_line(self.readline(), b"line 1\n", 1704198436290902843, "stderr")
+        assert_line(self.readline(), b"line 1\n", 1704198436290902843, "stderr")
+        assert_line(self.readline(), b"line 1\n", 1704198436290902843, "stderr")
+        assert_line(self.readline(), b"line 1\n", 1704198436290902843, "stderr")
+        assert_line(self.readline(), b"line 1\n", 1704198436290902843, "stderr")
+        assert_line(self.readline(), b"END PARTIAL MESSAGE\n", 1704198436290902843, "stdout")
+
+    def test_cri_skip_un_parseable_lines(self):
+        self.log_file = self._create_iterator(
+            {"path": self.__path, "parse_format": "cri"}
+        )
+        self.scan_for_new_bytes()
+
+        timestamp_gen = timestamp_generator(10)
+
+        lines = [
+            (next(timestamp_gen), body)
+            for body in [
+                b"stdout F stdout: line 1\n",
+                b"stderr F stderr: line 1\n",
+                b"BAD_FORMAT\n",
+                b"stdout F stdout: line 2\n",
+                b"stderr F stderr: line 2\n",
+                b"stderr P BEGIN PARTIAL_MESSAGE\n",
+                b"stdout P BEGIN PARTIAL_MESSAGE\n",
+                b"BAD_FORMAT\n",
+                b"stdout F -END PARTIAL_MESSAGE\n",
+                b"stderr F -END PARTIAL_MESSAGE\n"
+            ]
+        ]
+
+        self.append_file(self.__path, *map(lambda line: line[0].iso + b" " + line[1], lines))
+
+        self.scan_for_new_bytes()
+
+        assert_line(self.readline(), b"stdout: line 1\n", lines[0][0].nanos, "stdout")
+        assert_line(self.readline(), b"stderr: line 1\n", lines[1][0].nanos, "stderr")
+        assert_line(self.readline(), b"stdout: line 2\n", lines[3][0].nanos, "stdout")
+        assert_line(self.readline(), b"stderr: line 2\n", lines[4][0].nanos, "stderr")
+        assert_line(self.readline(), b"BEGIN PARTIAL_MESSAGE-END PARTIAL_MESSAGE\n", lines[6][0].nanos, "stdout")
+        assert_line(self.readline(), b"BEGIN PARTIAL_MESSAGE-END PARTIAL_MESSAGE\n", lines[5][0].nanos, "stderr")
 
     def test_multiple_line_groupers(self):
         log_config = {
@@ -1171,7 +1414,7 @@ class TestLogFileIterator(ScalyrTestCase):
         )
         self.scan_for_new_bytes()
         self.append_file(
-            self.__path, b"2015-08-03T09:12:43.56064743Z stdout P message\n"
+            self.__path, b"2015-08-03T09:12:43.56064743Z stdout F message\n"
         )
         self.scan_for_new_bytes()
 
@@ -1194,7 +1437,7 @@ class TestLogFileIterator(ScalyrTestCase):
         )
         self.scan_for_new_bytes()
         self.append_file(
-            self.__path, b"2015-08-03T09:12:43.56064743Z stdout P message\n"
+            self.__path, b"2015-08-03T09:12:43.56064743Z stdout F message\n"
         )
         self.scan_for_new_bytes()
 


### PR DESCRIPTION
https://sentinelone.atlassian.net/browse/DTIN-3315

CRI logs - partial lines support.

Partial and final lines are marked by P and F tags respectively.
Note that the timestamp of the matching message parts do not need to match and both stdout and stderr are mixed together.

Sample:

```
2016-10-06T00:17:09.669794202Z stdout F The content of the stdout log entry 1
2016-10-06T00:17:09.669794202Z stderr F The content of the stderr log entry 1
2016-10-06T00:17:09.669794202Z stdout P First line of stdout log entry 2
2016-10-06T00:17:09.669794202Z stderr F The content of the stderr log entry 2
2016-10-06T00:17:09.669794202Z stdout F Second line of the stdout log entry 2
```

Resulting in:
stdout:
```
The content of the stdout log entry 1
First line of stdout log entry 2 Second line of the stdout log entry 2
```

Resulting in:
stderr:
```
The content of the stderr log entry 1
The content of the stderr log entry 2
```


