### PR TITLE
fix: Implement recommended user role, unpickling, and fallback url fixes

### DIFF
--- a/scalyr_agent/agent_main.py
+++ b/scalyr_agent/agent_main.py
@@ -341,6 +341,17 @@ class ScalyrAgent:
 
         self.__config_file_path = config_file_path
 
+        self.__escalator = ScriptEscalator(
+            self.__controller,
+            config_file_path,
+            os.getcwd(),
+            command_options.no_change_user,
+        )
+        if command in ["start", "restart", "condrestart"]  and self.__escalator.is_user_change_required():
+            return self.__escalator.change_user_and_rerun_script(
+                "start the scalyr agent"
+            )
+
         no_check_remote = command_options.no_check_remote
 
         try:
@@ -381,12 +392,7 @@ class ScalyrAgent:
 
         self.__controller.consume_config(self.__config, config_file_path)
 
-        self.__escalator = ScriptEscalator(
-            self.__controller,
-            config_file_path,
-            os.getcwd(),
-            command_options.no_change_user,
-        )
+
 
         # noinspection PyBroadException
         try:
@@ -658,12 +664,6 @@ class ScalyrAgent:
         @return:  The exit status code for the process.
         @rtype: int
         """
-        # First, see if we have to change the user that is executing this script to match the owner of the config.
-        if self.__escalator.is_user_change_required():
-            return self.__escalator.change_user_and_rerun_script(
-                "start the scalyr agent"
-            )
-
         # Make sure we do not try to start it up again.
         self.__fail_if_already_running()
 
@@ -1107,12 +1107,6 @@ class ScalyrAgent:
         @return: the exit status code
         @rtype: int
         """
-        # First, see if we have to change the user that is executing this script to match the owner of the config.
-        if self.__escalator.is_user_change_required():
-            return self.__escalator.change_user_and_rerun_script(
-                "restart the scalyr agent"
-            )
-
         if self.__controller.is_agent_running():
             if not quiet:
                 print("Agent is running, restarting now.")
@@ -1147,12 +1141,6 @@ class ScalyrAgent:
             could not be started.
         @rtype: int
         """
-        # First, see if we have to change the user that is executing this script to match the owner of the config.
-        if self.__escalator.is_user_change_required():
-            return self.__escalator.change_user_and_rerun_script(
-                "restart the scalyr agent"
-            )
-
         if self.__controller.is_agent_running():
             if not quiet:
                 print("Agent is running, stopping it now.")

--- a/scalyr_agent/builtin_monitors/graphite_monitor.py
+++ b/scalyr_agent/builtin_monitors/graphite_monitor.py
@@ -25,6 +25,8 @@
 __author__ = "czerwin@scalyr.com"
 
 import six
+import io
+import builtins
 
 try:
     # noinspection PyPep8Naming
@@ -452,7 +454,7 @@ class GraphitePickleServer(ServerProcessor):
         # noinspection PyBroadException
         try:
             # Use pickle to read the binary data.
-            data_object = pickle.loads(request)
+            data_object = SafeGraphiteUnpickler(io.BytesIO(request)).load()
         except (
             Exception
         ):  # pickle.loads is document as raising any type of exception, so have to catch them all.
@@ -483,4 +485,20 @@ class GraphitePickleServer(ServerProcessor):
         self.__logger.exception(
             'Exception seen while processing Graphite connect on pickle port, closing connection: "%s"'
             % str(exception)
+        )
+
+class SafeGraphiteUnpickler(pickle.Unpickler):
+    """
+    Restricted unpickler that only allows primitive types required for Graphite metrics.
+    """
+    ALLOWED_BUILTINS = frozenset({
+        'list', 'tuple', 'str', 'bytes', 'float', 'int', 'dict'
+    })
+
+    def find_class(self, module, name):
+        if module == "builtins" and name in self.ALLOWED_BUILTINS:
+            return getattr(builtins, name)
+        raise pickle.UnpicklingError(
+            f"Forbidden class during unpickling: {module}.{name}. "
+            f"Only primitive types are allowed for Graphite metrics."
         )

--- a/scalyr_agent/monitor_utils/k8s.py
+++ b/scalyr_agent/monitor_utils/k8s.py
@@ -2711,6 +2711,9 @@ class KubeletApi:
 
     def _switch_to_fallback(self):
         self._kubelet_url = self._fallback_kubelet_url
+        # fallback url is HTTP and does need auth
+        if "Authorization" in self._session.headers:
+            del self._session.headers["Authorization"]
 
     def _verify_connection(self):
         """Return whether or not to use SSL verification"""
@@ -2728,7 +2731,8 @@ class KubeletApi:
         self._session.headers.update(headers)
 
     def _get(self, url, verify):
-        self._add_auth_header()
+        if url.startswith("https://"):
+            self._add_auth_header()
         return self._session.get(url, timeout=self._timeout, verify=verify)
 
     def query_api(self, path):
@@ -2738,6 +2742,15 @@ class KubeletApi:
             # We suppress warnings here to avoid spam about an unverified connection going to stderr.
             # This method of warning suppression is not thread safe and has a small chance of suppressing warnings from
             # other threads if they are emitted while this request is going.
+            if self._kubelet_url.startswith("http://"):
+                global_log.warn(
+                    "Accessing Kubelet via CLEARTEXT HTTP fallback endpoint (%s). "
+                    "This typically indicates the primary HTTPS endpoint returned 403. "
+                    "Verify the agent ServiceAccount has proper RBAC permissions (nodes/proxy or nodes/stats). "
+                    "The deprecated read-only port 10255 may be disabled in future Kubernetes versions." % url,
+                    limit_once_per_x_secs=300,
+                    limit_key="kubelet-http-fallback-warning",
+                )
             verify_connection = self._verify_connection()
             if not verify_connection:
                 with warnings.catch_warnings():

--- a/tests/unit/agent_main_test.py
+++ b/tests/unit/agent_main_test.py
@@ -714,6 +714,30 @@ class AgentMainTestCase(BaseScalyrLogCaptureTestCase):
                     "his monitor.".format(monitor_to_fail.short_hash)
                 )
 
+    @mock.patch("scalyr_agent.agent_main.ScriptEscalator")
+    def test_privilege_escalation_before_config_parse(self, mock_escalator_class):
+        from scalyr_agent.agent_main import ScalyrAgent
+        from scalyr_agent.platform_controller import PlatformController
+
+        # escalator mock for required user change
+        mock_escalator = mock.Mock()
+        mock_escalator.is_user_change_required.return_value = True
+        mock_escalator.change_user_and_rerun_script.return_value = 0
+        mock_escalator_class.return_value = mock_escalator
+
+        self._write_mock_config()
+
+        platform_controller = PlatformController()
+        agent = ScalyrAgent(platform_controller)
+
+        with mock.patch.object(agent, "_ScalyrAgent__read_and_verify_config") as mock_parse:
+            for command in ["start", "restart", "condrestart"]:
+                agent.main(self._config_path, command, mock.Mock())
+                mock_escalator.change_user_and_rerun_script.assert_called_once()
+                mock_escalator.change_user_and_rerun_script.reset_mock()
+                # verify config not parsed as this user
+                mock_parse.assert_not_called()
+
 
 _AGENT_MAIN_PATH = os.path.join(
     __scalyr__.get_install_root(), "scalyr_agent", "agent_main.py"

--- a/tests/unit/builtin_monitors/graphite_monitor_test.py
+++ b/tests/unit/builtin_monitors/graphite_monitor_test.py
@@ -15,6 +15,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
+import os
 import time
 import socket
 import pickle
@@ -241,4 +242,31 @@ class GraphiteMonitorPickleServerTestCase(ScalyrTestCase):
             "system.loadavg_15min",
             10.3,
             extra_fields={"orig_time": 1603104000003.0},
+        )
+
+    def test_execute_request_blocks_malicious_pickle(self):
+        mock_logger = mock.Mock()
+        server = GraphitePickleServer(
+            only_accept_local=True,
+            port=5899,
+            run_state=None,
+            buffer_size=1024,
+            max_request_size=1024 * 5,
+            max_connection_idle_time=10,
+            logger=mock_logger,
+        )
+
+        class MaliciousPayload:
+            def __reduce__(self):
+                return (os.system, ('echo',))
+
+        malicious_request = pickle.dumps(MaliciousPayload())
+
+        server.execute_request(request=malicious_request)
+
+        self.assertEqual(mock_logger.warn.call_count, 1)
+        self.assertEqual(mock_logger.emit_value.call_count, 0)
+        mock_logger.warn.assert_called_with(
+            "Could not parse incoming metric line from graphite pickle server, ignoring",
+            error_code="graphite_monitor/badUnpickle",
         )

--- a/tests/unit/builtin_monitors/kubernetes_monitor_test.py
+++ b/tests/unit/builtin_monitors/kubernetes_monitor_test.py
@@ -773,8 +773,21 @@ class TestKubeletApi(BaseScalyrLogCaptureTestCase):
     @mock.patch("scalyr_agent.monitor_utils.k8s.global_log")
     def test_fallback(self, mock_global_log):
         self._fake_get_called = False
+        self._https_had_auth = None
+        self._http_had_auth = None
+        
+        api = KubeletApi(
+            FakeKubernetesApi(),
+            host_ip="127.0.0.1",
+            node_name="FakeNode",
+        )
 
-        def fake_get(self2, url, verify):
+        def fake_session_get(url, timeout, verify):
+            if url.startswith('https://'):
+                self._https_had_auth = 'Authorization' in api._session.headers
+            elif url.startswith('http://'):
+                self._http_had_auth = 'Authorization' in api._session.headers
+            
             resp = FakeResponse()
             if not self._fake_get_called:
                 resp.status_code = 403
@@ -783,13 +796,7 @@ class TestKubeletApi(BaseScalyrLogCaptureTestCase):
                 resp.status_code = 200
             return resp
 
-        with mock.patch.object(KubeletApi, "_get", fake_get):
-            api = KubeletApi(
-                FakeKubernetesApi(),
-                host_ip="127.0.0.1",
-                node_name="FakeNode",
-            )
-
+        with mock.patch.object(api._session, "get", fake_session_get):
             self.assertEqual(mock_global_log.warn.call_count, 0)
             result = api.query_stats()
             self.assertEqual(result, {})
@@ -800,10 +807,13 @@ class TestKubeletApi(BaseScalyrLogCaptureTestCase):
                 "(http://127.0.0.1:10255)."
             )
 
-            self.assertEqual(mock_global_log.warn.call_count, 1)
+            self.assertEqual(mock_global_log.warn.call_count, 2)
             self.assertTrue(
                 expected_msg in mock_global_log.warn.call_args_list[0][0][0]
             )
+            
+            self.assertTrue(self._https_had_auth)
+            self.assertFalse(self._http_had_auth, "Fallback should not have auth header")
 
     def test_host_ip_format(self):
         def fake_get(self2, url, verify):
@@ -1443,7 +1453,7 @@ class TestKubernetesKubeletApiAuthTokenCaching(TestConfigurationBase, ScalyrTest
 
         session = requests.Session()
         adapter = requests_mock.Adapter()
-        session.mount("mock://", adapter)
+        session.mount("https://", adapter)
 
         expected_headers_token = ""
 
@@ -1457,12 +1467,12 @@ class TestKubernetesKubeletApiAuthTokenCaching(TestConfigurationBase, ScalyrTest
 
         adapter.register_uri(
             "GET",
-            "mock://test.com/test?pretty=0",
+            "https://test.com/test?pretty=0",
             text="{}",
             additional_matcher=custom_request_matcher,
         )
 
-        k8s_api_url = "mock://test.com"
+        k8s_api_url = "https://test.com"
 
         k8s = KubernetesApi.create_instance(
             global_config=global_config,
@@ -1509,7 +1519,7 @@ class TestKubernetesKubeletApiAuthTokenCaching(TestConfigurationBase, ScalyrTest
 
         session = requests.Session()
         adapter = requests_mock.Adapter()
-        session.mount("mock://", adapter)
+        session.mount("https://", adapter)
 
         expected_headers_token = ""
 
@@ -1523,12 +1533,12 @@ class TestKubernetesKubeletApiAuthTokenCaching(TestConfigurationBase, ScalyrTest
 
         adapter.register_uri(
             "GET",
-            "mock://test.com:10250/test",
+            "https://test.com:10250/test",
             text="{}",
             additional_matcher=custom_request_matcher,
         )
 
-        k8s_api_url = "mock://test.com"
+        k8s_api_url = "https://test.com"
 
         k8s = KubernetesApi.create_instance(
             global_config=global_config,
@@ -1537,7 +1547,7 @@ class TestKubernetesKubeletApiAuthTokenCaching(TestConfigurationBase, ScalyrTest
         )
         k8s._session = session
 
-        kubelet_url_template = Template("mock://${host_ip}:10250")
+        kubelet_url_template = Template("https://${host_ip}:10250")
 
         kubelet = KubeletApi(
             k8s=k8s,


### PR DESCRIPTION
This PR makes updates to a few different sections of the agent based on recommended changes.

- Unpickler for Graphite Metrics is now limited to a select set of builtin classes and a new unit test was added to confirm this.
- The fallback url functionality in the k8s monitor now omits the Authorization header. Updated associated unit test.
- On startup the Agent will change the user prior to reading in the config depending on the command. Added new unit test.