### PR TITLE
fix: [DTIN-7349] Add RPM digest flag

### DIFF
--- a/package_builders/managed_packages/managed_packages_builders.py
+++ b/package_builders/managed_packages/managed_packages_builders.py
@@ -221,6 +221,7 @@ class LinuxPackageBuilder(Builder):
                 "--directories", f"/var/lib/{AGENT_SUBDIR_NAME}",
                 "--directories", f"/var/log/{AGENT_SUBDIR_NAME}",
                 "--rpm-use-file-permissions",
+                "--rpm-digest", "sha256",
                 "--deb-use-file-permissions",
                 "--verbose",
                 # fmt: on


### PR DESCRIPTION
This PR adds the RPM digest flag to set the FILEDIGESTALGO so it does not default to MD5. 