### PR TITLE
DTIN-6259: AutoFlushingRotatingUniqueFileHandler lock fix

### DIFF
--- a/scalyr_agent/monitor_utils/auto_flushing_rotating_unique_file_handler.py
+++ b/scalyr_agent/monitor_utils/auto_flushing_rotating_unique_file_handler.py
@@ -138,7 +138,9 @@ class AutoFlushingRotatingUniqueFileHandler(AutoFlushingRotatingFileHandler):
                 self._current_file.flush()
             else:
                 if self._timer is None:
-                    self._timer = threading.Timer(self._flush_delay, self._delayed_flush)
+                    self._timer = threading.Timer(
+                        self._flush_delay, self._delayed_flush
+                    )
                     self._timer.start()
 
             self._current_size += size


### PR DESCRIPTION
- emit (which acquires the lock) was calling flush which also attempts to acquire the lock resulting in deadlock
- Rearrange locking and timer invocation more cleanly