### PR TITLE
Options to omit labels in K8s pod logs

### DIFF
--- a/.github/workflows/reusable-agent-build-linux-packages-new.yml
+++ b/.github/workflows/reusable-agent-build-linux-packages-new.yml
@@ -181,19 +181,19 @@ jobs:
           - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "ubuntu2004",    "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
           - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "ubuntu1804",    "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
           - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "ubuntu1604",    "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
-          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "ubuntu1404",    "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "ubuntu1404",    "remote-machine-type": "docker", runner: "ubuntu-22.04" }
           - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "debian10",      "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
-          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "debian11",      "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
-          - { "package_type": "rpm", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "centos8",       "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "debian11",      "remote-machine-type": "docker", runner: "ubuntu-22.04" }
+          - { "package_type": "rpm", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "centos8",       "remote-machine-type": "docker", runner: "ubuntu-22.04" }
           - { "package_type": "rpm", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "centos7",       "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
-          - { "package_type": "rpm", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "centos6",       "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "rpm", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "centos6",       "remote-machine-type": "docker", runner: "ubuntu-22.04" }
           - { "package_type": "rpm", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "amazonlinux2",  "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
-          - { "package_type": "deb", "builder": "aio-aarch64", "arch": "arm64",  "distro-name": "ubuntu1404",    "remote-machine-type": "ec2", runner: "aws-aarch64" }
-          - { "package_type": "rpm", "builder": "aio-aarch64", "arch": "arm64",  "distro-name": "centos7",       "remote-machine-type": "ec2", runner: "aws-aarch64" }
+          - { "package_type": "deb", "builder": "aio-aarch64", "arch": "arm64",  "distro-name": "ubuntu1404",    "remote-machine-type": "docker", runner: "aws-aarch64" }
+          - { "package_type": "rpm", "builder": "aio-aarch64", "arch": "arm64",  "distro-name": "centos7",       "remote-machine-type": "docker", runner: "aws-aarch64" }
             # - { "package_type": "deb", "builder": "non-aio",     "arch": "x86_64", "distro-name": "ubuntu1404",    "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
-          - { "package_type": "deb", "builder": "non-aio",     "arch": "x86_64", "distro-name": "ubuntu2204",    "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "deb", "builder": "non-aio",     "arch": "x86_64", "distro-name": "ubuntu2204",    "remote-machine-type": "docker", runner: "ubuntu-22.04" }
             # - { "package_type": "rpm", "builder": "non-aio",     "arch": "x86_64", "distro-name": "centos7",       "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
-          - { "package_type": "rpm", "builder": "non-aio",     "arch": "x86_64", "distro-name": "amazonlinux2",  "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "rpm", "builder": "non-aio",     "arch": "x86_64", "distro-name": "amazonlinux2",  "remote-machine-type": "docker", runner: "ubuntu-22.04" }
     steps:
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4

--- a/.github/workflows/reusable-agent-build-linux-packages-new.yml
+++ b/.github/workflows/reusable-agent-build-linux-packages-new.yml
@@ -172,28 +172,28 @@ jobs:
     needs:
       - build_packages
 
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.test_target.runner }}
     strategy:
       fail-fast: false
       matrix:
         test_target:
-          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "ubuntu2204",    "remote-machine-type": "ec2"    }
-          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "ubuntu2004",    "remote-machine-type": "ec2"    }
-          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "ubuntu1804",    "remote-machine-type": "ec2"    }
-          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "ubuntu1604",    "remote-machine-type": "ec2"    }
-          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "ubuntu1404",    "remote-machine-type": "docker" }
-          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "debian10",      "remote-machine-type": "ec2"    }
-          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "debian11",      "remote-machine-type": "docker" }
-          - { "package_type": "rpm", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "centos8",       "remote-machine-type": "docker" }
-          - { "package_type": "rpm", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "centos7",       "remote-machine-type": "ec2"    }
-          - { "package_type": "rpm", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "centos6",       "remote-machine-type": "docker" }
-          - { "package_type": "rpm", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "amazonlinux2",  "remote-machine-type": "ec2"    }
-          - { "package_type": "deb", "builder": "aio-aarch64", "arch": "arm64",  "distro-name": "ubuntu1404",    "remote-machine-type": "docker" }
-          - { "package_type": "rpm", "builder": "aio-aarch64", "arch": "arm64",  "distro-name": "centos7",       "remote-machine-type": "docker" }
-            # - { "package_type": "deb", "builder": "non-aio",     "arch": "x86_64", "distro-name": "ubuntu1404",    "remote-machine-type": "docker" }
-          - { "package_type": "deb", "builder": "non-aio",     "arch": "x86_64", "distro-name": "ubuntu2204",    "remote-machine-type": "docker" }
-            # - { "package_type": "rpm", "builder": "non-aio",     "arch": "x86_64", "distro-name": "centos7",       "remote-machine-type": "docker" }
-          - { "package_type": "rpm", "builder": "non-aio",     "arch": "x86_64", "distro-name": "amazonlinux2",  "remote-machine-type": "docker" }
+          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "ubuntu2204",    "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "ubuntu2004",    "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "ubuntu1804",    "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "ubuntu1604",    "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "ubuntu1404",    "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "debian10",      "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "deb", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "debian11",      "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "rpm", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "centos8",       "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "rpm", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "centos7",       "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "rpm", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "centos6",       "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "rpm", "builder": "aio-x86_64",  "arch": "x86_64", "distro-name": "amazonlinux2",  "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "deb", "builder": "aio-aarch64", "arch": "arm64",  "distro-name": "ubuntu1404",    "remote-machine-type": "ec2", runner: "aws-aarch64" }
+          - { "package_type": "rpm", "builder": "aio-aarch64", "arch": "arm64",  "distro-name": "centos7",       "remote-machine-type": "ec2", runner: "aws-aarch64" }
+            # - { "package_type": "deb", "builder": "non-aio",     "arch": "x86_64", "distro-name": "ubuntu1404",    "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "deb", "builder": "non-aio",     "arch": "x86_64", "distro-name": "ubuntu2204",    "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+            # - { "package_type": "rpm", "builder": "non-aio",     "arch": "x86_64", "distro-name": "centos7",       "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
+          - { "package_type": "rpm", "builder": "non-aio",     "arch": "x86_64", "distro-name": "amazonlinux2",  "remote-machine-type": "ec2", runner: "ubuntu-22.04" }
     steps:
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4

--- a/docs/monitors/kubernetes_monitor.md
+++ b/docs/monitors/kubernetes_monitor.md
@@ -37,7 +37,7 @@ Besides the default API key stored in the scalyr/scalyr-api-key secret, the user
 #### Namespace level API keys
 ```log.config.scalyr.com/teams.{team_number}.secret: {secret_name}```
 
-Overrides the default API key for all pods in the namespace. 
+Overrides the default API key for all pods in the namespace.
 The `secret_name` is the name of the secret (stored in the same namespace) holding the Scalyr API key.
 The `teams_number` is an arbitrary unique number.
 
@@ -67,7 +67,7 @@ data:
 
 #### Simple visual example of Secret key annotation priority
 
-> [!NOTE]  
+> [!NOTE]
 > When no annotation is present for either the namespace or pod, the default secret _scalyr/scalyr-api-key_ is used.
 
 ![Annotation Priority](kubernetes_monitor_annotations_priority.png)
@@ -391,6 +391,8 @@ cluster.
 | `k8s_kubelet_host_ip`                         | Optional (defaults to None). Defines the host IP address for the Kubelet API. If None, the Kubernetes API will be queried for it | 
 | `k8s_kubelet_api_url_template`                | Optional (defaults to https://${host_ip}:10250). Defines the port and protocol to use when talking to the kubelet API. Allowed template variables are `node_name` and `host_ip`. | 
 | `k8s_sidecar_mode`                            | Optional, (defaults to False). If true, then logs will only be collected for containers running in the same Pod as the agent. This is used in situations requiring very high throughput. | 
+| `k8s_label_include_globs`                     | Optional, (defaults to ['*']). Specifies a list of K8s labels to be added to logs. | 
+| `k8s_label_exclude_globs`                     | Optional, (defaults to []]). Specifies a list of K8s labels to be ignored and not added to logs. | 
 
 <a name="metrics"></a>
 ## Metrics Reference

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -3671,6 +3671,232 @@ fields behave differently when configured via k8s annotations:
 * lineGroupers (not supported at all)
 * path (the path is always fixed for k8s container logs)
 
+### Configuring multiple accounts per container
+
+Besides the default API key stored in the scalyr/scalyr-api-key secret, the user can specify API keys for namespaces, pods and containers using annotations.
+
+#### Namespace level API keys
+```log.config.scalyr.com/teams.{team_number}.secret: {secret_name}```
+
+Overrides the default API key for all pods in the namespace.
+The `secret_name` is the name of the secret (stored in the same namespace) holding the Scalyr API key.
+The `teams_number` is an arbitrary unique number.
+
+#### Pod level API keys
+```log.config.scalyr.com/teams.{team_number}.secret: {secret_name}```
+
+Overrides the default API key and the namespace API key for all containers in the pod.
+The `secret_name` is the name of the secret (stored in the same namespace as the pod) holding the Scalyr API key.
+The `teams_number` is an arbitrary unique number.
+
+#### Container level API keys
+```log.config.scalyr.com/{container_name}.teams.{team_number}.secret: {secret_name}```
+
+Overrides the default API key, the namespace API key and the pod API keys for all containers in the pod.
+The `secret_name` is the name of the secret (stored in the same namespace as the pod) holding the Scalyr API key.
+The `teams_number` is an arbitrary unique number.
+
+#### API Key Secret structure
+
+```yaml
+apiVersion: v1
+kind: Secret
+data:
+  scalyr-api-key: <b64 encoded API key>
+```
+
+
+#### Simple visual example of Secret key annotation priority
+
+> [!NOTE]
+> When no annotation is present for either the namespace or pod, the default secret _scalyr/scalyr-api-key_ is used.
+
+![Annotation Priority](kubernetes_monitor_annotations_priority.png)
+
+
+#### Example:
+
+#### Configuration:
+
+##### Default API key for the Scalyr Agent
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scalyr-api-key
+  namespace: scalyr
+data:
+  scalyr-api-key: <b64 encoded SCALYR_API_KEY_WRITE_TEAM_1>
+```
+
+##### Workload Namespaces
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: workload-namespace-1
+  annotations:
+    log.config.scalyr.com/teams.1.secret: scalyr-api-key-team-2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: workload-namespace-2
+```
+
+##### API keys in the workload-namespace-1 Namespace
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scalyr-api-key-team-2
+  namespace: workload-namespace-1
+data:
+  scalyr-api-key: <b64 encoded SCALYR_API_KEY_WRITE_TEAM_2>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scalyr-api-key-team-3
+data:
+  scalyr-api-key: <b64 encoded SCALYR_API_KEY_WRITE_TEAM_3>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scalyr-api-key-team-4
+data:
+  scalyr-api-key: <b64 encoded SCALYR_API_KEY_WRITE_TEAM_4>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scalyr-api-key-team-5
+data:
+  scalyr-api-key: <b64 encoded SCALYR_API_KEY_WRITE_TEAM_5>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scalyr-api-key-team-6
+data:
+  scalyr-api-key: <b64 encoded SCALYR_API_KEY_WRITE_TEAM_6>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scalyr-api-key-team-7
+data:
+  scalyr-api-key: <b64 encoded SCALYR_API_KEY_WRITE_TEAM_7>
+```
+
+#### Workload Pods in the workload-namespace Namespace
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: multi-account-test
+  name: workload-pod-1
+  namespace: workload-namespace-1
+  annotations:
+    log.config.scalyr.com/teams.1.secret: "scalyr-api-key-team-3"
+    log.config.scalyr.com/teams.5.secret: "scalyr-api-key-team-4"
+    log.config.scalyr.com/workload-pod-1-container-1.teams.1.secret: "scalyr-api-key-team-5"
+    log.config.scalyr.com/workload-pod-1-container-2.teams.1.secret: "scalyr-api-key-team-6"
+    log.config.scalyr.com/workload-pod-1-container-2.teams.2.secret: "scalyr-api-key-team-7"
+spec:
+  containers:
+  - name: workload-pod-1-container-1
+    image: busybox
+    command:
+        - /bin/sh
+        - -c
+        - while true; do echo workload-pod-1-container-1; sleep 1; done
+  - name: workload-pod-1-container-2
+    image: busybox
+    command:
+        - /bin/sh
+        - -c
+        - while true; do echo workload-pod-1-container-2; sleep 1; done
+  - name: workload-pod-1-container-3
+    image: busybox
+    command:
+        - /bin/sh
+        - -c
+        - while true; do echo workload-pod-1-container-3; sleep 1; done
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: multi-account-test
+  name: workload-pod-2
+  namespace: workload-namespace-1
+spec:
+  containers:
+  - name: workload-pod-2-container-1
+    image: busybox
+    command:
+        - /bin/sh
+        - -c
+        - while true; do echo workload-pod-2-container-1; sleep 1; done
+```
+
+##### Workload Pod in workload-namespace-2 Namespace
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: multi-account-test
+  name: workload-pod-3
+  namespace: workload-namespace-2
+spec:
+  containers:
+  - name: workload-pod-3-container-1
+    image: busybox
+    command:
+        - /bin/sh
+        - -c
+        - while true; do echo workload-pod-3-container-1; sleep 1; done
+```
+
+#### Ingested data:
+
+
+| Container Name | API keys used to ingest logs                             | Note                        |
+| --- |----------------------------------------------------------|-----------------------------|
+| workload-pod-1-container-1 | SCALYR_API_KEY_WRITE_TEAM_4                              | Container specific api keys |
+| workload-pod-1-container-2 | SCALYR_API_KEY_WRITE_TEAM_5, SCALYR_API_KEY_WRITE_TEAM_6 | Container specific api keys |
+| workload-pod-1-container-3 | SCALYR_API_KEY_WRITE_TEAM_3, SCALYR_API_KEY_WRITE_TEAM_4 | Pod default api keys        |
+| workload-pod-2-container-1 | SCALYR_API_KEY_WRITE_TEAM_2                              | Namespace default api key   |
+| workload-pod-3-container-1 | SCALYR_API_KEY_WRITE_TEAM_1                              | Agent default api key       |
+
+
+#### Querying the data:
+
+```bash
+scalyr_readlog_token=SCALYR_API_KEY_WRITE_TEAM_1 scalyr query 'app="multi-account-test"' --columns=message
+# workload-pod-3-container-1
+
+scalyr_readlog_token=SCALYR_API_KEY_WRITE_TEAM_2 scalyr query 'app="multi-account-test"' --columns=message
+# workload-pod-2-container-1
+
+scalyr_readlog_token=SCALYR_API_KEY_WRITE_TEAM_3 scalyr query 'app="multi-account-test"' --columns=message
+# workload-pod-1-container-3
+
+scalyr_readlog_token=SCALYR_API_KEY_WRITE_TEAM_4 scalyr query 'app="multi-account-test"' --columns=message
+# workload-pod-1-container-3
+# workload-pod-1-container-1
+
+scalyr_readlog_token=SCALYR_API_KEY_WRITE_TEAM_5 scalyr query 'app="multi-account-test"' --columns=message
+# workload-pod-1-container-2
+
+scalyr_readlog_token=SCALYR_API_KEY_WRITE_TEAM_6 scalyr query 'app="multi-account-test"' --columns=message
+# workload-pod-1-container-2
+```
+
 ### Excluding Logs
 
 Containers and pods can be specifically included/excluded from having their logs collected and
@@ -3684,6 +3910,8 @@ are set. e.g.
 has the same effect as
 
     log.config.scalyr.com/include: false
+
+In an edge case when a short-lived container metadata is not available anymore via K8s API and some logs are found, they will be collected based on `k8s_include_all_containers` flag.
 
 By default the agent monitors the logs of all pods/containers, and you have to manually exclude
 pods/containers you don't want.  You can also set `k8s_include_all_containers: false` in the

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -441,6 +441,24 @@ define_config_option(
 #                     'Optional (defaults to False). If true, stdout/stderr logs will contain docker timestamps at the beginning of the line\n',
 #                     convert_to=bool, default=False)
 
+define_config_option(
+    __monitor__,
+    "k8s_label_include_globs",
+    "Optional, (defaults to False). Specifies a list of K8s labels to be ignored and not added to logs.",
+    convert_to=ArrayOfStrings,
+    default=["*"],
+    env_aware=True,
+)
+
+define_config_option(
+    __monitor__,
+    "k8s_label_exclude_globs",
+    "Optional, (defaults to False). Specifies a list of K8s labels to be ignored and not added to logs.",
+    convert_to=ArrayOfStrings,
+    default=[],
+    env_aware=True,
+)
+
 define_metric(
     __monitor__,
     "docker.net.rx_bytes",
@@ -3232,6 +3250,15 @@ class ContainerChecker(object):
 
         return attributes
 
+    def __is_label_allowed(self, label_name):
+        return any(
+            fnmatch.fnmatch(label_name, glob)
+            for glob in self._config.get("k8s_label_include_globs")
+        ) and not any(
+            fnmatch.fnmatch(label_name, glob)
+            for glob in self._config.get("k8s_label_exclude_globs")
+        )
+
     def __get_log_config_for_container(self, cid, info, k8s_cache, base_attributes):
         # type: (str, dict, KubernetesCache, JsonObject) -> List[Dict]
 
@@ -3300,7 +3327,8 @@ class ContainerChecker(object):
                     container_attributes["k8s_node"] = pod.node_name
 
                 for label, value in six.iteritems(pod.labels):
-                    container_attributes[label] = value
+                    if self.__is_label_allowed(label):
+                        container_attributes[label] = value
 
                 if "parser" in pod.labels:
                     parser = pod.labels["parser"]
@@ -3321,7 +3349,11 @@ class ContainerChecker(object):
                         # field `_k8s_ck`
                         container_attributes["_k8s_dn"] = controller.name
                         # `_k8s_dl` is translated to `k8s-labels`
-                        container_attributes["_k8s_dl"] = controller.flat_labels
+                        container_attributes["_k8s_dl"] = ",".join(
+                            f"{label}={value}"
+                            for label, value in controller.labels.items()
+                            if self.__is_label_allowed(label)
+                        )
                         # `_k8s_ck` is translated into the field key for
                         # `_k8s_dn`. Here are some examples: `k8s-deployment`,
                         # `k8s-daemon-set`, `k8s-stateful-set`, etc. If the

--- a/scalyr_agent/builtin_monitors/kubernetes_monitor.py
+++ b/scalyr_agent/builtin_monitors/kubernetes_monitor.py
@@ -444,7 +444,7 @@ define_config_option(
 define_config_option(
     __monitor__,
     "k8s_label_include_globs",
-    "Optional, (defaults to False). Specifies a list of K8s labels to be ignored and not added to logs.",
+    "Optional, (defaults to ['*']). Specifies a list of K8s labels to be added to logs.",
     convert_to=ArrayOfStrings,
     default=["*"],
     env_aware=True,
@@ -453,7 +453,7 @@ define_config_option(
 define_config_option(
     __monitor__,
     "k8s_label_exclude_globs",
-    "Optional, (defaults to False). Specifies a list of K8s labels to be ignored and not added to logs.",
+    "Optional, (defaults to []]). Specifies a list of K8s labels to be ignored and not added to logs.",
     convert_to=ArrayOfStrings,
     default=[],
     env_aware=True,

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -560,11 +560,7 @@ class Controller(object):
         self.access_time = None
         self.parent_name = parent_name
         self.parent_kind = parent_kind
-        flat_labels = []
-        for key, value in six.iteritems(labels):
-            flat_labels.append("%s=%s" % (key, value))
-
-        self.flat_labels = ",".join(flat_labels)
+        self.labels = labels
 
 
 class ApiQueryOptions(object):

--- a/scripts/cicd/common/scalyr_query.py
+++ b/scripts/cicd/common/scalyr_query.py
@@ -18,7 +18,8 @@ def scalyr_query(token: str, filter: str, time_start: str, retries: int):
             json={
                 "startTime": time_start,
                 "filter": filter
-            }
+            },
+            timeout=10
         )
 
     return query(post_request, retries)
@@ -35,7 +36,8 @@ def power_query(token: str, query_str: str, time_start: str, retries: int):
             json={
                 "startTime": time_start,
                 "query": query_str
-            }
+            },
+            timeout=10
         )
 
     return query(post_request, retries)

--- a/scripts/cicd/common/scalyr_query.py
+++ b/scripts/cicd/common/scalyr_query.py
@@ -1,0 +1,74 @@
+from http import HTTPStatus
+from typing import Callable
+
+import requests
+import time
+import os
+import sys
+
+
+def scalyr_query(token: str, filter: str, time_start: str, retries: int):
+    def post_request():
+        return requests.post(
+            "https://app.scalyr.com/api/query",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json"
+            },
+            json={
+                "startTime": time_start,
+                "filter": filter
+            }
+        )
+
+    return query(post_request, retries)
+
+
+def power_query(token: str, query_str: str, time_start: str, retries: int):
+    def post_request():
+        return requests.post(
+            "https://app.scalyr.com/api/powerQuery",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json"
+            },
+            json={
+                "startTime": time_start,
+                "query": query_str
+            }
+        )
+
+    return query(post_request, retries)
+
+
+def query(post_request: Callable, retries: int):
+    def retry_request():
+        retries_left = retries
+        response = post_request()
+
+        while response.status_code == HTTPStatus.TOO_MANY_REQUESTS and retries_left > 0:
+            print(f"Rate limited. Retrying in 10 seconds. Retries left: {retries_left}")
+            time.sleep(10)
+            response = post_request()
+            retries_left -= 1
+
+        return response
+
+    response = retry_request()
+
+    if not response.ok:
+        raise Exception(f"Query failed: {response.status_code}: {response.text}")
+
+    content = response.json()
+
+    if content["status"] != "success":
+        print(f"ERROR: Query failed: {content}")
+        raise Exception(f"Query failed: {content}")
+
+    return content
+
+
+def assert_env_non_empty(name):
+    if not os.environ.get(name):
+        print(f"ERROR: Environment variable {name} is not set or empty.")
+        sys.exit(1)

--- a/scripts/cicd/verify-k8s-labels-filtered.py
+++ b/scripts/cicd/verify-k8s-labels-filtered.py
@@ -1,0 +1,66 @@
+import json
+import os
+
+from .scalyr_query import assert_env_non_empty, scalyr_query
+
+
+def validate_env():
+    assert_env_non_empty("SERVER_HOST")
+    assert_env_non_empty("SCALYR_API_KEY")
+
+
+def main():
+    print("---------------------------------------")
+    print("Testing label filtering ...")
+    print()
+
+    validate_env()
+    SERVER_HOST = os.environ["SERVER_HOST"]
+    API_KEY = os.environ["SCALYR_API_KEY"]
+
+    result = scalyr_query(API_KEY, filter = f"app=\"pods-with-labels-app\" serverHost=\"{SERVER_HOST}\"", time_start="20m", retries=10)
+
+    INCLUDED_POD_LABELS = {
+        "include_this_label": "include_this_value",
+        "pod_include_this_label": "pod_include_this_value",
+        "wanted_label": "wanted_value"
+    }
+
+    EXCLUDED_POD_LABELS = {
+        "pod_label_1": "pod_value_1",  # Not matching include glob
+        "pod_label_2": "pod_value_2",  # Not matching include glob
+        "pod_label_unwanted_label": "unwanted_value",  # Not matching include glob,
+        "pod_include_this_label_exclude": "pod_include_this_value",  # Matching exclude glob
+        "pod_include_this_label_garbage": "random_value",  # Matching exclude glob
+        "pod_include_this_label_garbage_xxx": "random_value_2",  # Matching exclude glob
+        "garbage_pod_include_this_label": "random_value_2",  # Matching exclude glob
+        "unwanted_label": "unwanted_value"  # Not matching include glob
+    }
+
+    INCLUDED_CONTROLLER_LABELS = ",".join(
+        f"{label}={value}"
+        for label, value in {
+            "include_this_label": "include_this_value",
+            "controller_include_this_label": "controller_include_this_value",
+            "wanted_label": "wanted_value"
+        }.items()
+    )
+
+    assert len(result["matches"]) > 0, "No matches found"
+
+    attributes = result["matches"][0]["attributes"]
+
+    for label, value in INCLUDED_POD_LABELS.items():
+        assert attributes.get(label) == value, f"Pod label {label} does not match."
+
+    for label, value in EXCLUDED_POD_LABELS.items():
+        assert label not in attributes, f"Pod label {label} should not be present."
+
+    assert attributes.get("_k8_dl") == INCLUDED_CONTROLLER_LABELS, "Controller labels do not match."
+
+
+if __name__ == "__main__":
+    main()
+
+
+

--- a/scripts/cicd/verify-k8s-labels-filtered.py
+++ b/scripts/cicd/verify-k8s-labels-filtered.py
@@ -1,12 +1,12 @@
-import json
+#!/usr/bin/env python3
+
 import os
 
-from .scalyr_query import assert_env_non_empty, scalyr_query
-
+from common.scalyr_query import assert_env_non_empty, power_query, scalyr_query
 
 def validate_env():
     assert_env_non_empty("SERVER_HOST")
-    assert_env_non_empty("SCALYR_API_KEY")
+    assert_env_non_empty("SCALYR_API_KEY_READ")
 
 
 def main():
@@ -16,9 +16,10 @@ def main():
 
     validate_env()
     SERVER_HOST = os.environ["SERVER_HOST"]
-    API_KEY = os.environ["SCALYR_API_KEY"]
+    API_KEY = os.environ["SCALYR_API_KEY_READ"]
 
     result = scalyr_query(API_KEY, filter = f"app=\"pods-with-labels-app\" serverHost=\"{SERVER_HOST}\"", time_start="20m", retries=10)
+    power_result = power_query(API_KEY, query_str=f"app=\"pods-with-labels-app\" serverHost=\"{SERVER_HOST}\" | columns k8s-labels", time_start="20m", retries=10)
 
     INCLUDED_POD_LABELS = {
         "include_this_label": "include_this_value",
@@ -40,8 +41,8 @@ def main():
     INCLUDED_CONTROLLER_LABELS = ",".join(
         f"{label}={value}"
         for label, value in {
-            "include_this_label": "include_this_value",
             "controller_include_this_label": "controller_include_this_value",
+            "include_this_label": "include_this_value",
             "wanted_label": "wanted_value"
         }.items()
     )
@@ -56,7 +57,13 @@ def main():
     for label, value in EXCLUDED_POD_LABELS.items():
         assert label not in attributes, f"Pod label {label} should not be present."
 
-    assert attributes.get("_k8_dl") == INCLUDED_CONTROLLER_LABELS, "Controller labels do not match."
+
+    def sort_string_dict(s):
+        return ",".join(sorted(s.split(",")))
+
+    k8s_labels = sort_string_dict(power_result["values"][0][0])
+
+    assert k8s_labels == INCLUDED_CONTROLLER_LABELS, f"Controller labels do not match. Expected: {INCLUDED_CONTROLLER_LABELS}, got: {k8s_labels}"
 
 
 if __name__ == "__main__":

--- a/scripts/cicd/verify-multiaccount-records-have-been-ingested.py
+++ b/scripts/cicd/verify-multiaccount-records-have-been-ingested.py
@@ -14,21 +14,13 @@
 # limitations under the License.
 
 import os
-import sys
 import time
-from http import HTTPStatus
 from typing import Dict, Set
 
-import requests
 from kubernetes import client, config
 from tabulate import tabulate
 
-
-def assert_env_non_empty(name):
-    if not os.environ.get(name):
-        print(f"ERROR: Environment variable {name} is not set or empty.")
-        sys.exit(1)
-
+from common.scalyr_query import scalyr_query, assert_env_non_empty
 
 ENV_TOKENS = [
     "SCALYR_API_KEY_READ_TEAM_1",
@@ -61,52 +53,13 @@ def validate_env():
     assert_env_non_empty("SERVER_HOST")
 
 
-def query(token: str, server_host: str, time_start: str, retries: int):
-    def post_request():
-        return requests.post(
-            "https://app.scalyr.com/api/query",
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Content-Type": "application/json"
-            },
-            json={
-                "startTime": time_start,
-                "filter": f"app=\"multi-account-test\" serverHost=\"{server_host}\"",
-            },
-            timeout=20
-        )
-
-    def retry_request():
-        retries_left = retries
-        response = post_request()
-
-        while response.status_code == HTTPStatus.TOO_MANY_REQUESTS and retries_left > 0:
-            print(f"Rate limited. Retrying in 10 seconds. Retries left: {retries_left}")
-            time.sleep(10)
-            response = post_request()
-            retries_left -= 1
-
-        return response
-
-    response = retry_request()
-
-    if not response.ok:
-        raise Exception(f"Query failed: {response.status_code}: {response.text}")
-
-    content = response.json()
-
-    if content["status"] != "success":
-        print(f"ERROR: Query failed: {content}")
-        raise Exception(f"Query failed: {content}")
-
-    return content
-
-
 def get_container_ingested_map(tokens: Dict[str, str], server_host: str, time_start: str, retries=10) -> Dict[str, Set[str]]:
+    filter = f"app=\"multi-account-test\" serverHost=\"{server_host}\""
+
     return {
         token_name: set(
             match["message"].replace("MULTIPLE_ACCOUNT_TEST_CONTAINER_NAME:", "").strip()
-            for match in query(token, server_host, time_start, retries)["matches"]
+            for match in scalyr_query(token, filter, time_start, retries)["matches"]
         )
         for token_name, token in tokens.items()
     }
@@ -154,10 +107,6 @@ def main():
     # | workload-pod-1-container-3 | SCALYR_API_KEY_READ_TEAM_3, SCALYR_API_KEY_READ_TEAM_4   | Pod default api keys        |
     # | workload-pod-2-container-1 | SCALYR_API_KEY_READ_TEAM_2                               | Namespace default api key   |
     # | workload-pod-3-container-1 | SCALYR_API_KEY_READ_TEAM_1                               | Agent default api key       |
-
-    class AssertException(Exception):
-        def __init__(self, message):
-            super().__init__(message)
 
     def print_container_ingested_map(container_ingested_map):
         print(tabulate(

--- a/tests/e2e/k8s_k8s_monitor/pods-with-labels.yaml
+++ b/tests/e2e/k8s_k8s_monitor/pods-with-labels.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pods-with-labels-namespace
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: pods-with-labels-replicaset
+  namespace: pods-with-labels-namespace
+  labels:
+    controller_label_1: controller_value_1
+    controller_label_2: controller_value_2
+    controller_label_unwanted_label: unwanted_value
+    include_this_label: include_this_value
+    controller_include_this_label_exclude: pod_include_this_value
+    controller_include_this_label: controller_include_this_value
+    controller_include_this_label_garbage: random_value
+    controller_include_this_label_garbage_xxx: random_value_2
+    garbage_controller_include_this_label: random_value_2
+    wanted_label: wanted_value
+    unwanted_label: unwanted_value
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pods-with-labels-app
+  template:
+    metadata:
+      labels:
+        app: pods-with-labels-app
+        pod_label_1: pod_value_1
+        pod_label_2: pod_value_2
+        pod_label_unwanted_label: unwanted_value
+        include_this_label: include_this_value
+        pod_include_this_label_exclude: pod_include_this_value
+        pod_include_this_label: pod_include_this_value
+        pod_include_this_label_garbage: random_value
+        pod_include_this_label_garbage_xxx: random_value_2
+        garbage_pod_include_this_label: random_value_2
+        wanted_label: wanted_value
+        unwanted_label: unwanted_value
+    spec:
+      containers:
+        - name: pods-with-labels-container
+          image: busybox:1.28
+          command:
+            - "sh"
+            - "-c"
+            - "while true; do echo 'Hello, Kubernetes!'; sleep 10; done"

--- a/tests/e2e/scalyr-agent-2-daemonset.yaml
+++ b/tests/e2e/scalyr-agent-2-daemonset.yaml
@@ -9,7 +9,8 @@ data:
       "k8s_logs": [
         {
           "attributes": {
-            "container_name": "${k8s_container_name}"}
+            "container_name": "${k8s_container_name}"
+          }
         }
       ]
     }
@@ -31,7 +32,9 @@ data:
       "monitors":[
         {
           "module": "scalyr_agent.builtin_monitors.kubernetes_monitor",
-          "stop_agent_on_failure": true
+          "stop_agent_on_failure": true,
+          "k8s_label_include_globs": ["app", "*include_this_label*", "wanted_label"],
+          "k8s_label_exclude_globs": ["*garbage*","*exclude*"]
         }
       ]
     }

--- a/tests/unit/builtin_monitors/container_checker_test.py
+++ b/tests/unit/builtin_monitors/container_checker_test.py
@@ -35,7 +35,7 @@ class MockRunState():
 
     def wait_for_next_loop_start(self):
         with self.next_loop_condition:
-            if not self.next_loop_condition.wait(timeout=5):
+            if not self.next_loop_condition.wait(timeout=15):
                 raise Exception("Failed to acquire started lock")
 
     def is_running(self):

--- a/tests/unit/builtin_monitors/container_checker_test.py.py
+++ b/tests/unit/builtin_monitors/container_checker_test.py.py
@@ -15,7 +15,7 @@ from scalyr_agent.monitor_utils.k8s import (
 )
 from scalyr_agent.monitor_utils.annotation_config import process_annotations
 
-__author__ = "echee@scalyr.com"
+__author__ = "ales.novak@scalyr.com"
 
 
 from scalyr_agent.builtin_monitors.kubernetes_monitor import (

--- a/tests/unit/configuration_k8s_test.py
+++ b/tests/unit/configuration_k8s_test.py
@@ -100,6 +100,8 @@ class TestConfigurationK8s(TestConfigurationBase):
             "k8s_kubelet_host_ip": (STANDARD_PREFIX, False, bool),
             "k8s_kubelet_api_url_template": (STANDARD_PREFIX, False, bool),
             "gather_k8s_pod_info": (STANDARD_PREFIX, True, bool),
+            "k8s_label_include_globs": (STANDARD_PREFIX, TEST_ARRAY_OF_STRINGS, ArrayOfStrings),
+            "k8s_label_exclude_globs": (STANDARD_PREFIX, TEST_ARRAY_OF_STRINGS, ArrayOfStrings),
         }
 
         k8s_events_testmap = {


### PR DESCRIPTION
From documentation:
| `k8s_label_include_globs`                     | Optional, (defaults to ['*']). Specifies a list of K8s labels to be added to logs. | 
| `k8s_label_exclude_globs`                     | Optional, (defaults to []]). Specifies a list of K8s labels to be ignored and not added to logs. |

Follows the same logic as label_include_globs and label_exclude_globs from the docker_monitor.

Implements:
https://sentinelone.atlassian.net/browse/DTIN-3678

As part of this PR I've added some multiaccount documentation from the generated md file to the kubernetes_monitor.py mondule.