### PR TITLE
fix: add new regex module, util wrappers for backwards compatability

### DIFF
--- a/dev-requirements-new.txt
+++ b/dev-requirements-new.txt
@@ -12,6 +12,8 @@ python-dateutil==2.8.2
 repoze.lru==0.7
 six==1.17.0
 urllib3==2.6.3
+regex==2021.11.10; python_version >= '2.7' and python_version < '3.0'
+regex==2024.11.6; python_version >= '3.10'
 
 # Required for redis monitor.
 redis==2.10.5

--- a/scalyr_agent/configuration.py
+++ b/scalyr_agent/configuration.py
@@ -4819,7 +4819,7 @@ class Configuration:
             value = config_object.get_string(field, none_if_missing=True)
 
             if value is not None:
-                re.compile(value)
+                scalyr_util.compile_regex(value)
                 return
         except Exception:
             raise BadConfiguration(

--- a/scalyr_agent/log_processing.py
+++ b/scalyr_agent/log_processing.py
@@ -1607,7 +1607,7 @@ class LogFileIterator:
         found_new_line = False
         new_line_checker = None
         if check_for_new_lines:
-            new_line_checker = re.compile(b"[\n\r]")
+            new_line_checker = scalyr_util.compile_regex(b"[\n\r]")
 
         for pending_file in self.__pending_files:
             if read_position < pending_file.position_end:
@@ -1624,7 +1624,7 @@ class LogFileIterator:
 
                 if content is not None:
                     if check_for_new_lines and not found_new_line:
-                        found_new_line = new_line_checker.match(content) is not None
+                        found_new_line = scalyr_util.regex_match(new_line_checker, content) is not None
 
                     buffer_start = self.__buffer.tell()
                     self.__buffer.write(content)
@@ -3220,7 +3220,7 @@ class LogLineSampler:
             match, then returns None.
         """
         for sampling_rule in self.__sampling_rules:
-            if sampling_rule.match_expression.search(line) is not None:
+            if scalyr_util.regex_search(sampling_rule.match_expression, line) is not None:
                 return sampling_rule
         return None
 
@@ -3251,7 +3251,7 @@ class SamplingRule:
     """Encapsulates all data for one sampling rule."""
 
     def __init__(self, match_expression, sampling_rate):
-        self.match_expression = re.compile(match_expression)
+        self.match_expression = scalyr_util.compile_regex(match_expression)
         self.sampling_rate = sampling_rate
         self.total_matches = 0
         self.total_passes = 0
@@ -3354,7 +3354,7 @@ class LogLineRedacter:
 
         def __replace_groups_with_hashed_content(re_ex, replacement_ex, line):
 
-            _matches = re.finditer(re_ex, line)
+            _matches = scalyr_util.regex_finditer(re_ex, line)
 
             replacement_matches = 0
 
@@ -3411,7 +3411,7 @@ class LogLineRedacter:
                     line,
                 )
             else:
-                (result, matches) = re.subn(
+                (result, matches) = scalyr_util.regex_subn(
                     redaction_rule.redaction_expression,
                     redaction_rule.replacement_text,
                     line,
@@ -3430,7 +3430,7 @@ class LogLineRedacter:
                     line.decode("utf-8", "replace"),
                 )
             else:
-                (result, matches) = re.subn(
+                (result, matches) = scalyr_util.regex_subn(
                     redaction_rule.redaction_expression,
                     redaction_rule.replacement_text,
                     line.decode("utf-8", "replace"),
@@ -3455,7 +3455,7 @@ class RedactionRule:
     """Encapsulates all data for one redaction rule."""
 
     def __init__(self, redaction_expression, replacement_text, hash_salt=""):
-        self.redaction_expression = re.compile(redaction_expression)
+        self.redaction_expression = scalyr_util.compile_regex(redaction_expression)
         self.replacement_text = replacement_text
         self.hash_salt = hash_salt
         self.total_lines = 0
@@ -3880,8 +3880,8 @@ class LogMatcher:
             elif isinstance(rename, JsonObject):
                 if "match" in rename and "replacement" in rename:
                     try:
-                        pattern = re.compile(rename["match"])
-                        result = re.sub(pattern, rename["replacement"], matched_file)
+                        pattern = scalyr_util.compile_regex(rename["match"])
+                        result = scalyr_util.regex_sub(pattern, rename["replacement"], matched_file)
                         if result == matched_file:
                             log.warning(
                                 "Regex '%s' used to rename logfile '%s', but logfile name was not changed."

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -2762,12 +2762,12 @@ def get_flat_dictionary_memory_usage(data):
     return size
 
 
-def compile_regex(pattern, flags=0, timeout=5.0):
+def compile_regex(pattern, flags=0):
     """
     Compile a regular expression with timeout protection if available.
     """
     if regex is not None:
-        return regex.compile(pattern, flags, timeout=timeout)
+        return regex.compile(pattern, flags)
     else:
         return re.compile(pattern, flags)
 

--- a/scalyr_agent/util.py
+++ b/scalyr_agent/util.py
@@ -90,6 +90,11 @@ except ImportError:
 
     new_md5 = False
 
+try:
+    import regex
+except ImportError:
+    regex = None
+
 
 ORJSON_NOT_AVAILABLE_MSG = """
 orjson library is not available. You can install it using pip.
@@ -2755,3 +2760,53 @@ def get_flat_dictionary_memory_usage(data):
         map(sys.getsizeof, data.keys())
     )
     return size
+
+
+def compile_regex(pattern, flags=0, timeout=5.0):
+    """
+    Compile a regular expression with timeout protection if available.
+    """
+    if regex is not None:
+        return regex.compile(pattern, flags, timeout=timeout)
+    else:
+        return re.compile(pattern, flags)
+
+
+def regex_sub(pattern, repl, string, timeout=5.0):
+    """Executes sub with the appropriate regex module."""
+    if regex is not None:
+        return regex.sub(pattern, repl, string, timeout=timeout)
+    else:
+        return re.sub(pattern, repl, string)
+
+
+def regex_subn(pattern, repl, string, timeout=5.0):
+    """Executes subn with the appropriate regex module."""
+    if regex is not None:
+        return regex.subn(pattern, repl, string, timeout=timeout)
+    else:
+        return re.subn(pattern, repl, string)
+
+
+def regex_finditer(pattern, string, timeout=5.0):
+    """Executes finditer with the appropriate regex module."""
+    if regex is not None:
+        return regex.finditer(pattern, string, timeout=timeout)
+    else:
+        return re.finditer(pattern, string)
+
+
+def regex_search(pattern, string, timeout=5.0):
+    """Executes search with the appropriate regex module."""
+    if regex is not None:
+        return regex.search(pattern, string, timeout=timeout)
+    else:
+        return re.search(pattern, string)
+
+
+def regex_match(pattern, string, timeout=5.0):
+    """Executes match with the appropriate regex module."""
+    if regex is not None:
+        return regex.match(pattern, string, timeout=timeout)
+    else:
+        return re.match(pattern, string)


### PR DESCRIPTION
This PR adds a separate `regex` module to incorporate timeouts into the different regex calls. This mitigates issues with overly complex regex patterns. 

Add the module into requirements. Per the module description, `2021.11.10` for Python 2 and then `2024.11.6` for Python 3.10 and later. In-between versions are then handled by the util wrappers. 