### PR TITLE
Update Ubuntu-fips image base to 2.0.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 Scalyr Agent 2 Changes By Release
 =================================
 
-## 2.2.22 "Victor" - Jun 23, 2026
+## 2.2.22 "Victor" - Jul 1, 2026
 <!---
-Packaged by Tristan McCarty <tristan.mccarty@sentinelone.com> on Jun 23, 2026 16:00 -0800
+Packaged by Tristan McCarty <tristan.mccarty@sentinelone.com> on Jul 1, 2026 16:00 -0800
 --->
 
 Changes:
 * Update Windows MSI packaging to extract files at installation
+* Base Ubuntu Fips image was upgraded to 2.0.77
 
 Fixes:
 * Added RPM digest flag to the build process

--- a/package_builders/container_images/base_images/ubuntu-fips.Dockerfile
+++ b/package_builders/container_images/base_images/ubuntu-fips.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.eng.sentinelone.tech/docker-release/common/ubuntu-base/python313:2.0.74 as base
+FROM artifactory.eng.sentinelone.tech/docker-release/common/ubuntu-base/python313:2.0.77 as base
 
 FROM base as dependencies-builder-base
 ENV DEBIANFRONTEND=noninteractive


### PR DESCRIPTION
This is a small PR that increments the Ubuntu-fips image base to 2.0.77 as an extra change for the for 2.2.22 Agent "Victor" release. Updates the Changelog as well.