### PR TITLE
Fix - Race condition when trying to add a log file that's been scheduled for removal

### DIFF
--- a/scalyr_agent/copying_manager/copying_manager.py
+++ b/scalyr_agent/copying_manager/copying_manager.py
@@ -27,7 +27,6 @@ import signal
 import errno
 import fnmatch
 import json
-from collections import defaultdict
 
 WORKER_SESSION_PROCESS_MONITOR_ID_PREFIX = "agent_worker_"
 

--- a/scalyr_agent/copying_manager/copying_manager.py
+++ b/scalyr_agent/copying_manager/copying_manager.py
@@ -378,8 +378,7 @@ class PathWorkerIdDict(object):
     """
 
     def __init__(self):
-        self.__paths = {}
-        # type: Dict[six.text_type, Dict[six.text_type, object]]
+        self.__paths = {}  # type: Dict[six.text_type, Dict[six.text_type, object]]
 
     def set(self, path, worker_id, value):
         # type: (six.text_type, six.text_type, object) -> None

--- a/scalyr_agent/copying_manager/copying_manager.py
+++ b/scalyr_agent/copying_manager/copying_manager.py
@@ -379,30 +379,23 @@ class PathWorkerIdDict(object):
     """
 
     def __init__(self):
-        self.__paths = defaultdict(
-            dict
-        )  # type: Dict[six.text_type, Dict[six.text_type, object]]
+        self.__paths = {}
+        # type: Dict[six.text_type, Dict[six.text_type, object]]
 
     def set(self, path, worker_id, value):
         # type: (six.text_type, six.text_type, object) -> None
+        if path not in self.__paths:
+            self.__paths[path] = {}
+
         self.__paths[path][worker_id] = value
 
     def get_path(self, path):
-
-        # We don't want to be creating an empty default dict by get.
-        if path not in self.__paths:
-            return {}.items()
-
-        return self.__paths[path].items()
+        return self.__paths.get(path, {}).items()
 
     def get(self, path, worker_id, default=None):
         # type: (six.text_type, six.text_type, Optional[object]) -> Optional[object]
 
-        # We don't want to be creating an empty default dict by get.
-        if path not in self.__paths:
-            return default
-
-        return self.__paths[path].get(worker_id, default)
+        return self.__paths.get(path, {}).get(worker_id, default)
 
     def complement_keys(self, path, worker_ids):
         # type: (six.text_type, List[six.text_type]) -> List[Tuple[six.text_type, six.text_type]]
@@ -417,7 +410,7 @@ class PathWorkerIdDict(object):
 
     def contains(self, path, worker_id):
         # type: (six.text_type, six.text_type) -> bool
-        return worker_id in self.__paths[path]
+        return worker_id in self.__paths.get(path, {})
 
     def copy(self):
         # type: () -> PathWorkerIdDict
@@ -446,10 +439,12 @@ class PathWorkerIdDict(object):
     def pop(self, path, worker_id, default=None):
         # type: (six.text_type, six.text_type, Optional[object]) -> Optional[object]
 
-        value = self.__paths[path].pop(worker_id, default)
-
-        if not self.__paths[path]:
-            self.__paths.pop(path)
+        if path in self.__paths:
+            value = self.__paths[path].pop(worker_id, default)
+            if not self.__paths[path]:
+                self.__paths.pop(path)
+        else:
+            value = default
 
         return value
 

--- a/tests/unit/copying_manager_tests/copying_manager_test.py
+++ b/tests/unit/copying_manager_tests/copying_manager_test.py
@@ -163,6 +163,56 @@ class TestPathWorkerIdDict(object):
 
         assert d.get("path1", "worker_id1") is None
 
+    def test_get_nonexistent_path(self):
+        d = PathWorkerIdDict()
+        assert d.get_path("nonexistent") == {}.items()
+
+    def test_get_nonexistent_key(self):
+        d = PathWorkerIdDict()
+        assert d.get("nonexistent", "nonexistent") is None
+
+    def test_pop_nonexistent_key(self):
+        d = PathWorkerIdDict()
+        try:
+            assert d.pop("nonexistent", "nonexistent") is None
+        except Exception:
+            pytest.fail("pop raised an exception unexpectedly")
+
+    def test_complement_keys_nonexistent_path(self):
+        d = PathWorkerIdDict()
+        try:
+            assert d.complement_keys("nonexistent", ["nonexistent"]) == []
+        except Exception:
+            pytest.fail("pop raised an exception unexpectedly")
+
+    def test_contains_nonexistent_path(self):
+        d = PathWorkerIdDict()
+        try:
+            assert not d.contains("nonexistent_path", "worker_id")
+        except Exception:
+            pytest.fail("pop raised an exception unexpectedly")
+
+    def test_set_nonexistent_path(self):
+        d = PathWorkerIdDict()
+        try:
+            d.set("nonexistent_path", "worker_id", "value")
+            assert d.get("nonexistent_path", "worker_id") == "value"
+        except Exception:
+            pytest.fail("pop raised an exception unexpectedly")
+
+    def test_get_does_not_create_empty_path(self):
+        d = PathWorkerIdDict()
+        # We're testing a private field here to ensure optimal implementation avoiding memory leaks.
+        assert "worker_id" not in d._PathWorkerIdDict__paths == {}
+
+    def test_pop_removed_one_worker_only(self):
+        d = PathWorkerIdDict()
+        d.set("path1", "worker_id1", "value1")
+        d.set("path1", "worker_id2", "value2")
+        assert d.pop("path1", "worker_id1") == "value1"
+        assert d.get("path1", "worker_id1") is None
+        assert d.get("path1", "worker_id2") == "value2"
+
 
 class TestDynamicWorkers:
 


### PR DESCRIPTION
* Fixes https://sentinelone.atlassian.net/browse/DTIN-4631
* __lock has been change to reentrant RLock. 

Based on the comments the lock was initially meant to lock status fields used in generate_status.
Now it ensures synchronized access to fields needed for asynchonous workflow of log files. 
This is already causing a timeout when retrieving status from the agent (https://sentinelone.atlassian.net/browse/DTIN-4769) and will be handled in another PR.
	

**The Bug:**

When a log file (path, worker_id) is scheduled for removal, the removal is done in two separate steps:
*  **__remove_logs_scheduled_for_deletion**
	* Instructs all matchers from **__logs_pending_removal** to finish
	* Clears **__logs_pending_removal**
* **__purge_finished_log_matchers**
	* Removes all finished matchers from **__logs_pending_removal**, **__dynamic_matchers**, **__dynamic_paths**
	
The race condition can be reached when a path is scheduled for removal and the matchers are still finishing.
When **add_log_config** is called it considers log path to be active and skips adding it. The log file is later removed.

In log we can see sequence like this one:
```
Log ( log_path='xy', worker_id='default' ) for monitor 'scalyr_agent.builtin_monitors.kubernetes_monitor' is pending removal

Tried to add new log file 'xy' for monitor 'scalyr_agent.builtin_monitors.kubernetes_monitor', but it is already being monitored by 'scalyr_agent.builtin_monitors.kubernetes_monitor'

Removing log file ( log_path='xy', worker_id='default' ) for 'scheduled-deletion'
```

