### PR TITLE
Update K8s tags to 2.2.22 release

### DIFF
--- a/k8s/default-namespace/scalyr-agent-2.yaml
+++ b/k8s/default-namespace/scalyr-agent-2.yaml
@@ -50,7 +50,7 @@ spec:
         envFrom:
         - configMapRef:
             name: scalyr-config
-        image: scalyr/scalyr-k8s-agent:2.2.21
+        image: scalyr/scalyr-k8s-agent:2.2.22
         imagePullPolicy: Always
         name: scalyr-agent
         securityContext:

--- a/k8s/no-kustomize/scalyr-agent-2.yaml
+++ b/k8s/no-kustomize/scalyr-agent-2.yaml
@@ -50,7 +50,7 @@ spec:
         envFrom:
         - configMapRef:
             name: scalyr-config
-        image: scalyr/scalyr-k8s-agent:2.2.21
+        image: scalyr/scalyr-k8s-agent:2.2.22
         imagePullPolicy: Always
         name: scalyr-agent
         securityContext:

--- a/k8s/scalyr-agent-2-envfrom.yaml
+++ b/k8s/scalyr-agent-2-envfrom.yaml
@@ -49,7 +49,7 @@ spec:
         envFrom:
         - configMapRef:
             name: scalyr-config
-        image: scalyr/scalyr-k8s-agent:2.2.21
+        image: scalyr/scalyr-k8s-agent:2.2.22
         imagePullPolicy: Always
         name: scalyr-agent
         securityContext:

--- a/k8s/scalyr-agent-2.yaml
+++ b/k8s/scalyr-agent-2.yaml
@@ -49,7 +49,7 @@ spec:
         envFrom:
         - configMapRef:
             name: scalyr-config
-        image: scalyr/scalyr-k8s-agent:2.2.21
+        image: scalyr/scalyr-k8s-agent:2.2.22
         imagePullPolicy: Always
         name: scalyr-agent
         securityContext:


### PR DESCRIPTION
Now that the 2.2.22 release has been published, this PR increments the K8's yamls for the latest release. 