### PR TITLE
Update FIPS base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,16 @@ Scalyr Agent 2 Changes By Release
 
 ## 2.2.21 "Walter" - Apr 28, 2026
 <!---
-Packaged by Steven Czerwinski <stevenc@sentinelone.com> on Apr 28, 2026 09:00 -0800
+Packaged by Steven Czerwinski <stevenc@sentinelone.com> on Apr 29, 2026 16:00 -0800
 --->
 
 Changes:
 * Update OCI tarball name to use .oci extension
+* Update FIPS base image to use Python 3.13
 
 Fixes:
 * Fix pre/post install scripts to prefer Python 3
+* Fix FIPS base image bad stage name
 
 ## 2.2.20 "Xavier" - Apr 16, 2026
 <!---

--- a/agent_build_refactored/container_images/base_images/ubuntu-fips.Dockerfile
+++ b/agent_build_refactored/container_images/base_images/ubuntu-fips.Dockerfile
@@ -1,16 +1,13 @@
-FROM artifactory.eng.sentinelone.tech/docker-release/common/ubuntu-base/python311:2.0.48 as base
+FROM artifactory.eng.sentinelone.tech/docker-release/common/ubuntu-base/python313:2.0.74 as base
 
-FROM base as dependencies-build-base
+FROM base as dependencies-builder-base
 ENV DEBIANFRONTEND=noninteractive
-RUN apt-get update
-RUN apt-get install -y \
-    rustc \
-    cargo && \
-    apt-get autoremove --yes && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-
+RUN apt-get update  \
+    && apt-get install -y rustc cargo \
+    && python3.13 -m ensurepip --upgrade \
+    && apt-get autoremove --yes \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 FROM base as runtime-base
 # We upgrade current packages in order to keep everything up to date, including security updates.


### PR DESCRIPTION
Update to use Python 3.13 and fix target name to match new expected value.