### PR TITLE
Allow build-tarball to take target architectures as option

### DIFF
--- a/agent_build_refactored/container_images/image_builders.py
+++ b/agent_build_refactored/container_images/image_builders.py
@@ -228,10 +228,10 @@ class ContainerisedAgentBuilder(Builder):
         dockerfile_overrides = dockerfile_overrides or {}
 
         cmd_options = [
-            f"-f={bake_file}",
+            f"--file {bake_file}",
             "--progress=plain",
             f"--allow=fs.read={str(self.work_dir)}",
-            f"--set \\*.platform={",".join([x.as_docker_platform() for x in architectures])}",
+            f"--set \\*.platform={','.join([x.as_docker_platform() for x in architectures])}",
         ]
 
         for key, value in dockerfile_overrides.items():
@@ -294,14 +294,22 @@ class ContainerisedAgentBuilder(Builder):
         Build image in the form of the OCI tarball
         """
 
-        result_tarball = (
-            self.result_dir / f"{image_type.value}-{self.__class__.NAME}.tar"
+        architectures = architectures or self.get_supported_architectures()
+
+        if len(architectures) > 1:
+            architecture_name = "multiarch"
+        else:
+            architecture_name = architectures[0].value
+
+        agent_version = (SOURCE_ROOT / "VERSION").read_text().strip()
+        result_oci_tarball = (
+            self.result_dir / f"scalyr-agent-2-{image_type.value}-{self.__class__.NAME}-{ agent_version }-{architecture_name}.oci"
         )
 
         self._build(
             image_type=image_type,
             output=OCITarballBuildOutput(
-                dest=result_tarball,
+                dest=result_oci_tarball,
                 extract=False,
             ),
             architectures=architectures,
@@ -310,11 +318,11 @@ class ContainerisedAgentBuilder(Builder):
         if output_dir:
             output_dir.mkdir(parents=True, exist_ok=True)
             shutil.copy(
-                result_tarball,
+                result_oci_tarball,
                 output_dir,
             )
 
-        return result_tarball
+        return result_oci_tarball
 
 def _arch_to_docker_build_target_name(architecture: CpuArch):
 

--- a/build_package_new.py
+++ b/build_package_new.py
@@ -98,12 +98,13 @@ def _add_image_parsers():
     )
 
     image_build_parser = image_parser_action_subparsers.add_parser(
-        "build-tarball", help="Build image if a form of OCI layout tarball."
+        "build-oci", help="Build image if a form of OCI layout tarball."
     )
     _add_image_type_arg(image_build_parser)
     image_build_parser.add_argument(
-        "--output-dir", required=True, help="Output directory with tarball"
+        "--output-dir", required=True, help="Output directory with OCI tarball"
     )
+    image_build_parser.add_argument('--cpu-architecture', action='append', help="CPU architecture to build for (can be used multiple times for multi-arch builds).")
 
     cache_requirements_image_parser = image_parser_action_subparsers.add_parser(
         "cache-requirements",
@@ -196,14 +197,19 @@ if __name__ == "__main__":
                 image_type=ImageType(args.image_type),
                 result_image_name=args.image_name,
             )
-        if args.action == "build-tarball":
+        if args.action == "build-oci":
             if args.output_dir:
                 output_dir = pl.Path(args.output_dir)
             else:
                 output_dir = None
 
+            if args.cpu_architecture:
+                architectures = [ CpuArch(arch_type) for arch_type in args.cpu_architecture]
+            else:
+                architectures = None
+
             builder.build_oci_tarball(
-                image_type=ImageType(args.image_type), output_dir=output_dir
+                image_type=ImageType(args.image_type), output_dir=output_dir, architectures=architectures
             )
             exit(0)
         elif args.action == "cache-requirements":


### PR DESCRIPTION
This allows for building image tarballs for a specific architecture instead of all supported architectures.

Also update OCI tarball name to use .oci extension and include version number and architecture to be
consistent with other artifacts.