### PR TITLE
Agent status timeout configurable

### DIFF
--- a/.circleci/smoketest_k8s.sh
+++ b/.circleci/smoketest_k8s.sh
@@ -70,7 +70,7 @@ if [[ "$delete_existing_objects" == "delete_existing_k8s_objs" ]]; then
     kubectl delete daemonset scalyr-agent-2 || true
     kubectl delete configmap scalyr-config || true
     kubectl delete secret scalyr-api-key || true
-    kubectl delete -f https://raw.githubusercontent.com/scalyr/scalyr-agent-2/release/k8s/scalyr-service-account.yaml || true
+    kubectl delete -f ./k8s/scalyr-service-account.yaml || true
     echo "::endgroup::"
 fi
 
@@ -78,7 +78,7 @@ echo ""
 echo "::group::Creating k8s objects"
 echo "=================================================="
 # Create service account
-kubectl create -f https://raw.githubusercontent.com/scalyr/scalyr-agent-2/release/k8s/scalyr-service-account.yaml
+kubectl create -f ./k8s/scalyr-service-account.yaml
 
 # Define api key
 kubectl create secret generic scalyr-api-key --from-literal=scalyr-api-key=${SCALYR_API_KEY}

--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -926,7 +926,7 @@ class ScalyrAgent(object):
                 return 2
 
         # We wait for five seconds at most to get the status.
-        deadline = time.time() + 5
+        deadline = time.time() + self.__config.agent_status_timeout
 
         last_debug_stat_time = 0
         # Now loop until we see it show up.
@@ -980,9 +980,9 @@ class ScalyrAgent(object):
                     debug_stats_str = ""
 
                 print(
-                    "Failed to get status within 5 seconds.  Giving up.  The agent process is "
+                    "Failed to get status within %d seconds.  Giving up.  The agent process is "
                     "possibly stuck.  See %s for more details.\n%s"
-                    % (agent_log, debug_stats_str),
+                    % (self.__config.agent_status_timeout, agent_log, debug_stats_str),
                     file=sys.stderr,
                 )
                 return 1
@@ -2329,8 +2329,8 @@ class ScalyrAgent(object):
 
         log.log(
             scalyr_logging.DEBUG_LEVEL_4,
-            'Wrote agent status data in "%s" format to %s'
-            % (status_format, final_file_path),
+            'Wrote agent status data in "%s" format to %s in %.2f seconds'
+            % (status_format, final_file_path, time.time() - start_ts),
         )
 
         return final_file_path

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -1499,6 +1499,11 @@ class Configuration(object):
         return self.__get_config().get_string("api_key")
 
     @property
+    def agent_status_timeout(self):
+        """Returns the configuration value for 'agent_status_timeout'."""
+        return self.__get_config().get_int("agent_status_timeout")
+
+    @property
     def scalyr_server(self):
         """Returns the configuration value for 'scalyr_server'."""
         return self.__get_config().get_string("scalyr_server")
@@ -3600,6 +3605,14 @@ class Configuration(object):
             config,
             "max_allowed_checkpoint_age",
             15 * 60,
+            description,
+            apply_defaults,
+        )
+
+        self.__verify_or_set_optional_int(
+            config,
+            "agent_status_timeout",
+            30,
             description,
             apply_defaults,
         )


### PR DESCRIPTION
Introducing a a new config key “agent_status_timeout” and setting it to 30s by default.

When the agent is under a heavier load it can take more than 5 seconds to generate status.
It's caused by thread switching. I've noticed such a switch is usually triggered by IO operations. Reading a 4 byte file can take 3 seconds in wall time.
Unfortunatelly there's no way in python to prioritize a thread.

